### PR TITLE
feat: add test branch staging workflow and deploy improvements

### DIFF
--- a/.clinerules
+++ b/.clinerules
@@ -149,6 +149,165 @@ Check with: `git worktree list`
 - `_reserve/*` branches are temporary worktrees for Cline session isolation
 - These can be cleaned up between sessions if not in use
 
+# ⚠️ MANDATORY: Testing Workflow (test → main Staging)
+
+**All changes flow through `test` branch before reaching `main`.**
+
+## Branch Roles
+
+| Branch | Purpose | Deploy Behavior |
+|--------|---------|-----------------|
+| `test` | Staging/testing | Auto-deploy on push |
+| `main` | Production | Manual deploy only |
+| `issue/*`, `fix/*`, `task/*` | Feature branches | Never deployed directly |
+
+## Workflow Steps
+
+### 1. Develop in Worktree
+```bash
+git worktree add /Users/jackmcintyre/worktrees/issue-42 -b issue/42
+# Make changes, commit, push
+```
+
+### 2. Open PR
+Create PR via `gh pr create` (see Pull Request Workflow section)
+
+### 3. Merge to Test for Testing
+```bash
+git checkout test
+git pull origin test
+git merge --no-ff issue/42
+git push origin test
+# Auto-deploy triggers automatically
+```
+
+### 4. Test in Home Assistant
+Verify the changes work correctly in HA
+
+### 5. If Issues Found
+- Fix in the original worktree
+- Push to PR branch
+- Merge to test again:
+  ```bash
+  git checkout test
+  git merge --no-ff issue/42
+  git push origin test
+  ```
+- Retest
+
+### 6. When Satisfied
+Merge PR to main via GitHub (this closes the PR automatically)
+
+### 7. Cleanup
+```bash
+git worktree remove /Users/jackmcintyre/worktrees/issue-42
+git branch -d issue/42
+```
+
+## ⚠️ CRITICAL: PR State Check Before Committing
+
+**Before committing in a worktree, ALWAYS check if the PR is already merged:**
+
+```bash
+gh pr view --json state,number
+```
+
+### If PR State is `MERGED` or `CLOSED`:
+- **STOP** - Do NOT add commits to this branch
+- Create a NEW worktree for any additional work
+- Open a NEW PR for the new changes
+
+### Why This Matters
+- Prevents adding commits to already-merged PRs
+- Keeps git history clean
+- Avoids confusion about what's deployed
+
+## Post-Merge Cleanup
+
+After a PR is merged to main:
+
+```bash
+# 1. Remove the worktree
+git worktree remove /Users/jackmcintyre/worktrees/{worktree-name}
+
+# 2. Delete local branch (if merged)
+git branch -d {branch-name}
+
+# 3. Sync test with main (reset test to main)
+git checkout test
+git fetch origin
+git reset --hard origin/main
+git push origin test --force
+```
+
+## Flow Diagram
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                      DEVELOPMENT FLOW                           │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                 │
+│   worktree/issue-42  ──PR──►  test  ──merge──►  main           │
+│        │                        │                   │           │
+│        │                        │                   │           │
+│        │                   AUTO-DEPLOY         MANUAL DEPLOY    │
+│        │                        │                   │           │
+│        │                        ▼                   ▼           │
+│        │                   ┌─────────┐         ┌─────────┐      │
+│        └──────────────────►│   HA    │◄────────│   HA    │      │
+│           (for testing)    │ (test)  │         │ (prod)  │      │
+│                           └─────────┘         └─────────┘      │
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+# Deploy Script Reference
+
+The `deploy.sh` script deploys LocalShift to Home Assistant.
+
+## Usage
+
+```bash
+./deploy.sh                    # Deploy test branch (default, for testing)
+./deploy.sh --branch main      # Deploy main branch (production)
+./deploy.sh --branch test      # Explicitly deploy test branch
+./deploy.sh --no-reload        # Deploy without reloading HA integration
+./deploy.sh --dry-run          # Preview changes without deploying
+./deploy.sh --watch            # Watch for changes and auto-deploy
+```
+
+## Environment Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `HA_CONFIG` | HA config directory | `/homeassistant` |
+| `HA_URL` | HA API URL | `http://homeassistant:8123` |
+| `HA_LONG_LIVED_TOKEN` | HA API token for reload | (none) |
+
+## What Deploy Does
+
+1. **Backs up** existing installation to `$HA_CONFIG/backups/`
+2. **Pulls** from the specified branch (test or main)
+3. **Copies** files from `custom_components/localshift/` to HA config
+4. **Reloads** integration via HA API (if token set)
+
+## When to Use Which Branch
+
+| Scenario | Command |
+|----------|---------|
+| Testing a PR | `./deploy.sh` (test branch) |
+| After merging to test | Automatic (auto-deploy) |
+| Production deployment | `./deploy.sh --branch main` |
+| Preview changes | `./deploy.sh --dry-run` |
+
+## User Requests for Deploy
+
+When the user says:
+- "deploy" → Run `./deploy.sh` (test branch)
+- "deploy to production" → Run `./deploy.sh --branch main`
+- "deploy main" → Run `./deploy.sh --branch main`
+- "preview deploy" → Run `./deploy.sh --dry-run`
+
 # GitHub Issues Workflow
 
 ## Overview

