### PR TITLE
refactor: move price functions from solar_utils to price_calculator

### DIFF
--- a/custom_components/localshift/computation_engine_lib/__init__.py
+++ b/custom_components/localshift/computation_engine_lib/__init__.py
@@ -9,11 +9,14 @@ from .forecast_computer import ForecastComputer
 from .grid_charge_decision import GridChargeDecisionEngine
 from .history_fetcher import HistoryFetcher
 from .mode_decision import ModeDecisionEngine
-from .price_calculator import PriceCalculator
+from .price_calculator import (
+    PriceCalculator,
+    get_price_for_slot,
+    get_price_for_slot_or_none,
+)
 from .proactive_export import ProactiveExportEngine
 from .soc_simulator import SocSimulator
 from .solar_utils import (
-    get_price_for_slot,
     get_solar_for_5min_slot,
     get_solar_for_15min_slot,
     get_solar_for_slot,
@@ -50,6 +53,7 @@ __all__ = [
     "build_hourly_forecast_summary",
     "calculate_spike_price_threshold",
     "get_price_for_slot",
+    "get_price_for_slot_or_none",
     "get_solar_for_15min_slot",
     "get_solar_for_5min_slot",
     "get_solar_for_slot",

--- a/custom_components/localshift/computation_engine_lib/excess_solar.py
+++ b/custom_components/localshift/computation_engine_lib/excess_solar.py
@@ -14,7 +14,8 @@ from ..const import (
     DEFAULT_BATTERY_TARGET,
 )
 from ..coordinator_data import CoordinatorData
-from .solar_utils import get_price_for_slot_or_none, get_solar_for_15min_slot
+from .price_calculator import get_price_for_slot_or_none
+from .solar_utils import get_solar_for_15min_slot
 
 
 class ExcessSolarEngine:

--- a/custom_components/localshift/computation_engine_lib/fit_analyzer.py
+++ b/custom_components/localshift/computation_engine_lib/fit_analyzer.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta
 
-from .solar_utils import get_price_for_slot, get_price_for_slot_or_none
+from .price_calculator import get_price_for_slot, get_price_for_slot_or_none
 
 
 class FitAnalyzer:

--- a/custom_components/localshift/computation_engine_lib/forecast_computer.py
+++ b/custom_components/localshift/computation_engine_lib/forecast_computer.py
@@ -36,10 +36,10 @@ from ..coordinator_data import CoordinatorData
 from .excess_solar import ExcessSolarEngine
 from .fit_analyzer import FitAnalyzer
 from .grid_charge_decision import GridChargeDecisionEngine
+from .price_calculator import get_price_for_slot
 from .proactive_export import ProactiveExportEngine
 from .soc_simulator import SocSimulator
 from .solar_utils import (
-    get_price_for_slot,
     get_solar_for_15min_slot,
     get_solar_for_15min_slot_or_none,
 )

--- a/custom_components/localshift/computation_engine_lib/price_calculator.py
+++ b/custom_components/localshift/computation_engine_lib/price_calculator.py
@@ -21,6 +21,139 @@ from ..const import (
     DEFAULT_MAX_PRECHARGE_PRICE,
 )
 from ..coordinator_data import CoordinatorData
+from .utils import parse_forecast_dt
+
+
+def get_price_for_slot(
+    price_forecasts: list[dict[str, Any]],
+    slot_start: datetime,
+) -> float:
+    """Get price for a slot from Amber forecast data.
+
+    Amber mixes 5-min dispatch intervals (near-term) with 30-min extended
+    forecast periods.  The overlap scan below handles both correctly.
+
+    When no period overlaps the slot (e.g. a 5-min slot that falls in the
+    gap between two non-adjacent 30-min entries), falls back to the most
+    recent entry whose start_time <= slot_start so that prices are never
+    silently zeroed out due to resolution mismatches.
+    """
+    if not price_forecasts:
+        return 0.0
+
+    # Ensure slot boundaries are timezone-aware local datetimes
+    if slot_start.tzinfo is None:
+        slot_start = dt_util.as_local(dt_util.as_utc(slot_start))
+    else:
+        slot_start = dt_util.as_local(slot_start)
+
+    slot_end = slot_start + timedelta(minutes=15)
+
+    prices_in_slot: list[float] = []
+    fallback_price: float = 0.0
+    fallback_start: datetime | None = None
+
+    for entry in price_forecasts:
+        if not isinstance(entry, dict):
+            continue
+
+        start_raw = entry.get("start_time")
+        if start_raw is None:
+            continue
+
+        start_dt = parse_forecast_dt(start_raw)
+        if start_dt is None:
+            continue
+
+        start_local = dt_util.as_local(start_dt)
+
+        # Overlap check: use per-entry duration from the data when available,
+        # otherwise assume 5 minutes (standard Amber dispatch interval).
+        duration_minutes: int = int(entry.get("duration", 5))
+        end_local = start_local + timedelta(minutes=duration_minutes)
+
+        if start_local < slot_end and end_local > slot_start:
+            price = float(entry.get("per_kwh", 0.0))
+            prices_in_slot.append(price)
+
+        # Track most-recent entry at or before slot_start for fallback
+        if start_local <= slot_start:
+            if fallback_start is None or start_local > fallback_start:
+                fallback_start = start_local
+                fallback_price = float(entry.get("per_kwh", 0.0))
+
+    if prices_in_slot:
+        return sum(prices_in_slot) / len(prices_in_slot)
+
+    # Fallback: use the most recent price entry that started before this slot.
+    # This handles the case where the Amber forecast has 30-min extended periods
+    # that don't fully overlap short near-term slots (gap at :10/:15/:40/:45).
+    return fallback_price
+
+
+def get_price_for_slot_or_none(
+    price_forecasts: list[dict[str, Any]],
+    slot_start: datetime,
+) -> float | None:
+    """Get price for a slot, returning None only when the forecast has no data.
+
+    Unlike get_price_for_slot(), this returns None (not 0.0) when the forecast
+    list is empty or contains no entry at or before slot_start — allowing callers
+    to distinguish "missing forecast" from a genuine $0.00 price.
+
+    Uses the same duration-aware overlap + most-recent fallback as
+    get_price_for_slot() so that 30-min extended periods are handled correctly.
+    """
+    if not price_forecasts:
+        return None
+
+    # Ensure slot boundaries are timezone-aware local datetimes
+    if slot_start.tzinfo is None:
+        slot_start = dt_util.as_local(dt_util.as_utc(slot_start))
+    else:
+        slot_start = dt_util.as_local(slot_start)
+
+    slot_end = slot_start + timedelta(minutes=15)
+
+    prices_in_slot: list[float] = []
+    fallback_price: float = 0.0
+    fallback_start: datetime | None = None
+
+    for entry in price_forecasts:
+        if not isinstance(entry, dict):
+            continue
+
+        start_raw = entry.get("start_time")
+        if start_raw is None:
+            continue
+
+        start_dt = parse_forecast_dt(start_raw)
+        if start_dt is None:
+            continue
+
+        start_local = dt_util.as_local(start_dt)
+
+        duration_minutes: int = int(entry.get("duration", 5))
+        end_local = start_local + timedelta(minutes=duration_minutes)
+
+        if start_local < slot_end and end_local > slot_start:
+            price = float(entry.get("per_kwh", 0.0))
+            prices_in_slot.append(price)
+
+        if start_local <= slot_start:
+            if fallback_start is None or start_local > fallback_start:
+                fallback_start = start_local
+                fallback_price = float(entry.get("per_kwh", 0.0))
+
+    if prices_in_slot:
+        return sum(prices_in_slot) / len(prices_in_slot)
+
+    # Return fallback price when the forecast exists but doesn't directly overlap.
+    # Return None only when there is no entry at or before slot_start at all
+    # (i.e. the forecast doesn't cover this time yet).
+    if fallback_start is None:
+        return None
+    return fallback_price
 
 
 class PriceCalculator:

--- a/custom_components/localshift/computation_engine_lib/proactive_export.py
+++ b/custom_components/localshift/computation_engine_lib/proactive_export.py
@@ -7,7 +7,7 @@ from collections.abc import Callable
 from datetime import datetime, timedelta
 
 from ..const import BATTERY_CAPACITY_KWH, DEFAULT_EXPORT_PRICE_MARGIN
-from .solar_utils import get_price_for_slot
+from .price_calculator import get_price_for_slot
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/localshift/computation_engine_lib/soc_simulator.py
+++ b/custom_components/localshift/computation_engine_lib/soc_simulator.py
@@ -12,7 +12,8 @@ from ..const import (
     CHARGE_RATE_GRID_KW,
     CHARGE_RATE_SOLAR_KW,
 )
-from .solar_utils import get_price_for_slot, get_solar_for_15min_slot
+from .price_calculator import get_price_for_slot
+from .solar_utils import get_solar_for_15min_slot
 
 
 class SocSimulator:

--- a/custom_components/localshift/computation_engine_lib/solar_utils.py
+++ b/custom_components/localshift/computation_engine_lib/solar_utils.py
@@ -1,7 +1,9 @@
-"""Solar and price calculation utilities.
+"""Solar forecasting utilities.
 
-This module contains methods for solar forecasting and price calculations
-that are self-contained and don't modify CoordinatorData directly.
+This module contains methods for solar forecasting that are self-contained
+and don't modify CoordinatorData directly.
+
+Price-related utilities have been moved to price_calculator.py.
 """
 
 from __future__ import annotations
@@ -15,138 +17,6 @@ _LOGGER = logging.getLogger(__name__)
 from homeassistant.util import dt as dt_util
 
 from .utils import parse_forecast_dt
-
-
-def get_price_for_slot(
-    price_forecasts: list[dict[str, Any]],
-    slot_start: datetime,
-) -> float:
-    """Get price for a slot from Amber forecast data.
-
-    Amber mixes 5-min dispatch intervals (near-term) with 30-min extended
-    forecast periods.  The overlap scan below handles both correctly.
-
-    When no period overlaps the slot (e.g. a 5-min slot that falls in the
-    gap between two non-adjacent 30-min entries), falls back to the most
-    recent entry whose start_time <= slot_start so that prices are never
-    silently zeroed out due to resolution mismatches.
-    """
-    if not price_forecasts:
-        return 0.0
-
-    # Ensure slot boundaries are timezone-aware local datetimes
-    if slot_start.tzinfo is None:
-        slot_start = dt_util.as_local(dt_util.as_utc(slot_start))
-    else:
-        slot_start = dt_util.as_local(slot_start)
-
-    slot_end = slot_start + timedelta(minutes=15)
-
-    prices_in_slot: list[float] = []
-    fallback_price: float = 0.0
-    fallback_start: datetime | None = None
-
-    for entry in price_forecasts:
-        if not isinstance(entry, dict):
-            continue
-
-        start_raw = entry.get("start_time")
-        if start_raw is None:
-            continue
-
-        start_dt = parse_forecast_dt(start_raw)
-        if start_dt is None:
-            continue
-
-        start_local = dt_util.as_local(start_dt)
-
-        # Overlap check: use per-entry duration from the data when available,
-        # otherwise assume 5 minutes (standard Amber dispatch interval).
-        duration_minutes: int = int(entry.get("duration", 5))
-        end_local = start_local + timedelta(minutes=duration_minutes)
-
-        if start_local < slot_end and end_local > slot_start:
-            price = float(entry.get("per_kwh", 0.0))
-            prices_in_slot.append(price)
-
-        # Track most-recent entry at or before slot_start for fallback
-        if start_local <= slot_start:
-            if fallback_start is None or start_local > fallback_start:
-                fallback_start = start_local
-                fallback_price = float(entry.get("per_kwh", 0.0))
-
-    if prices_in_slot:
-        return sum(prices_in_slot) / len(prices_in_slot)
-
-    # Fallback: use the most recent price entry that started before this slot.
-    # This handles the case where the Amber forecast has 30-min extended periods
-    # that don't fully overlap short near-term slots (gap at :10/:15/:40/:45).
-    return fallback_price
-
-
-def get_price_for_slot_or_none(
-    price_forecasts: list[dict[str, Any]],
-    slot_start: datetime,
-) -> float | None:
-    """Get price for a slot, returning None only when the forecast has no data.
-
-    Unlike get_price_for_slot(), this returns None (not 0.0) when the forecast
-    list is empty or contains no entry at or before slot_start — allowing callers
-    to distinguish "missing forecast" from a genuine $0.00 price.
-
-    Uses the same duration-aware overlap + most-recent fallback as
-    get_price_for_slot() so that 30-min extended periods are handled correctly.
-    """
-    if not price_forecasts:
-        return None
-
-    # Ensure slot boundaries are timezone-aware local datetimes
-    if slot_start.tzinfo is None:
-        slot_start = dt_util.as_local(dt_util.as_utc(slot_start))
-    else:
-        slot_start = dt_util.as_local(slot_start)
-
-    slot_end = slot_start + timedelta(minutes=15)
-
-    prices_in_slot: list[float] = []
-    fallback_price: float = 0.0
-    fallback_start: datetime | None = None
-
-    for entry in price_forecasts:
-        if not isinstance(entry, dict):
-            continue
-
-        start_raw = entry.get("start_time")
-        if start_raw is None:
-            continue
-
-        start_dt = parse_forecast_dt(start_raw)
-        if start_dt is None:
-            continue
-
-        start_local = dt_util.as_local(start_dt)
-
-        duration_minutes: int = int(entry.get("duration", 5))
-        end_local = start_local + timedelta(minutes=duration_minutes)
-
-        if start_local < slot_end and end_local > slot_start:
-            price = float(entry.get("per_kwh", 0.0))
-            prices_in_slot.append(price)
-
-        if start_local <= slot_start:
-            if fallback_start is None or start_local > fallback_start:
-                fallback_start = start_local
-                fallback_price = float(entry.get("per_kwh", 0.0))
-
-    if prices_in_slot:
-        return sum(prices_in_slot) / len(prices_in_slot)
-
-    # Return fallback price when the forecast exists but doesn't directly overlap.
-    # Return None only when there is no entry at or before slot_start at all
-    # (i.e. the forecast doesn't cover this time yet).
-    if fallback_start is None:
-        return None
-    return fallback_price
 
 
 def get_solar_for_15min_slot(


### PR DESCRIPTION
## Summary
Extract price calculation functions from `solar_utils.py` to `price_calculator.py` for better module organization.

## Changes Made
- Move `get_price_for_slot()` to `price_calculator.py`
- Move `get_price_for_slot_or_none()` to `price_calculator.py`
- Update all imports in dependent modules:
  - `excess_solar.py`
  - `fit_analyzer.py`
  - `forecast_computer.py`
  - `proactive_export.py`
  - `soc_simulator.py`
- Update `__init__.py` exports

## Rationale
This improves separation of concerns:
- `solar_utils.py` now focuses solely on solar forecasting (Solcast data processing)
- `price_calculator.py` handles Amber price lookups and calculations

## Testing
- All 63 tests pass in `test_battery_controller.py` and `test_forecast_computer.py`
- Pre-commit hooks pass (ruff, vulture, bandit, pyright)

Closes #149