### PR TITLE
fix: restore .clinerules lost in merge commit

### DIFF
--- a/.clinerules
+++ b/.clinerules
@@ -1,0 +1,356 @@
+Do not use sed, awk, or direct shell commands to edit files. Only use the provided write_to_file or apply_diff tools for modifying code.
+
+# ⚠️ MANDATORY: BEFORE ANY TASK
+
+**This applies to ALL tasks, no matter how simple. Failure to follow this is a process violation.**
+
+1. **FIRST ACTION:** Run `git worktree list` to check current worktree status
+2. **If output shows only the main repo (no worktree path matches current directory):**
+   - For GitHub issues: `git worktree add /Users/jackmcintyre/worktrees/issue-{NNN} -b issue/{NNN}`
+   - For ad-hoc tasks: `git worktree add /Users/jackmcintyre/worktrees/{task-name} -b task/{task-name}`
+3. **Change directory to the worktree before making ANY file changes**
+4. **Only then proceed with the actual task**
+
+This ensures isolation between tasks and prevents changes to the main repo.
+
+## ⚠️ FOUND CHANGES ON MAIN (Crashed Session / Orphaned Changes)
+
+**If you discover staged or unstaged changes on main (e.g., from a crashed session):**
+
+1. **STOP** - Do not immediately commit
+2. **Alert the user** that changes exist on main and ask for direction:
+   - Option A: Move changes to a worktree (recommended)
+   - Option B: Commit directly on main (only if user explicitly confirms)
+3. **To move changes to a worktree:**
+   ```bash
+   # Stash changes if needed
+   git stash push -m "orphaned changes from crashed session"
+   
+   # Create worktree
+   git worktree add /Users/jackmcintyre/worktrees/{task-name} -b task/{task-name}
+   
+   # In worktree, apply the stash
+   cd /Users/jackmcintyre/worktrees/{task-name}
+   git stash pop
+   ```
+4. **Only commit directly on main** if:
+   - User explicitly confirms (e.g., "commit as is")
+   - Changes are trivial (typo fixes, documentation)
+   - You have explained the process violation
+
+**This prevents accidental commits on main from orphaned changes.**
+
+# ⚠️ MANDATORY: PLANNING BEFORE IMPLEMENTATION
+
+**This applies to non-trivial coding tasks. Failure to follow this is a process violation.**
+
+## Trivial Changes (Plan NOT Required)
+- Typo fixes in comments or documentation
+- Formatting/whitespace changes
+- Version number or date updates
+- Single-line configuration tweaks
+
+## Non-Trivial Changes (Plan REQUIRED)
+- New functionality or features
+- Bug fixes with logic changes
+- Refactoring across multiple files
+- API/interface changes
+- Database schema or data model changes
+
+## When in Doubt
+**Create a plan.** It's cheap insurance against mistakes.
+
+## Planning Workflow
+1. **BEFORE writing code for non-trivial changes**, create a `*_plan.md` file
+2. **Plan must outline:**
+   - Changes required
+   - Files affected
+   - Approach and reasoning
+3. **Plan file handling (one of):**
+   - Match a pattern in `.gitignore` (e.g., `*_plan.md`) - preferred
+   - Delete the plan file before committing changes
+4. **Implementation follows the plan**
+
+# ⚠️ MANDATORY: DEEP THINKING MODE
+
+**When entering deep thinking mode, a plan file may be created. This must be done in a worktree.**
+
+1. **BEFORE creating a plan file:** Ensure you are in a worktree (follow the worktree workflow above)
+2. **Why this matters:** Multiple agents may work on different tasks simultaneously. If a plan is created on main, it will be overwritten by other agents
+3. **Plan files are gitignored:** Files matching `*_plan.md` are ignored by git to prevent conflicts, but still need worktree isolation for agent coordination
+
+### Deep Thinking Mode Workflow
+1. Check worktree status with `git worktree list`
+2. If not in a worktree, create one before proceeding
+3. Create/modify a `*_plan.md` file in the worktree
+4. The plan stays local to that worktree and won't interfere with other agents
+
+# Worktree Workflow
+
+## Overview
+Each Cline task should operate in its own git worktree. This provides:
+- Isolation between tasks
+- Ability to work on multiple tasks in parallel
+- Clean separation of changes
+- No need to stash/commit unfinished work when switching tasks
+
+## Worktree Directory Structure
+- All worktrees are stored in `/Users/jackmcintyre/worktrees/`
+- Naming convention: `issue-{NNN}` (e.g., `issue-1`, `issue-42`)
+
+## Starting a New Task
+1. **Pull latest changes first:**
+   ```bash
+   git pull origin main
+   ```
+   This ensures you're branching from the latest state and prevents divergence.
+2. **Create worktree for GitHub issue:**
+   ```bash
+   git worktree add /Users/jackmcintyre/worktrees/issue-{NNN} -b issue/{NNN}
+   ```
+3. **Or create worktree for ad-hoc task:**
+   ```bash
+   git worktree add /Users/jackmcintyre/worktrees/{task-name} -b task/{task-name}
+   ```
+4. **Change directory to the worktree before making changes**
+
+## During Task Execution
+- All file operations should target the worktree directory
+- The worktree shares the same git history but has its own working directory
+- Run tests and pre-commit hooks within the worktree
+
+## ⚠️ CRITICAL RULES
+
+### Never Commit Directly on Main
+- **Main branch is protected** - All changes must come via PR merges from worktree branches
+- If you find yourself on `main` with uncommitted changes, create a worktree immediately
+- Direct commits on `main` cause divergence when PRs are merged on GitHub
+
+### Git Configuration (Recommended)
+Set these globally to prevent ambiguous pull behavior:
+```bash
+git config --global pull.ff only
+```
+This makes `git pull` fail if branches have diverged, forcing an explicit choice of rebase or merge.
+
+## Completing a Task
+1. Run pre-commit hooks in the worktree
+2. Ask user to commit or merge changes
+3. After merge/completion, clean up:
+   ```bash
+   git worktree remove /Users/jackmcintyre/worktrees/{worktree-name}
+   git branch -d {branch-name}  # if merged
+   ```
+
+## Current Worktrees
+Check with: `git worktree list`
+
+## Reserve Worktrees
+- `_reserve/*` branches are temporary worktrees for Cline session isolation
+- These can be cleaned up between sessions if not in use
+
+# GitHub Issues Workflow
+
+## Overview
+GitHub Issues is the primary system for tracking backlog items, bugs, and feature requests. All work should be tracked via issues.
+
+## Priority Labels
+- `priority: critical` - Critical (affects core functionality)
+- `priority: high` - High priority (reliability & robustness)
+- `priority: medium` - Medium priority (code quality & maintainability)
+- `priority: low` - Low priority (cosmetic & nice-to-have)
+
+## Status Labels
+- `status: proposed` - New item, not yet started
+- `status: in-progress` - Currently being worked on
+- `status: blocked` - Blocked by dependency or external factor
+
+## Creating New Issues
+```bash
+gh issue create --title "Title" --body "Description" --label "priority: medium,status: proposed"
+```
+
+## Starting Work on an Issue
+1. Update issue status:
+   ```bash
+   gh issue edit {NNN} --add-label "status: in-progress"
+   ```
+2. Create worktree:
+   ```bash
+   git worktree add /Users/jackmcintyre/worktrees/issue-{NNN} -b issue/{NNN}
+   ```
+
+## Completing an Issue
+1. Run pre-commit hooks to verify code quality
+2. Ask user to commit changes
+3. Close the issue with resolution:
+   ```bash
+   gh issue close {NNN} --comment "Completed in #{PR_NUMBER}"
+   ```
+
+## Viewing Issues
+```bash
+gh issue list --state open                    # Open issues
+gh issue list --state all --limit 20          # All recent issues
+gh issue view {NNN}                           # View specific issue
+```
+
+## Before Starting Any Task
+- Check open issues with `gh issue list --state open`
+- Review priorities (critical > high > medium > low)
+
+## Commit Workflow
+- After completing changes, run pre-commit hooks to verify code quality
+- AFTER pre-commit passes, ask the user to commit rather than auto-committing
+- Wait for user confirmation before running git commit
+- Reference the issue number in commit messages: `Fixes #NNN` or `Closes #NNN`
+
+# Pull Request Workflow
+
+## ⚠️ MANDATORY: Open PR Before Task Completion
+
+**A task is NOT complete until a PR has been opened.** This is a hard requirement.
+
+### Task Completion Checklist
+1. Make all code changes in the worktree
+2. Run pre-commit hooks to verify code quality
+3. Commit changes with appropriate message
+4. **Open a PR using `gh pr create`**
+5. Only then consider the task complete
+
+### Why This Matters
+- Ensures all changes go through code review
+- Maintains a clean git history on main
+- Provides visibility into what's being merged
+- Allows CI/CD checks to run before merge
+
+### PR Creation Command
+```bash
+gh pr create --title "feat: description" --body "## Summary
+Brief description
+
+## Changes Made
+- Change 1
+- Change 2
+
+## Testing
+- Test details
+
+Closes #NNN"
+```
+
+## ⚠️ CRITICAL: PR-Issue Linking
+
+**Every PR MUST link to its related issue using GitHub's keywords.** This ensures issues automatically close when PRs are merged.
+
+### Required Keywords (use one of these)
+- `Closes #NNN` - For features/enhancements
+- `Fixes #NNN` - For bug fixes
+- `Resolves #NNN` - For either
+
+### Example PR Body
+```markdown
+## Summary
+Brief description of changes
+
+## Changes Made
+- Change 1
+- Change 2
+
+## Testing
+- Test details
+
+Closes #42
+```
+
+### ⚠️ Common Mistakes to Avoid
+- ❌ `Closes #N/A` - Not a valid issue reference
+- ❌ `Closes #med-005` - Labels are not issue numbers
+- ❌ `Closes issue-42` - Must use `#` prefix with number only
+- ✅ `Closes #42` - Correct format
+
+### Creating PRs with Issue Links
+When creating a PR via `gh pr create`, ensure the body includes the closing keyword:
+```bash
+gh pr create --title "feat: description" --body "## Summary
+...
+Closes #NNN"
+```
+
+### If PR Was Merged Without Issue Link
+If a PR was already merged without proper linking, manually close the issue:
+```bash
+gh issue close {NNN} --comment "Completed in PR #{PR_NUMBER}"
+```
+
+# Documentation Automation Rules
+
+## Inline Documentation
+- When editing any Python file in `custom_components/localshift/`, check for:
+  - Missing docstrings on classes and public methods
+  - Methods >20 lines without inline comments for complex logic
+- Add Google-style docstrings following existing codebase patterns
+
+## /docs/ Directory Maintenance
+- After modifying sensor implementations → Prompt to update `docs/ENTITY_REFERENCE.md`
+- After modifying core computation logic (computation_engine, state_machine, battery_controller) → Prompt to update `docs/ARCHITECTURE.md`
+- After architectural changes → Prompt to add entry to `docs/CHANGE_DETECTION.md`
+- After modifying config flow → Prompt to update `docs/DEVELOPER_GUIDE.md`
+
+## Documentation Responsibilities Matrix
+| File Category | Inline Docs | /docs/ Updates |
+|---------------|--------------|----------------|
+| Sensors (`sensor.py`, `binary_sensor.py`) | ✅ | Update `ENTITY_REFERENCE.md` |
+| Core Engine (`computation_engine.py`) | ✅ | Update `ARCHITECTURE.md` |
+| State Management (`state_machine.py`) | ✅ | Update `ARCHITECTURE.md` |
+| Battery Control (`battery_controller.py`) | ✅ | Update `ARCHITECTURE.md` |
+| Config Flow (`config_flow.py`) | ✅ | Update `DEVELOPER_GUIDE.md` |
+| Coordinator (`coordinator.py`) | ✅ | Update `ARCHITECTURE.md` |
+
+## Documentation Prompts
+When completing an edit that affects documentation:
+1. Add/update inline docstrings as needed
+2. Prompt user to include /docs/ updates
+3. Include summary of documentation changes in completion message
+
+## Entity Count Synchronization
+
+When adding or removing entities from the integration, update documentation in multiple places:
+
+### Files to Update When Adding/Removing Entities:
+
+1. **`docs/ENTITY_REFERENCE.md`** - Primary entity documentation
+   - Update overview table with correct counts
+   - Add/remove entity entries with full documentation
+   - Ensure numbering is sequential
+
+2. **`README.md`** - User-facing entity summary
+   - Update section headers with correct counts (e.g., "### Sensors (12)")
+   - Add/remove entity rows in tables
+   - Keep descriptions concise (one line each)
+
+3. **`docs/DEVELOPER_GUIDE.md`** - Developer reference
+   - Update entity counts in project structure section
+   - Update any code examples that reference entity counts
+
+### Entity Count Verification
+
+Before committing changes that affect entities:
+1. Count entities in `sensor.py`, `binary_sensor.py`, `switch.py`, `number.py`, `button.py`
+2. Verify counts match in all documentation files
+3. Total entities = sensors + binary_sensors + switches + numbers + buttons
+
+### Current Entity Counts (as of 2026-02-24):
+| Category | Count |
+|----------|-------|
+| Sensors | 24 |
+| Binary Sensors | 10 |
+| Switches | 11 |
+| Numbers | 8 |
+| Buttons | 6 |
+| **Total** | **59** |
+
+When these counts change, update:
+- This file (`.clinerules`)
+- `docs/ENTITY_REFERENCE.md` overview table
+- `README.md` entity section headers


### PR DESCRIPTION
## Summary
Restores the .clinerules file that was accidentally emptied during merge conflict resolution in commit 6fc0ded.

## Problem
The .clinerules file (356 lines of workflow rules) was lost during a merge. This caused Cline to ignore the established workflow rules, resulting in direct commits on main.

## Changes Made
- Restored .clinerules from commit 9ab6120

## Key Rules Restored
- Mandatory worktree creation before any task
- Never commit directly on main
- Orphaned changes handling workflow
- PR workflow requirements
- Documentation automation rules
- Entity count synchronization

## Testing
- File verified to have 356 lines
- Pre-commit hooks passed