--- a/deploy.sh
+++ b/deploy.sh
@@ -10,11 +10,17 @@
 #   3. HA_URL env var set for API endpoint (optional, default: http://homeassistant:8123)
 #
 # Usage:
-#   ./deploy.sh [--no-reload] [--dry-run]
+#   ./deploy.sh                    # Deploy test branch (default)
+#   ./deploy.sh --branch main      # Deploy main branch (production)
+#   ./deploy.sh --branch test      # Explicitly deploy test branch
+#   ./deploy.sh --no-reload        # Deploy without reloading HA integration
+#   ./deploy.sh --dry-run          # Preview changes without deploying
+#   ./deploy.sh --watch            # Watch for changes and auto-deploy
 #
-# Options:
-#   --no-reload   Skip the API reload step
-#   --dry-run     Show what would be done without making changes
+# Branch Strategy:
+#   - test branch: Staging/testing, auto-deploys on push
+#   - main branch: Production, manual deploy only
+#   - Feature branches: Never deployed directly, merge to test first
 
 set -e
 
@@ -26,13 +32,16 @@ COMPONENT_NAME="localshift"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SOURCE_DIR="$SCRIPT_DIR/custom_components/$COMPONENT_NAME"
 DEST_DIR="$HA_CONFIG/custom_components/$COMPONENT_NAME"
+DEFAULT_BRANCH="test"
 
 # Parse arguments
 NO_RELOAD=false
 DRY_RUN=false
+WATCH_MODE=false
+TARGET_BRANCH=""
 
-for arg in "$@"; do
-    case $arg in
+while [[ $# -gt 0 ]]; do
+    case $1 in
         --no-reload)
             NO_RELOAD=true
             shift
@@ -41,12 +50,30 @@ for arg in "$@"; do
             DRY_RUN=true
             shift
             ;;
+        --watch)
+            WATCH_MODE=true
+            shift
+            ;;
+        --branch)
+            TARGET_BRANCH="$2"
+            shift 2
+            ;;
+        --branch=*)
+            TARGET_BRANCH="${1#*=}"
+            shift
+            ;;
         *)
-            echo "Unknown argument: $arg"
+            echo "Unknown argument: $1"
+            echo "Usage: $0 [--branch test|main] [--no-reload] [--dry-run] [--watch]"
             exit 1
             ;;
     esac
 done
+
+# Default to test branch if not specified
+if [ -z "$TARGET_BRANCH" ]; then
+    TARGET_BRANCH="$DEFAULT_BRANCH"
+fi
 
 # Color output (disable if not a terminal)
 if [ -t 1 ]; then
