### PR TITLE
fix: increase HVAC power estimation heuristics

### DIFF
--- a/custom_components/localshift/thermal_manager.py
+++ b/custom_components/localshift/thermal_manager.py
@@ -625,11 +625,11 @@ class ThermalManager:
                 # Estimate based on temperature differential
                 cooling_trigger = self.get_cooling_trigger_temp()
                 temp_diff = max(0, temperature - cooling_trigger)
-                return min(3.0, temp_diff * 0.3)  # ~0.3 kW per degree over trigger
+                return min(4.0, temp_diff * 0.5)  # ~0.5 kW per degree over trigger
             elif daily_mode == ThermalMode.HEAT:
                 heating_trigger = self.get_heating_trigger_temp()
                 temp_diff = max(0, heating_trigger - temperature)
-                return min(2.5, temp_diff * 0.25)  # ~0.25 kW per degree under trigger
+                return min(3.5, temp_diff * 0.35)  # ~0.35 kW per degree under trigger
 
         return total_power
 
@@ -708,8 +708,8 @@ class ThermalManager:
         # If no learned power, use a default estimate based on typical AC
         if valid_entities == 0:
             # Typical split system AC: 2-4 kW
-            # Use conservative estimate of 2.5 kW
-            total_hvac_power_kw = 2.5
+            # Use estimate of 3.5 kW (observed ~4 kW in user's system)
+            total_hvac_power_kw = 3.5
             _LOGGER.debug(
                 "No learned HVAC power, using default estimate: %.1f kW",
                 total_hvac_power_kw,


### PR DESCRIPTION
## Summary
Increase HVAC power estimation heuristics to better match observed consumption patterns (~4 kW vs previous 2.5 kW default).

## Changes Made
- Default HVAC estimate: 2.5 kW → **3.5 kW**
- Per-degree cooling: 0.3 kW/°C → **0.5 kW/°C**  
- Cooling cap: 3.0 kW → **4.0 kW**
- Heating cap: 2.5 kW → **3.5 kW** (0.35 kW/°C)

## Why This Matters
The previous estimates were underestimating HVAC consumption, causing:
1. Lower consumption forecasts than actual
2. SOC forecasts that were too optimistic
3. Potential for unexpected battery depletion

## Layered Approach with Issue #170 Learning
This is a "training wheels" fix:
- **Immediate benefit**: Better forecasts right away
- **No conflict**: The learning system's `consumption_forecast_bias` can still fine-tune
- **Future handoff**: Once learning gathers 50+ decisions, it can override if needed

## Testing
- All 34 thermal_manager tests pass
- Pre-commit hooks pass (ruff, pyright, bandit, vulture)