### PR TITLE
Fix temperature forecast using modern weather.get_forecasts service

### DIFF
--- a/custom_components/localshift/computation_engine.py
+++ b/custom_components/localshift/computation_engine.py
@@ -1628,6 +1628,36 @@ class ComputationEngine:
             await self._weather_correlation.async_save()
             self._last_weather_save_hour = current_hour
 
+    async def async_refresh_weather_forecast(self) -> list | None:
+        """Refresh temperature forecast from weather entity.
+
+        Uses the modern weather.get_forecasts service (HA 2024.3+) with caching.
+        Should be called periodically (e.g., every 30 minutes) by the coordinator.
+
+        Returns:
+            List of TemperatureForecast objects, or None if unavailable.
+        """
+        if self._weather_correlation is None:
+            return None
+
+        weather_learning_enabled = self.entry.options.get(
+            CONF_WEATHER_LEARNING_ENABLED, DEFAULT_WEATHER_LEARNING_ENABLED
+        )
+
+        if not weather_learning_enabled:
+            return None
+
+        try:
+            forecasts = await self._weather_correlation.async_get_temperature_forecast()
+            _LOGGER.debug(
+                "Refreshed %d temperature forecasts from weather entity",
+                len(forecasts),
+            )
+            return forecasts
+        except Exception as e:
+            _LOGGER.warning("Failed to refresh weather forecast: %s", e)
+            return None
+
     def get_weather_adjusted_load(
         self, hour: int, base_load_kw: float
     ) -> tuple[float, str]:

--- a/custom_components/localshift/coordinator.py
+++ b/custom_components/localshift/coordinator.py
@@ -503,6 +503,12 @@ class LocalShiftCoordinator:
                 self._computation_engine.async_learn_weather_sample(self.data),
                 "localshift_weather_learning",
             )
+            # Refresh temperature forecast from weather entity (Issue #135)
+            # Uses modern weather.get_forecasts service with 30-min cache
+            self.hass.async_create_task(
+                self._refresh_weather_forecast(),
+                "localshift_weather_forecast",
+            )
             # Compute forecast accuracy metrics (Issue #37 Phase 2)
             self.hass.async_create_task(
                 self._computation_engine.async_compute_forecast_accuracy(self.data),
@@ -691,3 +697,29 @@ class LocalShiftCoordinator:
         """Send a notification via the notification service."""
         if self._notification_service is not None:
             await self._notification_service.send_notification(title, message)
+
+    async def _refresh_weather_forecast(self) -> None:
+        """Refresh temperature forecast from weather entity.
+
+        Uses the modern weather.get_forecasts service (HA 2024.3+) with caching.
+        Updates CoordinatorData with the latest forecast for use by sensors.
+        """
+        if self._computation_engine is None:
+            return
+
+        forecasts = await self._computation_engine.async_refresh_weather_forecast()
+
+        if forecasts is not None:
+            # Update CoordinatorData with the forecast data
+
+            self.data.weather_temperature_forecast = {}
+            for forecast in forecasts:
+                hour = forecast.slot_time.hour
+                temperature = forecast.temperature
+                if temperature is not None:
+                    self.data.weather_temperature_forecast[hour] = temperature
+
+            _LOGGER.debug(
+                "Updated weather forecast: %d hours of temperature data",
+                len(self.data.weather_temperature_forecast),
+            )

--- a/custom_components/localshift/state_reader.py
+++ b/custom_components/localshift/state_reader.py
@@ -235,10 +235,15 @@ class StateReader:
         self._read_weather_state(data)
 
     def _read_weather_state(self, data: CoordinatorData) -> None:
-        """Read weather entity state and forecast.
+        """Read weather entity current state (temperature and condition).
 
         Populates weather-related fields in CoordinatorData for use by
         the weather correlation system.
+
+        NOTE: Temperature forecast is fetched asynchronously via the coordinator's
+        _refresh_weather_forecast() method, which uses the modern weather.get_forecasts
+        service (HA 2024.3+). The forecast attribute on weather entities was deprecated
+        and removed in HA 2024.3+.
 
         Args:
             data: CoordinatorData instance to populate with weather data.
@@ -275,36 +280,14 @@ class StateReader:
         # Read current condition
         data.weather_condition = state.state
 
-        # Read temperature forecast
-        forecast_data = state.attributes.get("forecast", [])
-        data.weather_temperature_forecast = {}
-
-        for forecast_entry in forecast_data:
-            forecast_time_str = forecast_entry.get("datetime")
-            if not forecast_time_str:
-                continue
-
-            try:
-                # Parse the datetime to extract the hour
-                from homeassistant.util import dt as dt_util
-
-                forecast_time = dt_util.parse_datetime(forecast_time_str)
-                if forecast_time is None:
-                    continue
-
-                hour = forecast_time.hour
-                temperature = forecast_entry.get("temperature")
-
-                if temperature is not None:
-                    data.weather_temperature_forecast[hour] = float(temperature)
-
-            except (ValueError, TypeError):
-                continue
+        # NOTE: Temperature forecast is no longer read from the deprecated 'forecast' attribute.
+        # It's now fetched asynchronously via weather.get_forecasts service in the coordinator's
+        # _refresh_weather_forecast() method, which populates data.weather_temperature_forecast.
+        # The legacy 'forecast' attribute was removed in Home Assistant 2024.3+.
 
         _LOGGER.debug(
-            "Weather state read: entity=%s, temp=%.1f°C, condition=%s, forecast_hours=%d",
+            "Weather state read: entity=%s, temp=%.1f°C, condition=%s",
             weather_entity,
             data.weather_temperature_current,
             data.weather_condition,
-            len(data.weather_temperature_forecast),
         )

--- a/custom_components/localshift/weather_correlation.py
+++ b/custom_components/localshift/weather_correlation.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
@@ -42,6 +42,9 @@ STORAGE_KEY = "weather_correlation"
 # Confidence thresholds based on sample count
 CONFIDENCE_LOW_THRESHOLD = 7  # Less than 7 samples = low confidence
 CONFIDENCE_MEDIUM_THRESHOLD = 30  # 7-30 samples = medium, 30+ = high
+
+# Forecast cache settings
+FORECAST_CACHE_TTL = timedelta(minutes=30)
 
 
 @dataclass
@@ -192,6 +195,10 @@ class WeatherCorrelation:
             tuple[int, float, float]
         ] = []  # (hour, temp, load)
 
