### PR TITLE
feat(hvac): add HVAC-aware load forecasting (Issue #152)

### DIFF
--- a/custom_components/localshift/computation_engine.py
+++ b/custom_components/localshift/computation_engine.py
@@ -147,6 +147,9 @@ class ComputationEngine:
         # Baseline load profile for Issue #137 (set by coordinator)
         self._baseline_avg_kw: dict[int, float] = {}
 
+        # Thermal manager for HVAC-aware load forecasting (Issue #152)
+        self._thermal_manager: Any = None
+
     # ========================================================================
     # MAIN ENTRY POINT
     # ========================================================================
@@ -659,6 +662,21 @@ class ComputationEngine:
                 len(baseline_avg_kw),
                 sum(baseline_avg_kw.values()) / len(baseline_avg_kw),
             )
+
+    def set_thermal_manager(self, thermal_manager: Any | None) -> None:
+        """Set the thermal manager for HVAC-aware load forecasting (Issue #152).
+
+        Called by coordinator to provide the thermal manager instance.
+        This enables HVAC load prediction in the forecast.
+
+        Args:
+            thermal_manager: ThermalManager instance, or None to disable.
+        """
+        self._thermal_manager = thermal_manager
+        # Propagate to forecast computer
+        self._forecast_computer.set_thermal_manager(thermal_manager)
+        if thermal_manager:
+            _LOGGER.info("Thermal manager set for HVAC-aware load forecasting")
 
     def _compute_daily_15min_forecast(
         self,

--- a/custom_components/localshift/computation_engine_lib/forecast_computer.py
+++ b/custom_components/localshift/computation_engine_lib/forecast_computer.py
@@ -64,6 +64,7 @@ class ForecastComputer:
         ]
         | None = None,
         weather_correlation: Any | None = None,
+        thermal_manager: Any | None = None,
     ) -> None:
         """Initialize forecast computer.
 
@@ -73,12 +74,14 @@ class ForecastComputer:
             get_historical_func: Function to get historical hourly averages (combined profile)
             get_profile_for_day_func: Optional function to get day-aware profile (issue-60)
             weather_correlation: Optional WeatherCorrelation instance for temperature-based adjustments
+            thermal_manager: Optional ThermalManager instance for HVAC-aware load forecasting (Issue #152)
         """
         self.entry = entry
         self._get_entity_id = get_entity_id_func
         self._get_historical_hourly_averages = get_historical_func
         self._get_profile_for_day = get_profile_for_day_func
         self._weather_correlation = weather_correlation
+        self._thermal_manager = thermal_manager
 
         # Extracted helper modules (issue #145)
         self._fit_analyzer = FitAnalyzer()
@@ -104,6 +107,66 @@ class ForecastComputer:
     def set_weather_correlation(self, weather_correlation: Any | None) -> None:
         """Set or clear WeatherCorrelation dependency at runtime."""
         self._weather_correlation = weather_correlation
+
+    def set_thermal_manager(self, thermal_manager: Any | None) -> None:
+        """Set or clear ThermalManager dependency at runtime.
+
+        Args:
+            thermal_manager: ThermalManager instance for HVAC-aware load forecasting,
+                           or None to disable HVAC prediction.
+        """
+        self._thermal_manager = thermal_manager
+
+    def _predict_hvac_load_for_slot(
+        self,
+        slot_hour: int,
+        temperature: float | None,
+        daily_thermal_mode: str | None,
+    ) -> float:
+        """Predict HVAC load for a given slot.
+
+        Uses the thermal manager's learned HVAC power data and the daily
+        thermal mode to predict how much HVAC load to expect.
+
+        Args:
+            slot_hour: Hour of day (0-23)
+            temperature: Forecasted temperature in °C, or None
+            daily_thermal_mode: Current daily thermal mode ("off", "cool", "heat", "dry")
+
+        Returns:
+            Predicted HVAC load in kW, or 0.0 if unavailable.
+        """
+        if self._thermal_manager is None:
+            return 0.0
+
+        if daily_thermal_mode is None or daily_thermal_mode == "off":
+            return 0.0
+
+        # Import ThermalMode for comparison
+        try:
+            from ..const import ThermalMode
+
+            mode = ThermalMode(daily_thermal_mode)
+        except (ValueError, ImportError):
+            return 0.0
+
+        # Use temperature if available, otherwise use a default estimate
+        temp = temperature if temperature is not None else 25.0
+
+        try:
+            hvac_kw = self._thermal_manager.predict_hvac_load(
+                hour=slot_hour,
+                temperature=temp,
+                daily_mode=mode,
+            )
+            return max(0.0, hvac_kw)
+        except Exception as err:
+            _LOGGER.debug(
+                "HVAC prediction failed for hour %d: %s",
+                slot_hour,
+                err,
+            )
+            return 0.0
 
     def _parse_time_option(self, key: str, default: str) -> time:
         """Parse a time string option (HH:MM:SS) into a time object."""
