### PR TITLE
test: add realistic HA state simulation fixtures

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,13 @@
-"""Test fixtures and configuration for localshift tests."""
+"""Test fixtures and configuration for localshift tests.
+
+This module provides both simple mocks for basic unit tests and realistic
+HA state simulations for tests that need to verify behavior with real-world
+entity states.
+
+For tests that need realistic HA behavior, use:
+- mock_hass_with_states: A hass instance with MockStates
+- realistic_entity_states: Default entity states for LocalShift
+"""
 
 from datetime import datetime
 from unittest.mock import MagicMock
@@ -11,10 +20,32 @@ from custom_components.localshift.computation_engine import (
 )
 from custom_components.localshift.coordinator_data import CoordinatorData
 
+# Import realistic HA state simulation
+from tests.fixtures.ha_entities import (
+    MockState,
+    MockStates,
+    create_amber_price_forecast_state,
+    create_default_entity_states,
+    create_sample_amber_price_forecast,
+    create_sample_solcast_forecast,
+    create_solcast_forecast_state,
+    create_unavailable_entity_states,
+    create_unknown_entity_states,
+)
+
+# =============================================================================
+# SIMPLE MOCKS (for basic unit tests)
+# =============================================================================
+
 
 @pytest.fixture
 def mock_hass():
-    """Create a mock Home Assistant instance."""
+    """Create a mock Home Assistant instance.
+
+    This is a simple mock suitable for tests that don't need realistic
+    entity state behavior. For realistic HA state simulation, use
+    mock_hass_with_states instead.
+    """
     hass = MagicMock()
     hass.states = {}
     hass.data = {}
