### PR TITLE
fix: add public API for recomputation to fix encapsulation

### DIFF
--- a/custom_components/localshift/__init__.py
+++ b/custom_components/localshift/__init__.py
@@ -53,7 +53,5 @@ async def _async_options_updated(
 ) -> None:
     """Handle options update — trigger a re-evaluation with new thresholds."""
     coordinator: LocalShiftCoordinator = entry.runtime_data
-    coordinator._compute_derived_values()
-    coordinator._notify_listeners()
-    await coordinator.async_evaluate_state_machine()
+    await coordinator.async_recompute_and_evaluate()
     _LOGGER.info("LocalShift options updated, re-evaluating")

--- a/custom_components/localshift/coordinator.py
+++ b/custom_components/localshift/coordinator.py
@@ -413,6 +413,16 @@ class LocalShiftCoordinator:
         """
         await self._evaluate_state_machine()
 
+    async def async_recompute_and_evaluate(self) -> None:
+        """Public method for triggering recomputation and state evaluation.
+
+        Called by switch and number platforms when configuration changes.
+        Encapsulates the pattern: compute derived values → notify listeners → evaluate state machine.
+        """
+        self._compute_derived_values()
+        self._notify_listeners()
+        await self.async_evaluate_state_machine()
+
     async def _evaluate_state_machine(self) -> None:
         """Compare desired mode with commanded mode and execute transitions."""
         if self._state_machine is not None and self._computation_engine is not None:

--- a/custom_components/localshift/number.py
+++ b/custom_components/localshift/number.py
@@ -137,6 +137,4 @@ class LocalShiftNumber(NumberEntity):
 
         # Trigger immediate re-evaluation with new threshold values
         # This fixes the issue where threshold changes only took effect on next periodic tick (up to 1 min delay)
-        self.coordinator._compute_derived_values()
-        self.coordinator._notify_listeners()
-        await self.coordinator.async_evaluate_state_machine()
+        await self.coordinator.async_recompute_and_evaluate()

--- a/custom_components/localshift/switch.py
+++ b/custom_components/localshift/switch.py
@@ -125,9 +125,7 @@ class LocalShiftSwitch(SwitchEntity):
             _LOGGER.info("LocalShift automation enabled")
 
         # Re-evaluate derived values and trigger state machine
-        self.coordinator._compute_derived_values()
-        self.coordinator._notify_listeners()
-        await self.coordinator.async_evaluate_state_machine()
+        await self.coordinator.async_recompute_and_evaluate()
 
     async def async_turn_off(self, **_kwargs) -> None:
         """Turn the switch off."""
@@ -152,6 +150,4 @@ class LocalShiftSwitch(SwitchEntity):
                 )
 
         # Re-evaluate derived values and trigger state machine
-        self.coordinator._compute_derived_values()
-        self.coordinator._notify_listeners()
-        await self.coordinator.async_evaluate_state_machine()
+        await self.coordinator.async_recompute_and_evaluate()


### PR DESCRIPTION
## Summary
Add `async_recompute_and_evaluate()` public method to coordinator and update external platforms to use it instead of accessing private methods directly.

## Changes Made
- Added public `async_recompute_and_evaluate()` method to `coordinator.py`
- Updated `switch.py` to use new public method
- Updated `number.py` to use new public method  
- Updated `__init__.py` to use new public method

## Testing
- All 94 tests pass
- Pre-commit hooks pass (ruff, ruff-format, vulture, pyright)

Closes #8