### PR TITLE
fix: AC now turns on/off with thermal control

### DIFF
--- a/custom_components/localshift/thermal_manager.py
+++ b/custom_components/localshift/thermal_manager.py
@@ -1274,6 +1274,10 @@ class ThermalManager:
         where offsets would accumulate on each tick. Instead, it calculates
         the new setpoint from the original baseline.
 
+        Also controls HVAC mode:
+        - When activating (offset != 0): Turns AC on in cool/heat mode
+        - When deactivating (offset == 0): Turns AC off
+
         Args:
             data: CoordinatorData with current state.
             setpoint_offset: Setpoint adjustment in °C (positive = higher temp).
@@ -1287,11 +1291,46 @@ class ThermalManager:
             self._clear_original_setpoints()
             return
 
-        # If offset is 0, restore original setpoints and clear tracking
+        # Determine HVAC mode from daily thermal mode
+        daily_mode = data.daily_thermal_mode
+        if daily_mode == ThermalMode.COOL:
+            hvac_mode = "cool"
+        elif daily_mode == ThermalMode.HEAT:
+            hvac_mode = "heat"
+        else:
+            # For DRY/OFF modes, don't control HVAC
+            _LOGGER.debug(
+                "Skipping climate control for mode: %s",
+                daily_mode.value,
+            )
+            return
+
+        # If offset is 0, turn off AC and restore original setpoints
         if setpoint_offset == 0.0:
             if self._current_active_offset != 0.0:
-                # We had an active offset, now need to restore
+                # We had an active offset, now need to turn off and restore
                 for entity_id in control_entities:
+                    # Turn off AC
+                    try:
+                        await self.hass.services.async_call(
+                            "climate",
+                            "set_hvac_mode",
+                            {
+                                "entity_id": entity_id,
+                                "hvac_mode": "off",
+                            },
+                            blocking=False,
+                        )
+                        _LOGGER.info(
+                            "Turned off %s (thermal control deactivated)",
+                            entity_id,
+                        )
+                    except Exception as err:
+                        _LOGGER.warning(
+                            "Failed to turn off %s: %s", entity_id, err
+                        )
+
+                    # Restore original setpoint
                     if entity_id in self._original_setpoints:
                         original = self._original_setpoints[entity_id]
                         try:
@@ -1345,7 +1384,26 @@ class ThermalManager:
             # Clamp to reasonable range
             new_setpoint = max(16.0, min(30.0, new_setpoint))
 
-            # Apply via climate.set_temperature service
+            # Turn on AC with correct HVAC mode
+            try:
+                await self.hass.services.async_call(
+                    "climate",
+                    "set_hvac_mode",
+                    {
+                        "entity_id": entity_id,
+                        "hvac_mode": hvac_mode,
+                    },
+                    blocking=False,
+                )
+                _LOGGER.info(
+                    "Turned on %s in %s mode (thermal control activated)",
+                    entity_id,
+                    hvac_mode,
+                )
+            except Exception as err:
+                _LOGGER.warning("Failed to turn on %s: %s", entity_id, err)
+
+            # Apply setpoint via climate.set_temperature service
             try:
                 await self.hass.services.async_call(
                     "climate",


### PR DESCRIPTION
## Summary
The thermal manager was only adjusting setpoints but not actually turning the AC on or off. This fix adds HVAC mode control.

## Problem
When room temperature exceeded the cooling trigger threshold, the thermal manager would calculate a new setpoint but the AC would remain off because it was never sent a `climate.set_hvac_mode` command.

## Solution
Modified `async_apply_climate_control()` in `thermal_manager.py` to:

- **When activating (offset != 0):** Turns AC on in cool/heat mode via `climate.set_hvac_mode`
- **When deactivating (offset == 0):** Turns AC off via `climate.set_hvac_mode`

## Changes Made
- Added HVAC mode control to `async_apply_climate_control()`
- When activating: calls `climate.set_hvac_mode` with "cool" or "heat" before setting temperature
- When deactivating: calls `climate.set_hvac_mode` with "off" and restores original setpoint

## Testing
- Verified the logic change in code review
- The fix ensures AC will now actually start cooling when thermal control activates

## Files Changed
- `custom_components/localshift/thermal_manager.py` (+61 lines, -3 lines)