### PR TITLE
fix: remove reset learning buttons from dashboard

### DIFF
--- a/custom_components/localshift/dashboard.yaml
+++ b/custom_components/localshift/dashboard.yaml
@@ -489,19 +489,6 @@ views:
               {% endfor %}
               {% endif %}
 
-          - type: button
-            name: Reset Learning
-            icon: mdi:brain-off
-            tap_action:
-              action: call-service
-              service: button.press
-              target:
-                entity_id: button.localshift_reset_learning
-            icon_height: 40px
-            hold_action:
-              action: none
-
-
   # =============================================================================
   # VIEW 2: CONTROLS (Adjust Settings Occasionally)
   # =============================================================================
@@ -591,16 +578,6 @@ views:
               service: button.press
               target:
                 entity_id: button.localshift_update_forecast
-            icon_height: 40px
-
-          - type: button
-            name: Reset Learning
-            icon: mdi:brain-off
-            tap_action:
-              action: call-service
-              service: button.press
-              target:
-                entity_id: button.localshift_reset_learning
             icon_height: 40px
 
       # Live System (Tesla Controls)


### PR DESCRIPTION
## Summary
Remove 'Reset Learning' buttons from the dashboard as requested in #228.

## Changes Made
- Removed 'Reset Learning' button from View 1 (Dashboard) - Learning System section
- Removed 'Reset Learning' button from View 2 (Controls) - Manual Actions section

## Testing
- Deployed and verified integration loads without errors
- The underlying `button.localshift_reset_learning` entity still exists and can be triggered via Developer Tools if needed

Closes #228