### PR TITLE
fix: wire up weather correlation learning to coordinator

### DIFF
--- a/custom_components/localshift/coordinator.py
+++ b/custom_components/localshift/coordinator.py
@@ -236,6 +236,9 @@ class LocalShiftCoordinator:
         # Also fetch recent 1-hour load average for weighted forecasting
         await self._computation_engine.async_get_recent_load_1hr(load_entity_id)
 
+        # Initialize weather correlation for temperature-based load prediction
+        await self._computation_engine.async_initialize_weather_correlation()
+
         # Wait for Solcast data to be ready before computing forecasts
         # This prevents errors when Solcast hasn't initialized yet
         await self._wait_for_solcast_and_compute()
@@ -447,6 +450,14 @@ class LocalShiftCoordinator:
 
         # Cost accumulation uses the raw state we just read (sync, no lock needed)
         self._accumulate_costs()
+
+        # Learn from current temperature/load for weather correlation
+        # This runs asynchronously and won't block the periodic tick
+        if self._computation_engine is not None:
+            self.hass.async_create_task(
+                self._computation_engine.async_learn_weather_sample(self.data),
+                "localshift_weather_learning",
+            )
 
         # Derived-value computation and listener notification happen inside the
         # evaluate lock so that back-to-back periodic ticks don't concurrently


### PR DESCRIPTION
## Summary
The weather correlation feature was implemented but never connected to the coordinator lifecycle, causing "Samples: 0" and "Confidence: low" to always show on the dashboard.

## Changes Made
- Added call to `async_initialize_weather_correlation()` during coordinator startup
- Added call to `async_learn_weather_sample()` during each periodic tick (1-minute interval)

## Root Cause
The `weather_correlation.py` module and its learning methods in `computation_engine.py` were fully implemented, but the glue code in `coordinator.py` was missing. The coordinator never initialized the weather correlation system and never triggered learning.

## Testing
- All 337 tests pass
- Pre-commit hooks (ruff, ruff-format, vulture, pyright) pass

## Expected Behavior After Fix
After deploying this fix, the Weather Correlation card on the dashboard will:
1. Initialize the learning system at startup
2. Accumulate samples every minute from temperature/load observations
3. Gradually increase confidence from "low" to "medium" to "high" as sample count grows (7+ samples = medium, 30+ samples = high)