### PR TITLE
feat: split forecast_daily sensor to resolve 16KB attribute limit

### DIFF
--- a/.clinerules
+++ b/.clinerules
@@ -282,15 +282,15 @@ Before committing changes that affect entities:
 2. Verify counts match in all documentation files
 3. Total entities = sensors + binary_sensors + switches + numbers + buttons
 
-### Current Entity Counts (as of 2026-02-20):
+### Current Entity Counts (as of 2026-02-21):
 | Category | Count |
 |----------|-------|
-| Sensors | 12 |
+| Sensors | 15 |
 | Binary Sensors | 9 |
 | Switches | 10 |
 | Numbers | 8 |
 | Buttons | 5 |
-| **Total** | **44** |
+| **Total** | **47** |
 
 When these counts change, update:
 - This file (`.clinerules`)

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ These are also available as number entities on the dashboard for quick adjustmen
 
 All entities are grouped under a single **LocalShift** device in Settings → Devices & Services.
 
-### Sensors (12)
+### Sensors (15)
 
 | Entity ID | Description |
 |---|---|
@@ -92,7 +92,10 @@ All entities are grouped under a single **LocalShift** device in Settings → De
 | `sensor.localshift_cost_electricity_net` | Net cost with import/export/savings/charge cost attributes |
 | `sensor.localshift_decision_log` | Mode change history with reasons |
 | `sensor.localshift_forecast_history` | Historical forecast predictions for comparison |
-| `sensor.localshift_forecast_daily` | Full 24-hour forecast with 15-minute granularity |
+| `sensor.localshift_forecast_daily` | Core 24-hour forecast with SOC, solar, and consumption data |
+| `sensor.localshift_forecast_prices` | Price forecast data for history collection |
+| `sensor.localshift_forecast_grid` | Grid interaction forecast data for history collection |
+| `sensor.localshift_forecast_diagnostics` | Diagnostic and debug data for the forecast system |
 | `sensor.localshift_target_soc_minimum` | Minimum target SOC for discharge modes |
 | `sensor.localshift_excess_solar_kwh` | Forecasted excess solar for load shifting |
 | `sensor.localshift_load_shift_signal` | Actionable signal for load-shifting automations |