@@ -54,12 +81,14 @@ if [ -t 1 ]; then
     GREEN='\033[0;32m'
     YELLOW='\033[0;33m'
     BLUE='\033[0;34m'
+    CYAN='\033[0;36m'
     NC='\033[0m' # No Color
 else
     RED=''
     GREEN=''
     YELLOW=''
     BLUE=''
+    CYAN=''
     NC=''
 fi
 
@@ -67,6 +96,7 @@ log_info() { echo -e "${BLUE}ℹ${NC} $1"; }
 log_success() { echo -e "${GREEN}✓${NC} $1"; }
 log_warning() { echo -e "${YELLOW}⚠${NC} $1"; }
 log_error() { echo -e "${RED}✗${NC} $1"; }
+log_deploy() { echo -e "${CYAN}🚀${NC} $1"; }
 
 # Check prerequisites
 log_info "Checking prerequisites..."
@@ -83,24 +113,99 @@ if [ ! -d "$HA_CONFIG" ]; then
     exit 1
 fi
 
+# Watch mode - monitor for changes and auto-deploy
+if [ "$WATCH_MODE" = true ]; then
+    log_info "Starting watch mode - monitoring for changes..."
+    log_info "Target branch: $TARGET_BRANCH"
+    log_info "Press Ctrl+C to stop"
+    echo ""
+    
+    # Check for inotifywait
+    if ! command -v inotifywait &> /dev/null; then
+        log_error "inotifywait not found. Install with: apt-get install inotify-tools"
+        exit 1
+    fi
+    
+    # Initial deploy
+    log_deploy "Performing initial deployment..."
+    "$SCRIPT_DIR/deploy.sh" --branch "$TARGET_BRANCH" --no-reload
+    
+    # Watch for changes
+    inotifywait -m -r -e modify,create,delete,move "$SOURCE_DIR" 2>/dev/null | while read -r path action file; do
+        # Ignore __pycache__ and .pyc files
+        if [[ "$path" == *"__pycache__"* ]] || [[ "$file" == *.pyc ]]; then
+            continue
+        fi
+        
+        echo ""
+        log_info "Change detected: $path$file ($action)"
+        log_deploy "Redeploying..."
+        
+        # Redeploy
+        "$SCRIPT_DIR/deploy.sh" --branch "$TARGET_BRANCH" --no-reload
+        
+        # Reload integration via API
+        if [ -n "$HA_TOKEN" ]; then
+            log_info "Reloading integration via API..."
+            ENTRY_ID=$(curl -s -X GET \
+                -H "Authorization: Bearer $HA_TOKEN" \
+                -H "Content-Type: application/json" \
+                "${HA_URL%/}/api/config/config_entries/entry" 2>/dev/null | \
+                jq -r '.[] | select(.domain == "localshift") | .entry_id' 2>/dev/null | head -1 || true)
+            
+            if [ -n "$ENTRY_ID" ]; then
+                curl -s -X POST \
+                    -H "Authorization: Bearer $HA_TOKEN" \
+                    -H "Content-Type: application/json" \
+                    "$HA_URL/api/services/homeassistant/reload_config_entry" \
+                    -d "{\"entry_id\": \"$ENTRY_ID\"}" > /dev/null 2>&1 || true
+                log_success "Integration reloaded"
+            fi
+        fi
+        
+        log_success "Watch mode active - waiting for changes..."
+    done
+    
+    exit 0
+fi
+
 # Dry run mode
 if [ "$DRY_RUN" = true ]; then
     log_warning "DRY RUN MODE - No changes will be made"
     echo ""
     echo "Would perform the following:"
