### PR TITLE
fix: add shutdown and periodic save for learning data persistence

### DIFF
--- a/custom_components/localshift/computation_engine_lib/decision_outcome_tracker.py
+++ b/custom_components/localshift/computation_engine_lib/decision_outcome_tracker.py
@@ -552,8 +552,8 @@ class DecisionOutcomeTracker:
             "completed_decisions": [r.to_dict() for r in self._completed_decisions],
         }
         await self._store.async_save(data)
-        _LOGGER.debug(
-            "Saved %d pending + %d completed decision records to storage",
+        _LOGGER.info(
+            "Decision tracker saved: %d pending + %d completed records",
             len(self._pending_decisions),
             len(self._completed_decisions),
         )

--- a/custom_components/localshift/coordinator.py
+++ b/custom_components/localshift/coordinator.py
@@ -66,6 +66,9 @@ _LOGGER = logging.getLogger(__name__)
 # How often the coordinator re-evaluates (matches A16/A9 cadence)
 PERIODIC_INTERVAL = timedelta(minutes=1)
 
+# How often to save learning data to storage (prevents data loss on restart)
+LEARNING_SAVE_INTERVAL = timedelta(minutes=5)
+
 # Solcast startup retry configuration
 SOLCAST_STARTUP_RETRY_DELAY = timedelta(seconds=30)
 SOLCAST_MAX_STARTUP_RETRIES = 3
@@ -89,6 +92,7 @@ class LocalShiftCoordinator:
         self._unsub_midnight: CALLBACK_TYPE | None = None
         self._unsub_daily_summary: CALLBACK_TYPE | None = None
         self._unsub_thermal_mode_decision: CALLBACK_TYPE | None = None
+        self._unsub_learning_save: CALLBACK_TYPE | None = None
         self._update_callbacks: list[CALLBACK_TYPE] = []
 
         # Switch state bridge — switches read/write via these methods
@@ -340,6 +344,13 @@ class LocalShiftCoordinator:
             second=0,
         )
 
+        # Periodic learning data save (every 5 minutes) to prevent data loss on restart
+        self._unsub_learning_save = async_track_time_interval(
+            self.hass,
+            self._handle_learning_save,
+            LEARNING_SAVE_INTERVAL,
+        )
+
         # Read initial state and compute
         self._read_all_external_state()
 
@@ -380,13 +391,18 @@ class LocalShiftCoordinator:
         )
 
     async def async_stop(self) -> None:
-        """Stop listening and clean up."""
+        """Stop listening and clean up.
+
+        Saves all learning data to storage before shutdown to prevent data loss.
+        """
+        # Unsubscribe all timers
         for unsub in (
             self._unsub_state,
             self._unsub_timer,
             self._unsub_midnight,
             self._unsub_daily_summary,
             self._unsub_thermal_mode_decision,
+            self._unsub_learning_save,
         ):
             if unsub:
                 unsub()
@@ -395,12 +411,72 @@ class LocalShiftCoordinator:
         self._unsub_midnight = None
         self._unsub_daily_summary = None
         self._unsub_thermal_mode_decision = None
+        self._unsub_learning_save = None
+
+        # Save all learning data to storage before shutdown
+        await self._save_learning_data()
 
         # (backlog-med-004) Clean up historical load cache on shutdown
         if self._computation_engine is not None:
             self._computation_engine.clear_historical_cache()
 
         _LOGGER.info("LocalShift coordinator stopped")
+
+    async def _save_learning_data(self) -> None:
+        """Save all learning system data to storage.
+
+        Called on shutdown and periodically to prevent data loss.
+        """
+        saved_components = []
+
+        # Save decision outcomes
+        if self.decision_tracker is not None:
+            try:
+                await self.decision_tracker.async_save()
+                saved_components.append(
+                    f"decisions:{self.decision_tracker.completed_count}"
+                )
+            except Exception as e:
+                _LOGGER.error("Failed to save decision tracker: %s", e)
+
+        # Save parameter optimizer
+        if self.param_optimizer is not None:
+            try:
+                await self.param_optimizer.async_save()
+                saved_components.append("param_optimizer")
+            except Exception as e:
+                _LOGGER.error("Failed to save parameter optimizer: %s", e)
+
+        # Save pattern analyzer
+        if self.pattern_analyzer is not None:
+            try:
+                await self.pattern_analyzer.async_save()
+                saved_components.append("pattern_analyzer")
+            except Exception as e:
+                _LOGGER.error("Failed to save pattern analyzer: %s", e)
+
+        # Save optimization controller
+        if self.optimization_controller is not None:
+            try:
+                await self.optimization_controller.async_save()
+                saved_components.append("optimization_controller")
+            except Exception as e:
+                _LOGGER.error("Failed to save optimization controller: %s", e)
+
+        if saved_components:
+            _LOGGER.info("Learning data saved: %s", ", ".join(saved_components))
+
+    @callback
+    def _handle_learning_save(self, now: datetime) -> None:
+        """Periodic save of learning data to prevent data loss on restart.
+
+        Fires every 5 minutes to ensure data is persisted even if HA
+        restarts unexpectedly.
+        """
+        self.hass.async_create_task(
+            self._save_learning_data(),
+            "localshift_periodic_learning_save",
+        )
 
     # ------------------------------------------------------------------
     # Entity update subscription (for sensor/binary_sensor entities)


### PR DESCRIPTION
## Summary
Fixes decision data loss on Home Assistant restart by adding proper persistence mechanisms.

## Problem
After a restart, the dashboard showed "0 decisions today" even though decisions had been recorded during the session. Investigation revealed:
1. The storage file existed but was empty (`completed_decisions: []`)
2. `async_stop()` did not save learning data before shutdown
3. No periodic save mechanism existed (only saved on backfill events)

## Changes Made
- **Add `_save_learning_data()` method** - Saves all learning components (decision_tracker, param_optimizer, pattern_analyzer, optimization_controller)
- **Add shutdown save** - Call `_save_learning_data()` in `async_stop()` before cleanup
- **Add periodic save timer** - Every 5 minutes via `_handle_learning_save()` callback
- **Improve logging** - Changed debug to info level in decision_outcome_tracker for better visibility

## Testing
- Verified code syntax with Python AST parser
- Manual testing required: Deploy and verify decisions persist after HA restart

## Files Changed
- `custom_components/localshift/coordinator.py` - Added save mechanisms
- `custom_components/localshift/computation_engine_lib/decision_outcome_tracker.py` - Improved logging