### PR TITLE
refactor: remove redundant grid import/export sensors

### DIFF
--- a/custom_components/localshift/computation_engine.py
+++ b/custom_components/localshift/computation_engine.py
@@ -208,10 +208,6 @@ class ComputationEngine:
         before_dw = now_t < dw_start_time
         after_dw = now_t >= dw_start_time
 
-        # ---- Step 1: Directional power (always positive) ----
-        data.grid_import_power_kw = max(data.grid_power_kw, 0.0)
-        data.grid_export_power_kw = max(-data.grid_power_kw, 0.0)
-
         # ---- Step 2: Mode detection from Teslemetry state ----
         data.force_discharge_active = (
             data.operation_mode == "autonomous" and data.backup_reserve < 11

--- a/custom_components/localshift/coordinator_data.py
+++ b/custom_components/localshift/coordinator_data.py
@@ -69,8 +69,6 @@ class CoordinatorData:
     solar_weighted_avg_fit: float = 0.0
     solar_remaining_kwh: float = 0.0
     active_mode: BatteryMode = BatteryMode.SELF_CONSUMPTION
-    grid_import_power_kw: float = 0.0
-    grid_export_power_kw: float = 0.0
     solar_battery_forecast: dict[str, Any] = field(default_factory=dict)
     decision_log: list[dict[str, Any]] = field(default_factory=list)
     forecast_history: list[dict[str, Any]] = field(default_factory=list)

--- a/custom_components/localshift/sensor.py
+++ b/custom_components/localshift/sensor.py
@@ -5,12 +5,10 @@ from __future__ import annotations
 from typing import Any
 
 from homeassistant.components.sensor import (
-    SensorDeviceClass,
     SensorEntity,
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import UnitOfPower
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -33,8 +31,6 @@ async def async_setup_entry(
         SolarWeightedAvgFITSensor(coordinator, entry),
         ActiveModeSensor(coordinator, entry),
         SolarBatteryForecastSensor(coordinator, entry),
-        GridImportPowerSensor(coordinator, entry),
-        GridExportPowerSensor(coordinator, entry),
         NetElectricityCostSensor(coordinator, entry),
         DecisionLogSensor(coordinator, entry),
         ForecastHistorySensor(coordinator, entry),
@@ -179,34 +175,6 @@ class SolarBatteryForecastSensor(LocalShiftSensorBase):
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return full forecast as attributes."""
         return self.coordinator.data.solar_battery_forecast
-
-
-class GridImportPowerSensor(LocalShiftSensorBase):
-    """Grid import power (always >= 0)."""
-
-    _attr_unique_id = "localshift_power_grid_import"
-    _attr_name = "Power Grid Import"
-    _attr_icon = "mdi:transmission-tower-import"
-    _attr_device_class = SensorDeviceClass.POWER
-    _attr_native_unit_of_measurement = UnitOfPower.KILO_WATT
-    _attr_state_class = SensorStateClass.MEASUREMENT
-
-    def _update_from_coordinator(self) -> None:
-        self._attr_native_value = round(self.coordinator.data.grid_import_power_kw, 3)
-
-
-class GridExportPowerSensor(LocalShiftSensorBase):
-    """Grid export power (always >= 0)."""
-
-    _attr_unique_id = "localshift_power_grid_export"
-    _attr_name = "Power Grid Export"
-    _attr_icon = "mdi:transmission-tower-export"
-    _attr_device_class = SensorDeviceClass.POWER
-    _attr_native_unit_of_measurement = UnitOfPower.KILO_WATT
-    _attr_state_class = SensorStateClass.MEASUREMENT
-
-    def _update_from_coordinator(self) -> None:
-        self._attr_native_value = round(self.coordinator.data.grid_export_power_kw, 3)
 
 
 class NetElectricityCostSensor(LocalShiftSensorBase):

--- a/dashboards/localshift.yaml
+++ b/dashboards/localshift.yaml
@@ -429,14 +429,9 @@ views:
             icon: mdi:battery-charging
 
           - type: tile
-            entity: sensor.localshift_power_grid_import
-            name: Grid Import
-            icon: mdi:transmission-tower-import
-
-          - type: tile
-            entity: sensor.localshift_power_grid_export
-            name: Grid Export
-            icon: mdi:transmission-tower-export
+            entity: sensor.my_home_grid_power
+            name: Grid Power
+            icon: mdi:transmission-tower
 
           - type: tile
             entity: sensor.my_home_solar_power
@@ -542,9 +537,7 @@ views:
 
               Battery Power: {{ states('sensor.my_home_battery_power') }} kW
 
-              Grid Import: {{ states('sensor.localshift_power_grid_import') }} kW
-
-              Grid Export: {{ states('sensor.localshift_power_grid_export') }} kW
+              Grid Power: {{ states('sensor.my_home_grid_power') }} kW
 
               Solar Power: {{ states('sensor.my_home_solar_power') }} kW
 


### PR DESCRIPTION
## Summary
Remove `localshift_power_grid_import` and `localshift_power_grid_export` sensors as they simply duplicate Teslemetry's signed `grid_power` value.

## Changes Made
- Remove `GridImportPowerSensor` and `GridExportPowerSensor` classes from `sensor.py`
- Remove `grid_import_power_kw` and `grid_export_power_kw` fields from `coordinator_data.py`
- Remove computation from `computation_engine.py`
- Update dashboard to use `sensor.my_home_grid_power` directly

## Rationale
The split sensors were thin wrappers that computed:
- `grid_import_power_kw = max(grid_power_kw, 0.0)`
- `grid_export_power_kw = max(-grid_power_kw, 0.0)`

The underlying `grid_power_kw` is already read from Teslemetry entities. The `cost_tracker.py` already uses `grid_power_kw` directly for cost calculations, so these split sensors provided no internal value and only added unnecessary indirection.

## Testing
- All 94 tests pass
- Pre-commit hooks pass (ruff, ruff-format, vulture, pyright)

Closes #3