### PR TITLE
fix: update coordinator test to expect 2 timer subscriptions

### DIFF
--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -171,8 +171,8 @@ class TestAsyncStart:
 
             # Verify state change subscription
             mock_track_state.assert_called_once()
-            # Verify periodic timer subscription
-            mock_track_time.assert_called_once()
+            # Verify periodic timer subscriptions (periodic tick + learning save)
+            assert mock_track_time.call_count == 2
             # Verify midnight, daily summary, and thermal mode decision subscriptions
             assert mock_track_time_change.call_count == 3
 


### PR DESCRIPTION
## Summary
Fix failing test for coordinator timer subscriptions.

## Changes Made
- Updated `test_async_start_subscribes_to_events` to expect 2 calls to `async_track_time_interval` instead of 1

## Root Cause
The coordinator now subscribes to two time intervals:
1. `_handle_periodic_tick` - every 60 seconds (periodic tick)
2. `_handle_learning_save` - every 300 seconds (learning system persistence)

## Testing
- Test passes: `pytest tests/test_coordinator.py::TestAsyncStart::test_async_start_subscribes_to_events -v`

Fixes #238