### PR TITLE
fix: clear manual_override flag when pressing Self Consumption button

### DIFF
--- a/custom_components/localshift/button.py
+++ b/custom_components/localshift/button.py
@@ -156,6 +156,10 @@ class SelfConsumptionButton(LocalShiftButtonBase):
 
     async def async_press(self) -> None:
         """Handle button press."""
+        # Clear manual override flag and timestamp to return to automated control
+        self.coordinator.data.manual_override = False
+        if self.coordinator._state_machine is not None:
+            self.coordinator._state_machine.clear_manual_override_timestamp()
         await self.coordinator.async_set_self_consumption()
         if self.coordinator._notification_service is not None:
             await (

--- a/custom_components/localshift/state_machine.py
+++ b/custom_components/localshift/state_machine.py
@@ -735,6 +735,10 @@ class StateMachine:
         """Record when manual override was set for auto-clear timeout."""
         self._manual_override_set_at = dt_util.now()
 
+    def clear_manual_override_timestamp(self) -> None:
+        """Clear manual override timestamp when returning to automated control."""
+        self._manual_override_set_at = None
+
     @property
     def in_mode_transition(self) -> bool:
         """Check if currently in a mode transition."""


### PR DESCRIPTION
## Summary
The "Return to Self Consumption" button was not clearing the manual_override flag, causing the system to remain in manual mode even after the button was pressed.

## Problem
When users pressed manual mode buttons (Force Charge, Force Discharge, Boost Charge), the system correctly set `manual_override = True` and recorded a timestamp for auto-timeout.

However, when pressing the "Return to Self Consumption" button, the system:
- ✅ Set the battery to self consumption mode
- ❌ Did NOT clear the `manual_override` flag
- ❌ Did NOT clear the manual override timestamp

This meant the state machine still thought it was in manual control, preventing automated transitions.

## Solution
1. Updated `SelfConsumptionButton.async_press()` to:
   - Clear `manual_override = False`
   - Call `clear_manual_override_timestamp()` on the state machine

2. Added `clear_manual_override_timestamp()` method to `StateMachine` class

## Testing
- All 40 existing state machine tests pass
- Pre-commit hooks (ruff, vulture, bandit, pyright) all pass

## Changes Made
- `custom_components/localshift/button.py`: Updated SelfConsumptionButton
- `custom_components/localshift/state_machine.py`: Added clear_manual_override_timestamp() method