### PR TITLE
perf: remove pytest from pre-commit hooks for faster development

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,11 +17,3 @@ repos:
     hooks:
       - id: pyright
 
-  - repo: local
-    hooks:
-      - id: pytest
-        name: pytest
-        entry: .venv/bin/python3 -m pytest
-        language: system
-        pass_filenames: false
-        always_run: false


### PR DESCRIPTION
## Summary
Remove pytest from pre-commit hooks to dramatically speed up development workflow.

## Problem
Running 338 tests on every commit was slowing down development significantly. Each commit required waiting for the full test suite to complete.

## Solution
Remove the local pytest hook from pre-commit configuration. Tests should still be run:
- Manually before important commits
- In CI/CD pipeline
- When developing specific features: `pytest tests/test_specific_file.py`

## What's Still Checked
Pre-commit still runs fast checks:
- **ruff** - linting + formatting
- **vulture** - dead code detection  
- **pyright** - type checking

## Testing
Verified pre-commit runs successfully with only the remaining hooks.

## Impact
- Commits will be near-instant instead of waiting for 338 tests
- Tests remain valuable but run when developer chooses
- Standard pattern used by most Python projects