### PR TITLE
feat: integrate weather-adjusted load forecasting

### DIFF
--- a/custom_components/localshift/computation_engine.py
+++ b/custom_components/localshift/computation_engine.py
@@ -173,6 +173,9 @@ class ComputationEngine:
         # History fetcher for historical load data (delegated to separate module)
         self._history_fetcher = HistoryFetcher(hass, entry)
 
+        # Weather correlation for temperature-based consumption prediction
+        self._weather_correlation: WeatherCorrelation | None = None
+
         # Forecast computer for 15-minute battery SOC forecasting
         # Pass day-aware profile function for issue-60
         self._forecast_computer = ForecastComputer(
@@ -180,13 +183,11 @@ class ComputationEngine:
             get_entity_id_func,
             self._get_historical_hourly_averages,
             self._get_profile_for_day,
+            weather_correlation=self._weather_correlation,
         )
 
         # Change tracker for forecast regeneration
         self._forecast_change_tracker = ForecastChangeTracker()
-
-        # Weather correlation for temperature-based consumption prediction
-        self._weather_correlation: WeatherCorrelation | None = None
 
         # Local cache properties (delegated to history_fetcher for storage)
         self._last_weighting: float = DEFAULT_LOAD_WEIGHT_RECENT
@@ -1527,10 +1528,12 @@ class ComputationEngine:
         try:
             self._weather_correlation = WeatherCorrelation(self.hass, self.entry)
             await self._weather_correlation.async_initialize()
+            self._forecast_computer.set_weather_correlation(self._weather_correlation)
             _LOGGER.info("Weather correlation initialized successfully")
         except Exception as e:
             _LOGGER.error("Failed to initialize weather correlation: %s", e)
             self._weather_correlation = None
+            self._forecast_computer.set_weather_correlation(None)
 
     async def async_learn_weather_sample(self, data: CoordinatorData) -> None:
         """Learn from current temperature/load observation.

--- a/custom_components/localshift/computation_engine_lib/forecast_computer.py
+++ b/custom_components/localshift/computation_engine_lib/forecast_computer.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Callable
 from datetime import datetime, time, timedelta
+from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.util import dt as dt_util
@@ -54,6 +55,7 @@ class ForecastComputer:
             [datetime], tuple[dict[int, float], dict[int, int], str]
         ]
         | None = None,
+        weather_correlation: Any | None = None,
     ) -> None:
         """Initialize forecast computer.
 
@@ -62,11 +64,17 @@ class ForecastComputer:
             get_entity_id_func: Function to get entity IDs by config key
             get_historical_func: Function to get historical hourly averages (combined profile)
             get_profile_for_day_func: Optional function to get day-aware profile (issue-60)
+            weather_correlation: Optional WeatherCorrelation instance for temperature-based adjustments
         """
         self.entry = entry
         self._get_entity_id = get_entity_id_func
         self._get_historical_hourly_averages = get_historical_func
         self._get_profile_for_day = get_profile_for_day_func
+        self._weather_correlation = weather_correlation
+
+    def set_weather_correlation(self, weather_correlation: Any | None) -> None:
+        """Set or clear WeatherCorrelation dependency at runtime."""
+        self._weather_correlation = weather_correlation
 
     def _parse_time_option(self, key: str, default: str) -> time:
         """Parse a time string option (HH:MM:SS) into a time object."""
@@ -89,6 +97,7 @@ class ForecastComputer:
         current_hour: int | None,
         current_load_kw: float,
         recent_load_kw: float = 0.0,
+        temperature: float | None = None,
     ) -> tuple[float, str]:
         """Estimate hourly household consumption with time-distance-weighted blend.
 
@@ -97,6 +106,9 @@ class ForecastComputer:
 
         For distant hours (e.g., overnight when forecasting from midday),
         uses historical profile only to avoid overestimating load.