@@ -1504,7 +1567,7 @@ class ForecastComputer:
             slot_temp = temperature_by_hour.get(
                 (slot_start.year, slot_start.month, slot_start.day, slot_start.hour)
             )
-            load_kw, load_source = self._estimate_hourly_consumption_kw(
+            baseline_kw, load_source = self._estimate_hourly_consumption_kw(
                 historical_avg_kw,
                 slot_hour,
                 current_hour,
@@ -1519,7 +1582,42 @@ class ForecastComputer:
             consumption_source_counts[load_source] = (
                 consumption_source_counts.get(load_source, 0) + 1
             )
-            consumption_kwh = load_kw * slot_fraction
+
+            # Issue #152: Add HVAC prediction to total load forecast
+            # Grid charging decisions use baseline only (passed via baseline_avg_kw),
+            # but SOC forecast needs total = baseline + predicted_hvac
+            daily_thermal_mode = getattr(data, "daily_thermal_mode", None)
+            if isinstance(daily_thermal_mode, str):
+                pass  # Already a string
+            elif daily_thermal_mode is not None:
+                daily_thermal_mode = str(daily_thermal_mode)
+
+            hvac_kw = self._predict_hvac_load_for_slot(
+                slot_hour=slot_hour,
+                temperature=slot_temp,
+                daily_thermal_mode=daily_thermal_mode,
+            )
+
+            # Total load = baseline + HVAC prediction
+            # Grid charging decisions use baseline only (Issue #137 via baseline_avg_kw param)
+            # SOC forecast uses total to account for thermal load
+            total_load_kw = baseline_kw + hvac_kw
+
+            # Log HVAC contribution when significant
+            if hvac_kw > 0.1:
+                _LOGGER.debug(
+                    "HVAC_PREDICTION[%02d:%02d]: baseline=%.2f kW, hvac=%.2f kW, total=%.2f kW, mode=%s",
+                    slot_hour,
+                    slot_minute,
+                    baseline_kw,
+                    hvac_kw,
+                    total_load_kw,
+                    daily_thermal_mode or "off",
+                )
+                # Track HVAC prediction in source for diagnostics
+                load_source = f"{load_source}+hvac"
+
+            consumption_kwh = total_load_kw * slot_fraction
 
             # Calculate raw net energy for this slot
             net_kwh = solar_kwh - consumption_kwh


### PR DESCRIPTION
## Summary

This PR implements HVAC-aware load forecasting by composing the total forecast from baseline + predicted HVAC load.

**Design principle:**
- **SOC forecast** uses `total_load = baseline + hvac` (for accurate battery trajectory)
- **Grid charging decisions** use `baseline only` (to avoid HVAC feedback loop from Issue #137)

## Changes

1. **Wire thermal_manager to forecast_computer**
   - Add `thermal_manager` parameter to `ForecastComputer.__init__`
   - Add `set_thermal_manager()` method for runtime injection

2. **Implement HVAC prediction in forecast**
   - Add `_predict_hvac_load_for_slot()` method that calls `ThermalManager.predict_hvac_load()`
   - Compose total load as `baseline_kw + hvac_kw` in `compute_forecast()`

3. **Propagate thermal_manager from computation_engine**
   - Add `set_thermal_manager()` method to `ComputationEngine`
   - Forward thermal_manager to forecast_computer

4. **Maintain baseline-only for grid charging (Issue #137)**
   - Grid charging decisions continue using `baseline_avg_kw` parameter
   - This prevents the feedback loop where HVAC spikes trigger unnecessary charging

## Test Plan

- All existing tests pass (28/28 in test_forecast_computer.py)
- HVAC prediction returns 0.0 when thermal_manager is None
- HVAC prediction returns 0.0 when daily_thermal_mode is "off"

Closes #152