### PR TITLE
feat: Implement missing logic for defined constants

### DIFF
--- a/custom_components/localshift/computation_engine_lib/forecast_computer.py
+++ b/custom_components/localshift/computation_engine_lib/forecast_computer.py
@@ -578,10 +578,6 @@ class ForecastComputer:
             max_hours=max_hours,
         )
 
-    # Hysteresis margin for grid charging decisions (Issue #34)
-    # Once grid charging starts, require this much margin above target before stopping
-    GRID_CHARGE_HYSTERESIS_MARGIN_PCT = 5.0
-
     def _calculate_local_effective_cheap_price(
         self,
         slot_start: datetime,

--- a/custom_components/localshift/computation_engine_lib/pattern_analyzer.py
+++ b/custom_components/localshift/computation_engine_lib/pattern_analyzer.py
@@ -469,6 +469,15 @@ class PatternAnalyzer:
         """
         biases: list[BiasCorrection] = []
 
+        # Check if we have enough weeks of data for reliable bias detection
+        if self._weeks_of_data < MIN_WEEKS_OBSERVED:
+            _LOGGER.debug(
+                "Skipping bias detection: only %d weeks of data (need %d)",
+                self._weeks_of_data,
+                MIN_WEEKS_OBSERVED,
+            )
+            return biases
+
         for dimension_name, stats in report.dimensions.items():
             if stats.global_std == 0:
                 continue  # No variance, no biases

--- a/custom_components/localshift/entity_validator.py
+++ b/custom_components/localshift/entity_validator.py
@@ -77,16 +77,17 @@ class EntityHealth:
     last_valid_time: datetime | None = None
     error_message: str = ""
     consecutive_failures: int = 0
+    is_broken: bool = False  # Marked broken after FAILURE_THRESHOLD_ERROR failures
 
     @property
     def is_healthy(self) -> bool:
         """Return True if entity is healthy."""
-        return self.status == EntityStatus.OK
+        return self.status == EntityStatus.OK and not self.is_broken
 
     @property
     def is_available(self) -> bool:
         """Return True if entity has a usable value."""
-        return self.status in (EntityStatus.OK, EntityStatus.STALE)
+        return self.status in (EntityStatus.OK, EntityStatus.STALE) and not self.is_broken
 
 
 @dataclass
@@ -278,6 +279,7 @@ class EntityValidator:
             health.status = EntityStatus.MISSING
             health.error_message = f"Entity '{entity_id}' does not exist"
             health.consecutive_failures += 1
+            self._check_failure_thresholds(health, config_key)
             return health
 
         # Check if entity is unavailable or unknown
@@ -285,12 +287,14 @@ class EntityValidator:
             health.status = EntityStatus.UNAVAILABLE
             health.error_message = f"Entity '{entity_id}' is unavailable"
             health.consecutive_failures += 1
+            self._check_failure_thresholds(health, config_key)
             return health
 
         if state.state == "unknown":
             health.status = EntityStatus.UNKNOWN
             health.error_message = f"Entity '{entity_id}' has unknown state"
             health.consecutive_failures += 1
+            self._check_failure_thresholds(health, config_key)
             return health
 
         # Validate the value if we have validation rules
@@ -301,6 +305,7 @@ class EntityValidator:
             health.status = EntityStatus.INVALID_VALUE
             health.error_message = validation.error_message
             health.consecutive_failures += 1
+            self._check_failure_thresholds(health, config_key)
             return health
 
         # Check for staleness
@@ -324,6 +329,37 @@ class EntityValidator:
         health.consecutive_failures = 0
 
         return health
+
+    def _check_failure_thresholds(self, health: EntityHealth, config_key: str) -> None:
+        """Check failure thresholds and escalate status if needed.
+
+        Logs warnings at FAILURE_THRESHOLD_WARNING failures.
+        Marks entity as broken at FAILURE_THRESHOLD_ERROR failures.
+
+        Args:
+            health: EntityHealth to check
+            config_key: Configuration key for logging
+        """
+        # Log warning at threshold
+        if health.consecutive_failures == FAILURE_THRESHOLD_WARNING:
+            _LOGGER.warning(
+                "Entity '%s' (%s) has failed %d times consecutively - monitoring closely",
+                health.entity_id,
+                config_key,
+                health.consecutive_failures,
+            )
+
+        # Mark as broken at error threshold
+        if health.consecutive_failures >= FAILURE_THRESHOLD_ERROR:
+            if not health.is_broken:
+                health.is_broken = True
+                _LOGGER.error(
+                    "Entity '%s' (%s) marked as BROKEN after %d consecutive failures - "
+                    "check entity configuration or sensor availability",
+                    health.entity_id,
+                    config_key,
+                    health.consecutive_failures,
+                )
 
     def _validate_entity_value(
         self, config_key: str, state_value: str, attributes: dict
@@ -552,6 +588,7 @@ class EntityValidator:
                     else None
                 ),
                 "consecutive_failures": health.consecutive_failures,
+                "is_broken": health.is_broken,
                 "error_message": health.error_message if health.error_message else None,
             }
 
@@ -597,11 +634,20 @@ class EntityValidator:
         # Check all required entities
         for config_key, health in self._entity_health.items():
             if health.category == EntityCategory.REQUIRED:
+                # Block if entity is missing, unavailable, or marked as broken
                 if health.status in (EntityStatus.MISSING, EntityStatus.UNAVAILABLE):
                     _LOGGER.warning(
                         "Automation blocked: required entity '%s' is %s",
                         config_key,
                         health.status.value,
+                    )
+                    return False
+                if health.is_broken:
+                    _LOGGER.warning(
+                        "Automation blocked: required entity '%s' is marked as BROKEN "
+                        "(%d consecutive failures)",
+                        config_key,
+                        health.consecutive_failures,
                     )
                     return False
 

--- a/custom_components/localshift/state_machine.py
+++ b/custom_components/localshift/state_machine.py
@@ -93,6 +93,7 @@ class StateMachine:
         # control of the Powerwall and ignore external API commands.
         self._tesla_override_detected: bool = False
         self._tesla_override_detected_at: datetime | None = None
+        self._tesla_override_released_at: datetime | None = None  # Track when Tesla released control
 
     def _detect_tesla_override(self, data: CoordinatorData) -> bool:
         """Detect if Tesla has taken control (Storm Watch, Grid Event, VPP).
@@ -623,11 +624,33 @@ class StateMachine:
                     else timedelta(0)
                 )
                 _LOGGER.info(
-                    "[TESLA OVERRIDE] Tesla has released control after %s. Resuming normal health checks.",
+                    "[TESLA OVERRIDE] Tesla has released control after %s. "
+                    "Applying %s cooldown before resuming health checks.",
                     duration,
+                    TESLA_OVERRIDE_COOLDOWN,
                 )
                 self._tesla_override_detected = False