-    echo "  1. Backup: $DEST_DIR -> $HA_CONFIG/backups/${COMPONENT_NAME}.backup.<timestamp>"
-    echo "  2. Copy: $SOURCE_DIR -> $DEST_DIR"
-    echo "  3. Cleanup backups older than 7 days"
+    echo "  1. Pull from branch: $TARGET_BRANCH"
+    echo "  2. Backup: $DEST_DIR -> $HA_CONFIG/backups/${COMPONENT_NAME}.backup.<timestamp>"
+    echo "  3. Copy: $SOURCE_DIR -> $DEST_DIR"
+    echo "  4. Cleanup backups older than 7 days"
     if [ "$NO_RELOAD" = false ] && [ -n "$HA_TOKEN" ]; then
-        echo "  4. Reload integration via API: $HA_URL"
+        echo "  5. Reload integration via API: $HA_URL"
     fi
     exit 0
 fi
 
-# Pull latest changes if in a git repo
+# Pull from target branch
 if [ -d "$SCRIPT_DIR/.git" ] || git -C "$SCRIPT_DIR" rev-parse --git-dir > /dev/null 2>&1; then
-    log_info "Pulling latest changes..."
-    git -C "$SCRIPT_DIR" pull origin main || log_warning "Could not pull latest changes"
+    log_info "Pulling from branch: $TARGET_BRANCH"
+    
+    # Fetch the target branch
+    git -C "$SCRIPT_DIR" fetch origin "$TARGET_BRANCH" 2>/dev/null || true
+    
+    # Check if we're on the target branch or need to checkout
+    CURRENT_BRANCH=$(git -C "$SCRIPT_DIR" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+    
+    if [ "$CURRENT_BRANCH" != "$TARGET_BRANCH" ]; then
+        # We're in a worktree or different branch - pull and merge/reset
+        log_info "Current branch: $CURRENT_BRANCH, pulling $TARGET_BRANCH..."
+        
+        # For worktrees, we just pull the remote branch content
+        git -C "$SCRIPT_DIR" pull origin "$TARGET_BRANCH" --no-rebase 2>/dev/null || \
+            log_warning "Could not pull from $TARGET_BRANCH - continuing with current state"
+    else
+        # We're on the target branch - just pull
+        git -C "$SCRIPT_DIR" pull origin "$TARGET_BRANCH" 2>/dev/null || \
+            log_warning "Could not pull from $TARGET_BRANCH - continuing with current state"
+    fi
 fi
 
 # Create backup of existing installation
@@ -218,7 +323,8 @@ else
 fi
 
 echo ""
-log_success "Deployment complete!"
+log_deploy "Deployment complete!"
+log_info "Branch: $TARGET_BRANCH"
 log_info "Version: $(grep '"version"' "$DEST_DIR/manifest.json" | sed 's/.*"version": *"\([^"]*\)".*/\1/')"
 
 # Show backup location if one was created


### PR DESCRIPTION
## Summary
This PR adds a proper staging workflow using a `test` branch and improves the deploy script to support the new workflow.

## Changes Made

### .clinerules
- Add **test → main staging workflow** with clear branch roles
- Add **PR state check** before committing (prevents adding commits to merged PRs)
- Add **post-merge cleanup** instructions
- Add **deploy script reference** documentation so Cline understands deploy commands

### deploy.sh
- Add `--branch` flag to specify branch (default: `test`)
- Add `--watch` mode for auto-deploy on file changes
- Update default branch from `main` to `test`
- Improve branch detection for worktree scenarios

### Branch Setup
- Ensure `test` branch exists and tracks `origin/test`

## Testing Workflow

```
worktree/issue-42  ──PR──►  test  ──merge──►  main
      │                        │                   │
      │                   AUTO-DEPLOY         MANUAL DEPLOY
      │                        │                   │
      │                        ▼                   ▼
      │                   HA (test)           HA (prod)
```

1. PRs merge to `test` for testing
2. `test` auto-deploys to HA
3. After verification, merge to `main` for production

## Testing
- [x] Verify .clinerules documentation is clear
- [x] Verify deploy.sh --branch flag works
- [x] Verify test branch exists on origin