+        # Cached temperature forecast (updated periodically)
+        self._cached_forecasts: list[TemperatureForecast] = []
+        self._forecast_cache_time: datetime | None = None
+
     async def async_initialize(self) -> None:
         """Load persisted data from storage."""
         if self._initialized:
@@ -278,10 +285,109 @@ class WeatherCorrelation:
             )
 
         _LOGGER.debug(
-            "Got %d temperature forecasts from %s",
+            "Got %d temperature forecasts from %s (legacy attribute)",
             len(forecasts),
             weather_entity,
         )
+
+        return forecasts
+
+    async def async_get_temperature_forecast(
+        self, force_refresh: bool = False
+    ) -> list[TemperatureForecast]:
+        """Fetch forecasted temperatures using weather.get_forecasts service.
+
+        Uses Home Assistant's modern weather.get_forecasts service (HA 2024.3+)
+        with caching to avoid excessive service calls.
+
+        Args:
+            force_refresh: If True, bypass cache and fetch fresh data
+
+        Returns:
+            List of TemperatureForecast objects for upcoming hours.
+        """
+        weather_entity = self._data.weather_entity_id
+        if not weather_entity:
+            _LOGGER.debug("No weather entity configured")
+            return []
+
+        now = dt_util.now()
+
+        # Return cached forecasts if still valid
+        if (
+            not force_refresh
+            and self._forecast_cache_time is not None
+            and self._cached_forecasts
+            and (now - self._forecast_cache_time) < FORECAST_CACHE_TTL
+        ):
+            _LOGGER.debug(
+                "Returning %d cached temperature forecasts (age: %s)",
+                len(self._cached_forecasts),
+                now - self._forecast_cache_time,
+            )
+            return self._cached_forecasts
+
+        forecasts: list[TemperatureForecast] = []
+
+        # Try modern service call first (HA 2024.3+)
+        try:
+            response = await self.hass.services.async_call(
+                "weather",
+                "get_forecasts",
+                {"entity_id": weather_entity, "type": "hourly"},
+                blocking=True,
+                return_response=True,
+            )
+
+            if response and weather_entity in response:
+                forecast_data = response[weather_entity]
+
+                for forecast_entry in forecast_data:
+                    # Parse forecast datetime - HA uses "datetime" key
+                    forecast_time_str = forecast_entry.get("datetime")
+                    if not forecast_time_str:
+                        continue
+
+                    try:
+                        forecast_time = dt_util.parse_datetime(forecast_time_str)
+                        if forecast_time is None:
+                            continue
+                    except (ValueError, TypeError):
+                        continue
+
+                    # Only include forecasts for the next 24 hours
+                    hours_ahead = (forecast_time - now).total_seconds() / 3600
+                    if hours_ahead < 0 or hours_ahead > 24:
+                        continue
+
+                    temperature = forecast_entry.get("temperature")
+                    condition = forecast_entry.get("condition", "unknown")
+
+                    forecasts.append(
+                        TemperatureForecast(
+                            slot_time=forecast_time,
+                            temperature=temperature,
+                            condition=condition,
+                        )
+                    )
+
+                _LOGGER.info(
+                    "Fetched %d temperature forecasts via weather.get_forecasts service",
+                    len(forecasts),
+                )
+
+        except Exception as e:
+            _LOGGER.warning(
+                "Failed to fetch forecasts via weather.get_forecasts service: %s, "
+                "falling back to legacy attribute",
+                e,
+            )
+            # Fall back to legacy attribute method
+            forecasts = self.get_temperature_forecast()
+
+        # Update cache
+        self._cached_forecasts = forecasts
+        self._forecast_cache_time = now
 
         return forecasts
 


### PR DESCRIPTION
## Summary
Fixes the empty temperature forecast issue caused by Home Assistant 2024.3+ removing the deprecated `forecast` attribute from weather entities.

## Problem
The diagnostic output showed `Temperature Forecast: {}` because the `get_temperature_forecast()` method was reading the deprecated `state.attributes.get("forecast", [])` attribute which no longer exists in modern Home Assistant.

## Solution
- Added `async_get_temperature_forecast()` method that uses the modern `weather.get_forecasts` service call
- Implemented 30-minute caching to avoid excessive service calls
- Falls back to legacy attribute for backward compatibility with older HA versions
- Added periodic forecast refresh in the coordinator's periodic tick

## Changes Made
- `weather_correlation.py`: Add async method with service call and caching
- `computation_engine.py`: Add `async_refresh_weather_forecast()` method
- `coordinator.py`: Add periodic forecast refresh via `_refresh_weather_forecast()`
- `state_reader.py`: Remove deprecated forecast attribute reading

## Testing
- All 367 tests pass
- Pre-commit hooks pass (ruff, pyright, bandit, vulture)

Closes #135