### PR TITLE
feat: add automated deployment script for same-host HA setup

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,165 @@
+#!/bin/bash
+# deploy.sh - Deploy LocalShift to Home Assistant
+#
+# This script deploys the LocalShift integration to a Home Assistant instance.
+# It requires the HA config directory to be mounted into this container.
+#
+# Prerequisites:
+#   1. HA config mounted at /homeassistant (or set HA_CONFIG env var)
+#   2. HA_LONG_LIVED_TOKEN env var set for API reload (optional)
+#   3. HA_URL env var set for API endpoint (optional, default: http://homeassistant:8123)
+#
+# Usage:
+#   ./deploy.sh [--no-reload] [--dry-run]
+#
+# Options:
+#   --no-reload   Skip the API reload step
+#   --dry-run     Show what would be done without making changes
+
+set -e
+
+# Configuration (override with environment variables)
+HA_CONFIG="${HA_CONFIG:-/homeassistant}"
+HA_URL="${HA_URL:-http://homeassistant:8123}"
+HA_TOKEN="${HA_LONG_LIVED_TOKEN:-}"
+COMPONENT_NAME="localshift"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SOURCE_DIR="$SCRIPT_DIR/custom_components/$COMPONENT_NAME"
+DEST_DIR="$HA_CONFIG/custom_components/$COMPONENT_NAME"
+
+# Parse arguments
+NO_RELOAD=false
+DRY_RUN=false
+
+for arg in "$@"; do
+    case $arg in
+        --no-reload)
+            NO_RELOAD=true
+            shift
+            ;;
+        --dry-run)
+            DRY_RUN=true
+            shift
+            ;;
+        *)
+            echo "Unknown argument: $arg"
+            exit 1
+            ;;
+    esac
+done
+
+# Color output (disable if not a terminal)
+if [ -t 1 ]; then
+    RED='\033[0;31m'
+    GREEN='\033[0;32m'
+    YELLOW='\033[0;33m'
+    BLUE='\033[0;34m'
+    NC='\033[0m' # No Color
+else
+    RED=''
+    GREEN=''
+    YELLOW=''
+    BLUE=''
+    NC=''
+fi
+
+log_info() { echo -e "${BLUE}ℹ${NC} $1"; }
+log_success() { echo -e "${GREEN}✓${NC} $1"; }
+log_warning() { echo -e "${YELLOW}⚠${NC} $1"; }
+log_error() { echo -e "${RED}✗${NC} $1"; }
+
+# Check prerequisites
+log_info "Checking prerequisites..."
+
+if [ ! -d "$SOURCE_DIR" ]; then
+    log_error "Source directory not found: $SOURCE_DIR"
+    exit 1
+fi
+
+if [ ! -d "$HA_CONFIG" ]; then
+    log_error "HA config directory not found: $HA_CONFIG"
+    log_info "Make sure the HA config is mounted at $HA_CONFIG"
+    log_info "Or set HA_CONFIG environment variable"
+    exit 1
+fi
+
+# Dry run mode
+if [ "$DRY_RUN" = true ]; then
+    log_warning "DRY RUN MODE - No changes will be made"
+    echo ""
+    echo "Would perform the following:"
+    echo "  1. Backup: $DEST_DIR -> ${DEST_DIR}.backup.<timestamp>"
+    echo "  2. Copy: $SOURCE_DIR -> $DEST_DIR"
+    if [ "$NO_RELOAD" = false ] && [ -n "$HA_TOKEN" ]; then
+        echo "  3. Reload integration via API: $HA_URL"
+    fi
+    exit 0
+fi
+
+# Pull latest changes if in a git repo
+if [ -d "$SCRIPT_DIR/.git" ] || git -C "$SCRIPT_DIR" rev-parse --git-dir > /dev/null 2>&1; then
+    log_info "Pulling latest changes..."
+    git -C "$SCRIPT_DIR" pull origin main || log_warning "Could not pull latest changes"
+fi
+
+# Create backup of existing installation
+if [ -d "$DEST_DIR" ]; then
+    BACKUP_DIR="${DEST_DIR}.backup.$(date +%Y%m%d_%H%M%S)"
+    log_info "Backing up existing installation to: $BACKUP_DIR"
+    mv "$DEST_DIR" "$BACKUP_DIR"
+fi
+
+# Copy new version
+log_info "Copying files to HA config..."
+mkdir -p "$HA_CONFIG/custom_components"
+cp -r "$SOURCE_DIR" "$HA_CONFIG/custom_components/"
+log_success "Files copied successfully"
+
+# Set appropriate permissions
+log_info "Setting permissions..."
+chmod -R 755 "$DEST_DIR" 2>/dev/null || log_warning "Could not set permissions"
+
+# Reload integration via HA API
+if [ "$NO_RELOAD" = true ]; then
+    log_info "Skipping reload (--no-reload flag)"
+elif [ -z "$HA_TOKEN" ]; then
+    log_warning "No HA_LONG_LIVED_TOKEN set - skipping API reload"
+    log_info "You may need to restart Home Assistant or reload the integration manually"
+else
+    log_info "Attempting to reload integration via API..."
+    
+    # Get the config entry ID for localshift
+    ENTRY_ID=$(curl -s -X GET \
+        -H "Authorization: Bearer $HA_TOKEN" \
+        -H "Content-Type: application/json" \
+        "$HA_URL/api/config/config_entries/entry" 2>/dev/null | \
+        grep -o '"entry_id":"[^"]*","domain":"localshift"' | \
+        head -1 | \
+        sed 's/"entry_id":"\([^"]*\)".*/\1/' || true)
+    
+    if [ -n "$ENTRY_ID" ]; then
+        # Reload the config entry
+        RELOAD_RESULT=$(curl -s -X POST \
+            -H "Authorization: Bearer $HA_TOKEN" \
+            -H "Content-Type: application/json" \
+            "$HA_URL/api/services/homeassistant/reload_config_entry" \
+            -d "{\"entry_id\": \"$ENTRY_ID\"}" 2>/dev/null || true)
+        
+        if [ -z "$RELOAD_RESULT" ] || echo "$RELOAD_RESULT" | grep -q "error"; then
+            log_warning "Could not reload via API - may need manual reload"
+        else
+            log_success "Integration reloaded via API"
+        fi
+    else
+        log_warning "Could not find LocalShift config entry - may need manual reload"
+    fi
+fi
+
+echo ""
+log_success "Deployment complete!"
+log_info "Version: $(grep '"version"' "$DEST_DIR/manifest.json" | sed 's/.*"version": *"\([^"]*\)".*/\1/')"
+
+# Show backup location if one was created
+if [ -d "${DEST_DIR}.backup."* ] 2>/dev/null; then
+    log_info "Backup saved at: ${DEST_DIR}.backup.*"
+fi

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -718,6 +718,97 @@ cp -r custom_components/localshift ~/.config/homeassistant/custom_components/
 # Restart HA to load changes
 ```
 
+## Automated Deployment
+
+When running Cline and Home Assistant on the same host (in different Docker containers), you can automate deployment when `main` is updated.
+
+### Prerequisites
+
+1. **Mount HA config into Cline container:**
+
+   Add the HA config directory as a volume mount to your Cline/VSCode container:
+
+   ```yaml
+   # In docker-compose.yml for Cline container
+   services:
+     cline:
+       volumes:
+         - /mnt/user/appdata/Home-Assistant-Container:/homeassistant
+   ```
+
+   Or with Docker run:
+   ```bash
+   docker run ... -v /mnt/user/appdata/Home-Assistant-Container:/homeassistant ...
+   ```
+
+2. **Create a Home Assistant Long-Lived Access Token:**
+
+   - Go to HA Profile → Security → Long-Lived Access Tokens
+   - Create a token named "Cline Deploy"
+   - Set as environment variable: `export HA_LONG_LIVED_TOKEN="your_token_here"`
+
+### Deployment Script
+
+The `deploy.sh` script handles deployment:
+
+```bash
+# Basic deployment (pulls latest main, copies files, reloads integration)
+./deploy.sh
+
+# Dry run to see what would happen
+./deploy.sh --dry-run
+
+# Deploy without reloading (if you want to restart HA manually)
+./deploy.sh --no-reload
+```
+
+### Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `HA_CONFIG` | `/homeassistant` | Path to HA config directory |
+| `HA_URL` | `http://homeassistant:8123` | HA API URL |
+| `HA_LONG_LIVED_TOKEN` | (none) | Token for API reload |
+
+### Automatic Deployment on Pull
+
+To automatically deploy when pulling changes, create a git post-merge hook:
+
+```bash
+# Create .git/hooks/post-merge
+#!/bin/bash
+./deploy.sh
+
+# Make executable
+chmod +x .git/hooks/post-merge
+```
+
+Now whenever you `git pull` on main, the integration will automatically deploy.
+
+### What Gets Reloaded vs Requires Restart
+
+| Change Type | Reload Works? | Restart Needed? |
+|-------------|---------------|-----------------|
+| Python code changes | ✅ Yes | No |
+| `manifest.json` changes | ⚠️ Partial | Recommended |
+| New dependencies | ❌ No | Yes |
+| Config flow changes | ⚠️ Partial | Sometimes |
+
+### Manual Deployment
+
+If you prefer manual control:
+
+```bash
+# 1. Pull latest changes
+git pull origin main
+
+# 2. Copy to HA config
+cp -r custom_components/localshift /homeassistant/custom_components/
+
+# 3. Reload integration via HA UI
+# Settings → Devices & Services → LocalShift → ⋮ → Reload
+```
+
 ## References
 
 - `docs/ARCHITECTURE.md` - System architecture diagrams


### PR DESCRIPTION
## Summary
Add a deployment script and documentation for automatically deploying LocalShift to Home Assistant when running on the same host.

## Changes Made
- Add `deploy.sh` script for deploying LocalShift to Home Assistant
- Supports dry-run mode, no-reload option, and automatic backups
- Can reload integration via HA API (no restart needed for code changes)
- Update `docs/DEVELOPER_GUIDE.md` with deployment documentation
- Includes instructions for git post-merge hook automation

## Usage
```bash
# Basic deployment
./deploy.sh

# Dry run to see what would happen
./deploy.sh --dry-run

# Deploy without reloading
./deploy.sh --no-reload
```

## Prerequisites
1. Mount HA config into Cline container: `-v /mnt/user/appdata/Home-Assistant-Container:/homeassistant`
2. Create HA Long-Lived Access Token and set `HA_LONG_LIVED_TOKEN` env var

## Testing
- Script has been created with proper error handling
- Documentation added to DEVELOPER_GUIDE.md