### PR TITLE
fix: use blocking call for HVAC mode change

### DIFF
--- a/custom_components/localshift/thermal_manager.py
+++ b/custom_components/localshift/thermal_manager.py
@@ -1384,7 +1384,7 @@ class ThermalManager:
             # Clamp to reasonable range
             new_setpoint = max(16.0, min(30.0, new_setpoint))
 
-            # Turn on AC with correct HVAC mode
+            # Turn on AC with correct HVAC mode (blocking to ensure mode is set before temperature)
             try:
                 await self.hass.services.async_call(
                     "climate",
@@ -1393,7 +1393,7 @@ class ThermalManager:
                         "entity_id": entity_id,
                         "hvac_mode": hvac_mode,
                     },
-                    blocking=False,
+                    blocking=True,
                 )
                 _LOGGER.info(
                     "Turned on %s in %s mode (thermal control activated)",


### PR DESCRIPTION
Changed set_hvac_mode to use blocking=True to ensure the mode change completes before setting the temperature. This fixes a race condition where the temperature setpoint was being ignored because the mode change hadn't fully propagated yet.