### PR TITLE
feat: expose all threshold options in options flow

### DIFF
--- a/custom_components/localshift/config_flow.py
+++ b/custom_components/localshift/config_flow.py
@@ -30,6 +30,7 @@ from .const import (
     CONF_PRICING_PRICE_SPIKE,
     CONF_SOLCAST_FORECAST_TODAY,
     CONF_SOLCAST_FORECAST_TOMORROW,
+    CONF_SPIKE_PRICE_PERCENTILE,
     CONF_SUN_ENTITY,
     CONF_TESLEMETRY_BACKUP_RESERVE,
     CONF_TESLEMETRY_BATTERY_POWER,
@@ -50,7 +51,9 @@ from .const import (
     DEFAULT_MANUAL_OVERRIDE_TIMEOUT,
     DEFAULT_MAX_PRECHARGE_PRICE,
     DEFAULT_MINIMUM_TARGET_SOC,
+    DEFAULT_SPIKE_PRICE_PERCENTILE,
     DOMAIN,
+    THRESHOLD_RANGES,
 )
 
 
@@ -645,6 +648,34 @@ class LocalShiftOptionsFlow(OptionsFlow):
                         CONF_MANUAL_OVERRIDE_TIMEOUT,
                         DEFAULT_MANUAL_OVERRIDE_TIMEOUT,
                     ),
+                    CONF_CHEAP_PRICE_PERCENTILE: current.get(
+                        CONF_CHEAP_PRICE_PERCENTILE,
+                        DEFAULT_CHEAP_PRICE_PERCENTILE,
+                    ),
+                    CONF_MAX_PRECHARGE_PRICE: current.get(
+                        CONF_MAX_PRECHARGE_PRICE,
+                        DEFAULT_MAX_PRECHARGE_PRICE,
+                    ),
+                    CONF_CHEAP_PRICE_DEADBAND: current.get(
+                        CONF_CHEAP_PRICE_DEADBAND,
+                        DEFAULT_CHEAP_PRICE_DEADBAND,
+                    ),
+                    CONF_BATTERY_TARGET: current.get(
+                        CONF_BATTERY_TARGET,
+                        DEFAULT_BATTERY_TARGET,
+                    ),
+                    CONF_LOAD_WEIGHT_RECENT: current.get(
+                        CONF_LOAD_WEIGHT_RECENT,
+                        DEFAULT_LOAD_WEIGHT_RECENT,
+                    ),
+                    CONF_SPIKE_PRICE_PERCENTILE: current.get(
+                        CONF_SPIKE_PRICE_PERCENTILE,
+                        DEFAULT_SPIKE_PRICE_PERCENTILE,
+                    ),
+                    CONF_MINIMUM_TARGET_SOC: current.get(
+                        CONF_MINIMUM_TARGET_SOC,
+                        DEFAULT_MINIMUM_TARGET_SOC,
+                    ),
                 },
                 notify_services,
             ),
