### PR TITLE
feat: Add INFO-level logging for climate entity diagnostics

### DIFF
--- a/custom_components/localshift/state_reader.py
+++ b/custom_components/localshift/state_reader.py
@@ -434,12 +434,25 @@ class StateReader:
                 len(data.climate_unavailable_entities),
             )
 
-        _LOGGER.debug(
+        # INFO-level logging for visibility (Issue #193 follow-up)
+        _LOGGER.info(
             "Climate states read: %d entities (%d controlled), success=%s",
             len(climate_states),
             len(data.climate_control_entities),
             data.climate_read_success,
         )
+
+        # Log each entity's state at INFO level for troubleshooting
+        for entity_id, entity_state in climate_states.items():
+            _LOGGER.info(
+                "Climate entity: %s mode=%s action=%s setpoint=%.1f°C current=%.1f°C controlled=%s",
+                entity_id,
+                entity_state["state"],
+                entity_state["hvac_action"],
+                entity_state["setpoint"],
+                entity_state["current_temperature"] or 0.0,
+                entity_state["is_controlled"],
+            )
 
     def _read_float_attr(self, state: Any, attr: str, default: float = 0.0) -> float:
         """Read a float value from a state's attributes.

--- a/custom_components/localshift/thermal_manager.py
+++ b/custom_components/localshift/thermal_manager.py
@@ -1019,12 +1019,24 @@ class ThermalManager:
             Average temperature in °C, or None if no readings available.
         """
         temps: list[float] = []
-        for state_dict in data.climate_states.values():
+        entities_with_temp = []
+        entities_without_temp = []
+
+        for entity_id, state_dict in data.climate_states.items():
             current_temp = state_dict.get("current_temperature")
             if current_temp is not None and current_temp > 0:
                 temps.append(current_temp)
+                entities_with_temp.append(entity_id)
+            else:
+                entities_without_temp.append(entity_id)
 
         if not temps:
+            _LOGGER.info(
+                "No room temperature readings available from %d climate entities. "
+                "Entities without temp: %s",
+                len(data.climate_states),
+                entities_without_temp if entities_without_temp else "none",
+            )
             return None
 
         avg_temp = sum(temps) / len(temps)
@@ -1034,6 +1046,13 @@ class ThermalManager:
         self._recent_room_temps.append(avg_temp)
         if len(self._recent_room_temps) > 6:
             self._recent_room_temps.pop(0)
+
+        _LOGGER.info(
+            "Average room temperature: %.1f°C from %d entities (%s)",
+            avg_temp,
+            len(temps),
+            ", ".join(entities_with_temp),
+        )
 
         return avg_temp
 

--- a/docs/ENTITY_REFERENCE.md
+++ b/docs/ENTITY_REFERENCE.md
@@ -622,10 +622,15 @@ Added in Issue #63 Phase 6 for visibility into thermal control decisions.
 | `preconditioning_active` | bool | Whether pre-conditioning is active |
 | `solar_taper_active` | bool | Whether solar tapering is active |
 | `taper_setpoint_offset` | float | Current setpoint offset from solar taper |
+| `climate_read_success` | bool | Whether climate entities were read successfully (Issue #193) |
+| `climate_missing_entities` | list | Climate entities not found in HA state machine |
+| `climate_unavailable_entities` | list | Climate entities that are unknown/unavailable |
+| `climate_entities_configured` | list | All configured climate entity IDs |
+| `climate_entities_controlled` | list | Climate entities marked for control |
 
 **Icon:** Dynamic (air-conditioner when active, air-conditioner-off when inactive)
 
-**Use Case:** Monitor the real-time thermal control layer. Check the `reason` attribute to understand why the system is in its current state.
+**Use Case:** Monitor the real-time thermal control layer. Check the `reason` attribute to understand why the system is in its current state. Use `climate_read_success` to diagnose why thermal control may not be activating - if `false`, check `climate_missing_entities` and `climate_unavailable_entities` for configuration issues.
 
 ---
 

--- a/tests/test_thermal_manager.py
+++ b/tests/test_thermal_manager.py
@@ -454,7 +454,7 @@ class TestPreconditioning:
             data=coordinator_data,
             now=datetime(2026, 2, 16, 14, 0, 0),
             demand_window_start=time(15, 0),
-            _demand_window_end=time(21, 0),
+            demand_window_end=time(21, 0),
         )
         assert is_active is False
         assert offset == 0.0
@@ -470,7 +470,7 @@ class TestPreconditioning:
             data=coordinator_data,
             now=datetime(2026, 2, 16, 10, 0, 0),
             demand_window_start=time(15, 0),
-            _demand_window_end=time(21, 0),
+            demand_window_end=time(21, 0),
         )
         assert is_active is False
 
@@ -485,7 +485,7 @@ class TestPreconditioning:
             data=coordinator_data,
             now=datetime(2026, 2, 16, 14, 30, 0),
             demand_window_start=time(15, 0),
-            _demand_window_end=time(21, 0),
+            demand_window_end=time(21, 0),
         )
         assert is_active is True
         # COOL mode should lower setpoint (negative offset)
@@ -501,7 +501,7 @@ class TestPreconditioning:
             data=coordinator_data,
             now=datetime(2026, 2, 16, 14, 30, 0),
             demand_window_start=time(15, 0),
-            _demand_window_end=time(21, 0),
+            demand_window_end=time(21, 0),
         )
         assert is_active is True
         # HEAT mode should raise setpoint (positive offset)
@@ -516,7 +516,7 @@ class TestPreconditioning:
             data=coordinator_data,
             now=datetime(2026, 2, 16, 14, 30, 0),
             demand_window_start=time(15, 0),
-            _demand_window_end=time(21, 0),
+            demand_window_end=time(21, 0),
         )
         assert is_active is False
 


### PR DESCRIPTION
## Summary
Follow-up to Issue #193 - Enhanced logging for thermal manager climate entity diagnostics.

## Changes Made
- Changed climate state read success log from DEBUG to INFO level for visibility
- Added per-entity INFO logging for climate state details (mode, action, setpoint, current temp)
- Added INFO logging for average room temperature calculation with entity breakdown
- Updated ENTITY_REFERENCE.md with new diagnostic attributes on RealtimeThermalStatusSensor
- Fixed pre-existing test parameter name bug (`_demand_window_end` -> `demand_window_end`)

## Diagnostic Attributes Added
The `sensor.localshift_realtime_thermal_status` sensor now exposes:
- `climate_read_success` - Whether climate entities were read successfully
- `climate_missing_entities` - Entities not found in HA state machine
- `climate_unavailable_entities` - Entities that are unknown/unavailable
- `climate_entities_configured` - All configured climate entity IDs
- `climate_entities_controlled` - Climate entities marked for control

## Testing
All 34 tests pass in test_thermal_manager.py

## How to Use
After deploying, check Home Assistant logs for INFO-level messages like:
```
Climate states read: 2 entities (1 controlled), success=True
Climate entity: climate.living_room mode=cool action=cooling setpoint=22.0°C current=24.5°C controlled=True
Average room temperature: 24.5°C from 1 entities (climate.living_room)
```

If thermal control isn't activating, check the `climate_read_success` attribute on `sensor.localshift_realtime_thermal_status`.