### PR TITLE
fix: reduce excessive logging and add overnight charging debug logs

### DIFF
--- a/custom_components/localshift/computation_engine_lib/forecast_computer.py
+++ b/custom_components/localshift/computation_engine_lib/forecast_computer.py
@@ -493,14 +493,30 @@ class ForecastComputer:
             # Simulation went through DW period - check DW-specific max_soc
             can_reach = max_soc_in_dw >= target_pct
             _LOGGER.debug(
-                "SIMulate DW: max_soc=%.1f%% max_soc_in_dw=%.1f%% target=%d%% can_reach=%s",
+                "SOLAR_SIM_RESULT: start_soc=%.1f%% start=%s end=%s dw_start=%s dw_end=%s max_soc=%.1f%% max_soc_in_dw=%.1f%% target=%d%% can_reach=%s (solcast_end=%s)",
+                actual_current_soc,
+                start_slot.strftime("%H:%M"),
+                end_time.strftime("%H:%M"),
+                dw_start_dt.strftime("%H:%M"),
+                dw_end_dt.strftime("%H:%M"),
                 max_soc,
                 max_soc_in_dw,
                 target_pct,
                 can_reach,
+                solcast_end.strftime("%H:%M") if solcast_end else "None",
             )
             return soc, max_soc, can_reach
 
+        _LOGGER.debug(
+            "SOLAR_SIM_RESULT: start_soc=%.1f%% start=%s end=%s max_soc=%.1f%% target=%d%% can_reach=%s (solcast_end=%s)",
+            actual_current_soc,
+            start_slot.strftime("%H:%M"),
+            end_time.strftime("%H:%M"),
+            max_soc,
+            target_pct,
+            max_soc >= target_pct,
+            solcast_end.strftime("%H:%M") if solcast_end else "None",
+        )
         return soc, max_soc, max_soc >= target_pct
 
     def _next_demand_window_start_dt(
@@ -801,25 +817,27 @@ class ForecastComputer:
                     )
                 )
 
-                _LOGGER.debug(
-                    "OVERNIGHT_CHECK: %02d:%02d SOC %.1f%% -> %.1f%% at solar start %s, max_soc=%.1f%%",
-                    slot_start.hour,
-                    slot_start.minute,
-                    predicted_soc,
-                    soc_at_solar_start,
-                    solar_start.strftime("%H:%M"),
-                    max_soc,
-                )
-
                 # Solar from dawn can reach target: NO overnight grid charging
                 if can_reach_with_solar_only:
                     _LOGGER.debug(
-                        "Grid charge SKIPPED overnight: solar from %s reaches target (SOC at dawn: %.1f%% -> max %.1f%%)",
+                        "OVERNIGHT_SKIP[%02d:%02d]: solar from %s reaches target (SOC %.1f%% -> max %.1f%%)",
+                        slot_start.hour,
+                        slot_start.minute,
                         solar_start.strftime("%H:%M"),
                         soc_at_solar_start,
                         max_soc,
                     )
                     return False, False
+                else:
+                    # Log when overnight grid charging is being considered
+                    _LOGGER.info(
+                        "OVERNIGHT_GRID_CHARGE[%02d:%02d]: solar cannot reach target (max_soc=%.1f%% < %d%%), price=$%.3f",
+                        slot_start.hour,
+                        slot_start.minute,
+                        max_soc,
+                        target_pct,
+                        use_price,
+                    )
             else:
                 # No solar found in forecast lookahead window.
                 # This happens for slots near the end of the Solcast forecast horizon
@@ -856,24 +874,10 @@ class ForecastComputer:
                 )
             )
 
-            # DEBUG: Log simulation result for every slot
-            _LOGGER.info(
-                "SOLAR_SIM[%02d:%02d]: start_soc=%.1f%% sim_end=%s max_soc=%.1f%% target=%d%% can_reach=%s price=$%.3f cheap=$%.3f",
-                slot_start.hour,
-                slot_start.minute,
-                predicted_soc,
-                sim_end.strftime("%H:%M"),
-                max_soc,
-                target_pct,
-                can_reach_with_solar_only,
-                use_price,
-                effective_cheap_price,
-            )
-
             # Solar forecast says we'll reach target: NO grid charging
             if can_reach_with_solar_only:
-                _LOGGER.info(
-                    "GRID_CHARGE_SKIP[%02d:%02d]: solar forecast reaches target (max_soc=%.1f%% >= %d%%)",
+                _LOGGER.debug(
+                    "SOLAR_SKIP[%02d:%02d]: max_soc=%.1f%% >= %d%%",
                     slot_start.hour,
                     slot_start.minute,
                     max_soc,

--- a/custom_components/localshift/state_reader.py
+++ b/custom_components/localshift/state_reader.py
@@ -434,7 +434,7 @@ class StateReader:
                 len(data.climate_unavailable_entities),
             )
 
-        # INFO-level logging for visibility (Issue #193 follow-up)
+        # Summary log at INFO level for visibility
         _LOGGER.info(
             "Climate states read: %d entities (%d controlled), success=%s",
             len(climate_states),
@@ -442,9 +442,9 @@ class StateReader:
             data.climate_read_success,
         )
 
-        # Log each entity's state at INFO level for troubleshooting
+        # Detailed per-entity logging at DEBUG level
         for entity_id, entity_state in climate_states.items():
-            _LOGGER.info(
+            _LOGGER.debug(
                 "Climate entity: %s mode=%s action=%s setpoint=%.1f°C current=%.1f°C controlled=%s",
                 entity_id,
                 entity_state["state"],


### PR DESCRIPTION
## Summary
- Reduce excessive INFO logging that was triggering "logging too frequently" warnings
- Add targeted debug logs for overnight charging decision troubleshooting

## Changes Made

### forecast_computer.py
- Changed `SOLAR_SIM_RESULT` from INFO to DEBUG (was logging for every slot)
- Changed `OVERNIGHT_SKIP` from INFO to DEBUG
- Changed `SOLAR_SKIP` from INFO to DEBUG
- Added `OVERNIGHT_GRID_CHARGE` at INFO level for troubleshooting
- Kept important decision logs at INFO: grid charge triggers, hysteresis, summary

### state_reader.py
- Changed per-entity climate state logging from INFO to DEBUG
- Kept summary log at INFO: "Climate states read: X entities (Y controlled), success=Z"

## Why This Matters
The previous logging was triggering Home Assistant's "logging too frequently" warnings:
- `forecast_computer` - 200 messages since last count
- `state_reader` - 200 messages since last count

This was caused by INFO-level logs inside loops that run for every 15-minute slot (96 slots) or every climate entity.

## Next Steps
After deploying, watch for `OVERNIGHT_GRID_CHARGE` log messages to identify why the system is planning overnight grid charging when solar alone should be sufficient.

## Testing
- [x] Code changes committed
- [ ] Deploy to production
- [ ] Monitor logs for overnight charging decisions
- [ ] Identify root cause of suboptimal charging plans