### PR TITLE
fix: correct thermal management switch entity IDs in dashboard

### DIFF
--- a/custom_components/localshift/dashboard.yaml
+++ b/custom_components/localshift/dashboard.yaml
@@ -622,12 +622,12 @@ views:
             heading_style: title
 
           - type: tile
-            entity: switch.localshift_thermal_management_enabled
+            entity: switch.localshift_thermal_management
             name: Thermal Control
             icon: mdi:air-conditioner
 
           - type: tile
-            entity: switch.localshift_solar_taper_enabled
+            entity: switch.localshift_solar_taper
             name: Solar Taper
             icon: mdi:solar-power
 


### PR DESCRIPTION
## Summary
Fixed incorrect entity references in the dashboard Controls view (Thermal Management section).

## Changes Made
- `switch.localshift_thermal_management_enabled` → `switch.localshift_thermal_management`
- `switch.localshift_solar_taper_enabled` → `switch.localshift_solar_taper`

## Testing
- Verified entity IDs match the actual switch entity names defined in const.py