### PR TITLE
fix(thermal): rename _demand_window_end parameter to match caller

### DIFF
--- a/custom_components/localshift/thermal_manager.py
+++ b/custom_components/localshift/thermal_manager.py
@@ -748,7 +748,7 @@ class ThermalManager:
         data: CoordinatorData,
         now: datetime,
         demand_window_start: time,
-        _demand_window_end: time,
+        demand_window_end: time,  # pylint: disable=unused-argument
     ) -> tuple[bool, float]:
         """Determine if pre-conditioning should be active.
 
@@ -756,7 +756,7 @@ class ThermalManager:
             data: CoordinatorData with current state.
             now: Current datetime.
             demand_window_start: Demand window start time.
-            _demand_window_end: Demand window end time (unused, for API consistency).
+            demand_window_end: Demand window end time (unused, for API consistency).
 
         Returns:
             Tuple of (is_active, setpoint_offset).


### PR DESCRIPTION
## Summary
Fixes a TypeError that occurred every minute after merging PR #190.

## Problem
The `evaluate_preconditioning()` method defined the parameter as `_demand_window_end` (with underscore prefix to indicate unused), but `coordinator.py` called it with `demand_window_end=dw_end` (without underscore). Python requires exact name matching for keyword arguments.

## Error
```
TypeError: ThermalManager.evaluate_preconditioning() got an unexpected keyword argument 'demand_window_end'. Did you mean '_demand_window_end'?
```

## Fix
Changed the parameter name from `_demand_window_end` to `demand_window_end` in `thermal_manager.py` line 751, with a pylint disable comment for the unused argument.

## Testing
- Pre-commit hooks pass
- Method signature now matches caller