### PR TITLE
docs: fix dashboard URL path - requires hyphen

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ A ready-to-use Lovelace dashboard is included at `dashboards/localshift.yaml`. A
    lovelace:
      mode: storage
      dashboards:
-       localshift:
+       local-shift:  # URL path requires a hyphen
          mode: yaml
          filename: dashboards/localshift.yaml
          title: LocalShift

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ A ready-to-use Lovelace dashboard is included at `dashboards/localshift.yaml`. A
      dashboards:
        local-shift:  # URL path requires a hyphen
          mode: yaml
-         filename: dashboards/localshift.yaml
+         filename: custom_components/localshift/dashboard.yaml
          title: LocalShift
          icon: mdi:battery-sync
    ```

--- a/custom_components/localshift/dashboard.yaml
+++ b/custom_components/localshift/dashboard.yaml
@@ -1,0 +1,809 @@
+# =============================================================================
+# LocalShift Battery Automation Dashboard
+# =============================================================================
+#
+# Dashboard primarily uses entities from the localshift custom component.
+# Also references:
+#   - my_home_* entities from Tesla Powerwall integration
+#   - 100h_* entities from Amber Electric YAML package
+#
+# Add to configuration.yaml:
+#   lovelace:
+#     mode: storage
+#     dashboards:
+#       local-shift:  # URL path requires a hyphen
+#         mode: yaml
+#         filename: custom_components/localshift/dashboard.yaml
+#         title: LocalShift
+#         icon: mdi:battery-sync
+#
+# =============================================================================
+
+title: LocalShift
+views:
+  # =============================================================================
+  # VIEW 1: DASHBOARD (Main View - What You Check 20x/Day)
+  # =============================================================================
+  - title: Dashboard
+    path: dashboard
+    icon: mdi:view-dashboard
+    type: sections
+    max_columns: 2
+    sections:
+      # --- LEFT COLUMN: Power Flow & Forecast Chart ---
+      
+      # Power Flow Card
+      - type: grid
+        cards:
+          - type: custom:power-flow-card-plus
+            entities:
+              battery:
+                entity: sensor.my_home_battery_power
+                state_of_charge: sensor.my_home_percentage_charged
+              grid:
+                entity: sensor.my_home_grid_power
+                secondary_info: {}
+              solar:
+                entity: sensor.my_home_solar_power
+                display_zero_state: true
+              home:
+                secondary_info: {}
+                entity: sensor.my_home_load_power
+            clickable_entities: true
+            display_zero_lines: true
+            use_new_flow_rate_model: true
+            w_decimals: 0
+            kw_decimals: 1
+            min_flow_rate: 0.75
+            max_flow_rate: 6
+            max_expected_power: 2000
+            min_expected_power: 0.01
+            watt_threshold: 1000
+            transparency_zero_lines: 0
+            sort_individual_devices: false
+
+      # SOC Forecast Chart
+      - type: grid
+        cards:
+          - type: custom:apexcharts-card
+            header:
+              title: SOC - Past 24h & Future 24h
+              show: true
+            chart_type: line
+            graph_span: 48h
+            span:
+              offset: "+24h"
+            series:
+              - entity: sensor.my_home_percentage_charged
+                name: Actual SOC
+                color: "#3B82F6"
+                stroke_width: 3
+                curve: smooth
+                type: line
+                extend_to: false
+              - entity: sensor.localshift_forecast_daily
+                name: Planned SOC
+                color: "#F59E0B"
+                stroke_width: 2
+                stroke_dash: 5
+                type: line
+                extend_to: false
+                data_generator: |
+                  return (entity.attributes.soc_series || []).map(function(entry) {
+                    // Convert ISO timestamp to Epoch milliseconds for ApexCharts
+                    return [new Date(entry.time).getTime(), entry.soc];
+                  });
+            yaxis:
+              - min: 0
+                max: 100
+                decimals: 0
+            hours_12: false
+            now:
+              show: true
+              label: Now
+              color: "#EF4444"
+            cache: true
+            update_interval: "60sec"
+
+      # --- RIGHT COLUMN: Status & Actions ---
+
+      # Mode & Battery Status
+      - type: grid
+        cards:
+          - type: heading
+            heading: Mode & Battery
+            heading_style: title
+
+          - type: tile
+            entity: sensor.localshift_battery_mode
+            name: Mode
+
+          - type: gauge
+            entity: sensor.my_home_percentage_charged
+            name: Battery
+            min: 0
+            max: 100
+            severity:
+              green: 50
+              yellow: 20
+              red: 10
+            needle: true
+
+          - type: markdown
+            content: >
+              {% set mode = states('sensor.localshift_battery_mode') %}
+              {% set soc = states('sensor.my_home_percentage_charged') | int(0) %}
+              {% set target = states('number.localshift_battery_target') | int(100) %}
+              
+              {% if mode == 'manual' %}
+              🟠 **Manual control active** — automation disabled
+              
+              {% elif mode == 'spike_discharge' %}
+              🔴 **Exporting to grid** — price spike detected
+              
+              {% elif mode == 'boost_charging' %}
+              🟡 **Fast charging (5kW)** — urgent charge before demand window
+              
+              {% elif mode == 'grid_charging' %}
+              🟢 **Grid charging (3.3kW)** — price below threshold
+              
+              {% elif mode == 'proactive_export' %}
+              🟢 **Exporting battery** — negative feed-in price coming
+              
+              {% elif mode == 'demand_block' %}
+              🟠 **Demand window active** — protecting from grid imports
+              
+              {% else %}
+              ⚪ **Self consumption** — normal operation
+              
+              {% endif %}
+
+      # Today's Cost (Hero Metric)
+      - type: grid
+        cards:
+          - type: heading
+            heading: Today's Cost
+            heading_style: title
+
+          - type: markdown
+            content: >
+              {% set cost = 'sensor.localshift_cost_electricity_net' %}
+              {% set net = states(cost) | float(0) %}
+              {% if net >= 0 %}
+              # 💸 ${{ net | round(2) }}
+              {% else %}
+              # 💰 ${{ (net * -1) | round(2) }}
+              {% endif %}
+              
+              ---
+              
+              **Import:** ${{ state_attr(cost, 'grid_import_cost') | round(2) }}  
+              **Export:** ${{ state_attr(cost, 'grid_export_revenue') | round(2) }}
+
+          - type: heading
+            heading: Forecast (Rest of Day)
+            heading_style: title
+
+          - type: markdown
+            content: >
+              {% set forecast = 'sensor.localshift_forecast_prices' %}
+              {% set net = state_attr(forecast, 'forecast_net_cost') | float(0) %}
+              {% if net >= 0 %}
+              # 📊 ${{ net | round(2) }}
+              {% else %}
+              # 📈 ${{ (net * -1) | round(2) }}
+              {% endif %}
+              
+              ---
+              
+              **Import:** ${{ state_attr(forecast, 'forecast_import_cost') | round(2) }}  
+              **Export:** ${{ state_attr(forecast, 'forecast_export_revenue') | round(2) }}
+
+      # Prices & Alerts
+      - type: grid
+        cards:
+          - type: heading
+            heading: Prices & Alerts
+            heading_style: title
+
+          - type: tile
+            entity: sensor.100h_general_price
+            name: Buy Price
+            icon: mdi:cart-arrow-down
+
+          - type: tile
+            entity: sensor.100h_feed_in_price
+            name: Sell Price
+            icon: mdi:cart-arrow-up
+
+          - type: tile
+            entity: sensor.localshift_price_cheap_effective
+            name: Cheap Threshold
+            icon: mdi:tag-outline
+
+          - type: conditional
+            conditions:
+              - condition: state
+                entity: binary_sensor.100h_price_spike
+                state: "on"
+            card:
+              type: tile
+              entity: binary_sensor.100h_price_spike
+              name: Price Spike
+              color: red
+
+          - type: conditional
+            conditions:
+              - condition: state
+                entity: binary_sensor.localshift_demand_window
+                state: "on"
+            card:
+              type: tile
+              entity: binary_sensor.localshift_demand_window
+              name: Demand Window
+              color: orange
+
+      # Solar Outlook
+      - type: grid
+        cards:
+          - type: heading
+            heading: Solar Outlook
+            heading_style: title
+
+          - type: markdown
+            content: >
+              {% set forecast = 'sensor.localshift_forecast_battery' %}
+              {% set target = states('number.localshift_battery_target') | int(100) %}
+              {% set soc = states('sensor.my_home_percentage_charged') | int(0) %}
+              {% set can_reach = is_state('binary_sensor.localshift_solar_can_reach_target', 'on') %}
+              {% set boost_needed = is_state('binary_sensor.localshift_charge_boost_needed', 'on') %}
+              {% set deficit = state_attr(forecast, 'deficit_kwh') | float(0) %}
+              {% set solar = state_attr(forecast, 'solar_before_dw_kwh') | float(0) %}
+              {% set hours = state_attr(forecast, 'hours_to_target_time') | float(0) %}
+              
+              **Target:** {{ soc }}% → {{ target }}%  
+              **Solar remaining:** {{ solar | round(1) }} kWh  
+              **Hours to DW:** {{ hours | round(1) }}h  
+              
+              {% if can_reach %}
+              ✅ **On track** — solar can reach target
+              {% elif boost_needed %}
+              ⚡ **Boost needed** — grid charge at {{ (soc + (deficit * 100 / 13.5)) | round(0) }}%
+              {% else %}
+              ⚠️ **Solar gap** — {{ deficit | round(1) }} kWh deficit
+              {% endif %}
+
+      # Forecast Logic
+      - type: grid
+        cards:
+          - type: heading
+            heading: Forecast Logic
+            heading_style: title
+
+          - type: markdown
+            content: >
+              {% set diagnostics = 'sensor.localshift_forecast_diagnostics' %}
+              {% set profile_type = state_attr(diagnostics, 'consumption_profile_type') %}
+              {% set profile_selected = state_attr(diagnostics, 'forecast_profile_selected') %}
+              {% set weekday_counts = state_attr(diagnostics, 'weekday_sample_counts') | default({}) %}
+              {% set weekend_counts = state_attr(diagnostics, 'weekend_sample_counts') | default({}) %}
+              {% set weather_enabled = state_attr(diagnostics, 'weather_learning_enabled') %}
+              {% set weather_entity = state_attr(diagnostics, 'weather_entity_id') %}
+              {% set weather_temp = state_attr(diagnostics, 'weather_temperature_current') %}
+              {% set weather_confidence = state_attr(diagnostics, 'weather_correlation_confidence') %}
+              {% set weather_samples = state_attr(diagnostics, 'weather_sample_count') %}
+              {% set recent_load = state_attr(diagnostics, 'recent_load_1hr_kw') %}
+              {% set weighting = state_attr(diagnostics, 'consumption_weighting') %}
+              
+              **📊 Consumption Profile**
+              
+              {% if profile_type == 'weekday_weekend' %}
+              ✅ Separate weekday/weekend profiles
+              {% else %}
+              ⚠️ Combined profile (need more data)
+              {% endif %}
+              
+              • Today's profile: **{{ profile_selected }}**
+              • Weekday samples: {{ weekday_counts.values() | sum | default(0) }}
+              • Weekend samples: {{ weekend_counts.values() | sum | default(0) }}
+              
+              ---
+              
+              **🌤️ Weather Correlation**
+              
+              {% if weather_entity %}
+              • Entity: `{{ weather_entity }}`
+              • Current temp: {{ weather_temp }}°C
+              • Confidence: {{ weather_confidence }}
+              • Samples: {{ weather_samples }}
+              {% else %}
+              ⚠️ No weather entity configured
+              {% endif %}
+              
+              ---
+              
+              **⚡ Recent Load Blending**
+              
+              • 1-hour avg: {{ recent_load | round(2) }} kW
+              • Weight: {{ (weighting * 100) | round(0) }}% recent / {{ ((1 - weighting) * 100) | round(0) }}% historical
+
+      # Quick Actions
+      - type: grid
+        cards:
+          - type: heading
+            heading: Quick Actions
+            heading_style: title
+
+          - type: button
+            name: Self Consumption
+            icon: mdi:battery-sync
+            tap_action:
+              action: call-service
+              service: button.press
+              target:
+                entity_id: button.localshift_self_consumption
+            icon_height: 40px
+
+          - type: button
+            name: Force Charge
+            icon: mdi:battery-charging
+            tap_action:
+              action: call-service
+              service: button.press
+              target:
+                entity_id: button.localshift_force_charge
+            icon_height: 40px
+
+          - type: button
+            name: Boost Charge
+            icon: mdi:battery-charging-high
+            tap_action:
+              action: call-service
+              service: button.press
+              target:
+                entity_id: button.localshift_boost_charge
+            icon_height: 40px
+
+          - type: button
+            name: Force Discharge
+            icon: mdi:flash-alert
+            tap_action:
+              action: call-service
+              service: button.press
+              target:
+                entity_id: button.localshift_force_discharge
+            icon_height: 40px
+
+
+  # =============================================================================
+  # VIEW 2: CONTROLS (Adjust Settings Occasionally)
+  # =============================================================================
+  - title: Controls
+    path: controls
+    icon: mdi:tune
+    type: sections
+    max_columns: 2
+    sections:
+      # --- LEFT COLUMN ---
+
+      # Automation
+      - type: grid
+        cards:
+          - type: heading
+            heading: Automation
+            heading_style: title
+
+          - type: tile
+            entity: switch.localshift_automation_enabled
+            name: Automation
+            icon: mdi:power
+
+          - type: tile
+            entity: switch.localshift_dry_run
+            name: Dry Run
+            icon: mdi:test-tube
+            color: amber
+
+      # Manual Actions
+      - type: grid
+        cards:
+          - type: heading
+            heading: Manual Actions
+            heading_style: title
+
+          - type: button
+            name: Self Consumption
+            icon: mdi:battery-sync
+            tap_action:
+              action: call-service
+              service: button.press
+              target:
+                entity_id: button.localshift_self_consumption
+            icon_height: 40px
+
+          - type: button
+            name: Force Charge
+            icon: mdi:battery-charging
+            tap_action:
+              action: call-service
+              service: button.press
+              target:
+                entity_id: button.localshift_force_charge
+            icon_height: 40px
+
+          - type: button
+            name: Boost Charge
+            icon: mdi:battery-charging-high
+            tap_action:
+              action: call-service
+              service: button.press
+              target:
+                entity_id: button.localshift_boost_charge
+            icon_height: 40px
+
+          - type: button
+            name: Force Discharge
+            icon: mdi:flash-alert
+            tap_action:
+              action: call-service
+              service: button.press
+              target:
+                entity_id: button.localshift_force_discharge
+            icon_height: 40px
+
+          - type: button
+            name: Update Forecast
+            icon: mdi:refresh
+            tap_action:
+              action: call-service
+              service: button.press
+              target:
+                entity_id: button.localshift_update_forecast
+            icon_height: 40px
+
+      # Live System (Tesla Controls)
+      - type: grid
+        cards:
+          - type: heading
+            heading: Live System
+            heading_style: title
+
+          - type: tile
+            entity: select.my_home_operation_mode
+            name: Operation Mode
+
+          - type: tile
+            entity: number.my_home_backup_reserve
+            name: Backup Reserve
+            icon: mdi:battery-lock
+
+          - type: tile
+            entity: sensor.my_home_battery_power
+            name: Battery Power
+            icon: mdi:battery-charging
+
+          - type: tile
+            entity: sensor.my_home_grid_power
+            name: Grid Power
+            icon: mdi:transmission-tower
+
+          - type: tile
+            entity: sensor.my_home_solar_power
+            name: Solar Power
+            icon: mdi:solar-power
+
+      # --- RIGHT COLUMN ---
+
+      # Charging Rules
+      - type: grid
+        cards:
+          - type: heading
+            heading: Charging Rules
+            heading_style: title
+
+          - type: tile
+            entity: switch.localshift_spike_discharge_enabled
+            name: Spike Discharge
+
+          - type: tile
+            entity: switch.localshift_demand_window_block
+            name: Demand Block
+            color: orange
+
+          - type: tile
+            entity: switch.localshift_allow_dw_entry_under_target
+            name: Allow DW Entry Under Target
+            color: green
+
+      # Price Thresholds
+      - type: grid
+        cards:
+          - type: heading
+            heading: Price Thresholds
+            heading_style: title
+
+          - type: tile
+            entity: number.localshift_cheap_price_percentile
+            name: Cheap %
+
+          - type: tile
+            entity: number.localshift_max_pre_charge_price
+            name: Max Pre-charge
+
+          - type: tile
+            entity: number.localshift_price_deadband
+            name: Deadband
+
+          - type: markdown
+            content: >
+              **Current Effective:** ${{ states('sensor.localshift_price_cheap_effective') }}/kWh  
+              **Stop Charging At:** ${{ states('sensor.localshift_price_cheap_charge_stop') }}/kWh
+
+      # Forecast & Battery Settings
+      - type: grid
+        cards:
+          - type: heading
+            heading: Forecast & Battery
+            heading_style: title
+
+          - type: tile
+            entity: number.localshift_forecast_lookahead
+            name: Lookahead
+
+          - type: tile
+            entity: number.localshift_battery_target
+            name: Battery Target
+
+          - type: tile
+            entity: number.localshift_load_weight_recent
+            name: Load Weight
+            icon: mdi:scale-balance
+
+
+  # =============================================================================
+  # VIEW 3: DEBUG (Power User Diagnostics)
+  # =============================================================================
+  - title: Debug
+    path: debug
+    icon: mdi:bug
+    type: sections
+    max_columns: 1
+    sections:
+      # --- Debug State Summary ---
+      - type: grid
+        cards:
+          - type: heading
+            heading: Debug State Summary
+            heading_style: title
+
+          - type: markdown
+            content: >
+              ```
+              === DEBUG STATE SUMMARY ===
+              
+              Time: {{ now().strftime('%Y-%m-%d %H:%M:%S') }}
+              
+              === CURRENT STATE ===
+              
+              Mode: {{ states('sensor.localshift_battery_mode') }}
+              
+              SOC: {{ states('sensor.my_home_percentage_charged') }}%
+              
+              Battery Power: {{ states('sensor.my_home_battery_power') }} kW
+              
+              Grid Power: {{ states('sensor.my_home_grid_power') }} kW
+              
+              Solar Power: {{ states('sensor.my_home_solar_power') }} kW
+              
+              Buy Price: ${{ states('sensor.100h_general_price') }}/kWh
+              
+              Sell Price: ${{ states('sensor.100h_feed_in_price') }}/kWh
+              
+              Price Spike: {{ states('binary_sensor.100h_price_spike') }}
+              
+              Demand Window: {{ states('binary_sensor.localshift_demand_window') }}
+              
+              === INTERNAL STATE FLAGS ===
+              
+              Manual Override: {{ states('switch.localshift_automation_enabled') == 'off' }}
+              
+              Target Reached Today: {{ state_attr('sensor.localshift_forecast_battery', 'target_reached_today') }}
+              
+              Forecast Spike Within Window: {{ states('binary_sensor.localshift_price_spike_coming') }}
+              
+              Max Forecast Price: ${{ state_attr('binary_sensor.localshift_price_spike_coming', 'max_forecast_price') | default(0) }}/kWh
+              
+              Max Buy Forecast Price: ${{ state_attr('binary_sensor.localshift_price_spike_coming', 'max_buy_forecast_price') | default(0) }}/kWh
+              
+              Force Discharge Active: {{ states('sensor.localshift_battery_mode') == 'force_discharge' }}
+              
+              Force Charge Active: {{ states('sensor.localshift_battery_mode') == 'force_charge' }}
+              
+              Boost Charge Active: {{ states('sensor.localshift_battery_mode') == 'boost_charging' }}
+              
+              Solar Can Reach Target: {{ states('binary_sensor.localshift_solar_can_reach_target') }}
+              
+              Boost Charge Needed: {{ states('binary_sensor.localshift_charge_boost_needed') }}
+              
+              === DEBUG: MODE DECISION (from forecast_diagnostics) ===
+              
+              Mode Source: {{ state_attr('sensor.localshift_forecast_diagnostics', 'debug_mode_source') | default('unknown') }}
+              
+              Forecast Slot Found: {{ state_attr('sensor.localshift_forecast_diagnostics', 'debug_forecast_slot_found') | default(false) }}
+              
+              Forecast Slot Time: {{ state_attr('sensor.localshift_forecast_diagnostics', 'debug_forecast_slot_time') | default('-') }}
+              
+              First Forecast Slot: {{ state_attr('sensor.localshift_forecast_diagnostics', 'debug_first_forecast_slot_time') | default('-') }}
+              
+              Time Gap: {{ state_attr('sensor.localshift_forecast_diagnostics', 'debug_time_gap_seconds') | default(0) }}s
+              
+              Dry Run: {{ states('switch.localshift_dry_run') == 'on' }}
+              
+              === CONFIGURATION & THRESHOLDS ===
+              
+              Cheap Price Percentile: {{ states('number.localshift_cheap_price_percentile') }}%
+              
+              Max Pre-charge Price: ${{ states('number.localshift_max_pre_charge_price') }}/kWh
+              
+              Price Deadband: {{ states('number.localshift_price_deadband') }}
+              
+              Forecast Lookahead: {{ states('number.localshift_forecast_lookahead') }}h
+              
+              Battery Target: {{ states('number.localshift_battery_target') }}%
+              
+              Effective Cheap Price: ${{ states('sensor.localshift_price_cheap_effective') }}/kWh
+              
+              Cheap Charge Stop Price: ${{ states('sensor.localshift_price_cheap_charge_stop') }}/kWh
+              
+              Solar Weighted Avg FIT: ${{ states('sensor.localshift_solar_weighted_avg_fit') }}/kWh
+              
+              Solar Remaining: {{ state_attr('sensor.localshift_solar_weighted_avg_fit', 'total_solar_remaining_kwh') | default(0) }} kWh
+              
+              === FORECAST INFORMATION ===
+              
+              Solar Battery Forecast SOC: {{ state_attr('sensor.localshift_forecast_battery', 'predicted_soc') | default(0) }}%
+              
+              Forecast Deficit: {{ state_attr('sensor.localshift_forecast_battery', 'deficit_kwh') | default(0) }} kWh
+              
+              Solar Before DW: {{ state_attr('sensor.localshift_forecast_battery', 'solar_before_dw_kwh') | default(0) }} kWh
+              
+              Net Solar: {{ state_attr('sensor.localshift_forecast_battery', 'net_solar_kwh') | default(0) }} kWh
+              
+              Hours to DW: {{ state_attr('sensor.localshift_forecast_battery', 'hours_to_target_time') | default(0) }}h
+              
+              Can Reach Target: {{ state_attr('sensor.localshift_forecast_battery', 'can_reach_target') | default(true) }}
+              
+              Boost Needed: {{ state_attr('sensor.localshift_forecast_battery', 'boost_needed') }}
+              
+              Daily Forecast Entries: {{ states('sensor.localshift_forecast_daily') | int(default=0) }}
+              
+              Slot Count: {{ state_attr('sensor.localshift_forecast_daily', 'slot_count') | default(0) }}
+              
+              Forecast Hourly Entries: {{ state_attr('sensor.localshift_forecast_daily', 'forecast_hourly') | default([]) | length }}
+              
+              Solcast Today Entries: {{ state_attr('sensor.localshift_forecast_daily', 'solcast_today_entries') | default(0) }}
+              
+              Solcast Tomorrow Entries: {{ state_attr('sensor.localshift_forecast_daily', 'solcast_tomorrow_entries') | default(0) }}
+              
+              === FORECAST DIAGNOSTICS (from forecast_diagnostics sensor) ===
+              
+              Current Load: {{ state_attr('sensor.localshift_forecast_diagnostics', 'current_load_kw') | default(0) }} kW
+              
+              Recent 1hr Load: {{ state_attr('sensor.localshift_forecast_diagnostics', 'recent_load_1hr_kw') | default(0) }} kW
+              
+              Recent 1hr Statistic ID: {{ state_attr('sensor.localshift_forecast_diagnostics', 'recent_load_1hr_statistic_id') | default('') }}
+              
+              Recent 1hr Samples: {{ state_attr('sensor.localshift_forecast_diagnostics', 'recent_load_1hr_samples') | default(0) }}
+              
+              Recent 1hr Error: {{ state_attr('sensor.localshift_forecast_diagnostics', 'recent_load_1hr_last_error') | default('') }}
+              
+              Consumption Weighting: {{ state_attr('sensor.localshift_forecast_diagnostics', 'consumption_weighting') | default(0) }}
+              
+              Consumption Source: {{ state_attr('sensor.localshift_forecast_diagnostics', 'consumption_source') }}
+              
+              Consumption Source Counts: {{ state_attr('sensor.localshift_forecast_diagnostics', 'forecast_consumption_source_counts') | default({}) }}
+              
+              Consumption Profile Hours: {{ state_attr('sensor.localshift_forecast_diagnostics', 'consumption_profile_hours') | default(0) }}
+              
+              Consumption Fallback Hours: {{ state_attr('sensor.localshift_forecast_diagnostics', 'consumption_fallback_hours') | default(0) }}
+              
+              === DECISION LOG ===
+              
+              Latest Decision: {{ state_attr('sensor.localshift_decision_log', 'reason') | default('No decisions yet') }}
+              
+              Latest SOC: {{ state_attr('sensor.localshift_decision_log', 'soc') }}%
+              
+              Latest Buy Price: ${{ state_attr('sensor.localshift_decision_log', 'buy_price') }}/kWh
+              
+              Latest Sell Price: ${{ state_attr('sensor.localshift_decision_log', 'sell_price') }}/kWh
+              
+              Latest Timestamp: {{ state_attr('sensor.localshift_decision_log', 'timestamp') }}
+              
+              Recent History:
+              {% for entry in state_attr('sensor.localshift_decision_log', 'history') | default([]) | slice(-5) %}
+                - {{ entry.get('timestamp', '') }}: {{ entry.get('reason', '') }} (SOC: {{ entry.get('soc') }}%)
+              {% endfor %}
+              
+              === COST TRACKING ===
+              
+              Net Cost Today: ${{ states('sensor.localshift_cost_electricity_net') }}
+              
+              Import Cost: ${{ state_attr('sensor.localshift_cost_electricity_net', 'grid_import_cost') | default(0) }}
+              
+              Export Revenue: ${{ state_attr('sensor.localshift_cost_electricity_net', 'grid_export_revenue') | default(0) }}
+              
+              Battery Savings: ${{ state_attr('sensor.localshift_cost_electricity_net', 'battery_savings') | default(0) }}
+              
+              Battery Charge Cost: ${{ state_attr('sensor.localshift_cost_electricity_net', 'battery_charge_cost') | default(0) }}
+              
+              === WEATHER CORRELATION (from forecast_diagnostics) ===
+              
+              Weather Entity: {{ state_attr('sensor.localshift_forecast_diagnostics', 'weather_entity_id') | default('not configured') }}
+              
+              Current Temperature: {{ state_attr('sensor.localshift_forecast_diagnostics', 'weather_temperature_current') | default('N/A') }}°C
+              
+              Weather Condition: {{ state_attr('sensor.localshift_forecast_diagnostics', 'weather_condition') | default('unknown') }}
+              
+              Learning Enabled: {{ state_attr('sensor.localshift_forecast_diagnostics', 'weather_learning_enabled') }}
+              
+              Confidence: {{ state_attr('sensor.localshift_forecast_diagnostics', 'weather_correlation_confidence') | default('low') }}
+              
+              Total Samples: {{ state_attr('sensor.localshift_forecast_diagnostics', 'weather_sample_count') | default(0) }}
+              
+              Cooling Coefficient: {{ state_attr('sensor.localshift_forecast_diagnostics', 'weather_cooling_coefficient') | default(0) }} kW/°C
+              
+              Heating Coefficient: {{ state_attr('sensor.localshift_forecast_diagnostics', 'weather_heating_coefficient') | default(0) }} kW/°C
+              
+              Adjustment Applied: {{ state_attr('sensor.localshift_forecast_diagnostics', 'weather_adjustment_applied') | default(false) }}
+              
+              Temperature Forecast: {{ state_attr('sensor.localshift_forecast_diagnostics', 'weather_temperature_forecast') | default({}) }}
+              
+              === SYSTEM INFO ===
+              
+              Operation Mode: {{ states('select.my_home_operation_mode') }}
+              
+              Backup Reserve: {{ states('number.my_home_backup_reserve') }}%
+              
+              Allow Export: {{ states('select.my_home_allow_export') }}
+              
+              === END OF DEBUG SUMMARY ===
+              ```
+
+      # --- Decision Log ---
+      - type: grid
+        cards:
+          - type: heading
+            heading: Decision Log
+            heading_style: title
+          - type: logbook
+            target:
+              entity_id:
+                - sensor.localshift_battery_mode
+
+      # --- Unified Forecast Table ---
+      - type: grid
+        cards:
+          - type: heading
+            heading: 24-Hour Forecast (Unified)
+            heading_style: title
+
+          - type: markdown
+            content: |
+              **Grid Summary:** {{ state_attr('sensor.localshift_forecast_grid', 'grid_charge_slots') | default(0) }} grid charge slots, {{ state_attr('sensor.localshift_forecast_grid', 'proactive_export_slots') | default(0) }} proactive export slots | **Total Import:** {{ state_attr('sensor.localshift_forecast_grid', 'total_grid_import_kwh') | default(0) }} kWh | **Total Export:** {{ state_attr('sensor.localshift_forecast_grid', 'total_grid_export_kwh') | default(0) }} kWh
+              
+              **Price Thresholds:** Effective Cheap Price: ${{ state_attr('sensor.localshift_forecast_prices', 'effective_cheap_price') | default(0) }}/kWh | Cheap Charge Stop Price: ${{ state_attr('sensor.localshift_forecast_prices', 'cheap_charge_stop_price') | default(0) }}/kWh
+              
+              ```
+              Time  | SOC% | Solar  | Load   | Net    | Buy $  | Sell $ | GridIn | GridOut | GC | Boost | PE | Export
+              ------|------|--------|--------|--------|--------|--------|--------|---------|----|-------|----|--------
+              {%- set forecast_slots = state_attr('sensor.localshift_forecast_daily', 'forecast_slots') | default([]) %}
+              {%- set grid_data = state_attr('sensor.localshift_forecast_grid', 'grid_interaction') | default([]) %}
+              {%- set buy_prices = state_attr('sensor.localshift_forecast_prices', 'buy_prices') | default([]) %}
+              {%- set sell_prices = state_attr('sensor.localshift_forecast_prices', 'sell_prices') | default([]) %}
+              {%- for item in forecast_slots %}
+              {%- set grid_item = grid_data[loop.index0] | default({}) %}
+              {%- set buy_item = buy_prices[loop.index0] | default({}) %}
+              {%- set sell_item = sell_prices[loop.index0] | default({}) %}
+              {{ item.time }} | {{ "%.1f"|format(item.predicted_soc | float) }} | {{ "%.3f"|format(item.solar_kwh | float) }} | {{ "%.3f"|format(item.consumption_kwh | float) }} | {{ "%.3f"|format(item.net_kwh | float) }} | {{ "%.3f"|format(item.buy_price | float(0)) }} | {{ "%.3f"|format(item.sell_price | float(0)) }} | {{ "%.4f"|format(grid_item.grid_import_kwh | float) }} | {{ "%.4f"|format(grid_item.grid_export_kwh | float) }} | {{ 'Y' if grid_item.grid_charge else '-' }} | {{ 'Y' if grid_item.grid_charge_boost else '-' }} | {{ 'Y' if grid_item.proactive_export else '-' }} | {{ "%.4f"|format(grid_item.export_amount_kwh | float) }}
+              {%- endfor %}
+              ```

--- a/dashboards/localshift.yaml
+++ b/dashboards/localshift.yaml
@@ -11,7 +11,7 @@
 #   lovelace:
 #     mode: storage
 #     dashboards:
-#       localshift:
+#       local-shift:  # URL path requires a hyphen
 #         mode: yaml
 #         filename: dashboards/localshift.yaml
 #         title: LocalShift


### PR DESCRIPTION
Home Assistant requires dashboard URL paths to contain a hyphen.

Changed `localshift:` to `local-shift:` in documentation.

The dashboard configuration example now shows:
```yaml
lovelace:
  mode: storage
  dashboards:
    local-shift:  # URL path requires a hyphen
      mode: yaml
      filename: dashboards/localshift.yaml
      title: LocalShift
      icon: mdi:battery-sync
```

Fixes the error:
`Invalid config for 'lovelace' at configuration.yaml, line 210: Url path needs to contain a hyphen (-)`