### PR TITLE
feat: implement negative FIT avoidance for proactive exports

### DIFF
--- a/custom_components/localshift/computation_engine_lib/forecast_computer.py
+++ b/custom_components/localshift/computation_engine_lib/forecast_computer.py
@@ -39,6 +39,9 @@ _LOGGER = logging.getLogger(__name__)
 # 15-min slots throughout for consistent alignment with Solcast 30-minute periods
 TOTAL_SLOTS = 96  # 24 hours × 4 slots/hour
 
+# Proactive export constraints
+PROACTIVE_EXPORT_SOC_BUFFER_PCT = 5.0  # Minimum buffer above min SOC for exports
+
 
 class ForecastComputer:
     """Computes 24-hour battery forecast with 15-minute breakdown."""
@@ -1640,7 +1643,8 @@ class ForecastComputer:
         fill_point_elapsed_minutes: int | None = None,
         negative_fit_headroom_kwh: float = 0.0,
         in_negative_fit_window: bool = False,
-    ) -> tuple[bool, float]:
+        first_negative_fit_start: datetime | None = None,
+    ) -> tuple[bool, float, float]:
         """Determine if proactive export should happen at this slot.
 
         Proactive export has TWO modes:
@@ -1712,6 +1716,20 @@ class ForecastComputer:
         # This is the primary strategy for high-solar days.
 
         if negative_fit_headroom_kwh > 0 and not in_negative_fit_window:
+            # TIMING CHECK: Only export BEFORE the negative FIT window starts
+            # This prevents exports during or after the negative FIT window
+            if (
+                first_negative_fit_start is not None
+                and slot_start >= first_negative_fit_start
+            ):
+                _LOGGER.debug(
+                    "PROACTIVE_EXPORT: %02d:%02d BLOCKED - slot is at/after negative FIT window start %s",
+                    slot_hour,
+                    slot_start.minute,
+                    first_negative_fit_start.strftime("%H:%M"),
+                )
+                return False, 0.0, negative_fit_headroom_kwh
+
             # FIT must be strictly positive to export (preserve battery cycles)
             if use_price <= 0:
                 _LOGGER.debug(
@@ -1720,20 +1738,24 @@ class ForecastComputer:
                     slot_start.minute,
                     use_price,
                 )
-                return False, 0.0
+                return False, 0.0, negative_fit_headroom_kwh
 
-            # Must have SOC above minimum to export
-            if predicted_soc <= export_min_soc_pct:
+            # SOC BUFFER CHECK: Require minimum buffer above export_min_soc_pct
+            # This prevents exports when SOC is too close to the minimum
+            required_soc_for_export = (
+                export_min_soc_pct + PROACTIVE_EXPORT_SOC_BUFFER_PCT
+            )
+            if predicted_soc < required_soc_for_export:
                 _LOGGER.debug(
-                    "PROACTIVE_EXPORT: %02d:%02d BLOCKED - SOC %.1f%% <= min %.1f%% (negative FIT avoidance)",
+                    "PROACTIVE_EXPORT: %02d:%02d BLOCKED - SOC %.1f%% < min+buffer %.1f%% (negative FIT avoidance)",
                     slot_hour,
                     slot_start.minute,
                     predicted_soc,
-                    export_min_soc_pct,
+                    required_soc_for_export,
                 )
-                return False, 0.0
+                return False, 0.0, negative_fit_headroom_kwh
 
-            # Calculate how much we can export (above minimum SOC)
+            # Calculate how much we can export (above minimum SOC + buffer)
             available_above_min_kwh = (
                 (predicted_soc - export_min_soc_pct) / 100 * BATTERY_CAPACITY_KWH
             )
@@ -1747,18 +1769,21 @@ class ForecastComputer:
             )
 
             if export_amount > 0:
+                # Decrement headroom after export
+                updated_headroom = negative_fit_headroom_kwh - export_amount
                 _LOGGER.info(
-                    "PROACTIVE_EXPORT: %02d:%02d NEGATIVE_FIT_AVOIDANCE - FIT=$%.3f, headroom=%.2f kWh, exporting=%.3f kWh, SOC=%.1f%%",
+                    "PROACTIVE_EXPORT: %02d:%02d NEGATIVE_FIT_AVOIDANCE - FIT=$%.3f, headroom=%.2f->%.2f kWh, exporting=%.3f kWh, SOC=%.1f%%",
                     slot_hour,
                     slot_start.minute,
                     use_price,
                     negative_fit_headroom_kwh,
+                    updated_headroom,
                     export_amount,
                     predicted_soc,
                 )
-                return True, round(export_amount, 3)
+                return True, round(export_amount, 3), updated_headroom
 
-            return False, 0.0
+            return False, 0.0, negative_fit_headroom_kwh
 
         # ========================================================================
         # MODE 2: PRICE ARBITRAGE (Fallback - when no negative FIT window)
@@ -1768,7 +1793,7 @@ class ForecastComputer:
 
         # If we're already in a negative FIT window, don't do price arbitrage
         if in_negative_fit_window:
-            return False, 0.0
+            return False, 0.0, negative_fit_headroom_kwh
 
         # ABOVE-TARGET GATE: Only export when battery is at or above the target SOC.
         # Exporting from a battery below target worsens the deficit and forces solar
@@ -1782,7 +1807,7 @@ class ForecastComputer:
                 predicted_soc,
                 target_pct,
             )
-            return False, 0.0
+            return False, 0.0, negative_fit_headroom_kwh
 
         # During demand window: allow export but use dynamic floor protection.
         # The existing checks below (min_soc, buffer, ending SOC) provide adequate
@@ -1791,7 +1816,7 @@ class ForecastComputer:
 
         # Need buffer in battery (minimum reserve from config)
         if predicted_soc <= export_min_soc_pct:
-            return False, 0.0
+            return False, 0.0, negative_fit_headroom_kwh
 
         # Critical: Don't export if battery will already drop below threshold without exports
         # This prevents draining of battery too low
@@ -1801,7 +1826,7 @@ class ForecastComputer:
                 min_soc_no_exports,
                 export_min_soc_pct,
             )
-            return False, 0.0
+            return False, 0.0, negative_fit_headroom_kwh
 
         # Additional safety: Need some buffer above minimum
         # This provides a small safety margin for forecast uncertainty
@@ -1814,12 +1839,12 @@ class ForecastComputer:
                 export_min_soc_pct,
                 required_buffer_pct,
             )
-            return False, 0.0
+            return False, 0.0, negative_fit_headroom_kwh
 
         # Only export if we have forecasted excess (not just current SOC)
         # This prevents exporting when we might need to charge later
         if forecasted_excess_kwh <= 0:
-            return False, 0.0
+            return False, 0.0, negative_fit_headroom_kwh
 
         # FILL-POINT BASED EXPORT STRATEGY:
         # Only export BEFORE the battery would naturally fill from solar
@@ -1832,7 +1857,7 @@ class ForecastComputer:
                 slot_hour,
                 slot_start.minute,
             )
-            return False, 0.0
+            return False, 0.0, negative_fit_headroom_kwh
 
         # CONSTRAINT 2: Only export BEFORE the fill point
         # After the battery fills, there's no room for more solar
@@ -1844,7 +1869,7 @@ class ForecastComputer:
                 current_elapsed_minutes,
                 fill_point_elapsed_minutes,
             )
-            return False, 0.0
+            return False, 0.0, negative_fit_headroom_kwh
 
         # CONSTRAINT 3: Verify enough solar AFTER export to reach fill point
         # Calculate solar energy available between now and fill point
@@ -1870,7 +1895,7 @@ class ForecastComputer:
                     slot_hour,
                     slot_start.minute,
                 )
-                return False, 0.0
+                return False, 0.0, negative_fit_headroom_kwh
 
         # Calculate hours until fill point (for price window calculation)
         hours_until_fill = (
@@ -1881,7 +1906,7 @@ class ForecastComputer:
 
         # Never proactive-export into a non-positive FIT.
         if use_price <= 0:
-            return False, 0.0
+            return False, 0.0, negative_fit_headroom_kwh
 
         # KEY INSIGHT: Once the battery fills, surplus solar is exported automatically.
         # So the question is: "Should I export NOW at current price, or wait and export
@@ -1922,7 +1947,7 @@ class ForecastComputer:
                 fill_time.strftime("%H:%M"),
                 hours_until_fill,
             )
-            return False, 0.0
+            return False, 0.0, negative_fit_headroom_kwh
 
         # CRITICAL: Calculate total discharge (export + load) before deciding
         # If solar_kwh < consumption, battery is already discharging for load
@@ -1972,7 +1997,7 @@ class ForecastComputer:
                 net_discharge_kwh,
                 export_discharge_kwh,
             )
-            return False, 0.0
+            return False, 0.0, negative_fit_headroom_kwh
 
         # CRITICAL: Simulate overnight drain after this export
         # This ensures battery won't drop below minimum before solar starts
@@ -2003,7 +2028,7 @@ class ForecastComputer:
                     slot_hour,
                     slot_start.minute,
                 )
-                return False, 0.0
+                return False, 0.0, negative_fit_headroom_kwh
 
             if min_overnight_soc < export_min_soc_pct:
                 _LOGGER.debug(
@@ -2013,7 +2038,7 @@ class ForecastComputer:
                     min_overnight_soc,
                     export_min_soc_pct,
                 )
-                return False, 0.0
+                return False, 0.0, negative_fit_headroom_kwh
 
         # THROTTLING: Apply dynamic reserve (SOC - 5%) to limit export amount
         # This matches the actual throttling that will happen in battery_controller.py
@@ -2048,9 +2073,9 @@ class ForecastComputer:
                 export_amount,
                 soc_after_discharge,
             )
-            return True, round(export_amount, 3)
+            return True, round(export_amount, 3), negative_fit_headroom_kwh
 
-        return False, 0.0
+        return False, 0.0, negative_fit_headroom_kwh
 
     def compute_forecast(
         self,
@@ -2457,32 +2482,40 @@ class ForecastComputer:
                     in_negative_fit_window = True
                     break
 
-            should_proactive_export, proactive_export_amount = (
-                self._should_proactive_export_at_slot(
-                    slot_start=slot_start,
-                    slot_hour=slot_hour,
-                    solar_kwh=solar_kwh,
-                    slot_fit_price=_slot_fit_price,
-                    predicted_soc=predicted_soc,
-                    target_pct=target_pct,
-                    in_demand_window=in_demand_window,
-                    forecasted_excess_kwh=forecasted_excess_kwh,
-                    remaining_export_budget_kwh=remaining_export_budget,
-                    feed_in_forecast=data.feed_in_forecast,
-                    min_soc_no_exports=min_soc_no_exports,
-                    export_min_soc_pct=export_min_soc_pct,
-                    effective_cheap_price=data.effective_cheap_price,
-                    feed_in_price_current=data.feed_in_price,
-                    all_solcast=all_solcast,
-                    historical_avg_kw=historical_avg_kw,
-                    current_load_kw=data.load_power_kw,
-                    recent_load_kw=recent_load_kw,
-                    is_current_slot=is_first_slot,
-                    current_elapsed_minutes=elapsed_minutes,
-                    fill_point_elapsed_minutes=fill_point_elapsed_minutes,
-                    negative_fit_headroom_kwh=negative_fit_headroom_kwh,
-                    in_negative_fit_window=in_negative_fit_window,
-                )
+            # Get the first negative FIT window start for timing check
+            first_negative_fit_start = (
+                negative_fit_windows[0][0] if negative_fit_windows else None
+            )
+
+            (
+                should_proactive_export,
+                proactive_export_amount,
+                negative_fit_headroom_kwh,
+            ) = self._should_proactive_export_at_slot(
+                slot_start=slot_start,
+                slot_hour=slot_hour,
+                solar_kwh=solar_kwh,
+                slot_fit_price=_slot_fit_price,
+                predicted_soc=predicted_soc,
+                target_pct=target_pct,
+                in_demand_window=in_demand_window,
+                forecasted_excess_kwh=forecasted_excess_kwh,
+                remaining_export_budget_kwh=remaining_export_budget,
+                feed_in_forecast=data.feed_in_forecast,
+                min_soc_no_exports=min_soc_no_exports,
+                export_min_soc_pct=export_min_soc_pct,
+                effective_cheap_price=data.effective_cheap_price,
+                feed_in_price_current=data.feed_in_price,
+                all_solcast=all_solcast,
+                historical_avg_kw=historical_avg_kw,
+                current_load_kw=data.load_power_kw,
+                recent_load_kw=recent_load_kw,
+                is_current_slot=is_first_slot,
+                current_elapsed_minutes=elapsed_minutes,
+                fill_point_elapsed_minutes=fill_point_elapsed_minutes,
+                negative_fit_headroom_kwh=negative_fit_headroom_kwh,
+                in_negative_fit_window=in_negative_fit_window,
+                first_negative_fit_start=first_negative_fit_start,
             )
 
             # Apply proactive export if needed (discharge battery)

--- a/implementation_plan.md
+++ b/implementation_plan.md
@@ -1,364 +1,214 @@
-# Implementation Plan
+# Implementation Plan: Negative FIT Avoidance Algorithm Fix
 
 [Overview]
-Implement weather-aware consumption prediction using a degree-day model that learns the correlation between temperature and household load.
+Fix the negative FIT avoidance algorithm to properly time exports BEFORE the negative FIT window, decrement headroom after exports, and enforce SOC buffer constraints.
 
-Household consumption is heavily influenced by HVAC usage, particularly during temperature extremes. This implementation enables the LocalShift integration to learn temperature/load correlations and adjust consumption predictions based on forecasted temperatures, leading to more accurate demand window planning and reduced unexpected grid imports.
+The current implementation has three critical bugs causing exports at wrong times and wrong SOC levels:
+1. Headroom never decrements after exports, allowing unlimited exports
+2. Exports happen AFTER the negative FIT window instead of BEFORE
+3. No SOC buffer enforced (exports at min+0.6% instead of min+5%)
 
 [Types]
 
-The following type definitions and data structures are required:
+No new types required. The fix modifies existing function behavior and parameters.
 
+Constants to add:
 ```python
-# In new file: weather_correlation.py
-
-@dataclass
-class HourlyTemperatureCoefficients:
-    """Temperature sensitivity coefficients for a single hour.
-    
-    Attributes:
-        base_load_kw: Minimum load at mild temperatures (18-24°C band)
-        cooling_coefficient: Additional kW per degree above 24°C
-        heating_coefficient: Additional kW per degree below 18°C
-        sample_count: Number of data points used for learning
-        last_updated: When coefficients were last recalculated
-        confidence: low/medium/high based on sample count
-    """
-    base_load_kw: float = 0.0
-    cooling_coefficient: float = 0.0  # kW per °C above cooling threshold
-    heating_coefficient: float = 0.0  # kW per °C below heating threshold
-    sample_count: int = 0
-    last_updated: str = ""  # ISO format datetime
-    confidence: str = "low"
-
-
-@dataclass  
-class WeatherCorrelationData:
-    """Complete weather correlation data structure for storage.
-    
-    Attributes:
-        version: Schema version for migrations
-        weather_entity_id: Configured weather entity
-        cooling_threshold: Temperature above which cooling load increases
-        heating_threshold: Temperature below which heating load increases
-        hourly_coefficients: Dict mapping hour (0-23) to coefficients
-        learning_stats: Aggregated statistics for diagnostics
-    """
-    version: int = 1
-    weather_entity_id: str = ""
-    cooling_threshold: float = 24.0  # °C
-    heating_threshold: float = 18.0  # °C
-    hourly_coefficients: dict[int, HourlyTemperatureCoefficients] = field(default_factory=dict)
-    learning_stats: dict[str, Any] = field(default_factory=dict)
-
-
-@dataclass
-class TemperatureForecast:
-    """Temperature forecast for a time slot.
-    
-    Attributes:
-        slot_time: The datetime this forecast applies to
-        temperature: Forecasted temperature in °C
-        condition: Weather condition (sunny, cloudy, etc.)
-    """
-    slot_time: datetime
-    temperature: float | None = None
-    condition: str = "unknown"
-```
-
-Constants to add to `const.py`:
-
-```python
-# Weather configuration
-CONF_WEATHER_ENTITY = "weather_entity"
-DEFAULT_WEATHER_ENTITY = "weather.home"
-
-# Temperature thresholds (configurable)
-CONF_COOLING_THRESHOLD = "cooling_threshold"
-CONF_HEATING_THRESHOLD = "heating_threshold"
-DEFAULT_COOLING_THRESHOLD = 24.0  # °C
-DEFAULT_HEATING_THRESHOLD = 18.0  # °C
-
-# Learning configuration
-CONF_WEATHER_LEARNING_ENABLED = "weather_learning_enabled"
-DEFAULT_WEATHER_LEARNING_ENABLED = True
+# In forecast_computer.py
+PROACTIVE_EXPORT_SOC_BUFFER_PCT = 5.0  # Minimum buffer above min SOC for exports
 ```
 
 [Files]
 
-### New Files to Create
-
-1. **`custom_components/localshift/weather_correlation.py`** (~400 lines)
-   - `WeatherCorrelation` class - Main learning and prediction engine
-   - `HourlyTemperatureCoefficients` dataclass
-   - `WeatherCorrelationData` dataclass
-   - Storage load/save methods using HA's `storage` module
-   - Learning algorithm (incremental regression)
-   - Prediction method for consumption adjustment
-
 ### Files to Modify
 
-2. **`custom_components/localshift/const.py`**
-   - Add `CONF_WEATHER_ENTITY`, `CONF_COOLING_THRESHOLD`, `CONF_HEATING_THRESHOLD`, `CONF_WEATHER_LEARNING_ENABLED`
-   - Add default values for weather-related settings
-   - Add to `DEFAULT_ENTITY_IDS` dict
-
-3. **`custom_components/localshift/config_flow.py`**
-   - Add weather entity selector in `async_step_solcast` or new step
-   - Add temperature threshold configuration in options flow
-   - Pre-fill dropdown with first available weather entity
-
-4. **`custom_components/localshift/computation_engine_lib/history_fetcher.py`**
-   - Add method to fetch historical temperature data from HA statistics
-   - `async_get_historical_temperatures()` - fetch temperature stats for learning
-   - Integrate with weather entity's historical data
-
-5. **`custom_components/localshift/computation_engine_lib/forecast_computer.py`**
-   - Modify `_estimate_hourly_consumption_kw()` to apply weather adjustment
-   - Add method `_get_weather_adjusted_load()` that uses temperature forecast
-   - Add temperature forecast fetching from weather entity
-   - Apply learned coefficients when temperature data available
-
-6. **`custom_components/localshift/computation_engine.py`**
-   - Initialize `WeatherCorrelation` instance
-   - Add weather correlation to coordinator lifecycle (start/stop)
-   - Trigger learning updates on periodic tick
-   - Pass weather data to forecast computer
-
-7. **`custom_components/localshift/coordinator.py`**
-   - Add weather entity to monitored entities
-   - Handle weather state changes
-   - Store reference to WeatherCorrelation instance
-
-8. **`custom_components/localshift/coordinator_data.py`**
-   - Add fields for weather diagnostics:
-     - `weather_temperature_current: float`
-     - `weather_temperature_forecast: dict[int, float]` (hour -> temp)
-     - `weather_correlation_confidence: str`
-     - `weather_adjustment_applied: bool`
-
-9. **`custom_components/localshift/sensor.py`**
-   - Add `WeatherCorrelationSensor` to expose learned coefficients as attributes
-   - Add temperature-related attributes to existing sensors
-
-10. **`custom_components/localshift/state_reader.py`**
-    - Add method to read weather entity state and forecast
-    - `_read_weather_state()` - populate weather data into CoordinatorData
-
-### Files to Update for Documentation
-
-11. **`docs/ARCHITECTURE.md`**
-    - Add WeatherCorrelation component to architecture diagram
-    - Document weather data flow
-
-12. **`docs/ENTITY_REFERENCE.md`**
-    - Document new weather-related sensor attributes
+1. **`custom_components/localshift/computation_engine_lib/forecast_computer.py`**
+   
+   **Changes in `compute_forecast()` method:**
+   - Initialize `remaining_negative_fit_headroom_kwh` as a mutable variable
+   - Decrement `remaining_negative_fit_headroom_kwh` after each proactive export
+   - Pass `first_negative_fit_start` datetime for timing check
+   - Pass `remaining_negative_fit_headroom_kwh` (mutable) instead of static `negative_fit_headroom_kwh`
+   
+   **Changes in `_should_proactive_export_at_slot()` method:**
+   - Add `first_negative_fit_start: datetime | None` parameter
+   - Add `remaining_headroom_kwh: float` parameter (mutated by caller via return)
+   - Add timing check: only export if `slot_start < first_negative_fit_start`
+   - Add SOC buffer check: require `predicted_soc >= export_min_soc_pct + 5%`
+   - Return updated `remaining_headroom_kwh` as third return value
 
 [Functions]
 
-### New Functions
-
-1. **`WeatherCorrelation.__init__()`** (`weather_correlation.py`)
-   - Initialize with hass, entry, storage
-   - Load persisted coefficients from storage
-
-2. **`WeatherCorrelation.async_load()`** (`weather_correlation.py`)
-   - Load data from HA storage
-   - Return WeatherCorrelationData
-
-3. **`WeatherCorrelation.async_save()`** (`weather_correlation.py`)
-   - Persist coefficients to HA storage
-
-4. **`WeatherCorrelation.learn_from_sample()`** (`weather_correlation.py`)
-   - Update coefficients based on observed temperature/load pair
-   - Signature: `(hour: int, temperature: float, actual_load_kw: float) -> None`
-   - Incremental learning algorithm
-
-5. **`WeatherCorrelation.predict_load()`** (`weather_correlation.py`)
-   - Apply learned coefficients to predict load given temperature
-   - Signature: `(hour: int, temperature: float, base_load_kw: float) -> float`
-
-6. **`WeatherCorrelation.recalculate_coefficients()`** (`weather_correlation.py`)
-   - Full recalculation from historical data
-   - Called periodically (daily) to refine model
-
-7. **`WeatherCorrelation.get_temperature_forecast()`** (`weather_correlation.py`)
-   - Fetch forecasted temperatures from weather entity
-   - Return dict mapping hours to temperatures
-
-8. **`HistoryFetcher.async_get_historical_temperatures()`** (`history_fetcher.py`)
-   - Fetch historical temperature data from weather entity or statistics
-   - Return list of (datetime, temperature) tuples
-
-9. **`ForecastComputer._get_weather_adjusted_load()`** (`forecast_computer.py`)
-   - Apply weather correlation to base load estimate
-   - Signature: `(hour: int, base_load_kw: float, temperature: float | None) -> tuple[float, str]`
-
 ### Modified Functions
 
-10. **`ForecastComputer._estimate_hourly_consumption_kw()`** (`forecast_computer.py`)
-    - Current location: lines ~150-200
-    - Modification: Call `_get_weather_adjusted_load()` after base calculation
-    - Apply temperature-based adjustment when temperature forecast available
+1. **`_should_proactive_export_at_slot()`** (`forecast_computer.py`, ~line 1100)
+   
+   **Current signature:**
+   ```python
+   def _should_proactive_export_at_slot(
+       self,
+       slot_start: datetime,
+       slot_hour: int,
+       solar_kwh: float,
+       slot_fit_price: float,
+       predicted_soc: float,
+       target_pct: float,
+       in_demand_window: bool,
+       forecasted_excess_kwh: float,
+       remaining_export_budget_kwh: float,
+       feed_in_forecast: list[dict],
+       min_soc_no_exports: float,
+       export_min_soc_pct: float,
+       effective_cheap_price: float,
+       feed_in_price_current: float,
+       all_solcast: list[dict] | None = None,
+       historical_avg_kw: dict[int, float] | None = None,
+       current_load_kw: float = 0.0,
+       recent_load_kw: float = 0.0,
+       is_current_slot: bool = False,
+       current_elapsed_minutes: float = 0,
+       fill_point_elapsed_minutes: int | None = None,
+       negative_fit_headroom_kwh: float = 0.0,
+       in_negative_fit_window: bool = False,
+   ) -> tuple[bool, float]:
+   ```
+   
+   **New signature:**
+   ```python
+   def _should_proactive_export_at_slot(
+       self,
+       slot_start: datetime,
+       slot_hour: int,
+       solar_kwh: float,
+       slot_fit_price: float,
+       predicted_soc: float,
+       target_pct: float,
+       in_demand_window: bool,
+       forecasted_excess_kwh: float,
+       remaining_export_budget_kwh: float,
+       feed_in_forecast: list[dict],
+       min_soc_no_exports: float,
+       export_min_soc_pct: float,
+       effective_cheap_price: float,
+       feed_in_price_current: float,
+       all_solcast: list[dict] | None = None,
+       historical_avg_kw: dict[int, float] | None = None,
+       current_load_kw: float = 0.0,
+       recent_load_kw: float = 0.0,
+       is_current_slot: bool = False,
+       current_elapsed_minutes: float = 0,
+       fill_point_elapsed_minutes: int | None = None,
+       negative_fit_headroom_kwh: float = 0.0,  # Now mutated via return
+       in_negative_fit_window: bool = False,
+       first_negative_fit_start: datetime | None = None,  # NEW: timing gate
+   ) -> tuple[bool, float, float]:  # NEW: returns (should_export, amount, updated_headroom)
+   ```
+   
+   **Key logic changes:**
+   ```python
+   # MODE 1: NEGATIVE FIT AVOIDANCE
+   if negative_fit_headroom_kwh > 0 and not in_negative_fit_window:
+       # NEW: Only export BEFORE the negative FIT window starts
+       if first_negative_fit_start is not None and slot_start >= first_negative_fit_start:
+           _LOGGER.debug(
+               "PROACTIVE_EXPORT: %02d:%02d BLOCKED - slot is at/after negative FIT window start %s",
+               slot_hour, slot_start.minute, first_negative_fit_start.strftime("%H:%M")
+           )
+           return False, 0.0, negative_fit_headroom_kwh
+       
+       # NEW: Require SOC buffer (min + 5%)
+       required_soc_for_export = export_min_soc_pct + PROACTIVE_EXPORT_SOC_BUFFER_PCT
+       if predicted_soc < required_soc_for_export:
+           _LOGGER.debug(
+               "PROACTIVE_EXPORT: %02d:%02d BLOCKED - SOC %.1f%% < min+buffer %.1f%%",
+               slot_hour, slot_start.minute, predicted_soc, required_soc_for_export
+           )
+           return False, 0.0, negative_fit_headroom_kwh
+       
+       # ... existing FIT > 0 check ...
+       
+       # Calculate export amount
+       export_amount = min(negative_fit_headroom_kwh, available_above_min_kwh, max_export_rate_kwh)
+       
+       if export_amount > 0:
+           # NEW: Decrement headroom
+           updated_headroom = negative_fit_headroom_kwh - export_amount
+           _LOGGER.info(
+               "PROACTIVE_EXPORT: %02d:%02d NEGATIVE_FIT_AVOIDANCE - FIT=$%.3f, headroom=%.2f->%.2f kWh, exporting=%.3f kWh, SOC=%.1f%%",
+               slot_hour, slot_start.minute, use_price,
+               negative_fit_headroom_kwh, updated_headroom, export_amount, predicted_soc
+           )
+           return True, round(export_amount, 3), updated_headroom
+       
+       return False, 0.0, negative_fit_headroom_kwh
+   ```
 
-11. **`ConfigFlow.async_step_solcast()`** (`config_flow.py`)
-    - Add weather entity selector
-    - Validate weather entity exists
-
-12. **`OptionsFlow.async_step_init()`** (`config_flow.py`)
-    - Add temperature threshold sliders
-    - Add enable/disable toggle for weather learning
-
-13. **`LocalShiftCoordinator.async_start()`** (`coordinator.py`)
-    - Initialize WeatherCorrelation instance
-    - Load persisted coefficients
-
-14. **`LocalShiftCoordinator._handle_periodic_tick()`** (`coordinator.py`)
-    - Trigger learning update with current temperature/load observation
-
-15. **`StateReader.read_all_external_state()`** (`state_reader.py`)
-    - Add call to `_read_weather_state()`
+2. **`compute_forecast()`** (`forecast_computer.py`, ~line 1400)
+   
+   **Changes:**
+   ```python
+   # Find first negative FIT window start time
+   first_negative_fit_start = None
+   if negative_fit_windows:
+       first_negative_fit_start = negative_fit_windows[0][0]  # (start, end, min_price)
+   
+   # Initialize mutable headroom
+   remaining_negative_fit_headroom_kwh = negative_fit_headroom_kwh
+   
+   # In the slot loop, update call:
+   should_proactive_export, proactive_export_amount, remaining_negative_fit_headroom_kwh = (
+       self._should_proactive_export_at_slot(
+           # ... existing params ...
+           negative_fit_headroom_kwh=remaining_negative_fit_headroom_kwh,  # Pass mutable
+           in_negative_fit_window=in_negative_fit_window,
+           first_negative_fit_start=first_negative_fit_start,  # NEW
+       )
+   )
+   ```
 
 [Classes]
 
-### New Classes
-
-1. **`WeatherCorrelation`** (`weather_correlation.py`)
-   - Main class for weather-based consumption prediction
-   - Key methods:
-     - `async_initialize()` - Load from storage, setup
-     - `async_learn()` - Process new observation
-     - `predict_adjustment()` - Calculate load adjustment
-     - `get_diagnostics()` - Return learning stats
-   - Uses HA's `storage.Store` for persistence
-
-### Modified Classes
-
-2. **`HistoryFetcher`** (`history_fetcher.py`)
-   - Add temperature fetching capability
-   - New property: `_historical_temperatures: list[tuple[datetime, float]]`
-   - New method: `async_get_historical_temperatures()`
-
-3. **`ForecastComputer`** (`forecast_computer.py`)
-   - Add weather correlation reference
-   - Modify consumption estimation to include weather adjustment
-   - New property: `_weather_correlation: WeatherCorrelation | None`
-
-4. **`CoordinatorData`** (`coordinator_data.py`)
-   - Add weather-related fields (see Files section)
-
-5. **`LocalShiftCoordinator`** (`coordinator.py`)
-   - Add WeatherCorrelation instance
-   - Add weather entity to monitored entities
+No class changes required. Only method modifications.
 
 [Dependencies]
 
-### New Dependencies
-
-No new external dependencies required. All functionality uses built-in Home Assistant APIs:
-
-- `homeassistant.helpers.storage.Store` - For persistent coefficient storage
-- `homeassistant.components.weather` - For weather entity integration
-- `homeassistant.components.recorder.statistics` - For historical temperature data (already used)
-
-### Integration Dependencies
-
-The feature depends on:
-- Weather entity configured in Home Assistant (e.g., `weather.home`, BOM integration, OpenWeatherMap)
-- Weather entity must provide temperature forecasts (most weather integrations do)
+No new dependencies.
 
 [Testing]
 
-### Test Files Required
+### Test Cases Required
 
-1. **`tests/test_weather_correlation.py`** (~300 lines)
-   - Test `HourlyTemperatureCoefficients` dataclass
-   - Test `WeatherCorrelationData` serialization
-   - Test `learn_from_sample()` coefficient updates
-   - Test `predict_load()` accuracy
-   - Test storage save/load
-   - Test edge cases (no data, extreme temperatures)
+1. **Headroom decrements after export**
+   - Given: headroom = 5.0 kWh
+   - When: export 2.0 kWh
+   - Then: remaining_headroom = 3.0 kWh
 
-2. **`tests/test_forecast_computer_weather.py`** (~150 lines)
-   - Test `_get_weather_adjusted_load()` function
-   - Test integration with `_estimate_hourly_consumption_kw()`
-   - Test fallback when no temperature data
+2. **No export after negative FIT window starts**
+   - Given: negative FIT window starts at 08:00
+   - When: slot_time = 08:15
+   - Then: should_export = False
 
-3. **`tests/test_config_flow_weather.py`** (~100 lines)
-   - Test weather entity validation
-   - Test options flow for temperature thresholds
+3. **Export before negative FIT window**
+   - Given: negative FIT window starts at 08:00, headroom = 5 kWh, SOC = 50%
+   - When: slot_time = 07:45, FIT = $0.10
+   - Then: should_export = True
 
-### Test Scenarios
+4. **No export when SOC below buffer**
+   - Given: min_soc = 10%, buffer = 5%, SOC = 12%
+   - When: headroom > 0, FIT > 0
+   - Then: should_export = False (SOC < 15%)
 
-1. **Learning Accuracy**
-   - Given: 7 days of temperature/load observations
-   - When: Model learns coefficients
-   - Then: Predictions within 20% of actual for temperature extremes
-
-2. **Hot Day Prediction**
-   - Given: 35°C forecast for 2 PM, learned cooling_coefficient = 0.15 kW/°C
-   - When: Predicting load
-   - Then: Load = base + (35-24) × 0.15 = base + 1.65 kW
-
-3. **Cold Day Prediction**
-   - Given: 10°C forecast for 7 AM, learned heating_coefficient = 0.10 kW/°C
-   - When: Predicting load
-   - Then: Load = base + (18-10) × 0.10 = base + 0.8 kW
-
-4. **Mild Day Prediction**
-   - Given: 22°C forecast (within 18-24°C band)
-   - When: Predicting load
-   - Then: Load = base (no adjustment)
-
-5. **No Weather Entity**
-   - Given: Weather entity not configured
-   - When: System starts
-   - Then: Falls back to historical averages only (no errors)
-
-6. **Storage Persistence**
-   - Given: Learned coefficients from 30 days of data
-   - When: Home Assistant restarts
-   - Then: Coefficients loaded from storage, predictions continue
+5. **Export stops when headroom exhausted**
+   - Given: headroom = 1.0 kWh
+   - When: export 1.0 kWh
+   - Then: remaining_headroom = 0, subsequent exports blocked
 
 [Implementation Order]
 
-1. **Phase 1: Data Structures and Storage**
-   - Add constants to `const.py`
-   - Create `HourlyTemperatureCoefficients` and `WeatherCorrelationData` dataclasses
-   - Add weather fields to `CoordinatorData`
-
-2. **Phase 2: WeatherCorrelation Class**
-   - Implement `WeatherCorrelation` class with storage
-   - Implement `learn_from_sample()` method
-   - Implement `predict_load()` method
-   - Write unit tests for WeatherCorrelation
-
-3. **Phase 3: Configuration**
-   - Add weather entity selector to config flow
-   - Add temperature threshold options
-   - Validate weather entity configuration
-
-4. **Phase 4: Data Collection**
-   - Add `_read_weather_state()` to StateReader
-   - Add `async_get_historical_temperatures()` to HistoryFetcher
-   - Wire weather entity into coordinator
-
-5. **Phase 5: Integration with ForecastComputer**
-   - Add `_get_weather_adjusted_load()` method
-   - Modify `_estimate_hourly_consumption_kw()` to use weather adjustment
-   - Add temperature forecast fetching
-
-6. **Phase 6: Learning Loop**
-   - Trigger learning on periodic tick
-   - Store observations (temperature, actual load)
-   - Update coefficients incrementally
-
-7. **Phase 7: Diagnostics and Sensors**
-   - Add `WeatherCorrelationSensor` for visibility
-   - Add weather attributes to forecast sensor
-   - Update documentation
-
-8. **Phase 8: Testing and Validation**
-   - Complete test coverage
-   - Integration testing
-   - Manual validation with real data
+1. Add `PROACTIVE_EXPORT_SOC_BUFFER_PCT = 5.0` constant
+2. Modify `_should_proactive_export_at_slot()` signature and logic
+3. Modify `compute_forecast()` to track first_negative_fit_start
+4. Modify `compute_forecast()` to use mutable headroom variable
+5. Update the function call in the slot loop
+6. Add/update unit tests
+7. Run integration tests with high-solar-negative-fit scenario

--- a/tests/test_hybrid_timescale.py
+++ b/tests/test_hybrid_timescale.py
@@ -205,7 +205,8 @@ class TestFifteenMinSlots:
         base_time = datetime(2024, 6, 15, 8, 0, 0)
 
         # Test with a slot in the forecast
-        should_export, amount = computer._should_proactive_export_at_slot(
+        # Returns: (should_export: bool, amount: float, negative_fit_headroom_kwh)
+        should_export, amount, headroom = computer._should_proactive_export_at_slot(
             slot_start=base_time + timedelta(minutes=30),
             slot_hour=8,
             solar_kwh=0.5,
@@ -227,11 +228,13 @@ class TestFifteenMinSlots:
             is_current_slot=True,
             current_elapsed_minutes=30.0,
             fill_point_elapsed_minutes=360,
+            negative_fit_headroom_kwh=0.0,
         )
 
         # Should return valid results
         assert isinstance(should_export, bool)
         assert isinstance(amount, int | float)
+        assert isinstance(headroom, float)
         assert amount >= 0
 
     def test_edge_case_no_fill_point(


### PR DESCRIPTION
## Summary
Implements a proactive export strategy to avoid exporting solar at negative FIT (Feed-in Tariff) prices.

## Problem
When there's a negative FIT window coming, the system currently waits until the battery fills and then exports at negative prices, losing money.

## Solution
1. Detect upcoming negative FIT windows in the 24-hour forecast
2. Calculate solar energy that would be produced during negative FIT periods (after battery fills)
3. Create headroom by exporting BEFORE the negative FIT window at positive prices
4. Maximize revenue by avoiding negative FIT losses

## Changes Made
- Added `_calculate_solar_during_negative_fit` method to ForecastComputer
- Modified `_should_proactive_export_at_slot` to prioritize negative FIT avoidance over price arbitrage
- Added negative FIT headroom calculation in `compute_forecast`
- Updated method signature to return 3-tuple (should_export, amount, headroom)
- Updated test_hybrid_timescale.py for new return signature

## Algorithm
1. Find negative FIT windows in 24-hour forecast
2. Calculate solar energy during those windows (only after battery fill point)
3. Calculate headroom needed = solar during negative FIT - battery space at fill
4. Export proactively at positive FIT to create headroom

## Testing
- All 338 existing tests pass
- Updated test_hybrid_timescale.py for new 3-tuple return

## Benefits
- Avoids exporting solar at negative prices
- Maximizes revenue from excess solar
- Maintains battery reserve for overnight demand

Closes #73