### PR TITLE
fix: handle 4th return value from _simulate_future_soc_with_solar_only

### DIFF
--- a/custom_components/localshift/computation_engine.py
+++ b/custom_components/localshift/computation_engine.py
@@ -267,7 +267,7 @@ class ComputationEngine:
             all_solcast = [*data.solcast_today, *data.solcast_tomorrow]
 
             # Simulate solar-only charging through DW period
-            soc_at_end, max_soc, can_reach = (
+            soc_at_end, max_soc, can_reach, _ = (
                 self._forecast_computer._simulate_future_soc_with_solar_only(
                     actual_current_soc=data.soc,
                     start_slot=now_dt,

--- a/custom_components/localshift/computation_engine_lib/grid_charge_decision.py
+++ b/custom_components/localshift/computation_engine_lib/grid_charge_decision.py
@@ -352,7 +352,7 @@ class GridChargeDecisionEngine:
 
                 # Now simulate from solar start to next DW
                 # Use effective_target_pct for simulation (includes headroom)
-                soc_at_end, max_soc, can_reach_with_solar_only = (
+                soc_at_end, max_soc, can_reach_with_solar_only, _ = (
                     self._simulate_future_soc_with_solar_only(
                         actual_current_soc=max(min_soc_pct, adjusted_soc_at_solar),
                         start_slot=solar_start,  # Start from solar, not from now
@@ -405,7 +405,7 @@ class GridChargeDecisionEngine:
         else:
             # Daylight slot - use simulation with adaptive parameters
             # Use effective_target_pct for simulation (includes headroom)
-            soc_at_end, max_soc, can_reach_with_solar_only = (
+            soc_at_end, max_soc, can_reach_with_solar_only, _ = (
                 self._simulate_future_soc_with_solar_only(
                     actual_current_soc=predicted_soc,
                     start_slot=sim_start,

--- a/tests/test_hybrid_timescale.py
+++ b/tests/test_hybrid_timescale.py
@@ -308,7 +308,7 @@ class TestFifteenMinSlots:
         # Simulate 4 hours forward
         end_time = base_time + timedelta(hours=4)
 
-        soc_end, max_soc, can_reach = computer._simulate_future_soc_with_solar_only(
+        soc_end, max_soc, can_reach, _ = computer._simulate_future_soc_with_solar_only(
             actual_current_soc=60.0,
             start_slot=base_time,
             target_pct=80.0,


### PR DESCRIPTION
## Summary
Fix ValueError crash in computation_engine.py caused by return value mismatch.

## Changes Made
- Updated `computation_engine.py` line 270 to handle 4th return value (truncated)
- Updated `grid_charge_decision.py` (2 locations) to handle 4th return value
- Updated `test_hybrid_timescale.py` test to handle 4th return value

## Root Cause
The method `_simulate_future_soc_with_solar_only` in `forecast_computer.py` returns 4 values:
```python
return soc, max_soc, can_reach, truncated
```

But callers expected only 3 values, causing:
```
ValueError: too many values to unpack (expected 3)
```

## Testing
- Deployed to Home Assistant
- Verified no more ValueError crashes in logs
- State machine evaluation working correctly

Closes #230