+                self._tesla_override_released_at = now  # Track when Tesla released control
                 self._tesla_override_detected_at = None
+
+        # --- Tesla Override Cooldown ---
+        # After Tesla releases control, wait for the cooldown period before resuming
+        # health check corrections. This prevents conflicts during the transition.
+        if self._tesla_override_released_at is not None:
+            time_since_release = now - self._tesla_override_released_at
+            if time_since_release < TESLA_OVERRIDE_COOLDOWN:
+                remaining = (TESLA_OVERRIDE_COOLDOWN - time_since_release).total_seconds()
+                _LOGGER.debug(
+                    "[HEALTH CHECK] Skipping - in Tesla override cooldown (%.0fs remaining)",
+                    remaining,
+                )
+                return
+            else:
+                # Cooldown period has elapsed, clear the timestamp
+                _LOGGER.info(
+                    "[TESLA OVERRIDE] Cooldown period elapsed, resuming normal health checks"
+                )
+                self._tesla_override_released_at = None
 
         # Skip health check during transition grace period
         # This prevents false positives when Tesla API is still propagating


### PR DESCRIPTION
## Summary

This PR implements the missing logic for several constants that were defined but never used, as identified in issue #202.

## Changes Made

### 1. pattern_analyzer.py: `MIN_WEEKS_OBSERVED`
- Added check in `detect_biases()` to skip bias detection when less than 2 weeks of data
- Prevents false biases from being detected with insufficient history
- Logs debug message when skipping due to insufficient data

### 2. entity_validator.py: `FAILURE_THRESHOLD_WARNING`, `FAILURE_THRESHOLD_ERROR`
- Added `_check_failure_thresholds()` method to check and escalate failures
- Logs warning at 3 consecutive failures (monitoring closely)
- Marks entity as broken at 10 consecutive failures
- Added `is_broken` field to `EntityHealth` dataclass
- Updated `should_allow_automation()` to block when required entity is broken
- Updated `get_health_summary()` to include `is_broken` status

### 3. state_machine.py: `TESLA_OVERRIDE_COOLDOWN`
- Added `_tesla_override_released_at` attribute to track when Tesla releases control
- Applies 30-minute cooldown after Tesla releases control before resuming health checks
- Prevents command conflicts during the transition period after Storm Watch, Grid Events, or VPP events

### 4. forecast_computer.py: `GRID_CHARGE_HYSTERESIS_MARGIN_PCT`
- Removed unused constant (was defined but never referenced)
- Hysteresis is already implemented via a "stickiness" approach in `_should_grid_charge_at_slot()`

## Testing

- All modified files compile successfully (verified with `py_compile`)
- Changes are backward compatible

## Related

- Split from #184
- Related: #170 (learning system)
- Related: #34 (grid charge hysteresis)

Closes #202