### PR TITLE
fix: clear forecast cache when weather entity changes

### DIFF
--- a/custom_components/localshift/weather_correlation.py
+++ b/custom_components/localshift/weather_correlation.py
@@ -330,11 +330,14 @@ class WeatherCorrelation:
         # Update cached entity ID if changed
         if weather_entity != self._data.weather_entity_id:
             _LOGGER.info(
-                "Weather entity changed from %s to %s",
+                "Weather entity changed from %s to %s, clearing forecast cache",
                 self._data.weather_entity_id,
                 weather_entity,
             )
             self._data.weather_entity_id = weather_entity
+            # Clear cache to force fresh fetch with new entity
+            self._cached_forecasts = []
+            self._forecast_cache_time = None
 
         now = dt_util.now()
 


### PR DESCRIPTION
## Summary
Clears the forecast cache when the weather entity ID changes, forcing a fresh fetch with the new entity.

## Problem
When the weather entity ID changed, the old cached (empty) forecasts would persist for up to 30 minutes, causing `Temperature Forecast: {}` even after fixing the entity configuration.

## Changes Made
- Clear `_cached_forecasts` and `_forecast_cache_time` when the weather entity ID changes
- Log message now indicates cache is being cleared

## Testing
- All 367 tests pass
- Pre-commit hooks pass