### PR TITLE
feat: auto-trigger thermal mode re-determination on threshold changes

### DIFF
--- a/custom_components/localshift/coordinator.py
+++ b/custom_components/localshift/coordinator.py
@@ -846,6 +846,34 @@ class LocalShiftCoordinator:
         self._notify_listeners()
         await self.async_evaluate_state_machine()
 
+    async def async_redetermine_thermal_mode(self) -> None:
+        """Re-determine thermal mode after configuration changes.
+
+        Unlocks the daily thermal mode and re-runs the determination logic.
+        Called when thermal-related thresholds (heating/cooling trigger temps,
+        dehumidify trigger humidity) are changed by the user.
+        """
+        if self._thermal_manager is None:
+            return
+
+        if not self._thermal_manager.is_enabled():
+            _LOGGER.debug("Thermal management disabled, skipping re-determination")
+            return
+
+        # Unlock the mode to allow re-determination
+        self.data.daily_mode_locked = False
+        self.data.daily_mode_determined_at = ""
+
+        _LOGGER.info("Thermal mode unlocked for re-determination due to config change")
+
+        # Re-determine mode from current weather forecast
+        await self._determine_thermal_mode_if_needed(is_startup=False)
+
+        # Also recompute and evaluate since thermal mode affects decisions
+        self._compute_derived_values()
+        self._notify_listeners()
+        await self.async_evaluate_state_machine()
+
     def reschedule_daily_summary_timer(self) -> None:
         """Reschedule the daily summary timer with current demand_window_end.
 

--- a/custom_components/localshift/number.py
+++ b/custom_components/localshift/number.py
@@ -166,6 +166,17 @@ class LocalShiftNumber(NumberEntity):
         self.hass.config_entries.async_update_entry(self._entry, options=new_options)
         self.async_write_ha_state()
 
-        # Trigger immediate re-evaluation with new threshold values
-        # This fixes the issue where threshold changes only took effect on next periodic tick (up to 1 min delay)
-        await self.coordinator.async_recompute_and_evaluate()
+        # Check if this is a thermal-related threshold that requires mode re-determination
+        thermal_keys = {
+            CONF_COOLING_TRIGGER_TEMP,
+            CONF_HEATING_TRIGGER_TEMP,
+            CONF_DEHUMIDIFY_TRIGGER_HUMIDITY,
+        }
+
+        if self._conf_key in thermal_keys:
+            # Thermal thresholds affect daily mode determination - re-run it
+            await self.coordinator.async_redetermine_thermal_mode()
+        else:
+            # Trigger immediate re-evaluation with new threshold values
+            # This fixes the issue where threshold changes only took effect on next periodic tick (up to 1 min delay)
+            await self.coordinator.async_recompute_and_evaluate()


### PR DESCRIPTION
## Summary
When users change thermal-related thresholds (cooling/heating trigger temperature, dehumidify trigger humidity), the daily thermal mode is now automatically re-determined instead of waiting until the next day.

## Changes Made
- Add `async_redetermine_thermal_mode()` method to coordinator that unlocks the thermal mode and re-runs determination
- Modify `number.py` to detect thermal config changes and call the re-determination method
- Thermal mode now immediately updates when relevant thresholds are changed

## Affected Entities
- `number.localshift_cooling_trigger_temp`
- `number.localshift_heating_trigger_temp`
- `number.localshift_dehumidify_trigger_humidity`

## Testing
- All 34 thermal manager tests pass
- All 55 config flow and integration tests pass
- Pre-commit hooks pass (ruff, vulture, bandit, pyright)