### PR TITLE
fix: boost_charge_needed reads from current forecast slot

### DIFF
--- a/custom_components/localshift/computation_engine.py
+++ b/custom_components/localshift/computation_engine.py
@@ -257,15 +257,19 @@ class ComputationEngine:
         dw_entry = self._get_forecast_at_demand_window(data, target_hour)
         if dw_entry:
             data.solar_can_reach_target = dw_entry["predicted_soc"] >= target_pct
-            data.boost_charge_needed = dw_entry.get("grid_charge_boost", False)
         else:
             # Fallback if forecast doesn't span to DW (e.g., late in day)
             # Use current SOC as a conservative estimate
             data.solar_can_reach_target = data.soc >= target_pct
-            data.boost_charge_needed = False
 
         # ---- Step 6: boost_charge_needed ----
-        # (already set in Step 5 above)
+        # Read from CURRENT forecast slot (not DW entry) - fixes #44
+        # The boost_charge_needed flag indicates if boost charging is needed NOW,
+        # which is determined by the current slot's grid_charge_boost flag.
+        current_entry = self._get_forecast_entry_for_now(data, now_dt)
+        data.boost_charge_needed = (
+            current_entry.get("grid_charge_boost", False) if current_entry else False
+        )
 
         # ---- Step 6b: solar_can_reach_target_in_dw ----
         # Read from switch state (device-level toggle)


### PR DESCRIPTION
## Summary

Fixes the `boost_charge_needed` binary sensor to read from the current forecast slot instead of the Demand Window entry.

## Problem

The `boost_charge_needed` binary sensor showed `off` even when boost charging was actively needed and running. This created confusion for users trying to understand the system state.

## Root Cause

In `computation_engine.py`, the `boost_charge_needed` flag read from the **Demand Window entry** (e.g., 15:00 slot), not the **current time slot** (e.g., 14:45).

### Example Scenario

At 14:45 with SOC 97%:
- **14:45 (current slot):** `grid_charge_boost=True` (boost IS needed now)
- **15:00 (DW entry):** `grid_charge_boost=False` (boost not needed at DW start)

The binary sensor reported `off` because it read from the DW slot (15:00), but the system correctly activated boost charging at 14:45.

## Fix

Changed `boost_charge_needed` to check the **current forecast slot** using the existing `_get_forecast_entry_for_now()` method:

```python
# Read from CURRENT forecast slot (not DW entry) - fixes #44
current_entry = self._get_forecast_entry_for_now(data, now_dt)
data.boost_charge_needed = (
    current_entry.get("grid_charge_boost", False) if current_entry else False
)
```

## Testing

- All computation engine tests pass (43/44)
- 1 pre-existing test failure unrelated to this change
- No new test failures introduced

Fixes #44