--- a/custom_components/localshift/sensor.py
+++ b/custom_components/localshift/sensor.py
@@ -35,6 +35,10 @@ async def async_setup_entry(
         DecisionLogSensor(coordinator, entry),
         ForecastHistorySensor(coordinator, entry),
         DailyForecastSensor(coordinator, entry),
+        # New split sensors for Issue #37 (forecast history collection)
+        ForecastPricesSensor(coordinator, entry),
+        ForecastGridSensor(coordinator, entry),
+        ForecastDiagnosticsSensor(coordinator, entry),
         MinimumTargetSOCSensor(coordinator, entry),
         # Excess solar load shifting sensors (backlog-high-017)
         ExcessSolarSensor(coordinator, entry),
@@ -249,101 +253,236 @@ class ForecastHistorySensor(LocalShiftSensorBase):
 
 
 class DailyForecastSensor(LocalShiftSensorBase):
-    """Full 24-hour forecast with hourly breakdown."""
+    """Full 24-hour forecast with SOC, solar, and consumption data.
+
+    This sensor provides the core forecast data for dashboards and history.
+    Split from the original monolithic sensor to stay under 16KB limit (Issue #37).
+    """
 
     _attr_unique_id = "localshift_forecast_daily"
     _attr_name = "Forecast Daily"
     _attr_icon = "mdi:chart-bar"
 
     def _update_from_coordinator(self) -> None:
-        """Update with count of hourly entries."""
+        """Update with count of forecast slots."""
         self._attr_native_value = len(self.coordinator.data.daily_forecast)
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
-        """Return daily forecast with hourly breakdown."""
-        sample_counts = self.coordinator.data.consumption_hourly_sample_counts
-        profile_kw = self.coordinator.data.consumption_hourly_profile_kw
-        source_counts = self.coordinator.data.forecast_consumption_source_counts
-
-        # Debug: Include key 15-min slots for debugging grid import/export
-        # Show first 24 slots + every top of hour (to capture midday, evening etc)
-        debug_15min = []
-
-        for idx, slot in enumerate(self.coordinator.data.daily_forecast):
-            hour = slot.get("hour", 0)
-            minute = slot.get("minute", 0)
-            # Include: first 24 slots OR any slot at top of hour (minute == 0)
-            if idx < 24 or minute == 0:
-                debug_15min.append(
-                    {
-                        "hour": hour,
-                        "minute": minute,
-                        "soc": slot.get("predicted_soc"),
-                        "solar": slot.get("solar_kwh"),
-                        "load": slot.get("consumption_kwh"),
-                        "net": slot.get("net_kwh"),
-                        "grid_in": slot.get("grid_import_kwh"),
-                        "grid_out": slot.get("grid_export_kwh"),
-                        "grid_charge": slot.get("grid_charge", False),
-                        "grid_charge_boost": slot.get("grid_charge_boost", False),
-                        "proactive_export": slot.get("proactive_export", False),
-                        "export_amt": slot.get("export_amount_kwh", 0.0),
-                    }
-                )
-
-        # Calculate totals for diagnostics
-        total_grid_import = sum(slot.get("grid_in", 0) or 0 for slot in debug_15min)
-        total_grid_export = sum(slot.get("grid_out", 0) or 0 for slot in debug_15min)
-
-        # Build compact full-resolution slot list for the dashboard table.
-        # Short key names keep the total attribute size under the 16 KB HA recorder limit.
-        # Format: h=hour, m=minute, soc=predicted_soc%, sol/ld/net in kWh, gi/go=grid in/out kWh
+        """Return daily forecast with descriptive key names for clarity."""
+        # Build forecast slots with descriptive keys
+        # Each slot contains the essential time-series data for dashboards
         forecast_slots = []
         for slot in self.coordinator.data.daily_forecast:
             ts = slot.get("timestamp", "")
             forecast_slots.append(
                 {
                     "time": ts[11:16] if len(ts) >= 16 else "",  # "HH:MM"
-                    "h": slot.get("hour", 0),
-                    "m": slot.get("minute", 0),
-                    "soc": slot.get("predicted_soc"),
-                    "sol": slot.get("solar_kwh"),
-                    "ld": slot.get("consumption_kwh"),
-                    "net": slot.get("net_kwh"),
-                    "gi": slot.get("grid_import_kwh"),
-                    "go": slot.get("grid_export_kwh"),
-                    "gc": slot.get("grid_charge", False),
-                    "pe": slot.get("proactive_export", False),
-                    "bp": slot.get("buy_price"),
-                    "sp": slot.get("sell_price"),
+                    "hour": slot.get("hour", 0),
+                    "minute": slot.get("minute", 0),
+                    "predicted_soc": slot.get("predicted_soc"),
+                    "solar_kwh": slot.get("solar_kwh"),
+                    "consumption_kwh": slot.get("consumption_kwh"),
+                    "net_kwh": slot.get("net_kwh"),
+                    "buy_price": slot.get("buy_price"),
+                    "sell_price": slot.get("sell_price"),
+                }
+            )
+
+        # SOC series for graphing (lightweight format)
+        soc_series = []
+        for slot in self.coordinator.data.daily_forecast_soc_15min:
+            if len(slot) >= 2:
+                soc_series.append({"time": slot[0], "soc": slot[1]})
+
+        return {
+            # Core forecast data (96 slots × 8 fields ≈ 8KB)
+            "forecast_slots": forecast_slots,
+            # SOC time series for graphing
+            "soc_series": soc_series,
+            # Summary counts
+            "slot_count": len(self.coordinator.data.daily_forecast),
+            "solcast_today_entries": len(self.coordinator.data.solcast_today),
+            "solcast_tomorrow_entries": len(self.coordinator.data.solcast_tomorrow),
+            # Hourly summary for quick reference
+            "forecast_hourly": self.coordinator.data.daily_forecast_hourly,
+        }
+
+
+class ForecastPricesSensor(LocalShiftSensorBase):
+    """Price forecast data for history collection.
+
+    Split from DailyForecastSensor to stay under 16KB limit (Issue #37).
+    Provides buy/sell price time series for analysis and dashboards.
+    """
+
+    _attr_unique_id = "localshift_forecast_prices"
+    _attr_name = "Forecast Prices"
+    _attr_icon = "mdi:currency-usd"
+
+    def _update_from_coordinator(self) -> None:
+        """Update with current effective cheap price."""
+        self._attr_native_value = round(self.coordinator.data.effective_cheap_price, 4)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return price forecast data."""
+        # Build price time series with descriptive keys
+        buy_prices = []
+        sell_prices = []
+
+        for slot in self.coordinator.data.daily_forecast:
+            ts = slot.get("timestamp", "")
+            time_str = ts[11:16] if len(ts) >= 16 else ""
+            buy_prices.append(
+                {
+                    "time": time_str,
+                    "hour": slot.get("hour", 0),
+                    "minute": slot.get("minute", 0),
+                    "price": slot.get("buy_price"),
+                }
+            )
+            sell_prices.append(
+                {
+                    "time": time_str,
+                    "hour": slot.get("hour", 0),
+                    "minute": slot.get("minute", 0),
+                    "price": slot.get("sell_price"),
                 }
             )
 
         return {
-            # All forecast slots in compact form (short keys keep attribute under 16 KB limit).
-            "forecast_slots": forecast_slots,
-            "debug_15min_slots": debug_15min,
-            "debug_total_grid_import_kwh": round(total_grid_import, 3),
-            "debug_total_grid_export_kwh": round(total_grid_export, 3),
-            # New debug fields for troubleshooting mode decisions
-            "debug_forecast_slot_found": self.coordinator.data.debug_forecast_slot_found,
-            "debug_forecast_slot_time": self.coordinator.data.debug_forecast_slot_time,
-            "debug_first_forecast_slot_time": self.coordinator.data.debug_first_forecast_slot_time,
-            "debug_time_gap_seconds": round(
-                self.coordinator.data.debug_time_gap_seconds, 1
+            # Price time series (96 slots each ≈ 3KB total)
+            "buy_prices": buy_prices,
+            "sell_prices": sell_prices,
+            # Price thresholds
+            "effective_cheap_price": round(
+                self.coordinator.data.effective_cheap_price, 4
             ),
-            "debug_mode_source": self.coordinator.data.debug_mode_source,
-            "forecast_hourly": self.coordinator.data.daily_forecast_hourly,
-            "soc_series_15min": self.coordinator.data.daily_forecast_soc_15min,
-            "forecast_15min_slots": len(self.coordinator.data.daily_forecast),
-            "solcast_today_entries": len(self.coordinator.data.solcast_today),
-            "solcast_tomorrow_entries": len(self.coordinator.data.solcast_tomorrow),
-            "current_load_kw": round(self.coordinator.data.load_power_kw, 3),
+            "cheap_charge_stop_price": round(
+                self.coordinator.data.cheap_charge_stop_price, 4
+            ),
+            # Forecast cost totals (rest of today)
+            "forecast_import_cost": round(
+                self.coordinator.data.forecast_import_cost or 0.0, 2
+            ),
+            "forecast_export_revenue": round(
+                self.coordinator.data.forecast_export_revenue or 0.0, 2
+            ),
+            "forecast_net_cost": round(
+                self.coordinator.data.forecast_net_cost or 0.0, 2
+            ),
+            "forecast_grid_charge_cost": round(
+                self.coordinator.data.forecast_grid_charge_cost or 0.0, 2
+            ),
+            "forecast_proactive_export_revenue": round(
+                self.coordinator.data.forecast_proactive_export_revenue or 0.0, 2
+            ),
+        }
+
+
+class ForecastGridSensor(LocalShiftSensorBase):
+    """Grid interaction forecast data for history collection.
+
+    Split from DailyForecastSensor to stay under 16KB limit (Issue #37).
+    Provides grid import/export time series for analysis and dashboards.
+    """
+
+    _attr_unique_id = "localshift_forecast_grid"
+    _attr_name = "Forecast Grid"
+    _attr_icon = "mdi:transmission-tower"
+
+    def _update_from_coordinator(self) -> None:
+        """Update with total forecast grid import."""
+        total_import = sum(
+            slot.get("grid_import_kwh", 0) or 0
+            for slot in self.coordinator.data.daily_forecast
+        )
+        self._attr_native_value = round(total_import, 3)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return grid interaction forecast data."""
+        # Build grid interaction time series with descriptive keys
+        grid_interaction = []
+        total_import = 0.0
+        total_export = 0.0
+        grid_charge_slots = 0
+        proactive_export_slots = 0
+
+        for slot in self.coordinator.data.daily_forecast:
+            ts = slot.get("timestamp", "")
+            time_str = ts[11:16] if len(ts) >= 16 else ""
+            import_kwh = slot.get("grid_import_kwh", 0) or 0
+            export_kwh = slot.get("grid_export_kwh", 0) or 0
+            is_grid_charge = slot.get("grid_charge", False)
+            is_proactive_export = slot.get("proactive_export", False)
+
+            total_import += import_kwh
+            total_export += export_kwh
+            if is_grid_charge:
+                grid_charge_slots += 1
+            if is_proactive_export:
+                proactive_export_slots += 1
+
+            grid_interaction.append(
+                {
+                    "time": time_str,
+                    "hour": slot.get("hour", 0),
+                    "minute": slot.get("minute", 0),
+                    "grid_import_kwh": round(import_kwh, 4),
+                    "grid_export_kwh": round(export_kwh, 4),
+                    "grid_charge": is_grid_charge,
+                    "grid_charge_boost": slot.get("grid_charge_boost", False),
+                    "proactive_export": is_proactive_export,
+                    "export_amount_kwh": round(
+                        slot.get("export_amount_kwh", 0) or 0, 4
+                    ),
+                }
+            )
+
+        return {
+            # Grid interaction time series (96 slots × 8 fields ≈ 4KB)
+            "grid_interaction": grid_interaction,
+            # Summary totals
+            "total_grid_import_kwh": round(total_import, 3),
+            "total_grid_export_kwh": round(total_export, 3),
+            "grid_charge_slots": grid_charge_slots,
+            "proactive_export_slots": proactive_export_slots,
+        }
+
+
+class ForecastDiagnosticsSensor(LocalShiftSensorBase):
+    """Diagnostic and debug data for the forecast system.
+
+    Split from DailyForecastSensor to stay under 16KB limit (Issue #37).
+    Contains consumption profiles, weather correlation, and debug fields.
+    """
+
+    _attr_unique_id = "localshift_forecast_diagnostics"
+    _attr_name = "Forecast Diagnostics"
+    _attr_icon = "mdi:bug-outline"
+
+    def _update_from_coordinator(self) -> None:
+        """Update with consumption source."""
+        self._attr_native_value = self.coordinator.data.consumption_source
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return diagnostic and debug data."""
+        sample_counts = self.coordinator.data.consumption_hourly_sample_counts
+        profile_kw = self.coordinator.data.consumption_hourly_profile_kw
+        source_counts = self.coordinator.data.forecast_consumption_source_counts
+
+        return {
+            # Consumption profile information
             "consumption_source": self.coordinator.data.consumption_source,
             "consumption_statistic_id": self.coordinator.data.consumption_statistic_id,
             "consumption_profile_hours": self.coordinator.data.consumption_profile_hours,
             "consumption_fallback_hours": self.coordinator.data.consumption_fallback_hours,
+            "consumption_weighting": round(
+                self.coordinator.data.consumption_weighting, 2
+            ),
             "forecast_consumption_source_counts": dict(source_counts),
             "consumption_hourly_sample_counts": {
                 str(hour): count for hour, count in sorted(sample_counts.items())
@@ -352,11 +491,7 @@ class DailyForecastSensor(LocalShiftSensorBase):
                 str(hour): value for hour, value in sorted(profile_kw.items())
             },
             # Day-of-week aware consumption profiles (issue-60)
-            # consumption_profile_type: "weekday_weekend" means system has separate profiles
-            # "combined" means falling back to combined profile
             "consumption_profile_type": self.coordinator.data.consumption_profile_type,
-            # forecast_profile_selected: Which profile is actually being used for TODAY's forecast
-            # "weekday" (Mon-Fri), "weekend" (Sat-Sun), or "combined" (fallback)
             "forecast_profile_selected": self.coordinator.data.forecast_profile_selected,
             "weekday_sample_counts": {
                 str(hour): count
@@ -382,30 +517,22 @@ class DailyForecastSensor(LocalShiftSensorBase):
                     self.coordinator.data.weekend_hourly_profile_kw.items()
                 )
             },
+            # Recent load data
             "recent_load_1hr_kw": round(self.coordinator.data.recent_load_1hr_kw, 3),
             "recent_load_1hr_statistic_id": self.coordinator.data.recent_load_1hr_statistic_id,
             "recent_load_1hr_samples": self.coordinator.data.recent_load_1hr_samples,
             "recent_load_1hr_last_error": self.coordinator.data.recent_load_1hr_last_error,
-            "consumption_weighting": round(
-                self.coordinator.data.consumption_weighting, 2
+            "current_load_kw": round(self.coordinator.data.load_power_kw, 3),
+            # Debug fields for troubleshooting mode decisions
+            "debug_forecast_slot_found": self.coordinator.data.debug_forecast_slot_found,
+            "debug_forecast_slot_time": self.coordinator.data.debug_forecast_slot_time,
+            "debug_first_forecast_slot_time": self.coordinator.data.debug_first_forecast_slot_time,
+            "debug_time_gap_seconds": round(
+                self.coordinator.data.debug_time_gap_seconds, 1
             ),
+            "debug_mode_source": self.coordinator.data.debug_mode_source,
+            # Export permission
             "allow_export": self.coordinator.data.allow_export,
-            # Forecast cost totals (rest of today)
-            "forecast_import_cost": round(
-                self.coordinator.data.forecast_import_cost or 0.0, 2
-            ),
-            "forecast_export_revenue": round(
-                self.coordinator.data.forecast_export_revenue or 0.0, 2
-            ),
-            "forecast_net_cost": round(
-                self.coordinator.data.forecast_net_cost or 0.0, 2
-            ),
-            "forecast_grid_charge_cost": round(
-                self.coordinator.data.forecast_grid_charge_cost or 0.0, 2
-            ),
-            "forecast_proactive_export_revenue": round(
-                self.coordinator.data.forecast_proactive_export_revenue or 0.0, 2
-            ),
             # Weather correlation visibility (Issue #61)
             "weather_entity_id": self.coordinator.data.weather_entity_id,
             "weather_temperature_current": self.coordinator.data.weather_temperature_current,

--- a/dashboards/localshift.yaml
+++ b/dashboards/localshift.yaml
@@ -89,9 +89,9 @@ views:
                 type: line
                 extend_to: false
                 data_generator: |
-                  return (entity.attributes.soc_series_15min || []).map(function(entry) {
-                    // Convert ISO timestamp to epoch milliseconds for ApexCharts
-                    return [new Date(entry[0]).getTime(), entry[1]];
+                  return (entity.attributes.soc_series || []).map(function(entry) {
+                    // Convert ISO timestamp to Epoch milliseconds for ApexCharts
+                    return [new Date(entry.time).getTime(), entry.soc];
                   });
             yaxis:
               - min: 0
@@ -186,7 +186,7 @@ views:
 
           - type: markdown
             content: >
-              {% set forecast = 'sensor.localshift_forecast_daily' %}
+              {% set forecast = 'sensor.localshift_forecast_prices' %}
               {% set net = state_attr(forecast, 'forecast_net_cost') | float(0) %}
               {% if net >= 0 %}
               # 📊 ${{ net | round(2) }}
@@ -282,18 +282,18 @@ views:
 
           - type: markdown
             content: >
-              {% set forecast = 'sensor.localshift_forecast_daily' %}
-              {% set profile_type = state_attr(forecast, 'consumption_profile_type') %}
-              {% set profile_selected = state_attr(forecast, 'forecast_profile_selected') %}
-              {% set weekday_counts = state_attr(forecast, 'weekday_sample_counts') | default({}) %}
-              {% set weekend_counts = state_attr(forecast, 'weekend_sample_counts') | default({}) %}
-              {% set weather_enabled = state_attr(forecast, 'weather_learning_enabled') %}
-              {% set weather_entity = state_attr(forecast, 'weather_entity_id') %}
-              {% set weather_temp = state_attr(forecast, 'weather_temperature_current') %}
-              {% set weather_confidence = state_attr(forecast, 'weather_correlation_confidence') %}
-              {% set weather_samples = state_attr(forecast, 'weather_sample_count') %}
-              {% set recent_load = state_attr(forecast, 'recent_load_1hr_kw') %}
-              {% set weighting = state_attr(forecast, 'consumption_weighting') %}
+              {% set diagnostics = 'sensor.localshift_forecast_diagnostics' %}
+              {% set profile_type = state_attr(diagnostics, 'consumption_profile_type') %}
+              {% set profile_selected = state_attr(diagnostics, 'forecast_profile_selected') %}
+              {% set weekday_counts = state_attr(diagnostics, 'weekday_sample_counts') | default({}) %}
+              {% set weekend_counts = state_attr(diagnostics, 'weekend_sample_counts') | default({}) %}
+              {% set weather_enabled = state_attr(diagnostics, 'weather_learning_enabled') %}
+              {% set weather_entity = state_attr(diagnostics, 'weather_entity_id') %}
+              {% set weather_temp = state_attr(diagnostics, 'weather_temperature_current') %}
+              {% set weather_confidence = state_attr(diagnostics, 'weather_correlation_confidence') %}
+              {% set weather_samples = state_attr(diagnostics, 'weather_sample_count') %}
+              {% set recent_load = state_attr(diagnostics, 'recent_load_1hr_kw') %}
+              {% set weighting = state_attr(diagnostics, 'consumption_weighting') %}
               
               **📊 Consumption Profile**
               
@@ -580,190 +580,192 @@ views:
             content: >
               ```
               === DEBUG STATE SUMMARY ===
-
+              
               Time: {{ now().strftime('%Y-%m-%d %H:%M:%S') }}
-
+              
               === CURRENT STATE ===
-
+              
               Mode: {{ states('sensor.localshift_battery_mode') }}
-
+              
               SOC: {{ states('sensor.my_home_percentage_charged') }}%
-
+              
               Battery Power: {{ states('sensor.my_home_battery_power') }} kW
-
+              
               Grid Power: {{ states('sensor.my_home_grid_power') }} kW
-
+              
               Solar Power: {{ states('sensor.my_home_solar_power') }} kW
-
+              
               Buy Price: ${{ states('sensor.100h_general_price') }}/kWh
-
+              
               Sell Price: ${{ states('sensor.100h_feed_in_price') }}/kWh
-
+              
               Price Spike: {{ states('binary_sensor.100h_price_spike') }}
-
+              
               Demand Window: {{ states('binary_sensor.localshift_demand_window') }}
-
+              
               === INTERNAL STATE FLAGS ===
-
+              
               Manual Override: {{ states('switch.localshift_automation_enabled') == 'off' }}
-
+              
               Target Reached Today: {{ state_attr('sensor.localshift_forecast_battery', 'target_reached_today') }}
-
+              
               Forecast Spike Within Window: {{ states('binary_sensor.localshift_price_spike_coming') }}
-
+              
               Max Forecast Price: ${{ state_attr('binary_sensor.localshift_price_spike_coming', 'max_forecast_price') | default(0) }}/kWh
-
+              
               Max Buy Forecast Price: ${{ state_attr('binary_sensor.localshift_price_spike_coming', 'max_buy_forecast_price') | default(0) }}/kWh
-
+              
               Force Discharge Active: {{ states('sensor.localshift_battery_mode') == 'force_discharge' }}
-
+              
               Force Charge Active: {{ states('sensor.localshift_battery_mode') == 'force_charge' }}
-
+              
               Boost Charge Active: {{ states('sensor.localshift_battery_mode') == 'boost_charging' }}
-
+              
               Solar Can Reach Target: {{ states('binary_sensor.localshift_solar_can_reach_target') }}
-
+              
               Boost Charge Needed: {{ states('binary_sensor.localshift_charge_boost_needed') }}
-
-              === DEBUG: MODE DECISION ===
-
-              Mode Source: {{ state_attr('sensor.localshift_forecast_daily', 'debug_mode_source') | default('unknown') }}
-
-              Forecast Slot Found: {{ state_attr('sensor.localshift_forecast_daily', 'debug_forecast_slot_found') | default(false) }}
-
-              Forecast Slot Time: {{ state_attr('sensor.localshift_forecast_daily', 'debug_forecast_slot_time') | default('-') }}
-
-              First Forecast Slot: {{ state_attr('sensor.localshift_forecast_daily', 'debug_first_forecast_slot_time') | default('-') }}
-
-              Time Gap: {{ state_attr('sensor.localshift_forecast_daily', 'debug_time_gap_seconds') | default(0) }}s
-
+              
+              === DEBUG: MODE DECISION (from forecast_diagnostics) ===
+              
+              Mode Source: {{ state_attr('sensor.localshift_forecast_diagnostics', 'debug_mode_source') | default('unknown') }}
+              
+              Forecast Slot Found: {{ state_attr('sensor.localshift_forecast_diagnostics', 'debug_forecast_slot_found') | default(false) }}
+              
+              Forecast Slot Time: {{ state_attr('sensor.localshift_forecast_diagnostics', 'debug_forecast_slot_time') | default('-') }}
+              
+              First Forecast Slot: {{ state_attr('sensor.localshift_forecast_diagnostics', 'debug_first_forecast_slot_time') | default('-') }}
+              
+              Time Gap: {{ state_attr('sensor.localshift_forecast_diagnostics', 'debug_time_gap_seconds') | default(0) }}s
+              
               Dry Run: {{ states('switch.localshift_dry_run') == 'on' }}
-
+              
               === CONFIGURATION & THRESHOLDS ===
-
+              
               Cheap Price Percentile: {{ states('number.localshift_cheap_price_percentile') }}%
-
+              
               Max Pre-charge Price: ${{ states('number.localshift_max_pre_charge_price') }}/kWh
-
+              
               Price Deadband: {{ states('number.localshift_price_deadband') }}
-
+              
               Forecast Lookahead: {{ states('number.localshift_forecast_lookahead') }}h
-
+              
               Battery Target: {{ states('number.localshift_battery_target') }}%
-
+              
               Effective Cheap Price: ${{ states('sensor.localshift_price_cheap_effective') }}/kWh
-
+              
               Cheap Charge Stop Price: ${{ states('sensor.localshift_price_cheap_charge_stop') }}/kWh
-
+              
               Solar Weighted Avg FIT: ${{ states('sensor.localshift_solar_weighted_avg_fit') }}/kWh
-
+              
               Solar Remaining: {{ state_attr('sensor.localshift_solar_weighted_avg_fit', 'total_solar_remaining_kwh') | default(0) }} kWh
-
+              
               === FORECAST INFORMATION ===
-
+              
               Solar Battery Forecast SOC: {{ state_attr('sensor.localshift_forecast_battery', 'predicted_soc') | default(0) }}%
-
+              
               Forecast Deficit: {{ state_attr('sensor.localshift_forecast_battery', 'deficit_kwh') | default(0) }} kWh
-
+              
               Solar Before DW: {{ state_attr('sensor.localshift_forecast_battery', 'solar_before_dw_kwh') | default(0) }} kWh
-
+              
               Net Solar: {{ state_attr('sensor.localshift_forecast_battery', 'net_solar_kwh') | default(0) }} kWh
-
+              
               Hours to DW: {{ state_attr('sensor.localshift_forecast_battery', 'hours_to_target_time') | default(0) }}h
-
+              
               Can Reach Target: {{ state_attr('sensor.localshift_forecast_battery', 'can_reach_target') | default(true) }}
-
+              
               Boost Needed: {{ state_attr('sensor.localshift_forecast_battery', 'boost_needed') }}
-
+              
               Daily Forecast Entries: {{ states('sensor.localshift_forecast_daily') | int(default=0) }}
-
-              15-min Slots: {{ state_attr('sensor.localshift_forecast_daily', 'forecast_15min_slots') | default(0) }}
-
+              
+              Slot Count: {{ state_attr('sensor.localshift_forecast_daily', 'slot_count') | default(0) }}
+              
               Forecast Hourly Entries: {{ state_attr('sensor.localshift_forecast_daily', 'forecast_hourly') | default([]) | length }}
-
+              
               Solcast Today Entries: {{ state_attr('sensor.localshift_forecast_daily', 'solcast_today_entries') | default(0) }}
-
+              
               Solcast Tomorrow Entries: {{ state_attr('sensor.localshift_forecast_daily', 'solcast_tomorrow_entries') | default(0) }}
-
-              Current Load: {{ state_attr('sensor.localshift_forecast_daily', 'current_load_kw') | default(0) }} kW
-
-              Recent 1hr Load: {{ state_attr('sensor.localshift_forecast_daily', 'recent_load_1hr_kw') | default(0) }} kW
-
-              Recent 1hr Statistic ID: {{ state_attr('sensor.localshift_forecast_daily', 'recent_load_1hr_statistic_id') | default('') }}
-
-              Recent 1hr Samples: {{ state_attr('sensor.localshift_forecast_daily', 'recent_load_1hr_samples') | default(0) }}
-
-              Recent 1hr Error: {{ state_attr('sensor.localshift_forecast_daily', 'recent_load_1hr_last_error') | default('') }}
-
-              Consumption Weighting: {{ state_attr('sensor.localshift_forecast_daily', 'consumption_weighting') | default(0) }}
-
-              Consumption Source: {{ state_attr('sensor.localshift_forecast_daily', 'consumption_source') }}
-
-              Consumption Source Counts: {{ state_attr('sensor.localshift_forecast_daily', 'forecast_consumption_source_counts') | default({}) }}
-
-              Consumption Profile Hours: {{ state_attr('sensor.localshift_forecast_daily', 'consumption_profile_hours') | default(0) }}
-
-              Consumption Fallback Hours: {{ state_attr('sensor.localshift_forecast_daily', 'consumption_fallback_hours') | default(0) }}
-
+              
+              === FORECAST DIAGNOSTICS (from forecast_diagnostics sensor) ===
+              
+              Current Load: {{ state_attr('sensor.localshift_forecast_diagnostics', 'current_load_kw') | default(0) }} kW
+              
+              Recent 1hr Load: {{ state_attr('sensor.localshift_forecast_diagnostics', 'recent_load_1hr_kw') | default(0) }} kW
+              
+              Recent 1hr Statistic ID: {{ state_attr('sensor.localshift_forecast_diagnostics', 'recent_load_1hr_statistic_id') | default('') }}
+              
+              Recent 1hr Samples: {{ state_attr('sensor.localshift_forecast_diagnostics', 'recent_load_1hr_samples') | default(0) }}
+              
+              Recent 1hr Error: {{ state_attr('sensor.localshift_forecast_diagnostics', 'recent_load_1hr_last_error') | default('') }}
+              
+              Consumption Weighting: {{ state_attr('sensor.localshift_forecast_diagnostics', 'consumption_weighting') | default(0) }}
+              
+              Consumption Source: {{ state_attr('sensor.localshift_forecast_diagnostics', 'consumption_source') }}
+              
+              Consumption Source Counts: {{ state_attr('sensor.localshift_forecast_diagnostics', 'forecast_consumption_source_counts') | default({}) }}
+              
+              Consumption Profile Hours: {{ state_attr('sensor.localshift_forecast_diagnostics', 'consumption_profile_hours') | default(0) }}
+              
+              Consumption Fallback Hours: {{ state_attr('sensor.localshift_forecast_diagnostics', 'consumption_fallback_hours') | default(0) }}
+              
               === DECISION LOG ===
-
+              
               Latest Decision: {{ state_attr('sensor.localshift_decision_log', 'reason') | default('No decisions yet') }}
-
+              
               Latest SOC: {{ state_attr('sensor.localshift_decision_log', 'soc') }}%
-
+              
               Latest Buy Price: ${{ state_attr('sensor.localshift_decision_log', 'buy_price') }}/kWh
-
+              
               Latest Sell Price: ${{ state_attr('sensor.localshift_decision_log', 'sell_price') }}/kWh
-
+              
               Latest Timestamp: {{ state_attr('sensor.localshift_decision_log', 'timestamp') }}
-
+              
               Recent History:
               {% for entry in state_attr('sensor.localshift_decision_log', 'history') | default([]) | slice(-5) %}
                 - {{ entry.get('timestamp', '') }}: {{ entry.get('reason', '') }} (SOC: {{ entry.get('soc') }}%)
               {% endfor %}
-
+              
               === COST TRACKING ===
-
+              
               Net Cost Today: ${{ states('sensor.localshift_cost_electricity_net') }}
-
+              
               Import Cost: ${{ state_attr('sensor.localshift_cost_electricity_net', 'grid_import_cost') | default(0) }}
-
+              
               Export Revenue: ${{ state_attr('sensor.localshift_cost_electricity_net', 'grid_export_revenue') | default(0) }}
-
+              
               Battery Savings: ${{ state_attr('sensor.localshift_cost_electricity_net', 'battery_savings') | default(0) }}
-
+              
               Battery Charge Cost: ${{ state_attr('sensor.localshift_cost_electricity_net', 'battery_charge_cost') | default(0) }}
-
-              === WEATHER CORRELATION ===
-
-              Weather Entity: {{ state_attr('sensor.localshift_forecast_daily', 'weather_entity_id') | default('not configured') }}
-
-              Current Temperature: {{ state_attr('sensor.localshift_forecast_daily', 'weather_temperature_current') | default('N/A') }}°C
-
-              Weather Condition: {{ state_attr('sensor.localshift_forecast_daily', 'weather_condition') | default('unknown') }}
-
-              Learning Enabled: {{ state_attr('sensor.localshift_forecast_daily', 'weather_learning_enabled') }}
-
-              Confidence: {{ state_attr('sensor.localshift_forecast_daily', 'weather_correlation_confidence') | default('low') }}
-
-              Total Samples: {{ state_attr('sensor.localshift_forecast_daily', 'weather_sample_count') | default(0) }}
-
-              Cooling Coefficient: {{ state_attr('sensor.localshift_forecast_daily', 'weather_cooling_coefficient') | default(0) }} kW/°C
-
-              Heating Coefficient: {{ state_attr('sensor.localshift_forecast_daily', 'weather_heating_coefficient') | default(0) }} kW/°C
-
-              Adjustment Applied: {{ state_attr('sensor.localshift_forecast_daily', 'weather_adjustment_applied') | default(false) }}
-
-              Temperature Forecast: {{ state_attr('sensor.localshift_forecast_daily', 'weather_temperature_forecast') | default({}) }}
-
+              
+              === WEATHER CORRELATION (from forecast_diagnostics) ===
+              
+              Weather Entity: {{ state_attr('sensor.localshift_forecast_diagnostics', 'weather_entity_id') | default('not configured') }}
+              
+              Current Temperature: {{ state_attr('sensor.localshift_forecast_diagnostics', 'weather_temperature_current') | default('N/A') }}°C
+              
+              Weather Condition: {{ state_attr('sensor.localshift_forecast_diagnostics', 'weather_condition') | default('unknown') }}
+              
+              Learning Enabled: {{ state_attr('sensor.localshift_forecast_diagnostics', 'weather_learning_enabled') }}
+              
+              Confidence: {{ state_attr('sensor.localshift_forecast_diagnostics', 'weather_correlation_confidence') | default('low') }}
+              
+              Total Samples: {{ state_attr('sensor.localshift_forecast_diagnostics', 'weather_sample_count') | default(0) }}
+              
+              Cooling Coefficient: {{ state_attr('sensor.localshift_forecast_diagnostics', 'weather_cooling_coefficient') | default(0) }} kW/°C
+              
+              Heating Coefficient: {{ state_attr('sensor.localshift_forecast_diagnostics', 'weather_heating_coefficient') | default(0) }} kW/°C
+              
+              Adjustment Applied: {{ state_attr('sensor.localshift_forecast_diagnostics', 'weather_adjustment_applied') | default(false) }}
+              
+              Temperature Forecast: {{ state_attr('sensor.localshift_forecast_diagnostics', 'weather_temperature_forecast') | default({}) }}
+              
               === SYSTEM INFO ===
-
+              
               Operation Mode: {{ states('select.my_home_operation_mode') }}
-
+              
               Backup Reserve: {{ states('number.my_home_backup_reserve') }}%
-
+              
               Allow Export: {{ states('select.my_home_allow_export') }}
-
+              
               === END OF DEBUG SUMMARY ===
               ```
 
@@ -788,49 +790,53 @@ views:
           - type: markdown
             content: |
               ```
-              Time  | SOC (%) | Solar  | Load   | Net    | Grid In | Grid Out | GC | PE | Buy $  | Sell $
-              ------|---------|--------|--------|--------|---------|----------|----|----|---------|---------
+              Time  | SOC (%) | Solar  | Load   | Net    | Buy $  | Sell $
+              ------|---------|--------|--------|--------|--------|--------
               {%- for item in state_attr('sensor.localshift_forecast_daily', 'forecast_slots') | default([]) %}
-              {{ item.time }} | {{ "%.1f"|format(item.soc | float) }}     | {{ "%.3f"|format(item.sol | float) }} | {{ "%.3f"|format(item.ld | float) }} | {{ "%.3f"|format(item.net | float) }} | {{ "%.4f"|format(item.gi | float) }}     | {{ "%.4f"|format(item.go | float) }}     | {{ 'Y' if item.gc else '-' }}  | {{ 'Y' if item.pe else '-' }} | {{ "%.3f"|format(item.bp | float(0)) }} | {{ "%.3f"|format(item.sp | float(0)) }}
+              {{ item.time }} | {{ "%.1f"|format(item.predicted_soc | float) }}     | {{ "%.3f"|format(item.solar_kwh | float) }} | {{ "%.3f"|format(item.consumption_kwh | float) }} | {{ "%.3f"|format(item.net_kwh | float) }} | {{ "%.3f"|format(item.buy_price | float(0)) }} | {{ "%.3f"|format(item.sell_price | float(0)) }}
               {%- endfor %}
               ```
 
-      # --- Debug 15-min Slots ---
+      # --- Grid Interaction Forecast ---
       - type: grid
         cards:
           - type: heading
-            heading: Debug 15-min Forecast Slots
+            heading: Grid Interaction Forecast
             heading_style: title
 
           - type: markdown
             content: |
-              **Debug: Grid Import/Export Forecast (first 24 slots)**
-
-              First 24 x 15-min slots (next 6 hours):
-
+              **Summary:** {{ state_attr('sensor.localshift_forecast_grid', 'grid_charge_slots') | default(0) }} grid charge slots, {{ state_attr('sensor.localshift_forecast_grid', 'proactive_export_slots') | default(0) }} proactive export slots
+              
+              **Total Import:** {{ state_attr('sensor.localshift_forecast_grid', 'total_grid_import_kwh') | default(0) }} kWh
+              
+              **Total Export:** {{ state_attr('sensor.localshift_forecast_grid', 'total_grid_export_kwh') | default(0) }} kWh
+              
               ```
-              Slot | Time  | SOC  | Solar | Load  | Net   | GridIn | GridOut | Export | Buy   | Sell | Proactive
-              -----|-------|------|-------|-------|-------|--------|---------|--------|-------|------|-----------
-              {%- set general_forecast = state_attr('sensor.100h_general_forecast', 'forecasts') | default([]) %}
-              {%- set feedin_forecast = state_attr('sensor.100h_feed_in_forecast', 'forecasts') | default([]) %}
-              {%- for slot in state_attr('sensor.localshift_forecast_daily', 'debug_15min_slots')[:24] | default([]) %}
-              {%- set slot_minute = (slot.hour * 60 + slot.minute) %}
-              {%- set buy_price = namespace(value='-') %}
-              {%- set sell_price = namespace(value='-') %}
-              {%- for f in general_forecast %}
-                {%- set f_minute = (f.nem_date | as_datetime).hour * 60 + (f.nem_date | as_datetime).minute %}
-                {%- if buy_price.value == '-' and (slot_minute - 30) < f_minute <= (slot_minute + 30) %}
-                  {%- set buy_price.value = "%.2f"|format(f.per_kwh) %}
-                {%- endif %}
-              {%- endfor %}
-              {%- for f in feedin_forecast %}
-                {%- set f_minute = (f.nem_date | as_datetime).hour * 60 + (f.nem_date | as_datetime).minute %}
-                {%- if sell_price.value == '-' and (slot_minute - 30) < f_minute <= (slot_minute + 30) %}
-                  {%- set sell_price.value = "%.2f"|format(f.per_kwh) %}
-                {%- endif %}
-              {%- endfor %}
-              {%- set export_amt = "%.3f"|format(slot.export_amt) if slot.export_amt else '-' %}
-              {%- set proactive = 'YES' if slot.proactive_export else 'NO' %}
-              {{ loop.index }}    | {{ "%02d:%02d"|format(slot.hour, slot.minute) }}  | {{ "%.1f"|format(slot.soc) }}  | {{ "%.3f"|format(slot.solar) }} | {{ "%.3f"|format(slot.load) }} | {{ "%.3f"|format(slot.net) }} | {{ "%.3f"|format(slot.grid_in) }}    | {{ "%.3f"|format(slot.grid_out) }}     | {{ export_amt }}   | {{ buy_price.value }}  | {{ sell_price.value }} | {{ proactive }}
+              Time  | Grid In | Grid Out | GC | Boost | PE | Export
+              ------|---------|----------|----|-------|----|--------
+              {%- for item in state_attr('sensor.localshift_forecast_grid', 'grid_interaction') | default([]) %}
+              {{ item.time }} | {{ "%.4f"|format(item.grid_import_kwh | float) }} | {{ "%.4f"|format(item.grid_export_kwh | float) }} | {{ 'Y' if item.grid_charge else '-' }}  | {{ 'Y' if item.grid_charge_boost else '-' }}    | {{ 'Y' if item.proactive_export else '-' }}  | {{ "%.4f"|format(item.export_amount_kwh | float) }}
               {%- endfor %}
               ```
+
+      # --- Price Forecast ---
+      - type: grid
+        cards:
+          - type: heading
+            heading: Price Forecast
+            heading_style: title
+
+          - type: markdown
+            content: |
+              **Effective Cheap Price:** ${{ state_attr('sensor.localshift_forecast_prices', 'effective_cheap_price') | default(0) }}/kWh
+              
+              **Cheap Charge Stop Price:** ${{ state_attr('sensor.localshift_forecast_prices', 'cheap_charge_stop_price') | default(0) }}/kWh
+              
+              ```
+              Time  | Buy $  | Sell $
+              ------|--------|--------
+              {%- for item in state_attr('sensor.localshift_forecast_prices', 'buy_prices') | default([]) %}
+              {%- set sell_item = state_attr('sensor.localshift_forecast_prices', 'sell_prices')[loop.index0] | default({}) %}
+              {{ item.time }} | {{ "%.3f"|format(item.price | float(0)) }} | {{ "%.3f"|format(sell_item.price | float(0)) }}
+              {%- endfor %}

--- a/docs/ENTITY_REFERENCE.md
+++ b/docs/ENTITY_REFERENCE.md
@@ -4,11 +4,11 @@ Complete reference for all Home Assistant entities provided by the LocalShift in
 
 ## Overview
 
-The integration creates **44 entities** grouped under a single "LocalShift" device:
+The integration creates **47 entities** grouped under a single "LocalShift" device:
 
 | Category | Count | Entity Type |
 |----------|-------|-------------|
-| Sensors | 12 | `sensor` |
+| Sensors | 15 | `sensor` |
 | Binary Sensors | 9 | `binary_sensor` |
 | Switches | 10 | `switch` |
 | Numbers | 8 | `number` |
@@ -187,37 +187,163 @@ net_cost = grid_import_cost - grid_export_revenue
 
 ### 9. sensor.localshift_forecast_daily
 
-**Purpose:** Full 24-hour forecast with hybrid granularity (5-min near-term, 15-min long-term).
+**Purpose:** Core 24-hour forecast with SOC, solar, and consumption data.
 
-**State:** Count of forecast slots (112 total: 24 × 5-min + 88 × 15-min)
+Split from the original monolithic sensor to stay under Home Assistant's 16KB attribute limit (Issue #37). Related sensors: `forecast_prices`, `forecast_grid`, `forecast_diagnostics`.
+
+**State:** Count of forecast slots (96 × 15-min slots)
 
 **Attributes:**
 
 | Attribute | Type | Description |
 |-----------|------|-------------|
-| `forecast_slots` | list | All 112 forecast slots with compact keys |
+| `forecast_slots` | list | 96 slots with SOC, solar, consumption, prices |
+| `soc_series` | list | SOC time series for graphing `[{time, soc}, ...]` |
+| `slot_count` | int | Total number of forecast slots |
+| `solcast_today_entries` | int | Number of Solcast periods today |
+| `solcast_tomorrow_entries` | int | Number of Solcast periods tomorrow |
 | `forecast_hourly` | list | Hourly summary (24 entries) |
-| `soc_series_15min` | list | SOC at each slot |
-| `debug_15min_slots` | list | Key slots for debugging |
-| `forecast_15min_slots` | int | Total number of slots |
-| `solcast_today_entries` | int | Number of Solcast periods |
-| `solcast_tomorrow_entries` | int | Number of tomorrow periods |
-| `current_load_kw` | float | Current load estimation |
-| `consumption_source` | string | Source of consumption data |
-| `consumption_profile_hours` | int | Hours of profile data available |
-| `consumption_weighting` | float | Recent vs historical weighting |
-| `consumption_profile_type` | string | "weekday_weekend" or "combined_fallback" |
-| `weekday_sample_counts` | dict | Sample counts per hour for weekdays |
-| `weekend_sample_counts` | dict | Sample counts per hour for weekends |
-| `weekday_hourly_profile_kw` | dict | Weekday hourly consumption averages (kW) |
-| `weekend_hourly_profile_kw` | dict | Weekend hourly consumption averages (kW) |
-| `forecast_import_cost` | float | Expected grid import cost (rest of day) |
-| `forecast_export_revenue` | float | Expected grid export revenue (rest of day) |
-| `forecast_net_cost` | float | Expected net cost (rest of day) |
+
+**Forecast Slot Structure:**
+
+Each slot in `forecast_slots` contains:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `time` | string | HH:MM format |
+| `hour` | int | Hour (0-23) |
+| `minute` | int | Minute (0, 15, 30, 45) |
+| `predicted_soc` | float | Predicted battery SOC (%) |
+| `solar_kwh` | float | Solar production (kWh) |
+| `consumption_kwh` | float | Estimated consumption (kWh) |
+| `net_kwh` | float | Net energy (solar - consumption) |
+| `buy_price` | float | Buy price ($/kWh) |
+| `sell_price` | float | Sell price ($/kWh) |
 
 ---
 
-### 10. sensor.localshift_target_soc_minimum
+### 10. sensor.localshift_forecast_prices
+
+**Purpose:** Price forecast data for history collection.
+
+Split from `forecast_daily` to stay under 16KB limit (Issue #37).
+
+**State:** Current effective cheap price ($/kWh)
+
+**Attributes:**
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `buy_prices` | list | 96-slot buy price time series |
+| `sell_prices` | list | 96-slot sell price time series |
+| `effective_cheap_price` | float | Current cheap price threshold |
+| `cheap_charge_stop_price` | float | Stop charging threshold |
+| `forecast_import_cost` | float | Expected import cost (rest of day) |
+| `forecast_export_revenue` | float | Expected export revenue (rest of day) |
+| `forecast_net_cost` | float | Expected net cost (rest of day) |
+| `forecast_grid_charge_cost` | float | Expected grid charging cost |
+| `forecast_proactive_export_revenue` | float | Expected proactive export revenue |
+
+**Price Slot Structure:**
+
+Each slot in `buy_prices` and `sell_prices` contains:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `time` | string | HH:MM format |
+| `hour` | int | Hour (0-23) |
+| `minute` | int | Minute (0, 15, 30, 45) |
+| `price` | float | Price ($/kWh) |
+
+---
+
+### 11. sensor.localshift_forecast_grid
+
+**Purpose:** Grid interaction forecast data for history collection.
+
+Split from `forecast_daily` to stay under 16KB limit (Issue #37).
+
+**State:** Total forecast grid import (kWh)
+
+**Attributes:**
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `grid_interaction` | list | 96-slot grid interaction time series |
+| `total_grid_import_kwh` | float | Total grid import forecast (kWh) |
+| `total_grid_export_kwh` | float | Total grid export forecast (kWh) |
+| `grid_charge_slots` | int | Number of slots with grid charging |
+| `proactive_export_slots` | int | Number of slots with proactive export |
+
+**Grid Interaction Slot Structure:**
+
+Each slot in `grid_interaction` contains:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `time` | string | HH:MM format |
+| `hour` | int | Hour (0-23) |
+| `minute` | int | Minute (0, 15, 30, 45) |
+| `grid_import_kwh` | float | Grid import (kWh) |
+| `grid_export_kwh` | float | Grid export (kWh) |
+| `grid_charge` | bool | Grid charging active |
+| `grid_charge_boost` | bool | Boost charging active |
+| `proactive_export` | bool | Proactive export active |
+| `export_amount_kwh` | float | Export amount (kWh) |
+
+---
+
+### 12. sensor.localshift_forecast_diagnostics
+
+**Purpose:** Diagnostic and debug data for the forecast system.
+
+Split from `forecast_daily` to stay under 16KB limit (Issue #37).
+
+**State:** Consumption data source (e.g., "profile_hour", "live_load_fallback")
+
+**Attributes:**
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `consumption_source` | string | Source of consumption data |
+| `consumption_statistic_id` | string | HA statistic ID used |
+| `consumption_profile_hours` | int | Hours of profile data available |
+| `consumption_fallback_hours` | int | Hours using fallback data |
+| `consumption_weighting` | float | Recent vs historical weighting |
+| `forecast_consumption_source_counts` | dict | Count by source type |
+| `consumption_hourly_sample_counts` | dict | Samples per hour |
+| `consumption_hourly_profile_kw` | dict | Hourly consumption averages (kW) |
+| `consumption_profile_type` | string | "weekday_weekend" or "combined" |
+| `forecast_profile_selected` | string | Profile used for today |
+| `weekday_sample_counts` | dict | Weekday samples per hour |
+| `weekend_sample_counts` | dict | Weekend samples per hour |
+| `weekday_hourly_profile_kw` | dict | Weekday hourly averages |
+| `weekend_hourly_profile_kw` | dict | Weekend hourly averages |
+| `recent_load_1hr_kw` | float | Recent 1-hour average load |
+| `recent_load_1hr_statistic_id` | string | Statistic ID for recent load |
+| `recent_load_1hr_samples` | int | Samples in recent load calc |
+| `recent_load_1hr_last_error` | string | Last error message |
+| `current_load_kw` | float | Current load (kW) |
+| `debug_forecast_slot_found` | bool | Current slot found in forecast |
+| `debug_forecast_slot_time` | string | Time of matched slot |
+| `debug_first_forecast_slot_time` | string | Time of first forecast slot |
+| `debug_time_gap_seconds` | float | Seconds between now and first slot |
+| `debug_mode_source` | string | "forecast" or "fallback" |
+| `allow_export` | string | Export permission state |
+| `weather_entity_id` | string | Weather entity ID |
+| `weather_temperature_current` | float | Current temperature (°C) |
+| `weather_temperature_forecast` | dict | Hourly temperature forecast |
+| `weather_condition` | string | Current weather condition |
+| `weather_correlation_confidence` | string | low/medium/high |
+| `weather_adjustment_applied` | bool | Weather adjustment used |
+| `weather_learning_enabled` | bool | Learning enabled |
+| `weather_cooling_coefficient` | float | Cooling coefficient (kW/°C) |
+| `weather_heating_coefficient` | float | Heating coefficient (kW/°C) |
+| `weather_sample_count` | int | Learning samples collected |
+
+---
+
+### 13. sensor.localshift_target_soc_minimum
 
 **Purpose:** Minimum target SOC for discharge modes (base reserve).
 
@@ -229,7 +355,7 @@ This is the floor SOC maintained during spike discharge and proactive export mod
 
 ---
 
-### 11. sensor.localshift_excess_solar_kwh
+### 14. sensor.localshift_excess_solar_kwh
 
 **Purpose:** Forecasted excess solar energy available for discretionary loads.
 
@@ -256,7 +382,7 @@ This is the floor SOC maintained during spike discharge and proactive export mod
 
 ---
 
-### 12. sensor.localshift_load_shift_signal
+### 15. sensor.localshift_load_shift_signal
 
 **Purpose:** Simple actionable signal for load-shifting automations.
 
@@ -718,3 +844,5 @@ Buttons trigger manual actions
 5. **Enable dry run** — Use `switch.localshift_dry_run` to test without affecting the battery.
 
 6. **Monitor load shift signal** — Use `sensor.localshift_load_shift_signal` for simple automation triggers.
+
+7. **Check forecast diagnostics** — `sensor.localshift_forecast_diagnostics` contains debug fields and consumption profile information for troubleshooting forecast accuracy.


### PR DESCRIPTION
## Summary

Split the monolithic `DailyForecastSensor` into 4 focused sensors to resolve Home Assistant's 16KB attribute limit warning while enabling forecast history collection.

## Problem

The `sensor.localshift_forecast_daily` sensor's attributes exceeded Home Assistant's 16KB (16384 bytes) size limit, causing the recorder to skip storing the attributes in the database. This meant:
- No history for forecast data
- Log noise with repeated warnings
- Cannot query historical forecast data

## Changes Made

### New Sensors (3 added)

1. **`sensor.localshift_forecast_prices`** - Price forecast data for history collection
   - Buy/sell price time series (96 slots each)
   - Price thresholds and cost totals

2. **`sensor.localshift_forecast_grid`** - Grid interaction forecast data
   - Grid import/export time series (96 slots)
   - Summary totals and slot counts

3. **`sensor.localshift_forecast_diagnostics`** - Diagnostic and debug data
   - Consumption profiles, weather correlation
   - Debug fields for troubleshooting

### Refactored Sensor

**`sensor.localshift_forecast_daily`** - Now contains only core forecast data:
- SOC, solar, consumption data with descriptive keys
- SOC time series for graphing
- Summary counts

### Other Updates

- Dashboard updated to use new sensor attributes
- Documentation updated (`ENTITY_REFERENCE.md`, `README.md`)
- Entity counts updated (44 → 47 total entities)

## Key Improvements

- ✅ All sensors stay under 16KB limit
- ✅ Descriptive key names (vs previous short keys like `h`, `m`, `soc`)
- ✅ History collection enabled for all forecast data types
- ✅ No log noise from attribute size warnings

## Testing

- All 344 tests pass
- Pre-commit hooks pass (ruff, ruff-format, vulture, pyright)

Closes #37