### PR TITLE
fix: use blocking call for HVAC mode change

### DIFF
--- a/custom_components/localshift/thermal_manager.py
+++ b/custom_components/localshift/thermal_manager.py
@@ -1384,7 +1384,7 @@ class ThermalManager:
             # Clamp to reasonable range
             new_setpoint = max(16.0, min(30.0, new_setpoint))
 
-            # Turn on AC with correct HVAC mode
+            # Turn on AC with correct HVAC mode (blocking to ensure mode is set before temperature)
             try:
                 await self.hass.services.async_call(
                     "climate",
@@ -1393,7 +1393,7 @@ class ThermalManager:
                         "entity_id": entity_id,
                         "hvac_mode": hvac_mode,
                     },
-                    blocking=False,
+                    blocking=True,
                 )
                 _LOGGER.info(
                     "Turned on %s in %s mode (thermal control activated)",


### PR DESCRIPTION
## Summary
Changed `set_hvac_mode` to use `blocking=True` to ensure the mode change completes before setting the temperature.

## Problem
The temperature setpoint was not being applied when the AC turned on. This was caused by a race condition where `set_temperature` was called before `set_hvac_mode` had fully propagated to the climate integration.

## Solution
Changed the `set_hvac_mode` call from `blocking=False` to `blocking=True`. This ensures the mode change completes before the temperature setpoint is applied.

## Changes Made
- `thermal_manager.py`: Changed `blocking=False` to `blocking=True` in `set_hvac_mode` call

## Testing
- Verified the fix resolves the setpoint update issue
- The AC now correctly sets the target temperature after turning on

## Related
- Follow-up to PR #217 which added HVAC mode control