### PR TITLE
fix: decision log always showing 'no change' and enum display names

### DIFF
--- a/custom_components/localshift/computation_engine.py
+++ b/custom_components/localshift/computation_engine.py
@@ -1228,17 +1228,21 @@ class ComputationEngine:
         old_mode = self._previous_active_mode
         new_mode = data.active_mode
 
+        # Get friendly display names for modes
+        old_mode_display = old_mode.display_name if old_mode else "Unknown"
+        new_mode_display = new_mode.display_name if new_mode else "Unknown"
+
         if mode_change:
-            reason = f"Mode changed: {old_mode} -> {new_mode}"
-            # Only update previous mode when it actually changed
-            self._previous_active_mode = new_mode
+            reason = f"Mode changed: {old_mode_display} -> {new_mode_display}"
         else:
-            reason = f"Status update: {new_mode} (no change)"
+            reason = f"Status update: {new_mode_display}"
 
         entry = {
             "timestamp": now_dt.isoformat(),
-            "old_mode": old_mode if old_mode else "unknown",
-            "new_mode": new_mode,
+            "old_mode": old_mode.value if old_mode else "unknown",
+            "new_mode": new_mode.value if new_mode else "unknown",
+            "old_mode_display": old_mode_display,
+            "new_mode_display": new_mode_display,
             "buy_price": round(data.general_price, 2),
             "sell_price": round(data.feed_in_price, 2),
             "soc": round(data.soc),
@@ -1250,6 +1254,8 @@ class ComputationEngine:
         if len(data.decision_log) > 50:
             data.decision_log = data.decision_log[-50:]
 
+        # Always update previous mode so mode changes can be detected correctly
+        self._previous_active_mode = new_mode
         self._last_decision_log_time = now_dt
 
     def _get_expected_load_kw(

--- a/custom_components/localshift/const.py
+++ b/custom_components/localshift/const.py
@@ -26,6 +26,20 @@ class BatteryMode(str, Enum):
     DEMAND_BLOCK = "demand_block"
     MANUAL = "manual"
 
+    @property
+    def display_name(self) -> str:
+        """Return a user-friendly display name for the mode."""
+        names = {
+            BatteryMode.SELF_CONSUMPTION: "Self Consumption",
+            BatteryMode.GRID_CHARGING: "Grid Charging",
+            BatteryMode.BOOST_CHARGING: "Boost Charging",
+            BatteryMode.SPIKE_DISCHARGE: "Spike Discharge",
+            BatteryMode.PROACTIVE_EXPORT: "Proactive Export",
+            BatteryMode.DEMAND_BLOCK: "Demand Block",
+            BatteryMode.MANUAL: "Manual",
+        }
+        return names[self]
+
 
 # Teslemetry export modes (select.allow_export options)
 TESLEMETRY_EXPORT_PV_ONLY = "pv_only"


### PR DESCRIPTION
## Summary
Fixed two issues with the decision log:
1. Bug where `_previous_active_mode` was never updated, causing "(no change)" to appear on every entry
2. Enum values displayed as `BatteryMode.MANUAL` instead of friendly names

## Changes Made
- Fixed bug where `_previous_active_mode` was only updated when `mode_change=True`, creating a chicken-and-egg problem that prevented mode changes from ever being detected
- Added `display_name` property to `BatteryMode` enum for user-friendly strings
- Updated decision log to use friendly display names (e.g., "Manual" instead of "BatteryMode.MANUAL")
- Added `old_mode_display` and `new_mode_display` fields to log entries

## Testing
- All 337 tests pass
- Pre-commit hooks pass (ruff, ruff-format, vulture, pyright)

## Before
```
Status update: BatteryMode.MANUAL (no change)
```

## After
```
Status update: Manual
Mode changed: Self Consumption -> Grid Charging
```