### PR TITLE
fix: Calculate avg_room_temp before all thermal layers (Issue #193)

### DIFF
--- a/custom_components/localshift/thermal_manager.py
+++ b/custom_components/localshift/thermal_manager.py
@@ -1266,6 +1266,9 @@ class ThermalManager:
         if daily_mode not in (ThermalMode.HEAT, ThermalMode.COOL):
             return False, 0.0, f"Mode not applicable: {daily_mode.value}"
 
+        # Always calculate average room temperature (needed for all layers and diagnostics)
+        avg_room_temp = self.calculate_average_room_temp(data)
+
         # Layer 1: Check pre-conditioning (highest priority)
         precon_active, precon_offset = self.evaluate_preconditioning(
             data, now, demand_window_start, demand_window_end
@@ -1287,7 +1290,6 @@ class ThermalManager:
             return True, taper_offset, f"Solar taper ({excess_solar_kw:.1f}kW excess)"
 
         # Layer 3: Real-time control (base layer)
-        avg_room_temp = self.calculate_average_room_temp(data)
         if avg_room_temp is None:
             return False, 0.0, "No room temperature reading"
 


### PR DESCRIPTION
## Summary
Fixes a bug where avg_room_temp was always showing as None in diagnostics even when climate entities had valid current_temperature readings.

## Root Cause
The calculate_average_room_temp method was only called in Layer 3 (real-time control) of evaluate_realtime_thermal. If pre-conditioning (Layer 1) or solar tapering (Layer 2) was active, the method returned early without ever calculating the temperature.

## The Fix
Move the temperature calculation to happen at the start of evaluate_realtime_thermal, before checking any layers. This ensures the temperature is always calculated and available for:

1. Diagnostic sensors - The avg_room_temp attribute on sensor.localshift_realtime_thermal_status
2. All thermal control layers - Temperature available for future use in pre-conditioning/solar taper decisions
3. Trend tracking - Temperature history for turn-off decisions

## Testing
- All 34 tests in test_thermal_manager.py pass
- Manual verification: Climate entities with current_temperature: 24 will now show Average Room Temp: 24°C in dashboard

## Before/After

Before: Average Room Temp: None (BUG!)
After: Average Room Temp: 24.0°C (FIXED!)