@@ -117,3 +148,429 @@ def computation_engine(
 def now():
     """Return a fixed datetime for testing."""
     return datetime(2026, 2, 16, 16, 0, 0)
+
+
+# =============================================================================
+# REALISTIC HA STATE SIMULATION FIXTURES
+# =============================================================================
+
+
+@pytest.fixture
+def realistic_entity_states():
+    """Create realistic entity states for LocalShift testing.
+
+    This fixture provides a complete set of entity states that simulate
+    real Home Assistant entity behavior. Use with mock_hass_with_states.
+
+    Returns:
+        Dictionary mapping entity IDs to MockState objects
+    """
+    return create_default_entity_states(
+        soc=50.0,
+        operation_mode="autonomous",
+        backup_reserve=20.0,
+        grid_power_kw=0.0,
+        load_power_kw=0.5,
+        solar_power_kw=3.0,
+        battery_power_kw=-2.5,
+        general_price=0.25,
+        feed_in_price=0.08,
+        price_spike=False,
+    )
+
+
+@pytest.fixture
+def realistic_entity_states_with_forecasts(realistic_entity_states):
+    """Create realistic entity states including forecast data.
+
+    Extends realistic_entity_states with Solcast and Amber forecast data.
+
+    Returns:
+        Dictionary mapping entity IDs to MockState objects with forecasts
+    """
+    states = realistic_entity_states.copy()
+
+    # Add Solcast forecasts (using DEFAULT_ENTITY_IDS naming)
+    solcast_today = create_sample_solcast_forecast(num_periods=24, peak_kw=5.0)
+    solcast_tomorrow = create_sample_solcast_forecast(num_periods=24, peak_kw=4.5)
+
+    states["sensor.solcast_pv_forecast_forecast_today"] = create_solcast_forecast_state(
+        solcast_today,
+        entity_id="sensor.solcast_pv_forecast_forecast_today",
+    )
+    states["sensor.solcast_pv_forecast_forecast_tomorrow"] = (
+        create_solcast_forecast_state(
+            solcast_tomorrow,
+            entity_id="sensor.solcast_pv_forecast_forecast_tomorrow",
+        )
+    )
+
+    # Add Amber price forecasts (using DEFAULT_ENTITY_IDS naming)
+    general_forecast = create_sample_amber_price_forecast(
+        num_periods=48,
+        base_price=0.25,
+    )
+    feed_in_forecast = create_sample_amber_price_forecast(
+        num_periods=48,
+        base_price=0.08,
+    )
+
+    states["sensor.100h_general_forecast"] = create_amber_price_forecast_state(
+        general_forecast,
+        entity_id="sensor.100h_general_forecast",
+        friendly_name="General Price Forecast",
+    )
+    states["sensor.100h_feed_in_forecast"] = create_amber_price_forecast_state(
+        feed_in_forecast,
+        entity_id="sensor.100h_feed_in_forecast",
+        friendly_name="Feed-in Price Forecast",
+    )
+
+    return states
+
+
+@pytest.fixture
+def mock_hass_with_states(realistic_entity_states):
+    """Create a mock Home Assistant instance with realistic states.
+
+    This fixture provides a hass instance that simulates real HA behavior:
+    - hass.states.get() returns MockState objects or None
+    - States have .state and .attributes properties
+    - Entity availability is properly simulated
+
+    Use this for tests that need to verify behavior with realistic entity states.
+
+    Args:
+        realistic_entity_states: Default entity states from fixture
+
+    Returns:
+        MagicMock with realistic states.get() behavior
+    """
+    hass = MagicMock()
+    mock_states = MockStates(realistic_entity_states)
+
+    # Make hass.states.get() use MockStates.get()
+    hass.states.get = mock_states.get
+    hass.states.async_all = mock_states.async_all
+
+    # Allow tests to modify states
+    hass._mock_states = mock_states
+
+    hass.data = {}
+    return hass
+
+
+@pytest.fixture
+def mock_hass_with_forecasts(realistic_entity_states_with_forecasts):
+    """Create a mock Home Assistant instance with forecast data.
+
+    Same as mock_hass_with_states but includes Solcast and Amber forecasts.
+
+    Args:
+        realistic_entity_states_with_forecasts: Entity states with forecast data
+
+    Returns:
+        MagicMock with realistic states including forecasts
+    """
+    hass = MagicMock()
+    mock_states = MockStates(realistic_entity_states_with_forecasts)
+
+    hass.states.get = mock_states.get
+    hass.states.async_all = mock_states.async_all
+    hass._mock_states = mock_states
+
+    hass.data = {}
+    return hass
+
+
+# =============================================================================
+# EDGE CASE FIXTURES
+# =============================================================================
+
+
+@pytest.fixture
+def mock_hass_unavailable_entities(realistic_entity_states):
+    """Create a mock HA instance where all entities are unavailable.
+
+    Use this to test that the integration handles unavailable entities gracefully.
+
+    Returns:
+        MagicMock where all entities return state="unavailable"
+    """
+    entity_ids = list(realistic_entity_states.keys())
+    unavailable_states = create_unavailable_entity_states(entity_ids)
+
+    hass = MagicMock()
+    mock_states = MockStates(unavailable_states)
+
+    hass.states.get = mock_states.get
+    hass.states.async_all = mock_states.async_all
+    hass._mock_states = mock_states
+
+    hass.data = {}
+    return hass
+
+
+@pytest.fixture
+def mock_hass_unknown_entities(realistic_entity_states):
+    """Create a mock HA instance where all entities are unknown.
+
+    Use this to test that the integration handles unknown entity states.
+
+    Returns:
+        MagicMock where all entities return state="unknown"
+    """
+    entity_ids = list(realistic_entity_states.keys())
+    unknown_states = create_unknown_entity_states(entity_ids)
+
+    hass = MagicMock()
+    mock_states = MockStates(unknown_states)
+
+    hass.states.get = mock_states.get
+    hass.states.async_all = mock_states.async_all
+    hass._mock_states = mock_states
+
+    hass.data = {}
+    return hass
+
+
+@pytest.fixture
+def mock_hass_missing_entities():
+    """Create a mock HA instance where entities don't exist.
+
+    Use this to test that the integration handles missing entities gracefully.
+    hass.states.get() will return None for all entity IDs.
+
+    Returns:
+        MagicMock where states.get() returns None
+    """
+    hass = MagicMock()
+    mock_states = MockStates({})  # Empty states
+
+    hass.states.get = mock_states.get
+    hass.states.async_all = mock_states.async_all
+    hass._mock_states = mock_states
+
+    hass.data = {}
+    return hass
+
+
+@pytest.fixture
+def mock_hass_partial_availability(realistic_entity_states):
+    """Create a mock HA instance with mixed entity availability.
+
+    Some entities are available, some are unavailable, some are missing.
+    Use this to test partial failure scenarios.
+
+    Returns:
+        MagicMock with mixed entity availability
+    """
+    states = realistic_entity_states.copy()
+
+    # Make some entities unavailable (using DEFAULT_ENTITY_IDS naming)
+    states["sensor.my_home_percentage_charged"] = MockState(
+        "sensor.my_home_percentage_charged", "unavailable", {}
+    )
+    states["sensor.100h_general_price"] = MockState(
+        "sensor.100h_general_price", "unavailable", {}
+    )
+
+    # Remove some entities entirely (simulating missing entities)
+    del states["sensor.my_home_solar_power"]
+    del states["binary_sensor.100h_price_spike"]
+
+    hass = MagicMock()
+    mock_states = MockStates(states)
+
+    hass.states.get = mock_states.get
+    hass.states.async_all = mock_states.async_all
+    hass._mock_states = mock_states
+
+    hass.data = {}
+    return hass
+
+
+@pytest.fixture
+def mock_hass_price_spike(realistic_entity_states):
+    """Create a mock HA instance with price spike active.
+
+    Returns:
+        MagicMock with price_spike binary sensor set to 'on'
+    """
+    states = realistic_entity_states.copy()
+    states["binary_sensor.100h_price_spike"] = MockState(
+        "binary_sensor.100h_price_spike", "on", {}
+    )
+    states["sensor.100h_general_price"] = MockState(
+        "sensor.100h_general_price",
+        "2.50",
+        {"unit_of_measurement": "$/kWh", "friendly_name": "General Price"},
+    )
+
+    hass = MagicMock()
+    mock_states = MockStates(states)
+
+    hass.states.get = mock_states.get
+    hass.states.async_all = mock_states.async_all
+    hass._mock_states = mock_states
+
+    hass.data = {}
+    return hass
+
+
+@pytest.fixture
+def mock_hass_low_battery(realistic_entity_states):
+    """Create a mock HA instance with low battery SOC.
+
+    Returns:
+        MagicMock with SOC at 10%
+    """
+    states = realistic_entity_states.copy()
+    states["sensor.my_home_percentage_charged"] = MockState(
+        "sensor.my_home_percentage_charged",
+        "10.0",
+        {"unit_of_measurement": "%", "device_class": "battery"},
+    )
+
+    hass = MagicMock()
+    mock_states = MockStates(states)
+
+    hass.states.get = mock_states.get
+    hass.states.async_all = mock_states.async_all
+    hass._mock_states = mock_states
+
+    hass.data = {}
+    return hass
+
+
+@pytest.fixture
+def mock_hass_full_battery(realistic_entity_states):
+    """Create a mock HA instance with full battery SOC.
+
+    Returns:
+        MagicMock with SOC at 100%
+    """
+    states = realistic_entity_states.copy()
+    states["sensor.my_home_percentage_charged"] = MockState(
+        "sensor.my_home_percentage_charged",
+        "100.0",
+        {"unit_of_measurement": "%", "device_class": "battery"},
+    )
+
+    hass = MagicMock()
+    mock_states = MockStates(states)
+
+    hass.states.get = mock_states.get
+    hass.states.async_all = mock_states.async_all
+    hass._mock_states = mock_states
+
+    hass.data = {}
+    return hass
+
+
+@pytest.fixture
+def mock_hass_negative_prices(realistic_entity_states):
+    """Create a mock HA instance with negative electricity prices.
+
+    Returns:
+        MagicMock with negative general price
+    """
+    states = realistic_entity_states.copy()
+    states["sensor.100h_general_price"] = MockState(
+        "sensor.100h_general_price",
+        "-0.05",
+        {"unit_of_measurement": "$/kWh", "friendly_name": "General Price"},
+    )
+
+    hass = MagicMock()
+    mock_states = MockStates(states)
+
+    hass.states.get = mock_states.get
+    hass.states.async_all = mock_states.async_all
+    hass._mock_states = mock_states
+
+    hass.data = {}
+    return hass
+
+
+# =============================================================================
+# STATE READER FIXTURES
+# =============================================================================
+
+
+@pytest.fixture
+def state_reader(mock_hass_with_states, mock_entry):
+    """Create a StateReader instance with realistic HA states.
+
+    Use this for testing state reading functionality with realistic entity states.
+    """
+    from custom_components.localshift.state_reader import StateReader
+
+    return StateReader(mock_hass_with_states, mock_entry)
+
+
+@pytest.fixture
+def state_reader_unavailable(mock_hass_unavailable_entities, mock_entry):
+    """Create a StateReader with all entities unavailable."""
+    from custom_components.localshift.state_reader import StateReader
+
+    return StateReader(mock_hass_unavailable_entities, mock_entry)
+
+
+@pytest.fixture
+def state_reader_missing(mock_hass_missing_entities, mock_entry):
+    """Create a StateReader with missing entities."""
+    from custom_components.localshift.state_reader import StateReader
+
+    return StateReader(mock_hass_missing_entities, mock_entry)
+
+
+# =============================================================================
+# PARAMETRIZED FIXTURES FOR COMPREHENSIVE TESTING
+# =============================================================================
+
+
+@pytest.fixture(
+    params=[
+        "available",
+        "unavailable",
+        "unknown",
+        "missing",
+    ]
+)
+def mock_hass_various_states(request, realistic_entity_states):
+    """Parametrized fixture for testing various entity states.
+
+    Use this to run the same test against multiple availability scenarios:
+    - available: All entities have valid states
+    - unavailable: All entities have state="unavailable"
+    - unknown: All entities have state="unknown"
+    - missing: All entities return None from states.get()
+
+    Example:
+        def test_something(mock_hass_various_states):
+            # Test runs 4 times with different states
+            pass
+    """
+    availability = request.param
+
+    if availability == "available":
+        states = realistic_entity_states
+    elif availability == "unavailable":
+        entity_ids = list(realistic_entity_states.keys())
+        states = create_unavailable_entity_states(entity_ids)
+    elif availability == "unknown":
+        entity_ids = list(realistic_entity_states.keys())
+        states = create_unknown_entity_states(entity_ids)
+    else:  # missing
+        states = {}
+
+    hass = MagicMock()
+    mock_states = MockStates(states)
+
+    hass.states.get = mock_states.get
+    hass.states.async_all = mock_states.async_all
+    hass._mock_states = mock_states
+
+    hass.data = {}
+    return hass

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -1,0 +1,1 @@
+"""Test fixtures for realistic Home Assistant state simulation."""

--- a/tests/fixtures/ha_entities.py
+++ b/tests/fixtures/ha_entities.py
@@ -1,0 +1,658 @@
+"""Realistic Home Assistant entity state simulation for tests.
+
+This module provides mock classes and factories that simulate real Home Assistant
+entity behavior, including:
+- State objects with .state and .attributes properties
+- Entity availability states (available, unavailable, unknown)
+- Realistic attribute structures for different entity types
+
+The goal is to make unit tests catch bugs that would only appear in production
+by simulating real HA behavior rather than using oversimplified mocks.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+
+
+@dataclass
+class MockState:
+    """Mock of homeassistant.core.State with realistic behavior.
+
+    This class mimics the behavior of Home Assistant's State class,
+    including the state value, attributes, and common edge cases.
+    """
+
+    entity_id: str
+    state: str
+    attributes: dict[str, Any] = field(default_factory=dict)
+    last_changed: datetime | None = None
+    last_updated: datetime | None = None
+
+    def __post_init__(self):
+        """Set default timestamps if not provided."""
+        if self.last_changed is None:
+            self.last_changed = datetime.now()
+        if self.last_updated is None:
+            self.last_updated = self.last_changed
+
+    @property
+    def domain(self) -> str:
+        """Return the domain of the entity (e.g., 'sensor' from 'sensor.temperature')."""
+        return self.entity_id.split(".")[0]
+
+    @property
+    def object_id(self) -> str:
+        """Return the object ID (e.g., 'temperature' from 'sensor.temperature')."""
+        return self.entity_id.split(".", 1)[1]
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return state as dictionary (mimics HA State.as_dict())."""
+        return {
+            "entity_id": self.entity_id,
+            "state": self.state,
+            "attributes": self.attributes,
+            "last_changed": self.last_changed.isoformat()
+            if self.last_changed
+            else None,
+            "last_updated": self.last_updated.isoformat()
+            if self.last_updated
+            else None,
+        }
+
+
+class MockStates:
+    """Mock of homeassistant.core.States class.
+
+    Provides a realistic simulation of the hass.states interface,
+    including get(), async_all(), and entity availability handling.
+    """
+
+    def __init__(self, states: dict[str, MockState] | None = None):
+        """Initialize with optional pre-populated states.
+
+        Args:
+            states: Dictionary mapping entity_id to MockState objects
+        """
+        self._states: dict[str, MockState] = states or {}
+
+    def get(self, entity_id: str) -> MockState | None:
+        """Get state for an entity, returning None if not found.
+
+        This mimics hass.states.get() behavior exactly.
+        """
+        return self._states.get(entity_id)
+
+    def async_all(self, domain_filter: str | None = None) -> list[MockState]:
+        """Return all states, optionally filtered by domain.
+
+        Args:
+            domain_filter: Optional domain to filter by (e.g., 'sensor')
+
+        Returns:
+            List of MockState objects
+        """
+        if domain_filter is None:
+            return list(self._states.values())
+
+        return [
+            state
+            for state in self._states.values()
+            if state.entity_id.startswith(f"{domain_filter}.")
+        ]
+
+    def set(
+        self, entity_id: str, state: str, attributes: dict[str, Any] | None = None
+    ) -> None:
+        """Set or update an entity's state."""
+        self._states[entity_id] = MockState(
+            entity_id=entity_id,
+            state=state,
+            attributes=attributes or {},
+        )
+
+    def remove(self, entity_id: str) -> bool:
+        """Remove an entity. Returns True if entity existed."""
+        if entity_id in self._states:
+            del self._states[entity_id]
+            return True
+        return False
+
+    def set_unavailable(self, entity_id: str) -> None:
+        """Mark an entity as unavailable."""
+        self._states[entity_id] = MockState(
+            entity_id=entity_id,
+            state="unavailable",
+            attributes={},
+        )
+
+    def set_unknown(self, entity_id: str) -> None:
+        """Mark an entity as unknown."""
+        self._states[entity_id] = MockState(
+            entity_id=entity_id,
+            state="unknown",
+            attributes={},
+        )
+
+
+# =============================================================================
+# Entity State Factories
+# =============================================================================
+
+
+def create_sensor_state(
+    entity_id: str,
+    value: float | int | str,
+    unit: str | None = None,
+    device_class: str | None = None,
+    extra_attributes: dict[str, Any] | None = None,
+) -> MockState:
+    """Create a realistic sensor state.
+
+    Args:
+        entity_id: The entity ID (e.g., 'sensor.temperature')
+        value: The sensor value
+        unit: Unit of measurement
+        device_class: Device class (e.g., 'temperature', 'power')
+        extra_attributes: Additional attributes
+
+    Returns:
+        MockState with realistic sensor attributes
+    """
+    attributes: dict[str, Any] = {}
+    if unit:
+        attributes["unit_of_measurement"] = unit
+    if device_class:
+        attributes["device_class"] = device_class
+    if extra_attributes:
+        attributes.update(extra_attributes)
+
+    return MockState(
+        entity_id=entity_id,
+        state=str(value),
+        attributes=attributes,
+    )
+
+
+def create_powerwall_soc_state(
+    value: float, entity_id: str = "sensor.tesla_powerwall_soc"
+) -> MockState:
+    """Create a realistic Tesla Powerwall SOC sensor state.
+
+    Args:
+        value: State of charge percentage (0-100)
+        entity_id: Entity ID for the SOC sensor
+
+    Returns:
+        MockState with realistic Powerwall SOC attributes
+    """
+    return create_sensor_state(
+        entity_id=entity_id,
+        value=value,
+        unit="%",
+        device_class="battery",
+        extra_attributes={
+            "friendly_name": "Powerwall State of Charge",
+            "icon": "mdi:battery",
+        },
+    )
+
+
+def create_powerwall_operation_mode_state(
+    mode: str = "autonomous",
+    entity_id: str = "sensor.tesla_powerwall_operation_mode",
+) -> MockState:
+    """Create a realistic Tesla Powerwall operation mode sensor state.
+
+    Args:
+        mode: Operation mode (autonomous, backup, self_consumption, etc.)
+        entity_id: Entity ID for the operation mode sensor
+
+    Returns:
+        MockState with realistic operation mode attributes
+    """
+    return MockState(
+        entity_id=entity_id,
+        state=mode,
+        attributes={
+            "friendly_name": "Powerwall Operation Mode",
+            "icon": "mdi:home-battery",
+            "options": [
+                "self_consumption",
+                "autonomous",
+                "backup",
+                "economy",
+            ],
+        },
+    )
+
+
+def create_power_state(
+    value: float,
+    entity_id: str,
+    friendly_name: str,
+) -> MockState:
+    """Create a realistic power sensor state.
+
+    Args:
+        value: Power value in kW
+        entity_id: Entity ID for the power sensor
+        friendly_name: Friendly name for the sensor
+
+    Returns:
+        MockState with realistic power sensor attributes
+    """
+    return create_sensor_state(
+        entity_id=entity_id,
+        value=value,
+        unit="kW",
+        device_class="power",
+        extra_attributes={
+            "friendly_name": friendly_name,
+            "icon": "mdi:flash",
+        },
+    )
+
+
+def create_price_state(
+    value: float,
+    entity_id: str,
+    friendly_name: str,
+) -> MockState:
+    """Create a realistic price sensor state.
+
+    Args:
+        value: Price value in $/kWh
+        entity_id: Entity ID for the price sensor
+        friendly_name: Friendly name for the sensor
+
+    Returns:
+        MockState with realistic price sensor attributes
+    """
+    return create_sensor_state(
+        entity_id=entity_id,
+        value=value,
+        unit="$/kWh",
+        extra_attributes={
+            "friendly_name": friendly_name,
+            "icon": "mdi:currency-usd",
+        },
+    )
+
+
+def create_solcast_forecast_state(
+    forecasts: list[dict[str, Any]],
+    entity_id: str = "sensor.solcast_today",
+    attribute_name: str = "detailedForecast",
+) -> MockState:
+    """Create a realistic Solcast forecast sensor state.
+
+    Args:
+        forecasts: List of forecast dictionaries with period_start and pv_estimate
+        entity_id: Entity ID for the Solcast sensor
+        attribute_name: Attribute containing the forecast list
+
+    Returns:
+        MockState with realistic Solcast forecast attributes
+    """
+    return MockState(
+        entity_id=entity_id,
+        state=str(len(forecasts)),
+        attributes={
+            "friendly_name": "Solcast Forecast",
+            attribute_name: forecasts,
+            "icon": "mdi:solar-power",
+        },
+    )
+
+
+def create_amber_price_forecast_state(
+    forecasts: list[dict[str, Any]],
+    entity_id: str,
+    friendly_name: str,
+) -> MockState:
+    """Create a realistic Amber price forecast sensor state.
+
+    Args:
+        forecasts: List of forecast dictionaries with prices
+        entity_id: Entity ID for the forecast sensor
+        friendly_name: Friendly name for the sensor
+
+    Returns:
+        MockState with realistic Amber forecast attributes
+    """
+    return MockState(
+        entity_id=entity_id,
+        state="on",  # Amber forecast sensors are typically binary-ish
+        attributes={
+            "friendly_name": friendly_name,
+            "forecasts": forecasts,
+            "icon": "mdi:currency-usd",
+        },
+    )
+
+
+def create_binary_sensor_state(
+    entity_id: str,
+    is_on: bool,
+    device_class: str | None = None,
+    extra_attributes: dict[str, Any] | None = None,
+) -> MockState:
+    """Create a realistic binary sensor state.
+
+    Args:
+        entity_id: The entity ID (e.g., 'binary_sensor.price_spike')
+        is_on: Whether the binary sensor is on
+        device_class: Device class (e.g., 'power', 'battery_charging')
+        extra_attributes: Additional attributes
+
+    Returns:
+        MockState with realistic binary sensor attributes
+    """
+    attributes: dict[str, Any] = {}
+    if device_class:
+        attributes["device_class"] = device_class
+    if extra_attributes:
+        attributes.update(extra_attributes)
+
+    return MockState(
+        entity_id=entity_id,
+        state="on" if is_on else "off",
+        attributes=attributes,
+    )
+
+
+def create_sun_state(
+    elevation: float = 45.0,
+    rising: bool = True,
+    entity_id: str = "sun.sun",
+) -> MockState:
+    """Create a realistic sun.sun state.
+
+    Args:
+        elevation: Sun elevation in degrees
+        rising: Whether the sun is rising
+        entity_id: Entity ID for the sun entity
+
+    Returns:
+        MockState with realistic sun attributes
+    """
+    return MockState(
+        entity_id=entity_id,
+        state="above_horizon" if elevation > 0 else "below_horizon",
+        attributes={
+            "elevation": elevation,
+            "rising": rising,
+            "azimuth": 180.0,
+            "next_dawn": "2026-02-17T05:30:00",
+            "next_dusk": "2026-02-17T19:30:00",
+            "next_noon": "2026-02-17T12:00:00",
+            "next_rising": "2026-02-17T06:00:00",
+            "next_setting": "2026-02-17T18:00:00",
+            "friendly_name": "Sun",
+            "icon": "mdi:white-balance-sunny",
+        },
+    )
+
+
+# =============================================================================
+# Pre-built Entity Sets
+# =============================================================================
+
+
+def create_default_entity_states(
+    soc: float = 50.0,
+    operation_mode: str = "autonomous",
+    backup_reserve: float = 20.0,
+    grid_power_kw: float = 0.0,
+    load_power_kw: float = 0.5,
+    solar_power_kw: float = 3.0,
+    battery_power_kw: float = -2.5,
+    general_price: float = 0.25,
+    feed_in_price: float = 0.08,
+    price_spike: bool = False,
+    allow_export: str = "pv_only",
+) -> dict[str, MockState]:
+    """Create a complete set of entity states for LocalShift testing.
+
+    This creates realistic states for all entities that LocalShift monitors,
+    with sensible defaults that can be overridden for specific test scenarios.
+
+    Entity IDs match DEFAULT_ENTITY_IDS in const.py:
+    - Teslemetry: my_home_* entities
+    - Pricing: 100h_* entities (Amber Electric)
+    - Solcast: solcast_pv_forecast_* entities
+
+    Args:
+        soc: Battery state of charge percentage
+        operation_mode: Powerwall operation mode
+        backup_reserve: Backup reserve percentage
+        grid_power_kw: Grid power in kW (positive = import)
+        load_power_kw: Load power in kW
+        solar_power_kw: Solar power in kW
+        battery_power_kw: Battery power in kW (positive = charging)
+        general_price: General usage price in $/kWh
+        feed_in_price: Feed-in tariff in $/kWh
+        price_spike: Whether there's a price spike
+        allow_export: Allow export state (pv_only, battery_ok)
+
+    Returns:
+        Dictionary mapping entity IDs to MockState objects
+    """
+    return {
+        # Teslemetry entities (my_home_* naming)
+        "sensor.my_home_percentage_charged": create_powerwall_soc_state(
+            soc, entity_id="sensor.my_home_percentage_charged"
+        ),
+        "select.my_home_operation_mode": MockState(
+            entity_id="select.my_home_operation_mode",
+            state=operation_mode,
+            attributes={
+                "friendly_name": "Operation Mode",
+                "icon": "mdi:home-battery",
+                "options": [
+                    "self_consumption",
+                    "autonomous",
+                    "backup",
+                ],
+            },
+        ),
+        "number.my_home_backup_reserve": create_sensor_state(
+            "number.my_home_backup_reserve",
+            backup_reserve,
+            unit="%",
+        ),
+        "sensor.my_home_grid_power": create_power_state(
+            grid_power_kw,
+            "sensor.my_home_grid_power",
+            "Grid Power",
+        ),
+        "sensor.my_home_load_power": create_power_state(
+            load_power_kw,
+            "sensor.my_home_load_power",
+            "Load Power",
+        ),
+        "sensor.my_home_solar_power": create_power_state(
+            solar_power_kw,
+            "sensor.my_home_solar_power",
+            "Solar Power",
+        ),
+        "sensor.my_home_battery_power": create_power_state(
+            battery_power_kw,
+            "sensor.my_home_battery_power",
+            "Battery Power",
+        ),
+        "select.my_home_allow_export": MockState(
+            entity_id="select.my_home_allow_export",
+            state=allow_export,
+            attributes={
+                "friendly_name": "Allow Export",
+                "options": ["pv_only", "battery_ok"],
+            },
+        ),
+        # Pricing entities (100h_* naming for Amber Electric)
+        "sensor.100h_general_price": create_price_state(
+            general_price,
+            "sensor.100h_general_price",
+            "General Price",
+        ),
+        "sensor.100h_feed_in_price": create_price_state(
+            feed_in_price,
+            "sensor.100h_feed_in_price",
+            "Feed-in Price",
+        ),
+        "binary_sensor.100h_price_spike": create_binary_sensor_state(
+            "binary_sensor.100h_price_spike",
+            price_spike,
+        ),
+        # Sun entity
+        "sun.sun": create_sun_state(),
+    }
+
+
+def create_unavailable_entity_states(entity_ids: list[str]) -> dict[str, MockState]:
+    """Create unavailable states for specified entities.
+
+    Args:
+        entity_ids: List of entity IDs to mark as unavailable
+
+    Returns:
+        Dictionary mapping entity IDs to unavailable MockState objects
+    """
+    return {
+        entity_id: MockState(entity_id, "unavailable", {}) for entity_id in entity_ids
+    }
+
+
+def create_unknown_entity_states(entity_ids: list[str]) -> dict[str, MockState]:
+    """Create unknown states for specified entities.
+
+    Args:
+        entity_ids: List of entity IDs to mark as unknown
+
+    Returns:
+        Dictionary mapping entity IDs to unknown MockState objects
+    """
+    return {entity_id: MockState(entity_id, "unknown", {}) for entity_id in entity_ids}
+
+
+# =============================================================================
+# Sample Forecast Data
+# =============================================================================
+
+
+def create_sample_solcast_forecast(
+    num_periods: int = 24,
+    start_hour: int = 6,
+    peak_kw: float = 5.0,
+) -> list[dict[str, Any]]:
+    """Create sample Solcast forecast data.
+
+    Creates a realistic solar forecast curve that peaks at midday.
+
+    Args:
+        num_periods: Number of forecast periods
+        start_hour: Starting hour for forecasts
+        peak_kw: Peak generation in kW
+
+    Returns:
+        List of forecast dictionaries
+    """
+    import math
+
+    forecasts = []
+    base_date = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+
+    for i in range(num_periods):
+        hour = start_hour + i
+        # Create a bell curve peaking at noon
+        hour_of_day = hour % 24
+        if 6 <= hour_of_day <= 18:
+            # Bell curve centered at noon
+            normalized = (hour_of_day - 12) / 6
+            factor = math.exp(-2 * normalized**2)
+            pv_estimate = peak_kw * factor
+        else:
+            pv_estimate = 0.0
+
+        period_start = base_date.replace(hour=hour % 24)
+        if hour >= 24:
+            period_start = period_start.replace(day=period_start.day + 1)
+
+        forecasts.append(
+            {
+                "period_start": period_start.isoformat(),
+                "pv_estimate": round(pv_estimate, 3),
+                "pv_estimate10": round(pv_estimate * 0.9, 3),
+                "pv_estimate90": round(pv_estimate * 1.1, 3),
+            }
+        )
+
+    return forecasts
+
+
+def create_sample_amber_price_forecast(
+    num_periods: int = 48,
+    start_hour: int = 0,
+    base_price: float = 0.25,
+    spike_at: list[int] | None = None,
+    negative_at: list[int] | None = None,
+) -> list[dict[str, Any]]:
+    """Create sample Amber price forecast data.
+
+    Args:
+        num_periods: Number of 30-min forecast periods
+        start_hour: Starting hour for forecasts
+        base_price: Base price in $/kWh
+        spike_at: Hours where price spikes should occur
+        negative_at: Hours where negative prices should occur
+
+    Returns:
+        List of forecast dictionaries
+    """
+    spike_at = spike_at or []
+    negative_at = negative_at or []
+
+    forecasts = []
+    base_date = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+
+    for i in range(num_periods):
+        period_start = base_date.replace(
+            hour=(start_hour + i // 2) % 24, minute=(i % 2) * 30
+        )
+        hour = (start_hour + i // 2) % 24
+
+        # Determine price
+        if hour in negative_at:
+            price = -0.05  # Negative price
+        elif hour in spike_at:
+            price = 2.50  # Spike price
+        elif 6 <= hour < 10 or 17 <= hour < 21:
+            # Peak periods
+            price = base_price * 1.5
+        elif 10 <= hour < 17:
+            # Off-peak (solar hours)
+            price = base_price * 0.5
+        else:
+            # Shoulder
+            price = base_price
+
+        from datetime import timedelta
+
+        end_time = period_start + timedelta(minutes=30)
+        forecasts.append(
+            {
+                "duration_minutes": 30,
+                "date": period_start.strftime("%Y-%m-%d"),
+                "nem_time": period_start.strftime("%H:%M"),
+                "start_time": period_start.isoformat(),
+                "end_time": end_time.isoformat(),
+                "per_kwh": round(price, 4),
+                "spot_per_kwh": round(price * 0.9, 4),
+                "renewables": 0.5,
+            }
+        )
+
+    return forecasts

--- a/tests/test_state_reader_edge_cases.py
+++ b/tests/test_state_reader_edge_cases.py
@@ -1,0 +1,582 @@
+"""Tests for StateReader edge cases and entity availability handling.
+
+These tests verify that the StateReader correctly handles:
+- Unavailable entities (state="unavailable")
+- Unknown entities (state="unknown")
+- Missing entities (hass.states.get() returns None)
+- Partial availability (some entities available, some not)
+- Malformed state values
+- Missing attributes
+"""
+
+from custom_components.localshift.coordinator_data import CoordinatorData
+from custom_components.localshift.state_reader import StateReader
+
+# =============================================================================
+# BASIC STATE READ TESTS
+# =============================================================================
+
+
+class TestStateReaderBasicReads:
+    """Tests for basic state reading functionality."""
+
+    def test_read_float_from_available_entity(self, state_reader):
+        """Test reading a float from an available entity."""
+        data = CoordinatorData()
+        state_reader.read_all_external_state(data)
+
+        # Should have read the SOC value from the mock state
+        assert data.soc == 50.0
+
+    def test_read_string_from_available_entity(self, state_reader):
+        """Test reading a string from an available entity."""
+        data = CoordinatorData()
+        state_reader.read_all_external_state(data)
+
+        assert data.operation_mode == "autonomous"
+
+    def test_read_bool_from_binary_sensor(self, state_reader):
+        """Test reading a boolean from a binary sensor."""
+        data = CoordinatorData()
+        state_reader.read_all_external_state(data)
+
+        # Price spike should be False in default state
+        assert data.price_spike is False
+
+
+# =============================================================================
+# UNAVAILABLE ENTITY TESTS
+# =============================================================================
+
+
+class TestStateReaderUnavailableEntities:
+    """Tests for handling unavailable entities."""
+
+    def test_unavailable_soc_returns_default(self, state_reader_unavailable):
+        """Test that unavailable SOC returns default value (0.0)."""
+        data = CoordinatorData()
+        state_reader_unavailable.read_all_external_state(data)
+
+        # Should return default value when entity is unavailable
+        assert data.soc == 0.0
+
+    def test_unavailable_operation_mode_returns_default(self, state_reader_unavailable):
+        """Test that unavailable operation mode returns empty string."""
+        data = CoordinatorData()
+        state_reader_unavailable.read_all_external_state(data)
+
+        assert data.operation_mode == ""
+
+    def test_unavailable_price_returns_default(self, state_reader_unavailable):
+        """Test that unavailable price returns default value (0.0)."""
+        data = CoordinatorData()
+        state_reader_unavailable.read_all_external_state(data)
+
+        assert data.general_price == 0.0
+        assert data.feed_in_price == 0.0
+
+    def test_unavailable_binary_sensor_returns_false(self, state_reader_unavailable):
+        """Test that unavailable binary sensor returns False."""
+        data = CoordinatorData()
+        state_reader_unavailable.read_all_external_state(data)
+
+        assert data.price_spike is False
+
+
+# =============================================================================
+# UNKNOWN ENTITY TESTS
+# =============================================================================
+
+
+class TestStateReaderUnknownEntities:
+    """Tests for handling entities with unknown state."""
+
+    def test_unknown_soc_returns_default(self, mock_hass_unknown_entities, mock_entry):
+        """Test that unknown SOC returns default value."""
+        state_reader = StateReader(mock_hass_unknown_entities, mock_entry)
+        data = CoordinatorData()
+        state_reader.read_all_external_state(data)
+
+        assert data.soc == 0.0
+
+    def test_unknown_operation_mode_returns_default(
+        self, mock_hass_unknown_entities, mock_entry
+    ):
+        """Test that unknown operation mode returns empty string."""
+        state_reader = StateReader(mock_hass_unknown_entities, mock_entry)
+        data = CoordinatorData()
+        state_reader.read_all_external_state(data)
+
+        assert data.operation_mode == ""
+
+
+# =============================================================================
+# MISSING ENTITY TESTS
+# =============================================================================
+
+
+class TestStateReaderMissingEntities:
+    """Tests for handling missing entities (hass.states.get() returns None)."""
+
+    def test_missing_soc_returns_default(self, state_reader_missing):
+        """Test that missing SOC entity returns default value."""
+        data = CoordinatorData()
+        state_reader_missing.read_all_external_state(data)
+
+        assert data.soc == 0.0
+
+    def test_missing_operation_mode_returns_default(self, state_reader_missing):
+        """Test that missing operation mode entity returns empty string."""
+        data = CoordinatorData()
+        state_reader_missing.read_all_external_state(data)
+
+        assert data.operation_mode == ""
+
+    def test_missing_all_entities_no_crash(self, state_reader_missing):
+        """Test that reading with all entities missing doesn't crash."""
+        data = CoordinatorData()
+
+        # Should not raise any exceptions
+        state_reader_missing.read_all_external_state(data)
+
+        # All values should be defaults
+        assert data.soc == 0.0
+        assert data.operation_mode == ""
+        assert data.general_price == 0.0
+        assert data.feed_in_price == 0.0
+        assert data.price_spike is False
+
+
+# =============================================================================
+# PARTIAL AVAILABILITY TESTS
+# =============================================================================
+
+
+class TestStateReaderPartialAvailability:
+    """Tests for handling partial entity availability."""
+
+    def test_partial_availability_reads_available_entities(
+        self, mock_hass_partial_availability, mock_entry
+    ):
+        """Test that available entities are read correctly when some are unavailable."""
+        state_reader = StateReader(mock_hass_partial_availability, mock_entry)
+        data = CoordinatorData()
+        state_reader.read_all_external_state(data)
+
+        # SOC is unavailable, should be default
+        assert data.soc == 0.0
+
+        # General price is unavailable, should be default
+        assert data.general_price == 0.0
+
+        # Operation mode should still be readable
+        assert data.operation_mode == "autonomous"
+
+        # Feed-in price should still be readable
+        assert data.feed_in_price == 0.08
+
+    def test_partial_availability_missing_entities(
+        self, mock_hass_partial_availability, mock_entry
+    ):
+        """Test that missing entities return defaults."""
+        state_reader = StateReader(mock_hass_partial_availability, mock_entry)
+        data = CoordinatorData()
+        state_reader.read_all_external_state(data)
+
+        # Solar power entity is missing entirely
+        assert data.solar_power_kw == 0.0
+
+        # Price spike entity is missing
+        assert data.price_spike is False
+
+
+# =============================================================================
+# MALFORMED STATE VALUE TESTS
+# =============================================================================
+
+
+class TestStateReaderMalformedValues:
+    """Tests for handling malformed state values."""
+
+    def test_non_numeric_soc_returns_default(self, mock_hass_with_states, mock_entry):
+        """Test that non-numeric SOC returns default value."""
+        # Override SOC with non-numeric value (using DEFAULT_ENTITY_IDS naming)
+        mock_hass_with_states._mock_states.set(
+            "sensor.my_home_percentage_charged", "not_a_number", {}
+        )
+
+        state_reader = StateReader(mock_hass_with_states, mock_entry)
+        data = CoordinatorData()
+        state_reader.read_all_external_state(data)
+
+        assert data.soc == 0.0
+
+    def test_non_numeric_price_returns_default(self, mock_hass_with_states, mock_entry):
+        """Test that non-numeric price returns default value."""
+        mock_hass_with_states._mock_states.set(
+            "sensor.100h_general_price", "invalid", {}
+        )
+
+        state_reader = StateReader(mock_hass_with_states, mock_entry)
+        data = CoordinatorData()
+        state_reader.read_all_external_state(data)
+
+        assert data.general_price == 0.0
+
+    def test_empty_string_soc_returns_default(self, mock_hass_with_states, mock_entry):
+        """Test that empty string SOC returns default value."""
+        mock_hass_with_states._mock_states.set(
+            "sensor.my_home_percentage_charged", "", {}
+        )
+
+        state_reader = StateReader(mock_hass_with_states, mock_entry)
+        data = CoordinatorData()
+        state_reader.read_all_external_state(data)
+
+        assert data.soc == 0.0
+
+    def test_negative_soc_is_accepted(self, mock_hass_with_states, mock_entry):
+        """Test that negative SOC values are accepted (edge case)."""
+        mock_hass_with_states._mock_states.set(
+            "sensor.my_home_percentage_charged", "-5.0", {}
+        )
+
+        state_reader = StateReader(mock_hass_with_states, mock_entry)
+        data = CoordinatorData()
+        state_reader.read_all_external_state(data)
+
+        # Negative SOC is technically a valid float, so it should be read
+        # (validation happens elsewhere)
+        assert data.soc == -5.0
+
+    def test_very_large_soc_is_accepted(self, mock_hass_with_states, mock_entry):
+        """Test that very large SOC values are accepted (edge case)."""
+        mock_hass_with_states._mock_states.set(
+            "sensor.my_home_percentage_charged", "999999.99", {}
+        )
+
+        state_reader = StateReader(mock_hass_with_states, mock_entry)
+        data = CoordinatorData()
+        state_reader.read_all_external_state(data)
+
+        # Should be read as-is; validation happens elsewhere
+        assert data.soc == 999999.99
+
+
+# =============================================================================
+# ATTRIBUTE READING TESTS
+# =============================================================================
+
+
+class TestStateReaderAttributes:
+    """Tests for reading entity attributes."""
+
+    def test_missing_forecast_attribute_returns_empty_list(
+        self, mock_hass_with_states, mock_entry
+    ):
+        """Test that missing forecast attribute returns empty list."""
+        # Set entity without forecasts attribute (using DEFAULT_ENTITY_IDS naming)
+        mock_hass_with_states._mock_states.set(
+            "sensor.100h_general_forecast",
+            "on",
+            {},  # No attributes
+        )
+
+        state_reader = StateReader(mock_hass_with_states, mock_entry)
+        data = CoordinatorData()
+        state_reader.read_all_external_state(data)
+
+        assert data.general_forecast == []
+
+    def test_none_forecast_attribute_returns_empty_list(
+        self, mock_hass_with_states, mock_entry
+    ):
+        """Test that None forecast attribute returns empty list."""
+        mock_hass_with_states._mock_states.set(
+            "sensor.100h_general_forecast",
+            "on",
+            {"forecasts": None},
+        )
+
+        state_reader = StateReader(mock_hass_with_states, mock_entry)
+        data = CoordinatorData()
+        state_reader.read_all_external_state(data)
+
+        assert data.general_forecast == []
+
+    def test_valid_forecast_attribute_is_read(
+        self, mock_hass_with_forecasts, mock_entry
+    ):
+        """Test that valid forecast attribute is read correctly."""
+        state_reader = StateReader(mock_hass_with_forecasts, mock_entry)
+        data = CoordinatorData()
+        state_reader.read_all_external_state(data)
+
+        # Should have forecast data
+        assert len(data.general_forecast) > 0
+        assert len(data.feed_in_forecast) > 0
+
+
+# =============================================================================
+# PARAMETRIZED AVAILABILITY TESTS
+# =============================================================================
+
+
+class TestStateReaderParametrized:
+    """Parametrized tests for various availability scenarios."""
+
+    def test_read_all_external_state_never_crashes(
+        self, mock_hass_various_states, mock_entry
+    ):
+        """Test that read_all_external_state never crashes regardless of availability."""
+        state_reader = StateReader(mock_hass_various_states, mock_entry)
+        data = CoordinatorData()
+
+        # Should never raise an exception
+        state_reader.read_all_external_state(data)
+
+        # Data should be populated (with defaults if unavailable/missing)
+        assert isinstance(data.soc, float)
+        assert isinstance(data.operation_mode, str)
+        assert isinstance(data.general_price, float)
+
+    def test_soc_value_available(self, mock_hass_with_states, mock_entry):
+        """Test that SOC value is correct when entity is available."""
+        state_reader = StateReader(mock_hass_with_states, mock_entry)
+        data = CoordinatorData()
+        state_reader.read_all_external_state(data)
+
+        assert data.soc == 50.0
+
+    def test_soc_value_unavailable(self, mock_hass_unavailable_entities, mock_entry):
+        """Test that SOC value is default when entity is unavailable."""
+        state_reader = StateReader(mock_hass_unavailable_entities, mock_entry)
+        data = CoordinatorData()
+        state_reader.read_all_external_state(data)
+
+        assert data.soc == 0.0
+
+    def test_soc_value_unknown(self, mock_hass_unknown_entities, mock_entry):
+        """Test that SOC value is default when entity is unknown."""
+        state_reader = StateReader(mock_hass_unknown_entities, mock_entry)
+        data = CoordinatorData()
+        state_reader.read_all_external_state(data)
+
+        assert data.soc == 0.0
+
+    def test_soc_value_missing(self, mock_hass_missing_entities, mock_entry):
+        """Test that SOC value is default when entity is missing."""
+        state_reader = StateReader(mock_hass_missing_entities, mock_entry)
+        data = CoordinatorData()
+        state_reader.read_all_external_state(data)
+
+        assert data.soc == 0.0
+
+
+# =============================================================================
+# SOLCAST FORECAST EDGE CASES
+# =============================================================================
+
+
+class TestStateReaderSolcastForecasts:
+    """Tests for Solcast forecast reading edge cases."""
+
+    def test_solcast_unavailable_returns_empty_list(
+        self, mock_hass_unavailable_entities, mock_entry
+    ):
+        """Test that unavailable Solcast entity returns empty list."""
+        # Add Solcast entities to unavailable states
+        mock_hass_unavailable_entities._mock_states.set_unavailable(
+            "sensor.solcast_today"
+        )
+        mock_hass_unavailable_entities._mock_states.set_unavailable(
+            "sensor.solcast_tomorrow"
+        )
+
+        state_reader = StateReader(mock_hass_unavailable_entities, mock_entry)
+        data = CoordinatorData()
+        state_reader.read_all_external_state(data)
+
+        assert data.solcast_today == []
+        assert data.solcast_tomorrow == []
+
+    def test_solcast_missing_attribute_returns_empty_list(
+        self, mock_hass_with_states, mock_entry
+    ):
+        """Test that Solcast without forecast attribute returns empty list."""
+        mock_hass_with_states._mock_states.set(
+            "sensor.solcast_today",
+            "0",
+            {"friendly_name": "Solcast"},  # No forecast attribute
+        )
+
+        state_reader = StateReader(mock_hass_with_states, mock_entry)
+        data = CoordinatorData()
+        state_reader.read_all_external_state(data)
+
+        assert data.solcast_today == []
+
+    def test_solcast_with_detailed_forecast_attribute(
+        self, mock_hass_with_states, mock_entry
+    ):
+        """Test reading Solcast with detailedForecast attribute."""
+        forecast_data = [
+            {"period_start": "2026-02-16T06:00:00", "pv_estimate": 1.5},
+            {"period_start": "2026-02-16T07:00:00", "pv_estimate": 2.5},
+        ]
+
+        mock_hass_with_states._mock_states.set(
+            "sensor.solcast_today",
+            "2",
+            {"detailedForecast": forecast_data},
+        )
+
+        state_reader = StateReader(mock_hass_with_states, mock_entry)
+        data = CoordinatorData()
+        state_reader.read_all_external_state(data)
+
+        assert len(data.solcast_today) == 2
+
+    def test_solcast_with_detailed_hourly_attribute(
+        self, mock_hass_with_states, mock_entry
+    ):
+        """Test reading Solcast with detailedHourly attribute."""
+        forecast_data = [
+            {"period_start": "2026-02-16T06:00:00", "pv_estimate": 0.5},
+        ]
+
+        mock_hass_with_states._mock_states.set(
+            "sensor.solcast_today",
+            "1",
+            {"detailedHourly": forecast_data},
+        )
+
+        state_reader = StateReader(mock_hass_with_states, mock_entry)
+        data = CoordinatorData()
+        state_reader.read_all_external_state(data)
+
+        assert len(data.solcast_today) == 1
+
+    def test_solcast_with_forecast_attribute(self, mock_hass_with_states, mock_entry):
+        """Test reading Solcast with forecast attribute."""
+        forecast_data = [
+            {"start": "2026-02-16T06:00:00", "pv_estimate": 3.0},
+        ]
+
+        mock_hass_with_states._mock_states.set(
+            "sensor.solcast_today",
+            "1",
+            {"forecast": forecast_data},
+        )
+
+        state_reader = StateReader(mock_hass_with_states, mock_entry)
+        data = CoordinatorData()
+        state_reader.read_all_external_state(data)
+
+        assert len(data.solcast_today) == 1
+
+
+# =============================================================================
+# PRICE SPIKE EDGE CASES
+# =============================================================================
+
+
+class TestStateReaderPriceSpike:
+    """Tests for price spike reading."""
+
+    def test_price_spike_on(self, mock_hass_price_spike, mock_entry):
+        """Test reading price spike when it's on."""
+        state_reader = StateReader(mock_hass_price_spike, mock_entry)
+        data = CoordinatorData()
+        state_reader.read_all_external_state(data)
+
+        assert data.price_spike is True
+
+    def test_price_spike_off(self, state_reader):
+        """Test reading price spike when it's off."""
+        data = CoordinatorData()
+        state_reader.read_all_external_state(data)
+
+        assert data.price_spike is False
+
+    def test_price_spike_unavailable(self, state_reader_unavailable):
+        """Test reading price spike when entity is unavailable."""
+        data = CoordinatorData()
+        state_reader_unavailable.read_all_external_state(data)
+
+        assert data.price_spike is False
+
+    def test_price_spike_missing(self, state_reader_missing):
+        """Test reading price spike when entity is missing."""
+        data = CoordinatorData()
+        state_reader_missing.read_all_external_state(data)
+
+        assert data.price_spike is False
+
+
+# =============================================================================
+# INTEGRATION-STYLE TESTS
+# =============================================================================
+
+
+class TestStateReaderIntegration:
+    """Integration-style tests combining multiple scenarios."""
+
+    def test_full_state_read_with_all_entities(
+        self, mock_hass_with_forecasts, mock_entry
+    ):
+        """Test reading all entities with complete data."""
+        state_reader = StateReader(mock_hass_with_forecasts, mock_entry)
+        data = CoordinatorData()
+        state_reader.read_all_external_state(data)
+
+        # Verify all expected fields are populated
+        assert data.soc == 50.0
+        assert data.operation_mode == "autonomous"
+        assert data.backup_reserve == 20.0
+        assert data.grid_power_kw == 0.0
+        assert data.load_power_kw == 0.5
+        assert data.solar_power_kw == 3.0
+        assert data.battery_power_kw == -2.5
+        assert data.general_price == 0.25
+        assert data.feed_in_price == 0.08
+        assert data.price_spike is False
+
+        # Forecasts should be populated
+        assert len(data.general_forecast) > 0
+        assert len(data.feed_in_forecast) > 0
+        assert len(data.solcast_today) > 0
+        assert len(data.solcast_tomorrow) > 0
+
+    def test_state_read_idempotent(self, state_reader):
+        """Test that reading state multiple times is idempotent."""
+        data = CoordinatorData()
+
+        state_reader.read_all_external_state(data)
+        soc1 = data.soc
+        price1 = data.general_price
+
+        state_reader.read_all_external_state(data)
+        soc2 = data.soc
+        price2 = data.general_price
+
+        assert soc1 == soc2
+        assert price1 == price2
+
+    def test_state_read_clears_previous_data(self, mock_hass_with_states, mock_entry):
+        """Test that reading state overwrites previous data."""
+        state_reader = StateReader(mock_hass_with_states, mock_entry)
+
+        # Set up data with non-default values
+        data = CoordinatorData()
+        data.soc = 99.0
+        data.general_price = 5.0
+        data.operation_mode = "backup"
+
+        # Read state (should overwrite)
+        state_reader.read_all_external_state(data)
+
+        # Values should be from mock states, not previous values
+        assert data.soc == 50.0
+        assert data.general_price == 0.25
+        assert data.operation_mode == "autonomous"


### PR DESCRIPTION
## Summary

This PR addresses issue #9 by creating realistic Home Assistant entity state simulation fixtures that better match real HA behavior.

## Problem

Test mocks were using simplified data structures that didn't simulate real HA entity states:
- Tests passed with perfect data but could fail with real HA entity states
- No testing of entity unavailability scenarios
- No testing of state transition edge cases
- Mocks didn't simulate async HA behavior

## Solution

Created a comprehensive test fixture system:

### New Files
- `tests/fixtures/__init__.py` - Package initialization
- `tests/fixtures/ha_entities.py` - MockState, MockStates classes and entity factories
- `tests/test_state_reader_edge_cases.py` - 42 tests for edge cases

### Enhanced Fixtures in conftest.py
- `mock_hass_with_states` - HA instance with realistic states
- `mock_hass_with_forecasts` - HA instance with forecast data
- `mock_hass_unavailable_entities` - All entities unavailable
- `mock_hass_unknown_entities` - All entities unknown
- `mock_hass_missing_entities` - All entities missing
- `mock_hass_partial_availability` - Mixed availability
- `mock_hass_price_spike` - Price spike scenario
- `mock_hass_low_battery` - Low SOC scenario
- `mock_hass_negative_prices` - Negative price scenario
- `mock_hass_various_states` - Parametrized fixture

### Test Coverage
- Basic state reading (float, string, boolean)
- Unavailable entity handling
- Unknown entity handling
- Missing entity handling
- Partial availability scenarios
- Malformed state values (non-numeric, empty string)
- Attribute reading edge cases
- Solcast forecast edge cases
- Price spike edge cases
- Integration-style tests

## Testing

All 42 new tests pass. The existing test suite has 325 passing tests with 12 pre-existing failures unrelated to this change.

Closes #9