### PR TITLE
fix: reschedule daily summary timer when options change

### DIFF
--- a/custom_components/localshift/__init__.py
+++ b/custom_components/localshift/__init__.py
@@ -53,5 +53,7 @@ async def _async_options_updated(
 ) -> None:
     """Handle options update — trigger a re-evaluation with new thresholds."""
     coordinator: LocalShiftCoordinator = entry.runtime_data
+    # Reschedule daily summary timer in case demand_window_end changed
+    coordinator.reschedule_daily_summary_timer()
     await coordinator.async_recompute_and_evaluate()
     _LOGGER.info("LocalShift options updated, re-evaluating")

--- a/custom_components/localshift/coordinator.py
+++ b/custom_components/localshift/coordinator.py
@@ -542,6 +542,34 @@ class LocalShiftCoordinator:
         self._notify_listeners()
         await self.async_evaluate_state_machine()
 
+    def reschedule_daily_summary_timer(self) -> None:
+        """Reschedule the daily summary timer with current demand_window_end.
+
+        Called when options are updated to pick up new notification time
+        without requiring a restart.
+        """
+        # Unsubscribe existing timer if present
+        if self._unsub_daily_summary is not None:
+            self._unsub_daily_summary()
+            self._unsub_daily_summary = None
+
+        # Schedule new timer with updated time
+        dw_end = self._parse_time_option(
+            CONF_DEMAND_WINDOW_END, DEFAULT_DEMAND_WINDOW_END
+        )
+        self._unsub_daily_summary = async_track_time_change(
+            self.hass,
+            self._handle_daily_summary,
+            hour=dw_end.hour,
+            minute=dw_end.minute,
+            second=0,
+        )
+        _LOGGER.info(
+            "Daily summary timer rescheduled for %02d:%02d",
+            dw_end.hour,
+            dw_end.minute,
+        )
+
     async def _evaluate_state_machine(self) -> None:
         """Compare desired mode with commanded mode and execute transitions."""
         if self._state_machine is not None and self._computation_engine is not None:


### PR DESCRIPTION
## Summary
The daily summary notification timer was set once at coordinator startup. If users changed `demand_window_end` in options, the timer required a restart to pick up the new time.

## Changes Made
- Added `reschedule_daily_summary_timer()` method to the coordinator that:
  - Unsubscribes the existing timer (if any)
  - Schedules a new timer with the updated time
  - Logs the reschedule action
- Called from `_async_options_updated()` in `__init__.py` to ensure the timer is updated immediately when options change

## Testing
- All 29 coordinator tests pass
- Pre-commit hooks pass (ruff, ruff-format, vulture, pyright)

Closes #27