### PR TITLE
fix: add recovery mechanism for broken entity status

### DIFF
--- a/custom_components/localshift/__init__.py
+++ b/custom_components/localshift/__init__.py
@@ -55,5 +55,8 @@ async def _async_options_updated(
     coordinator: LocalShiftCoordinator = entry.runtime_data
     # Reschedule daily summary timer in case demand_window_end changed
     coordinator.reschedule_daily_summary_timer()
+    # Reset entity tracking for any changed entities (e.g., weather_entity)
+    # This clears broken status and allows recovery without restart
+    coordinator.reset_entity_tracking_on_options_change()
     await coordinator.async_recompute_and_evaluate()
     _LOGGER.info("LocalShift options updated, re-evaluating")

--- a/custom_components/localshift/coordinator.py
+++ b/custom_components/localshift/coordinator.py
@@ -987,6 +987,22 @@ class LocalShiftCoordinator:
         self._notify_listeners()
         await self.async_evaluate_state_machine()
 
+    def reset_entity_tracking_on_options_change(self) -> None:
+        """Reset entity tracking when options change.
+
+        This is called when the user reconfigures the integration via options flow.
+        It resets tracking for entities that may have changed (e.g., weather_entity)
+        to clear broken status and allow recovery without restart.
+        """
+        if self._entity_validator is None:
+            return
+
+        # Reset tracking for weather entity (most commonly reconfigured optional entity)
+        from .const import CONF_WEATHER_ENTITY
+        self._entity_validator.reset_entity_tracking(CONF_WEATHER_ENTITY)
+
+        _LOGGER.info("Reset entity tracking for options change")
+
     def reschedule_daily_summary_timer(self) -> None:
         """Reschedule the daily summary timer with current demand_window_end.
 

--- a/custom_components/localshift/entity_validator.py
+++ b/custom_components/localshift/entity_validator.py
@@ -273,6 +273,15 @@ class EntityValidator:
         health.entity_id = entity_id
         health.last_check = dt_util.now()
 
+        # Skip checking optional entities that are not configured (empty entity_id)
+        # This prevents false "MISSING" errors for optional features
+        if not entity_id and health.category == EntityCategory.OPTIONAL:
+            health.status = EntityStatus.OK
+            health.error_message = ""
+            health.consecutive_failures = 0
+            health.is_broken = False
+            return health
+
         # Check if entity exists
         state = self.hass.states.get(entity_id)
         if state is None:
@@ -321,7 +330,15 @@ class EntityValidator:
                 # Don't increment failures for stale - it still has a value
                 return health
 
-        # Entity is healthy
+        # Entity is healthy - clear broken status if it was previously set
+        if health.is_broken:
+            _LOGGER.info(
+                "Entity '%s' (%s) recovered from BROKEN status - now healthy",
+                health.entity_id,
+                config_key,
+            )
+            health.is_broken = False
+
         health.status = EntityStatus.OK
         health.error_message = ""
         health.last_valid_value = validation.value
@@ -335,6 +352,7 @@ class EntityValidator:
 
         Logs warnings at FAILURE_THRESHOLD_WARNING failures.
         Marks entity as broken at FAILURE_THRESHOLD_ERROR failures.
+        Uses WARNING level for optional entities instead of ERROR.
 
         Args:
             health: EntityHealth to check
@@ -353,7 +371,10 @@ class EntityValidator:
         if health.consecutive_failures >= FAILURE_THRESHOLD_ERROR:
             if not health.is_broken:
                 health.is_broken = True
-                _LOGGER.error(
+                # Use WARNING for optional entities, ERROR for required/recommended
+                log_level = logging.WARNING if health.category == EntityCategory.OPTIONAL else logging.ERROR
+                _LOGGER.log(
+                    log_level,
                     "Entity '%s' (%s) marked as BROKEN after %d consecutive failures - "
                     "check entity configuration or sensor availability",
                     health.entity_id,
@@ -681,3 +702,69 @@ class EntityValidator:
                 defaults[config_key] = None
 
         return defaults
+
+    def reset_broken_status(self, config_key: str | None = None) -> None:
+        """Reset broken status for one or all entities.
+
+        This allows recovery without restart when:
+        - User reconfigures entity via options flow
+        - Entity becomes available again after being broken
+
+        Args:
+            config_key: Specific entity to reset, or None to reset all
+        """
+        if config_key is not None:
+            # Reset specific entity
+            health = self._entity_health.get(config_key)
+            if health is not None and health.is_broken:
+                health.is_broken = False
+                health.consecutive_failures = 0
+                _LOGGER.info(
+                    "Reset broken status for entity '%s' (%s)",
+                    health.entity_id,
+                    config_key,
+                )
+        else:
+            # Reset all broken entities
+            reset_count = 0
+            for key, health in self._entity_health.items():
+                if health.is_broken:
+                    health.is_broken = False
+                    health.consecutive_failures = 0
+                    reset_count += 1
+
+            if reset_count > 0:
+                _LOGGER.info(
+                    "Reset broken status for %d entities",
+                    reset_count,
+                )
+
+    def reset_entity_tracking(self, config_key: str) -> None:
+        """Reset tracking for a specific entity when its ID changes.
+
+        Called when user reconfigures an entity via options flow.
+        Resets the entity health tracking to pick up the new entity ID.
+
+        Args:
+            config_key: Configuration key for the entity
+        """
+        health = self._entity_health.get(config_key)
+        if health is not None:
+            old_entity_id = health.entity_id
+            new_entity_id = self._get_entity_id(config_key)
+
+            # Reset tracking state
+            health.entity_id = new_entity_id
+            health.status = EntityStatus.OK
+            health.error_message = ""
+            health.consecutive_failures = 0
+            health.is_broken = False
+            health.last_valid_value = None
+            health.last_valid_time = None
+
+            _LOGGER.info(
+                "Reset entity tracking for '%s': '%s' -> '%s'",
+                config_key,
+                old_entity_id,
+                new_entity_id,
+            )


### PR DESCRIPTION
## Summary
Fixes issue where weather entity (and other optional entities) were marked as BROKEN after 10 consecutive failures with no way to recover without restarting Home Assistant.

## Changes Made
- **Auto-recovery**: When an entity check succeeds, it now automatically clears the `is_broken` flag if it was previously set
- **Reduced log severity**: Optional entities (like weather) now log WARNING instead of ERROR when marked as BROKEN
- **Skip empty optional entities**: If an optional entity has an empty entity_id (not configured), it's skipped entirely instead of being marked as MISSING
- **New `reset_broken_status()` method**: Allows manual reset of broken status for one or all entities
- **New `reset_entity_tracking()` method**: Resets tracking when entity ID changes via options flow
- **Options flow integration**: When user reconfigures the weather entity via options, the entity tracking is reset

## Testing
- Deployed to production Home Assistant instance
- Verified no ERROR logs for optional entities
- Integration status shows correct state

## Root Cause
The weather entity `weather.home` was configured but doesn't exist in the user's Home Assistant (they have `weather.forecast_home` instead). The entity validator was marking it as BROKEN after 10 failures with no recovery mechanism.

Closes #232