### PR TITLE
fix: mock storage layer in TestAsyncStart tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -630,6 +630,58 @@ def mock_hass_various_states(request, realistic_entity_states):
 
 
 # =============================================================================
+# STORAGE MOCK FIXTURE
+# =============================================================================
+
+
+@pytest.fixture
+def mock_storage():
+    """Mock Home Assistant's Store class for storage operations.
+
+    This fixture patches Store at all locations where it's imported to return
+    a mock store that properly handles async_load() and async_save().
+
+    The mock store returns None from async_load() (empty storage) and
+    async_save() is a no-op AsyncMock.
+
+    Use this for tests that initialize components with persistent storage:
+    - DecisionOutcomeTracker
+    - ParameterOptimizer
+    - PatternAnalyzer
+    - OptimizationController
+    - ThermalManager
+    """
+    mock_store = MagicMock()
+    mock_store.async_load = AsyncMock(return_value=None)
+    mock_store.async_save = AsyncMock()
+
+    # Patch Store at all locations where it's imported
+    with (
+        patch(
+            "custom_components.localshift.computation_engine_lib.decision_outcome_tracker.Store",
+            return_value=mock_store,
+        ),
+        patch(
+            "custom_components.localshift.computation_engine_lib.parameter_optimizer.Store",
+            return_value=mock_store,
+        ),
+        patch(
+            "custom_components.localshift.computation_engine_lib.pattern_analyzer.Store",
+            return_value=mock_store,
+        ),
+        patch(
+            "custom_components.localshift.computation_engine_lib.optimization_controller.Store",
+            return_value=mock_store,
+        ),
+        patch(
+            "custom_components.localshift.thermal_manager.Store",
+            return_value=mock_store,
+        ),
+    ):
+        yield mock_store
+
+
+# =============================================================================
 # RECORDER MOCK FIXTURE
 # =============================================================================
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -100,8 +100,14 @@ class TestCoordinatorInitialization:
 # =============================================================================
 
 
+@pytest.mark.usefixtures("mock_storage")
 class TestAsyncStart:
-    """Tests for async_start method."""
+    """Tests for async_start method.
+
+    Uses mock_storage fixture to mock HA's Store class for components
+    that use persistent storage (DecisionOutcomeTracker, ParameterOptimizer,
+    PatternAnalyzer, OptimizationController, ThermalManager).
+    """
 
     @pytest.mark.asyncio
     async def test_async_start_initializes_modules(self, coordinator, mock_recorder):


### PR DESCRIPTION
## Summary
Fix failing TestAsyncStart tests by adding a mock_storage fixture that properly mocks Home Assistant's Store class.

## Problem
3 tests in `tests/test_coordinator.py::TestAsyncStart` were failing with:
```
ValueError: not enough values to unpack (expected 2, got 0)
```

The error occurred because the test fixtures didn't properly mock the storage layer used by:
- DecisionOutcomeTracker
- ParameterOptimizer
- PatternAnalyzer
- OptimizationController
- ThermalManager

## Solution
Added a `mock_storage` fixture in `tests/conftest.py` that patches `Store` at all import locations to return a mock with:
- `async_load()` returning `None` (empty storage)
- `async_save()` as a no-op AsyncMock

## Changes Made
- Added `mock_storage` fixture to `tests/conftest.py`
- Updated `TestAsyncStart` class to use `@pytest.mark.usefixtures("mock_storage")`

## Testing
All 474 tests pass, including the 3 previously failing tests.

Fixes #201