### PR TITLE
Fix #50: Add proper async mock for recorder in coordinator tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ For tests that need realistic HA behavior, use:
 """
 
 from datetime import datetime
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -574,3 +574,25 @@ def mock_hass_various_states(request, realistic_entity_states):
 
     hass.data = {}
     return hass
+
+
+# =============================================================================
+# RECORDER MOCK FIXTURE
+# =============================================================================
+
+
+@pytest.fixture
+def mock_recorder():
+    """Mock the recorder instance for async executor job.
+
+    This fixture patches recorder.get_instance to return a mock that
+    properly supports async_add_executor_job as an AsyncMock.
+    """
+    mock_instance = MagicMock()
+    mock_instance.async_add_executor_job = AsyncMock(return_value=({}, {}))
+
+    with patch(
+        "homeassistant.components.recorder.get_instance",
+        return_value=mock_instance,
+    ):
+        yield mock_instance

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -104,7 +104,7 @@ class TestAsyncStart:
     """Tests for async_start method."""
 
     @pytest.mark.asyncio
-    async def test_async_start_initializes_modules(self, coordinator):
+    async def test_async_start_initializes_modules(self, coordinator, mock_recorder):
         """Test that async_start initializes all helper modules."""
         with (
             patch(
@@ -131,7 +131,7 @@ class TestAsyncStart:
             assert coordinator._notification_service is not None
 
     @pytest.mark.asyncio
-    async def test_async_start_subscribes_to_events(self, coordinator):
+    async def test_async_start_subscribes_to_events(self, coordinator, mock_recorder):
         """Test that async_start subscribes to state changes and timers."""
         with (
             patch(
@@ -158,7 +158,7 @@ class TestAsyncStart:
             assert mock_track_time_change.call_count == 2
 
     @pytest.mark.asyncio
-    async def test_async_start_sets_startup_grace(self, coordinator):
+    async def test_async_start_sets_startup_grace(self, coordinator, mock_recorder):
         """Test that async_start sets startup grace period."""
         with (
             patch(


### PR DESCRIPTION
## Summary
Fix the 3 failing async_start tests in test_coordinator.py by adding proper async mocking for the recorder instance.

## Problem
Three tests were failing with `TypeError: 'MagicMock' object can't be awaited`:
- `test_async_start_initializes_modules`
- `test_async_start_subscribes_to_events`
- `test_async_start_sets_startup_grace`

The issue occurred when `async_start` called `async_get_historical_hourly_averages` which uses `recorder.get_instance(hass).async_add_executor_job()`. The mock hass didn't have a proper recorder mock.

## Solution
- Added `mock_recorder` fixture in `conftest.py` that patches `recorder.get_instance`
- Configured `async_add_executor_job` as an `AsyncMock` returning empty dicts
- Updated the 3 TestAsyncStart tests to use the `mock_recorder` fixture

## Testing
- All 29 tests in test_coordinator.py now pass
- Pre-commit hooks (ruff, ruff-format, pyright) pass for modified files

Closes #50