### PR TITLE
fix: use grid with columns instead of horizontal-stack in dashboard

### DIFF
--- a/custom_components/localshift/dashboard.yaml
+++ b/custom_components/localshift/dashboard.yaml
@@ -159,7 +159,8 @@ views:
               {% endif %}
 
       # Today's Cost (Hero Metric)
-      - type: horizontal-stack
+      - type: grid
+        columns: 2
         cards:
           - type: markdown
             content: >


### PR DESCRIPTION
## Summary
Fixed invalid YAML structure in dashboard.yaml for Home Assistant's sections view.

## Changes Made
- Changed `type: horizontal-stack` to `type: grid` with `columns: 2` for the Today's Cost section
- The horizontal-stack type is not valid as a direct section in Home Assistant's sections view

## Testing
- YAML structure now valid for sections view
- Two markdown cards will display side-by-side in a 2-column grid layout