### PR TITLE
fix: replace MagicMock with AsyncMock for async method mocks

### DIFF
--- a/tests/test_battery_controller.py
+++ b/tests/test_battery_controller.py
@@ -1,7 +1,6 @@
 """Unit tests for BatteryController."""
 
-from unittest.mock import AsyncMock as AsyncMockClass
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -10,13 +9,6 @@ from custom_components.localshift.const import (
     TESLEMETRY_EXPORT_BATTERY_OK,
     TESLEMETRY_EXPORT_PV_ONLY,
 )
-
-
-class AsyncMock(MagicMock):
-    """Mock that can be awaited."""
-
-    async def __call__(self, *args, **kwargs):
-        return super().__call__(*args, **kwargs)
 
 
 @pytest.fixture
@@ -669,7 +661,7 @@ class TestValidateTransition:
         # Use mock_battery_sleep to make this instant
         with patch(
             "custom_components.localshift.battery_controller.asyncio.sleep",
-            new_callable=AsyncMockClass,
+            new_callable=AsyncMock,
         ):
             result = await battery_controller.validate_transition(
                 expected_operation_mode="autonomous",

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -15,7 +15,9 @@ def mock_hass_with_services():
     hass.services = MagicMock()
     hass.services.async_call = AsyncMock()
     hass.states = MagicMock()
-    hass.async_create_task = MagicMock()
+    # async_create_task receives coroutines - use a mock that consumes them
+    # to avoid "coroutine was never awaited" warnings
+    hass.async_create_task = MagicMock(side_effect=lambda coro, name=None: None)
     return hass
 
 
@@ -223,8 +225,8 @@ class TestHandleStateChange:
         coordinator._state_machine = MagicMock()
         coordinator._state_machine.in_mode_transition = False
 
-        # Mock hass for async_create_task
-        coordinator.hass.async_create_task = MagicMock()
+        # Mock hass for async_create_task - consume coroutines to avoid warnings
+        coordinator.hass.async_create_task = MagicMock(side_effect=lambda coro, name=None: None)
 
         # Create mock event
         event = MagicMock()
@@ -287,8 +289,8 @@ class TestHandlePeriodicTick:
         # Mock state machine
         coordinator._state_machine = MagicMock()
 
-        # Mock hass for async_create_task
-        coordinator.hass.async_create_task = MagicMock()
+        # Mock hass for async_create_task - consume coroutines to avoid warnings
+        coordinator.hass.async_create_task = MagicMock(side_effect=lambda coro, name=None: None)
 
         now = datetime(2026, 2, 16, 12, 0, 0)
         coordinator._handle_periodic_tick(now)
@@ -320,8 +322,8 @@ class TestHandlePeriodicTick:
         # Mock state machine
         coordinator._state_machine = MagicMock()
 
-        # Mock hass for async_create_task
-        coordinator.hass.async_create_task = MagicMock()
+        # Mock hass for async_create_task - consume coroutines to avoid warnings
+        coordinator.hass.async_create_task = MagicMock(side_effect=lambda coro, name=None: None)
 
         now = datetime(2026, 2, 16, 12, 0, 0)
         coordinator._handle_periodic_tick(now)

--- a/tests/test_thermal_manager.py
+++ b/tests/test_thermal_manager.py
@@ -28,7 +28,9 @@ def mock_hass():
     hass = MagicMock()
     hass.services = MagicMock()
     hass.services.async_call = AsyncMock()
-    hass.async_create_task = MagicMock()
+    # async_create_task receives coroutines - use a mock that consumes them
+    # to avoid "coroutine was never awaited" warnings
+    hass.async_create_task = MagicMock(side_effect=lambda coro, name=None: None)
     hass.loop = MagicMock()
     hass.data = {}
     return hass


### PR DESCRIPTION
## Summary
Fixes RuntimeWarning: coroutine was never awaited warnings in tests.

## Problem
Test suite produced warnings when mocking async methods:
```
RuntimeWarning: coroutine 'LocalShiftCoordinator._retry_solcast_check' was never awaited
RuntimeWarning: coroutine 'LocalShiftCoordinator._evaluate_state_machine' was never awaited
RuntimeWarning: coroutine 'LocalShiftCoordinator._refresh_weather_forecast' was never awaited
```

## Root Cause
Tests used `MagicMock` for async coordinator methods instead of `AsyncMock`. The mock captures coroutine objects but doesn't await them.

## Solution
- Use `side_effect=lambda coro, name=None: None` for `async_create_task` mocks to consume coroutines
- Remove custom `AsyncMock` class in test_battery_controller.py, use standard `unittest.mock.AsyncMock`

## Changes Made
- `tests/test_coordinator.py`: Fixed async_create_task mocks to consume coroutines
- `tests/test_thermal_manager.py`: Same fix for async_create_task mock
- `tests/test_battery_controller.py`: Removed custom AsyncMock class, use standard library version

## Testing
Tests pass correctly. Warnings are cosmetic noise only and don't affect test behavior.

Closes #177