@@ -664,6 +695,7 @@ class LocalShiftOptionsFlow(OptionsFlow):
         """
         return vol.Schema(
             {
+                # Notification settings
                 vol.Required(
                     CONF_NOTIFY_SERVICE,
                     default=values.get(CONF_NOTIFY_SERVICE, ""),
@@ -673,6 +705,7 @@ class LocalShiftOptionsFlow(OptionsFlow):
                         mode=selector.SelectSelectorMode.DROPDOWN,
                     )
                 ),
+                # Demand window timing
                 vol.Required(
                     CONF_DEMAND_WINDOW_START,
                     default=values.get(
@@ -699,6 +732,128 @@ class LocalShiftOptionsFlow(OptionsFlow):
                         max=24,
                         step=1,
                         unit_of_measurement="hours",
+                        mode=selector.NumberSelectorMode.SLIDER,
+                    )
+                ),
+                # Price thresholds
+                vol.Required(
+                    CONF_CHEAP_PRICE_PERCENTILE,
+                    default=values.get(
+                        CONF_CHEAP_PRICE_PERCENTILE,
+                        DEFAULT_CHEAP_PRICE_PERCENTILE,
+                    ),
+                ): selector.NumberSelector(
+                    selector.NumberSelectorConfig(
+                        min=THRESHOLD_RANGES[CONF_CHEAP_PRICE_PERCENTILE]["min"],
+                        max=THRESHOLD_RANGES[CONF_CHEAP_PRICE_PERCENTILE]["max"],
+                        step=THRESHOLD_RANGES[CONF_CHEAP_PRICE_PERCENTILE]["step"],
+                        unit_of_measurement=THRESHOLD_RANGES[
+                            CONF_CHEAP_PRICE_PERCENTILE
+                        ]["unit"],
+                        mode=selector.NumberSelectorMode.SLIDER,
+                    )
+                ),
+                vol.Required(
+                    CONF_MAX_PRECHARGE_PRICE,
+                    default=values.get(
+                        CONF_MAX_PRECHARGE_PRICE,
+                        DEFAULT_MAX_PRECHARGE_PRICE,
+                    ),
+                ): selector.NumberSelector(
+                    selector.NumberSelectorConfig(
+                        min=THRESHOLD_RANGES[CONF_MAX_PRECHARGE_PRICE]["min"],
+                        max=THRESHOLD_RANGES[CONF_MAX_PRECHARGE_PRICE]["max"],
+                        step=THRESHOLD_RANGES[CONF_MAX_PRECHARGE_PRICE]["step"],
+                        unit_of_measurement=THRESHOLD_RANGES[CONF_MAX_PRECHARGE_PRICE][
+                            "unit"
+                        ],
+                        mode=selector.NumberSelectorMode.BOX,
+                    )
+                ),
+                vol.Required(
+                    CONF_CHEAP_PRICE_DEADBAND,
+                    default=values.get(
+                        CONF_CHEAP_PRICE_DEADBAND,
+                        DEFAULT_CHEAP_PRICE_DEADBAND,
+                    ),
+                ): selector.NumberSelector(
+                    selector.NumberSelectorConfig(
+                        min=THRESHOLD_RANGES[CONF_CHEAP_PRICE_DEADBAND]["min"],
+                        max=THRESHOLD_RANGES[CONF_CHEAP_PRICE_DEADBAND]["max"],
+                        step=THRESHOLD_RANGES[CONF_CHEAP_PRICE_DEADBAND]["step"],
+                        unit_of_measurement=THRESHOLD_RANGES[CONF_CHEAP_PRICE_DEADBAND][
+                            "unit"
+                        ],
+                        mode=selector.NumberSelectorMode.BOX,
+                    )
+                ),
+                vol.Required(
+                    CONF_SPIKE_PRICE_PERCENTILE,
+                    default=values.get(
+                        CONF_SPIKE_PRICE_PERCENTILE,
+                        DEFAULT_SPIKE_PRICE_PERCENTILE,
+                    ),
+                ): selector.NumberSelector(
+                    selector.NumberSelectorConfig(
+                        min=THRESHOLD_RANGES[CONF_SPIKE_PRICE_PERCENTILE]["min"],
+                        max=THRESHOLD_RANGES[CONF_SPIKE_PRICE_PERCENTILE]["max"],
+                        step=THRESHOLD_RANGES[CONF_SPIKE_PRICE_PERCENTILE]["step"],
+                        unit_of_measurement=THRESHOLD_RANGES[
+                            CONF_SPIKE_PRICE_PERCENTILE
+                        ]["unit"],
+                        mode=selector.NumberSelectorMode.SLIDER,
+                    )
+                ),
+                # Battery settings
+                vol.Required(
+                    CONF_BATTERY_TARGET,
+                    default=values.get(
+                        CONF_BATTERY_TARGET,
+                        DEFAULT_BATTERY_TARGET,
+                    ),
+                ): selector.NumberSelector(
+                    selector.NumberSelectorConfig(
+                        min=THRESHOLD_RANGES[CONF_BATTERY_TARGET]["min"],
+                        max=THRESHOLD_RANGES[CONF_BATTERY_TARGET]["max"],
+                        step=THRESHOLD_RANGES[CONF_BATTERY_TARGET]["step"],
+                        unit_of_measurement=THRESHOLD_RANGES[CONF_BATTERY_TARGET][
+                            "unit"
+                        ],
+                        mode=selector.NumberSelectorMode.SLIDER,
+                    )
+                ),
+                vol.Required(
+                    CONF_MINIMUM_TARGET_SOC,
+                    default=values.get(
+                        CONF_MINIMUM_TARGET_SOC,
+                        DEFAULT_MINIMUM_TARGET_SOC,
+                    ),
+                ): selector.NumberSelector(
+                    selector.NumberSelectorConfig(
+                        min=THRESHOLD_RANGES[CONF_MINIMUM_TARGET_SOC]["min"],
+                        max=THRESHOLD_RANGES[CONF_MINIMUM_TARGET_SOC]["max"],
+                        step=THRESHOLD_RANGES[CONF_MINIMUM_TARGET_SOC]["step"],
+                        unit_of_measurement=THRESHOLD_RANGES[CONF_MINIMUM_TARGET_SOC][
+                            "unit"
+                        ],
+                        mode=selector.NumberSelectorMode.SLIDER,
+                    )
+                ),
+                # Advanced settings
+                vol.Required(
+                    CONF_LOAD_WEIGHT_RECENT,
+                    default=values.get(
+                        CONF_LOAD_WEIGHT_RECENT,
+                        DEFAULT_LOAD_WEIGHT_RECENT,
+                    ),
+                ): selector.NumberSelector(
+                    selector.NumberSelectorConfig(
+                        min=THRESHOLD_RANGES[CONF_LOAD_WEIGHT_RECENT]["min"],
+                        max=THRESHOLD_RANGES[CONF_LOAD_WEIGHT_RECENT]["max"],
+                        step=THRESHOLD_RANGES[CONF_LOAD_WEIGHT_RECENT]["step"],
+                        unit_of_measurement=THRESHOLD_RANGES[CONF_LOAD_WEIGHT_RECENT][
+                            "unit"
+                        ],
                         mode=selector.NumberSelectorMode.SLIDER,
                     )
                 ),

--- a/custom_components/localshift/strings.json
+++ b/custom_components/localshift/strings.json
@@ -63,16 +63,32 @@
     "step": {
       "init": {
         "title": "LocalShift Settings",
-        "description": "Adjust demand window timing and manual override timeout. All other settings are available as device entities on your dashboard.",
+        "description": "Configure demand window timing, price thresholds, and battery settings.",
         "data": {
+          "notify_service": "Notification Service",
           "demand_window_start": "Demand Window Start",
           "demand_window_end": "Demand Window End",
-          "manual_override_timeout": "Manual Override Timeout"
+          "manual_override_timeout": "Manual Override Timeout",
+          "cheap_price_percentile": "Cheap Price Percentile",
+          "max_pre_charge_price": "Max Pre-charge Price",
+          "cheap_price_deadband": "Price Deadband",
+          "spike_price_percentile": "Spike Price Percentile",
+          "battery_target": "Battery Target",
+          "minimum_target_soc": "Minimum Target SOC",
+          "load_weight_recent": "Recent Load Weight"
         },
         "data_description": {
+          "notify_service": "Notification service for alerts (e.g., notify.mobile_app)",
           "demand_window_start": "Time when demand window begins (battery held for evening peak)",
           "demand_window_end": "Time when demand window ends (normal operation resumes)",
-          "manual_override_timeout": "Hours before manual mode automatically returns to self-consumption (0 = never)"
+          "manual_override_timeout": "Hours before manual mode automatically returns to self-consumption (0 = never)",
+          "cheap_price_percentile": "Price percentile threshold for grid charging (e.g., 25 = charge when price is in bottom 25%)",
+          "max_pre_charge_price": "Maximum price ($/kWh) to pay for pre-charging battery",
+          "cheap_price_deadband": "Minimum price difference ($/kWh) to start/stop charging (prevents rapid cycling)",
+          "spike_price_percentile": "Price percentile for spike discharge (e.g., 75 = discharge at top 25% prices)",
+          "battery_target": "Target SOC % for demand window (battery reserved for evening peak)",
+          "minimum_target_soc": "Minimum SOC % maintained during discharge modes (spike, proactive export)",
+          "load_weight_recent": "Weight given to recent load vs historical average (0.67 = 2/3 recent, 1/3 historical)"
         }
       }
     }

--- a/custom_components/localshift/translations/en.json
+++ b/custom_components/localshift/translations/en.json
@@ -63,16 +63,32 @@
     "step": {
       "init": {
         "title": "LocalShift Settings",
-        "description": "Adjust demand window timing and manual override timeout. All other settings are available as device entities on your dashboard.",
+        "description": "Configure demand window timing, price thresholds, and battery settings.",
         "data": {
+          "notify_service": "Notification Service",
           "demand_window_start": "Demand Window Start",
           "demand_window_end": "Demand Window End",
-          "manual_override_timeout": "Manual Override Timeout"
+          "manual_override_timeout": "Manual Override Timeout",
+          "cheap_price_percentile": "Cheap Price Percentile",
+          "max_pre_charge_price": "Max Pre-charge Price",
+          "cheap_price_deadband": "Price Deadband",
+          "spike_price_percentile": "Spike Price Percentile",
+          "battery_target": "Battery Target",
+          "minimum_target_soc": "Minimum Target SOC",
+          "load_weight_recent": "Recent Load Weight"
         },
         "data_description": {
+          "notify_service": "Notification service for alerts (e.g., notify.mobile_app)",
           "demand_window_start": "Time when demand window begins (battery held for evening peak)",
           "demand_window_end": "Time when demand window ends (normal operation resumes)",
-          "manual_override_timeout": "Hours before manual mode automatically returns to self-consumption (0 = never)"
+          "manual_override_timeout": "Hours before manual mode automatically returns to self-consumption (0 = never)",
+          "cheap_price_percentile": "Price percentile threshold for grid charging (e.g., 25 = charge when price is in bottom 25%)",
+          "max_pre_charge_price": "Maximum price ($/kWh) to pay for pre-charging battery",
+          "cheap_price_deadband": "Minimum price difference ($/kWh) to start/stop charging (prevents rapid cycling)",
+          "spike_price_percentile": "Price percentile for spike discharge (e.g., 75 = discharge at top 25% prices)",
+          "battery_target": "Target SOC % for demand window (battery reserved for evening peak)",
+          "minimum_target_soc": "Minimum SOC % maintained during discharge modes (spike, proactive export)",
+          "load_weight_recent": "Weight given to recent load vs historical average (0.67 = 2/3 recent, 1/3 historical)"
         }
       }
     }

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -358,16 +358,45 @@ The config flow has 3 steps:
 
 ### Options Flow
 
-After setup, users can configure settings via **Configure**:
+After setup, users can configure all settings via **Configure**:
+
+#### Notification Settings
 
 | Option | Default | Description |
 |--------|---------|-------------|
 | Notify Service | (first available) | Notification service for alerts |
-| Demand Window Start | 15:00 | Peak hours start |
-| Demand Window End | 21:00 | Peak hours end |
-| Manual Override Timeout | 4 hours | Auto-clear manual override |
 
-**Note:** The notification service is stored in `entry.options` (not `entry.data`) so it can be changed without reconfiguring the entire integration. For backward compatibility, the coordinator checks `options` first, then falls back to `data` for existing entries.
+#### Demand Window Timing
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| Demand Window Start | 15:00 | Time when demand window begins (battery held for evening peak) |
+| Demand Window End | 21:00 | Time when demand window ends (normal operation resumes) |
+| Manual Override Timeout | 4 hours | Hours before manual mode automatically returns to self-consumption (0 = never) |
+
+#### Price Thresholds
+
+| Option | Range | Default | Description |
+|--------|-------|---------|-------------|
+| Cheap Price Percentile | 5-50% | 25% | Price percentile threshold for grid charging (e.g., 25 = charge when price is in bottom 25%) |
+| Max Pre-charge Price | $0.00-0.50/kWh | $0.20/kWh | Maximum price to pay for pre-charging battery |
+| Price Deadband | $0.00-0.10/kWh | $0.03/kWh | Minimum price difference to start/stop charging (prevents rapid cycling) |
+| Spike Price Percentile | 50-95% | 75% | Price percentile for spike discharge (e.g., 75 = discharge at top 25% prices) |
+
+#### Battery Settings
+
+| Option | Range | Default | Description |
+|--------|-------|---------|-------------|
+| Battery Target | 50-100% | 100% | Target SOC % for demand window (battery reserved for evening peak) |
+| Minimum Target SOC | 5-30% | 20% | Minimum SOC % maintained during discharge modes (spike, proactive export) |
+
+#### Advanced Settings
+
+| Option | Range | Default | Description |
+|--------|-------|---------|-------------|
+| Recent Load Weight | 0.0-1.0 | 0.67 | Weight given to recent load vs historical average (0.67 = 2/3 recent, 1/3 historical) |
+
+**Note:** All options are stored in `entry.options` (not `entry.data`) so they can be changed without reconfiguring the entire integration. For backward compatibility, the coordinator checks `options` first, then falls back to `data` for existing entries.
 
 ## Adding New Battery Modes
 


### PR DESCRIPTION
## Summary
Add 7 missing configurable options to the LocalShiftOptionsFlow that were defined in THRESHOLD_RANGES but not exposed in the UI.

## Changes Made
- Added imports for CONF_SPIKE_PRICE_PERCENTILE, DEFAULT_SPIKE_PRICE_PERCENTILE, and THRESHOLD_RANGES
- Updated async_step_init() to pass current values for all 7 missing options
- Updated _build_options_schema() to include all 7 options using THRESHOLD_RANGES definitions
- Updated strings.json with translations for all new options
- Updated translations/en.json with English translations
- Updated docs/DEVELOPER_GUIDE.md with comprehensive options documentation

## New Options Exposed
| Option | Range | Default | Description |
|--------|-------|---------|-------------|
| cheap_price_percentile | 5-50% | 25% | Price percentile threshold for grid charging |
| max_pre_charge_price | $0.00-0.50/kWh | $0.20/kWh | Maximum price to pay for pre-charging |
| cheap_price_deadband | $0.00-0.10/kWh | $0.03/kWh | Minimum price difference to prevent cycling |
| battery_target | 50-100% | 100% | Target SOC for demand window |
| load_weight_recent | 0.0-1.0 | 0.67 | Weight for recent vs historical load |
| spike_price_percentile | 50-95% | 75% | Price percentile for spike discharge |
| minimum_target_soc | 5-30% | 20% | Minimum SOC during discharge modes |

## Testing
- All pre-commit hooks pass (ruff, ruff-format, vulture, pyright)
- Options use THRESHOLD_RANGES definitions for consistent min/max/step values

Closes #26