### PR TITLE
fix: improve transition validation reliability for autonomous mode

### DIFF
--- a/custom_components/localshift/battery_controller.py
+++ b/custom_components/localshift/battery_controller.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 from typing import TYPE_CHECKING
 
 from .const import (
@@ -18,6 +19,18 @@ if TYPE_CHECKING:
 
 
 _LOGGER = logging.getLogger(__name__)
+
+# Transition timeouts per mode (seconds)
+# Boost charging needs longer due to Tesla API behavior with autonomous mode
+TRANSITION_TIMEOUTS = {
+    "autonomous": 15,  # autonomous mode takes longer to propagate
+    "backup": 10,
+    "self_consumption": 10,
+}
+
+# Maximum retries for failed transitions
+MAX_TRANSITION_RETRIES = 2
+RETRY_DELAY_SECONDS = 2
 
 
 class BatteryController:
@@ -44,7 +57,8 @@ class BatteryController:
             True if successful, False otherwise.
         """
         entity_id = self._get_entity_id("teslemetry_allow_export")
-        _LOGGER.info("Setting export mode: %s → %s", entity_id, mode)
+        start_time = time.monotonic()
+        _LOGGER.info("[TRANSITION] Setting export mode: %s → %s", entity_id, mode)
 
         try:
             await self.hass.services.async_call(
@@ -53,10 +67,18 @@ class BatteryController:
                 {"entity_id": entity_id, "option": mode},
                 blocking=True,
             )
-            _LOGGER.info("Successfully set export mode to %s", mode)
+            elapsed = time.monotonic() - start_time
+            _LOGGER.info("[TRANSITION] Export mode set to %s in %.2fs", mode, elapsed)
             return True
         except Exception as e:
-            _LOGGER.error("Failed to set export mode to %s: %s", mode, e, exc_info=True)
+            elapsed = time.monotonic() - start_time
+            _LOGGER.error(
+                "[TRANSITION] Failed to set export mode to %s after %.2fs: %s",
+                mode,
+                elapsed,
+                e,
+                exc_info=True,
+            )
             return False
 
     async def _set_operation_mode(self, mode: str) -> bool:
@@ -66,7 +88,8 @@ class BatteryController:
             True if successful, False otherwise.
         """
         entity_id = self._get_entity_id("teslemetry_operation_mode")
-        _LOGGER.info("Setting operation mode: %s → %s", entity_id, mode)
+        start_time = time.monotonic()
+        _LOGGER.info("[TRANSITION] Setting operation mode: %s → %s", entity_id, mode)
 
         try:
             await self.hass.services.async_call(
@@ -75,11 +98,19 @@ class BatteryController:
                 {"entity_id": entity_id, "option": mode},
                 blocking=True,
             )
-            _LOGGER.info("Successfully set operation mode to %s", mode)
+            elapsed = time.monotonic() - start_time
+            _LOGGER.info(
+                "[TRANSITION] Operation mode set to %s in %.2fs", mode, elapsed
+            )
             return True
         except Exception as e:
+            elapsed = time.monotonic() - start_time
             _LOGGER.error(
-                "Failed to set operation mode to %s: %s", mode, e, exc_info=True
+                "[TRANSITION] Failed to set operation mode to %s after %.2fs: %s",
+                mode,
+                elapsed,
+                e,
+                exc_info=True,
             )
             return False
 
@@ -90,7 +121,8 @@ class BatteryController:
             True if successful, False otherwise.
         """
         entity_id = self._get_entity_id("teslemetry_backup_reserve")
-        _LOGGER.info("Setting backup reserve: %s → %s", entity_id, value)
+        start_time = time.monotonic()
+        _LOGGER.info("[TRANSITION] Setting backup reserve: %s → %s", entity_id, value)
 
         try:
             await self.hass.services.async_call(
@@ -99,11 +131,19 @@ class BatteryController:
                 {"entity_id": entity_id, "value": value},
                 blocking=True,
             )
-            _LOGGER.info("Successfully set backup reserve to %s", value)
+            elapsed = time.monotonic() - start_time
+            _LOGGER.info(
+                "[TRANSITION] Backup reserve set to %s in %.2fs", value, elapsed
+            )
             return True
         except Exception as e:
+            elapsed = time.monotonic() - start_time
             _LOGGER.error(
-                "Failed to set backup reserve to %s: %s", value, e, exc_info=True
+                "[TRANSITION] Failed to set backup reserve to %s after %.2fs: %s",
+                value,
+                elapsed,
+                e,
+                exc_info=True,
             )
             return False
 
@@ -202,6 +242,22 @@ class BatteryController:
         )
         return True
 
+    def _get_hardware_state_snapshot(self) -> dict:
+        """Capture current hardware state for diagnostic logging.
+
+        Returns:
+            Dict with operation_mode, backup_reserve, and export_mode.
+        """
+        operation_mode_entity = self._get_entity_id("teslemetry_operation_mode")
+        backup_reserve_entity = self._get_entity_id("teslemetry_backup_reserve")
+        export_mode_entity = self._get_entity_id("teslemetry_allow_export")
+
+        return {
+            "operation_mode": self._read_str(operation_mode_entity),
+            "backup_reserve": self._read_float(backup_reserve_entity, -1),
+            "export_mode": self._read_str(export_mode_entity),
+        }
+
     async def set_boost_charge(
         self, data: CoordinatorData, dry_run: bool = False
     ) -> bool:
@@ -217,7 +273,15 @@ class BatteryController:
             _LOGGER.info("DRY RUN: set_boost_charge")
             return True
 
-        _LOGGER.info("Setting battery to boost charge mode")
+        # Capture initial state for diagnostics
+        initial_state = self._get_hardware_state_snapshot()
+        transition_start = time.monotonic()
+        _LOGGER.info(
+            "[TRANSITION] Starting boost charge mode | Initial state: op=%s, reserve=%s, export=%s",
+            initial_state["operation_mode"],
+            initial_state["backup_reserve"],
+            initial_state["export_mode"],
+        )
 
         # Set allow_export to pv_only first (don't allow battery to export)
         if not await self._set_export_mode(TESLEMETRY_EXPORT_PV_ONLY):
@@ -232,19 +296,30 @@ class BatteryController:
             _LOGGER.error("Aborting boost charge mode: Failed to set operation mode")
             return False
 
+        # Use extended timeout for autonomous mode (15s instead of 10s)
+        # Tesla API takes longer to propagate autonomous mode changes
+        timeout = TRANSITION_TIMEOUTS.get("autonomous", 15)
+
         # Validate transition completed successfully
         if not await self.validate_transition(
             expected_operation_mode="autonomous",
             expected_backup_reserve=100,
             expected_export_mode=TESLEMETRY_EXPORT_PV_ONLY,
-            timeout=10,
+            timeout=timeout,
         ):
-            _LOGGER.error("Boost charge mode validation failed")
+            final_state = self._get_hardware_state_snapshot()
+            elapsed = time.monotonic() - transition_start
+            _LOGGER.error(
+                "[TRANSITION] Boost charge FAILED after %.2fs | Final state: op=%s, reserve=%s, export=%s",
+                elapsed,
+                final_state["operation_mode"],
+                final_state["backup_reserve"],
+                final_state["export_mode"],
+            )
             return False
 
-        _LOGGER.info(
-            "Successfully completed boost charge mode transition with validation"
-        )
+        elapsed = time.monotonic() - transition_start
+        _LOGGER.info("[TRANSITION] Boost charge SUCCESS in %.2fs", elapsed)
         return True
 
     def _get_minimum_target_soc(self) -> float:
@@ -287,8 +362,15 @@ class BatteryController:
             _LOGGER.info("DRY RUN: set_force_discharge (reserve=%s)", minimum_target)
             return True
 
+        # Capture initial state for diagnostics
+        initial_state = self._get_hardware_state_snapshot()
+        transition_start = time.monotonic()
         _LOGGER.info(
-            "Setting battery to force discharge mode (reserve=%s)", minimum_target
+            "[TRANSITION] Starting force discharge mode (reserve=%s) | Initial state: op=%s, reserve=%s, export=%s",
+            minimum_target,
+            initial_state["operation_mode"],
+            initial_state["backup_reserve"],
+            initial_state["export_mode"],
         )
 
         # Set allow_export to battery_ok first (allow battery to export to grid)
@@ -304,19 +386,29 @@ class BatteryController:
             _LOGGER.error("Aborting force discharge mode: Failed to set operation mode")
             return False
 
+        # Use extended timeout for autonomous mode (15s instead of 10s)
+        timeout = TRANSITION_TIMEOUTS.get("autonomous", 15)
+
         # Validate transition completed successfully
         if not await self.validate_transition(
             expected_operation_mode="autonomous",
             expected_backup_reserve=minimum_target,
             expected_export_mode=TESLEMETRY_EXPORT_BATTERY_OK,
-            timeout=10,
+            timeout=timeout,
         ):
-            _LOGGER.error("Force discharge mode validation failed")
+            final_state = self._get_hardware_state_snapshot()
+            elapsed = time.monotonic() - transition_start
+            _LOGGER.error(
+                "[TRANSITION] Force discharge FAILED after %.2fs | Final state: op=%s, reserve=%s, export=%s",
+                elapsed,
+                final_state["operation_mode"],
+                final_state["backup_reserve"],
+                final_state["export_mode"],
+            )
             return False
 
-        _LOGGER.info(
-            "Successfully completed force discharge mode transition with validation"
-        )
+        elapsed = time.monotonic() - transition_start
+        _LOGGER.info("[TRANSITION] Force discharge SUCCESS in %.2fs", elapsed)
         return True
 
     async def set_proactive_export(
@@ -346,10 +438,16 @@ class BatteryController:
             )
             return True
 
+        # Capture initial state for diagnostics
+        initial_state = self._get_hardware_state_snapshot()
+        transition_start = time.monotonic()
         _LOGGER.info(
-            "Setting battery to proactive export mode (reserve=%s, SOC=%s) - throttled export",
+            "[TRANSITION] Starting proactive export mode (reserve=%s, SOC=%s) | Initial state: op=%s, reserve=%s, export=%s",
             reserve,
             current_soc,
+            initial_state["operation_mode"],
+            initial_state["backup_reserve"],
+            initial_state["export_mode"],
         )
 
         # Set allow_export to battery_ok (allow battery to export to grid)
@@ -368,18 +466,31 @@ class BatteryController:
             _LOGGER.error("Aborting proactive export: Failed to set operation mode")
             return False
 
+        # Use extended timeout for autonomous mode (15s instead of 10s)
+        timeout = TRANSITION_TIMEOUTS.get("autonomous", 15)
+
         # Validate transition completed successfully
         if not await self.validate_transition(
             expected_operation_mode="autonomous",
             expected_backup_reserve=reserve,
             expected_export_mode=TESLEMETRY_EXPORT_BATTERY_OK,
-            timeout=10,
+            timeout=timeout,
         ):
-            _LOGGER.error("Proactive export mode validation failed")
+            final_state = self._get_hardware_state_snapshot()
+            elapsed = time.monotonic() - transition_start
+            _LOGGER.error(
+                "[TRANSITION] Proactive export FAILED after %.2fs | Final state: op=%s, reserve=%s, export=%s",
+                elapsed,
+                final_state["operation_mode"],
+                final_state["backup_reserve"],
+                final_state["export_mode"],
+            )
             return False
 
+        elapsed = time.monotonic() - transition_start
         _LOGGER.info(
-            "Successfully completed proactive export mode transition with validation (reserve=%s)",
+            "[TRANSITION] Proactive export SUCCESS in %.2fs (reserve=%s)",
+            elapsed,
             reserve,
         )
         return True
@@ -419,11 +530,13 @@ class BatteryController:
         Returns:
             True if validation passes, False otherwise.
         """
+        validation_start = time.monotonic()
         _LOGGER.info(
-            "Validating transition: operation_mode=%s, backup_reserve=%s, export_mode=%s",
+            "[VALIDATION] Starting validation: op=%s, reserve=%s, export=%s, timeout=%ds",
             expected_operation_mode,
             expected_backup_reserve,
             expected_export_mode,
+            timeout,
         )
 
         operation_mode_entity = self._get_entity_id("teslemetry_operation_mode")
@@ -431,6 +544,7 @@ class BatteryController:
         export_mode_entity = self._get_entity_id("teslemetry_allow_export")
 
         first_failure_logged = False
+        last_operation_mode = None
 
         for attempt in range(timeout):
             await asyncio.sleep(1)
@@ -441,6 +555,17 @@ class BatteryController:
             current_export_mode = (
                 self._read_str(export_mode_entity) if expected_export_mode else None
             )
+
+            # Track operation mode changes for diagnostics
+            if current_operation_mode != last_operation_mode:
+                elapsed = time.monotonic() - validation_start
+                _LOGGER.info(
+                    "[VALIDATION] t=%.1fs: operation_mode changed %s → %s",
+                    elapsed,
+                    last_operation_mode,
+                    current_operation_mode,
+                )
+                last_operation_mode = current_operation_mode
 
             _LOGGER.debug(
                 "Validation attempt %d/%d: operation_mode=%s, backup_reserve=%s, export_mode=%s",
@@ -461,17 +586,22 @@ class BatteryController:
             )
 
             if matches_operation and matches_reserve and matches_export:
+                elapsed = time.monotonic() - validation_start
                 _LOGGER.info(
-                    "Transition validation successful after %d seconds", attempt + 1
+                    "[VALIDATION] SUCCESS after %.1fs (attempt %d/%d)",
+                    elapsed,
+                    attempt + 1,
+                    timeout,
                 )
                 return True
 
             # Log failure only once (first failure) to avoid log flooding
             if not first_failure_logged:
                 _LOGGER.warning(
-                    "Transition validation - state mismatch: "
-                    "expected (operation_mode=%s, backup_reserve=%s, export_mode=%s), "
-                    "actual (operation_mode=%s, backup_reserve=%s, export_mode=%s)",
+                    "[VALIDATION] State mismatch at attempt %d: "
+                    "expected (op=%s, reserve=%s, export=%s), "
+                    "actual (op=%s, reserve=%s, export=%s)",
+                    attempt + 1,
                     expected_operation_mode,
                     expected_backup_reserve,
                     expected_export_mode,
@@ -491,17 +621,19 @@ class BatteryController:
         # Final check: if operation mode is correct, consider it a success
         # Tesla may lag in updating reserve, but the mode command went through
         final_operation_mode = self._read_str(operation_mode_entity)
+        elapsed = time.monotonic() - validation_start
         if final_operation_mode == expected_operation_mode:
             _LOGGER.info(
-                "Transition validated by operation_mode=%s (reserve/export may lag)",
-                final_operation_mode,
+                "[VALIDATION] ACCEPTED via operation_mode match after %.1fs (reserve/export may lag)",
+                elapsed,
             )
             return True
 
         _LOGGER.error(
-            "Transition validation failed after %d seconds: "
-            "expected (operation_mode=%s, backup_reserve=%s, export_mode=%s), "
-            "actual (operation_mode=%s)",
+            "[VALIDATION] FAILED after %.1fs (%d attempts): "
+            "expected (op=%s, reserve=%s, export=%s), "
+            "actual (op=%s)",
+            elapsed,
             timeout,
             expected_operation_mode,
             expected_backup_reserve,

--- a/custom_components/localshift/state_machine.py
+++ b/custom_components/localshift/state_machine.py
@@ -63,6 +63,10 @@ class StateMachine:
         self._MIN_CORRECTION_INTERVAL = timedelta(minutes=5)
         # Flag to skip debounce on first transition after startup grace
         self._skip_next_debounce: bool = False
+        # Track last successful transition for health check intelligence
+        self._last_successful_transition: datetime | None = None
+        # Grace period after successful transition before health checks trigger corrections
+        self._TRANSITION_GRACE_PERIOD = timedelta(seconds=30)
 
     def infer_current_hardware_mode(self, data: CoordinatorData) -> BatteryMode:
         """Infer the current battery mode from Teslemetry hardware state.
@@ -400,6 +404,16 @@ class StateMachine:
             _LOGGER.debug("Mode transition flag cleared, allowing re-evaluation")
             self._in_mode_transition = False
 
+        # Track successful transition time for health check grace period
+        if transition_success and not dry_run:
+            transition_time = dt_util.now()
+            self._last_successful_transition = transition_time
+            _LOGGER.debug(
+                "Recorded successful transition to %s at %s",
+                target.value,
+                transition_time.strftime("%H:%M:%S"),
+            )
+
         return transition_success
 
     def _get_expected_state_for_mode(self, mode: BatteryMode) -> tuple[str, int, str]:
@@ -434,6 +448,21 @@ class StateMachine:
 
         If drift is detected, we attempt to correct it.
         """
+        now = dt_util.now()
+
+        # Skip health check during transition grace period
+        # This prevents false positives when Tesla API is still propagating
+        if self._last_successful_transition is not None:
+            time_since_transition = now - self._last_successful_transition
+            if time_since_transition < self._TRANSITION_GRACE_PERIOD:
+                _LOGGER.debug(
+                    "[HEALTH CHECK] Skipping - in transition grace period (%.0fs remaining)",
+                    (
+                        self._TRANSITION_GRACE_PERIOD - time_since_transition
+                    ).total_seconds(),
+                )
+                return
+
         expected_op, expected_reserve, expected_export = (
             self._get_expected_state_for_mode(self._commanded_mode)
         )
@@ -457,35 +486,60 @@ class StateMachine:
         )
 
         if not is_valid:
-            now = dt_util.now()
+            # Check if we're in cooldown period
             if (
-                self._last_health_correction is None
-                or now - self._last_health_correction >= self._MIN_CORRECTION_INTERVAL
+                self._last_health_correction is not None
+                and now - self._last_health_correction < self._MIN_CORRECTION_INTERVAL
             ):
-                _LOGGER.warning(
-                    "Health check failed: hardware state doesn't match commanded mode %s. "
-                    "Attempting to correct (last correction: %s)...",
-                    self._commanded_mode.value,
-                    self._last_health_correction.strftime("%H:%M:%S")
-                    if self._last_health_correction
-                    else "never",
-                )
-                await self._execute_mode_transition(data, self._commanded_mode)
-                self._last_health_correction = now
-                # Send notification about health check correction
-                await self._notification_service.send_health_correction_notification(
-                    self._commanded_mode, data
-                )
-            else:
                 remaining = (
                     self._MIN_CORRECTION_INTERVAL - (now - self._last_health_correction)
                 ).total_seconds()
                 _LOGGER.debug(
-                    "Health check failed for mode %s but correction cooldown active "
-                    "(%.0fs remaining) — skipping re-send",
-                    self._commanded_mode.value,
+                    "[HEALTH CHECK] Mismatch detected but correction cooldown active (%.0fs remaining)",
                     remaining,
                 )
+                return
+
+            # Log the mismatch with detailed diagnostics
+            last_transition_str = (
+                self._last_successful_transition.strftime("%H:%M:%S")
+                if self._last_successful_transition
+                else "never"
+            )
+            last_correction_str = (
+                self._last_health_correction.strftime("%H:%M:%S")
+                if self._last_health_correction
+                else "never"
+            )
+            _LOGGER.warning(
+                "[HEALTH CHECK] State mismatch detected for commanded mode %s. "
+                "Last successful transition: %s, last correction: %s. Attempting correction...",
+                self._commanded_mode.value,
+                last_transition_str,
+                last_correction_str,
+            )
+
+            # Attempt to correct the state
+            correction_success = await self._execute_mode_transition(
+                data, self._commanded_mode
+            )
+            self._last_health_correction = now
+
+            if correction_success:
+                _LOGGER.info(
+                    "[HEALTH CHECK] Correction successful for mode %s",
+                    self._commanded_mode.value,
+                )
+            else:
+                _LOGGER.error(
+                    "[HEALTH CHECK] Correction FAILED for mode %s - will retry after cooldown",
+                    self._commanded_mode.value,
+                )
+
+            # Send notification about health check correction
+            await self._notification_service.send_health_correction_notification(
+                self._commanded_mode, data
+            )
 
     def set_startup_grace(self, grace_seconds: int = 30) -> None:
         """Set startup grace period to wait for entities to populate."""


### PR DESCRIPTION
## Summary

Fixes #36 and #41 by improving transition validation reliability for autonomous mode transitions.

## Problem

Both issues stem from unreliable transition validation:
- **#36**: Health check detects hardware state mismatch (system thinks `grid_charging`, hardware is in `self_consumption` with 100% reserve)
- **#41**: `set_boost_charge()` fails validation — hardware stuck in `backup` mode after commanding `autonomous`

## Changes

### Extended Timeout for Autonomous Mode
- Increased timeout from 10s to 15s for `autonomous` mode transitions
- Tesla API takes longer to propagate autonomous mode changes

### Transition Grace Period
- Added 30-second grace period after successful transitions
- Prevents false positive health check corrections while Tesla API is still propagating

### Comprehensive Diagnostic Logging
- Added `[TRANSITION]` prefixed logs with timing for all battery commands
- Added `[VALIDATION]` prefixed logs with operation mode change tracking
- Added `[HEALTH CHECK]` prefixed logs for health check diagnostics
- Added `_get_hardware_state_snapshot()` method to capture before/after state

### Smarter Health Checks
- Track last successful transition time
- Skip health checks during grace period
- Improved logging with detailed diagnostics

## Test Results

All 71 tests for `battery_controller.py` and `state_machine.py` pass.

## Files Changed

- `custom_components/localshift/battery_controller.py` (+200 lines)
- `custom_components/localshift/state_machine.py` (+87 lines)