+
+        When temperature is provided and weather correlation is available with
+        sufficient confidence, applies temperature-based adjustments for heating/cooling.
 
         Returns tuple of (kW, source_tag).
         """
@@ -113,6 +125,10 @@ class ForecastComputer:
 
         # Check if we have valid historical data
         has_historical = historical_kw > 0
+
+        # Calculate base load using existing logic
+        base_load_kw = 0.0
+        base_source = ""
 
         # TIME-DISTANCE WEIGHTING: Only blend recent load for hours close to now
         # When current_hour is None (simulations without time context), skip blending
@@ -131,18 +147,53 @@ class ForecastComputer:
                 and recent_weight > 0
                 and has_historical
             ):
-                weighted = (recent_weight * recent_load_kw) + (
+                base_load_kw = (recent_weight * recent_load_kw) + (
                     historical_weight * historical_kw
                 )
-                return round(weighted, 3), "weighted_load"
+                base_source = "weighted_load"
 
         # Fallback to historical if available (primary path for distant hours)
-        if has_historical:
-            return round(historical_kw, 3), "profile_hour"
+        if not base_source and has_historical:
+            base_load_kw = historical_kw
+            base_source = "profile_hour"
 
         # Fallback to current load
-        base_kw = current_load_kw if current_load_kw > 0 else 0.6
-        return round(base_kw, 3), "live_load_fallback"
+        if not base_source:
+            base_load_kw = current_load_kw if current_load_kw > 0 else 0.6
+            base_source = "live_load_fallback"
+
+        # WEATHER CORRELATION: Apply temperature-based adjustment if available
+        # Only apply when:
+        # 1. Weather correlation is initialized
+        # 2. Temperature is provided
+        # 3. We have base load to adjust
+        # 4. Confidence is medium or high (not low)
+        if (
+            self._weather_correlation is not None
+            and temperature is not None
+            and base_load_kw > 0
+        ):
+            # Get coefficients for this hour
+            coef = self._weather_correlation.get_coefficients_for_hour(slot_hour)
+            if coef is not None and coef.confidence in ("medium", "high"):
+                # Apply weather-based prediction
+                adjusted_load, adjustment_source = (
+                    self._weather_correlation.predict_load(
+                        hour=slot_hour,
+                        temperature=temperature,
+                        base_load_kw=base_load_kw,
+                    )
+                )
+                # Only use adjustment if it's not a fallback
+                if adjustment_source not in (
+                    "no_coefficients",
+                    "low_confidence",
+                    "invalid_hour",
+                ):
+                    return round(adjusted_load, 3), adjustment_source
+
+        # Return base load without weather adjustment
+        return round(base_load_kw, 3), base_source
 
     def _simulate_future_soc_with_solar_only(
         self,
@@ -2105,6 +2156,32 @@ class ForecastComputer:
         # Get all Solcast forecasts
         all_solcast = [*data.solcast_today, *data.solcast_tomorrow]
 
+        # Weather temperature forecasts (hourly), keyed by local date/hour for fast lookup.
+        temperature_by_hour: dict[tuple[int, int, int, int], float] = {}
+        if self._weather_correlation is not None:
+            try:
+                for forecast in self._weather_correlation.get_temperature_forecast():
+                    if forecast.temperature is None:
+                        continue
+                    temp = float(forecast.temperature)
+                    slot_local = dt_util.as_local(forecast.slot_time)
+                    key = (
+                        slot_local.year,
+                        slot_local.month,
+                        slot_local.day,
+                        slot_local.hour,
+                    )
+                    # Keep first forecast for each hour.
+                    if key not in temperature_by_hour:
+                        temperature_by_hour[key] = temp
+            except Exception as err:
+                _LOGGER.debug(
+                    "Failed to read temperature forecast for load adjustment: %s", err
+                )
+
+        # Reset and re-populate during this forecast cycle.
+        data.weather_adjustment_applied = False
+
         # Publish consumption profile diagnostics for transparency
         data.consumption_source = (
             historical_load_source if historical_avg_kw else "live_load_fallback"
@@ -2179,6 +2256,9 @@ class ForecastComputer:
         for offset in range(96):
             slot_start = base_slot + timedelta(minutes=15 * offset)
             slot_hour = slot_start.hour
+            slot_temp = temperature_by_hour.get(
+                (slot_start.year, slot_start.month, slot_start.day, slot_start.hour)
+            )
 
             solar_kwh = get_solar_for_15min_slot(all_solcast, slot_start)
             load_kw, _ = self._estimate_hourly_consumption_kw(
@@ -2187,6 +2267,7 @@ class ForecastComputer:
                 current_hour,
                 data.load_power_kw,
                 recent_load_kw,
+                slot_temp,
             )
             consumption_kwh = load_kw / 4
             net_kwh = solar_kwh - consumption_kwh
@@ -2306,13 +2387,19 @@ class ForecastComputer:
                 get_solar_for_15min_slot(all_solcast, slot_start, debug_log=True)
 
             # Get expected consumption scaled to this slot's duration.
+            slot_temp = temperature_by_hour.get(
+                (slot_start.year, slot_start.month, slot_start.day, slot_start.hour)
+            )
             load_kw, load_source = self._estimate_hourly_consumption_kw(
                 historical_avg_kw,
                 slot_hour,
                 current_hour,
                 data.load_power_kw,
                 recent_load_kw,
+                slot_temp,
             )
+            if load_source.startswith("weather_"):
+                data.weather_adjustment_applied = True
             if load_source != "profile_hour":
                 data.consumption_fallback_hours += 1
             consumption_source_counts[load_source] = (

--- a/tests/test_computation_engine.py
+++ b/tests/test_computation_engine.py
@@ -1,7 +1,7 @@
 """Unit tests for ComputationEngine."""
 
 from datetime import datetime, time, timedelta, timezone
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -592,3 +592,26 @@ class TestComputeDaily15MinForecast:
             computation_engine._compute_daily_15min_forecast(coordinator_data, now_dt)
             # Should have empty forecast
             assert coordinator_data.daily_forecast == []
+
+
+@pytest.mark.asyncio
+async def test_async_initialize_weather_correlation_updates_forecast_computer(
+    computation_engine,
+):
+    """Weather initialization should wire correlation into ForecastComputer."""
+    computation_engine.entry.options["weather_learning_enabled"] = True
+
+    with patch(
+        "custom_components.localshift.computation_engine.WeatherCorrelation"
+    ) as mock_weather_cls:
+        mock_weather = MagicMock()
+        mock_weather.async_initialize = AsyncMock(return_value=None)
+        mock_weather_cls.return_value = mock_weather
+
+        with patch.object(
+            computation_engine._forecast_computer,
+            "set_weather_correlation",
+        ) as mock_set_weather:
+            await computation_engine.async_initialize_weather_correlation()
+
+        mock_set_weather.assert_called_once_with(mock_weather)

--- a/tests/test_forecast_computer.py
+++ b/tests/test_forecast_computer.py
@@ -71,6 +71,84 @@ def test_estimate_hourly_consumption_fallback(mock_entry, mock_get_entity_id):
     assert source == "live_load_fallback"
 
 
+def test_estimate_hourly_consumption_applies_weather_adjustment(
+    mock_entry, mock_get_entity_id
+):
+    """Uses weather-adjusted prediction when confidence is medium/high."""
+
+    class _Coeff:
+        confidence = "medium"
+
+    class _Weather:
+        def get_coefficients_for_hour(self, _hour):
+            return _Coeff()
+
+        def predict_load(self, hour, temperature, base_load_kw):
+            assert hour == 17
+            assert temperature == 35.0
+            return base_load_kw + 0.4, "weather_cooling"
+
+    entry = mock_entry
+    entry.options = {"load_weight_recent": 0.7}
+
+    computer = ForecastComputer(
+        entry,
+        mock_get_entity_id,
+        lambda x: {},
+        weather_correlation=_Weather(),
+    )
+
+    kw, source = computer._estimate_hourly_consumption_kw(
+        {17: 0.6},
+        17,
+        17,
+        0.4,
+        0.5,
+        temperature=35.0,
+    )
+
+    assert source == "weather_cooling"
+    assert kw > 0.6
+
+
+def test_estimate_hourly_consumption_skips_low_confidence_weather(
+    mock_entry, mock_get_entity_id
+):
+    """Falls back to base source when weather model confidence is low."""
+
+    class _Coeff:
+        confidence = "low"
+
+    class _Weather:
+        def get_coefficients_for_hour(self, _hour):
+            return _Coeff()
+
+        def predict_load(self, hour, temperature, base_load_kw):  # pragma: no cover
+            return base_load_kw + 1.0, "weather_cooling"
+
+    entry = mock_entry
+    entry.options = {"load_weight_recent": 0.7}
+
+    computer = ForecastComputer(
+        entry,
+        mock_get_entity_id,
+        lambda x: {},
+        weather_correlation=_Weather(),
+    )
+
+    kw, source = computer._estimate_hourly_consumption_kw(
+        {17: 0.6},
+        17,
+        17,
+        0.4,
+        0.5,
+        temperature=35.0,
+    )
+
+    assert source == "weighted_load"
+    assert kw == pytest.approx(0.53, rel=0.01)
+
+
 def test_find_negative_fit_windows_no_negatives(mock_entry, mock_get_entity_id):
     """Test negative FIT window detection with no negative prices."""
     entry = mock_entry


### PR DESCRIPTION
## Summary
Integrate weather-based load adjustments into forecast consumption estimation for issue #127.

## Changes Made
- Wired ComputationEngine weather-correlation lifecycle into ForecastComputer via runtime setter.
- Updated ForecastComputer to:
  - pass hourly temperature forecast context into consumption estimation,
  - apply weather adjustments only when coefficient confidence is medium/high,
  - set weather_adjustment_applied when weather-based source is used.
- Added/updated tests for:
  - weather adjustment usage and low-confidence fallback in tests/test_forecast_computer.py,
  - weather-correlation wiring during async initialization in tests/test_computation_engine.py.

## Testing
- uv run pytest -q tests/test_forecast_computer.py tests/test_computation_engine.py
- uv run pre-commit run --all-files

Closes #127
