### PR TITLE
Add debug logging for grid charging solar simulation

### DIFF
--- a/custom_components/localshift/computation_engine_lib/forecast_computer.py
+++ b/custom_components/localshift/computation_engine_lib/forecast_computer.py
@@ -701,10 +701,26 @@ class ForecastComputer:
                 )
             )
 
+            # DEBUG: Log simulation result for every slot
+            _LOGGER.info(
+                "SOLAR_SIM[%02d:%02d]: start_soc=%.1f%% sim_end=%s max_soc=%.1f%% target=%d%% can_reach=%s price=$%.3f cheap=$%.3f",
+                slot_start.hour,
+                slot_start.minute,
+                predicted_soc,
+                sim_end.strftime("%H:%M"),
+                max_soc,
+                target_pct,
+                can_reach_with_solar_only,
+                use_price,
+                effective_cheap_price,
+            )
+
             # Solar forecast says we'll reach target: NO grid charging
             if can_reach_with_solar_only:
-                _LOGGER.debug(
-                    "Grid charge SKIPPED: solar forecast reaches target before DW (max_soc=%.1f%% >= %d%%)",
+                _LOGGER.info(
+                    "GRID_CHARGE_SKIP[%02d:%02d]: solar forecast reaches target (max_soc=%.1f%% >= %d%%)",
+                    slot_start.hour,
+                    slot_start.minute,
                     max_soc,
                     target_pct,
                 )


### PR DESCRIPTION
## Summary
- Add INFO-level logging for solar simulation results per slot
- Log start_soc, sim_end, max_soc, target, can_reach, price, cheap threshold
- Helps debug inconsistent grid charging decisions

## Issue Under Investigation
Grid charging forecast shows inconsistent behavior:
- Some cheap-priced slots skip charging  
- Target SOC (95%) not reached despite available cheap slots
- Max SOC reached: 86.4%

Example anomaly:
- 09:10 ($0.125) - skips charging
- 09:40 ($0.130) - charges
- 10:25 ($0.155) - charges

The solar simulation appears to return inconsistent `can_reach_with_solar_only` results between adjacent slots.

## Testing
- All 28 tests pass
- Ready for integration testing in HA to capture logs