### PR TITLE
fix: reduce excessive forecast logging noise

### DIFF
--- a/custom_components/localshift/computation_engine_lib/forecast_computer.py
+++ b/custom_components/localshift/computation_engine_lib/forecast_computer.py
@@ -568,7 +568,7 @@ class ForecastComputer:
 
                 # Solar from dawn can reach target: NO overnight grid charging
                 if can_reach_with_solar_only:
-                    _LOGGER.info(
+                    _LOGGER.debug(
                         "Grid charge SKIPPED overnight: solar from %s reaches target (SOC at dawn: %.1f%% -> max %.1f%%)",
                         solar_start.strftime("%H:%M"),
                         soc_at_solar_start,
@@ -593,7 +593,7 @@ class ForecastComputer:
                 )
 
                 if can_reach_with_solar_only:
-                    _LOGGER.info(
+                    _LOGGER.debug(
                         "Grid charge SKIPPED: solar forecast reaches target before DW (max_soc=%.1f%% >= %d%%)",
                         max_soc,
                         target_pct,
@@ -618,7 +618,7 @@ class ForecastComputer:
 
             # Solar forecast says we'll reach target: NO grid charging
             if can_reach_with_solar_only:
-                _LOGGER.info(
+                _LOGGER.debug(
                     "Grid charge SKIPPED: solar forecast reaches target before DW (max_soc=%.1f%% >= %d%%)",
                     max_soc,
                     target_pct,
@@ -2331,6 +2331,19 @@ class ForecastComputer:
                 ", ".join(missing_solar_slots[:10])
                 + ("..." if len(missing_solar_slots) > 10 else ""),
             )
+
+        # ========================================================================
+        # SUMMARY LOGGING: Grid charging decisions across all 96 slots
+        # ========================================================================
+        grid_charge_slots = sum(
+            1 for slot in daily_forecast if slot.get("grid_charge", False)
+        )
+        skipped_slots = TOTAL_SLOTS - grid_charge_slots
+        _LOGGER.info(
+            "Grid charging forecast: %d slot(s) with grid charging, %d slot(s) skipped (solar sufficient or price not cheap)",
+            grid_charge_slots,
+            skipped_slots,
+        )
 
         # ========================================================================
         # CALCULATE FORECAST COSTS (rest of today)


### PR DESCRIPTION
## Problem
The forecast computer generates excessive log output during normal operation, making it difficult to identify actual issues in the logs.

## Observed Behavior
The same message was repeated 50+ times:
```
Grid charge SKIPPED overnight: solar from 07:30 reaches target (SOC at dawn: 35.6% -> max 100.0%)
Grid charge SKIPPED: solar forecast reaches target before DW (max_soc=100.0% >= 100%)
```

## Solution
- Changed 3 INFO logs to DEBUG in `_should_grid_charge_at_slot()`
- Added summary INFO log at end of `compute_forecast()`

## Impact
- **Before:** 50-96 INFO messages per forecast cycle
- **After:** 1 summary INFO message per forecast cycle
- **DEBUG mode:** Still provides full diagnostic detail

Closes #38