### PR TITLE
fix: use proper Callable type hints instead of lowercase callable

### DIFF
--- a/custom_components/localshift/computation_engine.py
+++ b/custom_components/localshift/computation_engine.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 from datetime import datetime, time, timedelta
 from typing import Any
 
@@ -150,8 +151,8 @@ class ComputationEngine:
         self,
         hass: HomeAssistant,
         entry: ConfigEntry,
-        get_entity_id_func: callable,
-        get_switch_state_func: callable,
+        get_entity_id_func: Callable[[str], str],
+        get_switch_state_func: Callable[[str], bool],
     ) -> None:
         """Initialize computation engine.
 

--- a/custom_components/localshift/computation_engine_lib/forecast_computer.py
+++ b/custom_components/localshift/computation_engine_lib/forecast_computer.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 from datetime import datetime, time, timedelta
 
 from homeassistant.config_entries import ConfigEntry
@@ -45,8 +46,8 @@ class ForecastComputer:
     def __init__(
         self,
         entry: ConfigEntry,
-        get_entity_id_func: callable,
-        get_historical_func: callable,
+        get_entity_id_func: Callable[[str], str],
+        get_historical_func: Callable[[str], dict[int, float]],
     ) -> None:
         """Initialize forecast computer.
 

--- a/tests/test_hybrid_timescale.py
+++ b/tests/test_hybrid_timescale.py
@@ -38,7 +38,7 @@ class TestFifteenMinSlots:
         return ForecastComputer(
             entry=mock_entry,
             get_entity_id_func=lambda x: f"sensor.{x}",
-            get_historical_func=lambda: {},
+            get_historical_func=lambda entity_id: {},
         )
 
     @pytest.fixture


### PR DESCRIPTION
## Summary
Updated type hints to use proper `Callable` type annotations from the `typing` module instead of lowercase `callable` (built-in type).

## Changes Made
- Updated `computation_engine.py` to use `Callable[[str], str]` and `Callable[[str], bool]`
- Updated `forecast_computer.py` to use `Callable[[str], str]` and `Callable[[str], dict[int, float]]`
- Fixed test file to match updated function signatures

## Testing
All pre-commit hooks passed (ruff, ruff-format, vulture, pyright)

Closes #5