### PR TITLE
fix: always apply setpoint adjustment, even when offset unchanged

### DIFF
--- a/custom_components/localshift/thermal_manager.py
+++ b/custom_components/localshift/thermal_manager.py
@@ -1355,14 +1355,10 @@ class ThermalManager:
             self._clear_original_setpoints()
             return
 
-        # Skip if this is the same offset we already applied
-        # (avoid unnecessary service calls)
-        if setpoint_offset == self._current_active_offset:
-            _LOGGER.debug(
-                "Offset %.1f°C already active, skipping adjustment",
-                setpoint_offset,
-            )
-            return
+        # Note: We intentionally do NOT skip when offset is the same as before.
+        # The user may have manually changed the setpoint, or the AC may have been
+        # on with a different setpoint. We always re-apply to ensure correctness.
+        # The set_temperature call is idempotent, so repeated calls are harmless.
 
         # Capture original setpoints if this is a new control session
         if not self._original_setpoints:


### PR DESCRIPTION
## Summary
Removed the skip check when the offset is the same. This fixes the issue where the setpoint was not updated when the AC was already on with a different setpoint.

## Problem
When the AC was already on (e.g., set to 26°C by the user), and thermal control activated with the same offset as before (e.g., -2.0°C), the code would skip the adjustment entirely:

```python
if setpoint_offset == self._current_active_offset:
    return  # Skipped!
```

This meant the setpoint stayed at 26°C instead of being adjusted to the correct value.

## Solution
Removed the skip check. The `set_temperature` call is idempotent, so calling it multiple times with the same value is harmless. This ensures the setpoint is always correct even if:
- The user manually changed the setpoint
- The AC was already running with a different setpoint
- The offset happens to be the same as before

## Changes Made
- Removed the "same offset" skip check in `async_apply_climate_control()`
- Added a comment explaining why we always apply the adjustment

## Testing
- Verified that the setpoint is now updated correctly when the AC is already on

## Related
- PR #217 - Added HVAC mode control
- PR #218 - Fixed race condition with blocking mode change