### PR TITLE
debug: add OVERNIGHT_SIM log to trace simulation parameters

### DIFF
--- a/custom_components/localshift/computation_engine_lib/forecast_computer.py
+++ b/custom_components/localshift/computation_engine_lib/forecast_computer.py
@@ -794,6 +794,17 @@ class ForecastComputer:
                     min_soc_pct=min_soc_pct,
                 )
 
+                # DEBUG: Log simulation parameters for troubleshooting
+                _LOGGER.info(
+                    "OVERNIGHT_SIM[%02d:%02d]: predicted_soc=%.1f%%, solar_start=%s, soc_at_solar_start=%.1f%%, sim_end=%s",
+                    slot_start.hour,
+                    slot_start.minute,
+                    predicted_soc,
+                    solar_start.strftime("%H:%M"),
+                    soc_at_solar_start,
+                    sim_end.strftime("%H:%M"),
+                )
+
                 # Now simulate from solar start to next DW
                 # ISSUE #137: Pass baseline for grid charging decisions
                 # FIX: Pass dw_end_time for proper DW-period max_soc tracking


### PR DESCRIPTION
## Purpose
Add detailed logging to diagnose why overnight grid charging is being triggered incorrectly.

## The Issue
The system is planning overnight grid charging when solar alone should be sufficient. The logs show:
- `max_soc=11.0%` for overnight slots (21:10-02:40)
- This is clearly wrong - with 48 Solcast entries for tomorrow, solar should charge the battery

## Debug Logging Added
`OVERNIGHT_SIM[HH:MM]` log shows:
- `predicted_soc` - The forecasted SOC at this slot
- `solar_start` - When solar production starts (found via Solcast)
- `soc_at_solar_start` - SOC after overnight drain to solar start
- `sim_end` - When the simulation ends (should be next DW)

This will help identify:
1. Is the simulation being truncated by Solcast horizon?
2. Is the overnight drain calculation correct?
3. Is the solar start time being found correctly?

## Next Steps
1. Deploy this debug version
2. Collect logs showing the simulation parameters
3. Identify the root cause
4. Implement the fix