### PR TITLE
fix: set daily_thermal_mode in setpoint tracking tests

### DIFF
--- a/tests/test_thermal_manager.py
+++ b/tests/test_thermal_manager.py
@@ -665,6 +665,7 @@ class TestClimateControl:
     async def test_tracks_original_setpoint(self, thermal_manager, coordinator_data):
         """Climate control tracks original setpoint to prevent ratchet."""
         thermal_manager._get_switch_state = lambda k: k == "thermal_management_enabled"
+        coordinator_data.daily_thermal_mode = ThermalMode.COOL
         coordinator_data.climate_control_entities = ["climate.living_room"]
         coordinator_data.climate_states = {
             "climate.living_room": {
@@ -700,6 +701,7 @@ class TestClimateControl:
         thermal_manager._get_switch_state = lambda k: k == "thermal_management_enabled"
         thermal_manager._original_setpoints = {"climate.living_room": 24.0}
         thermal_manager._current_active_offset = -2.0
+        coordinator_data.daily_thermal_mode = ThermalMode.COOL
         coordinator_data.climate_control_entities = ["climate.living_room"]
 
         await thermal_manager.async_apply_climate_control(


### PR DESCRIPTION
## Summary
Fix two failing tests in thermal manager related to original setpoint tracking.

## Root Cause
The tests `test_tracks_original_setpoint` and `test_clears_tracking_when_offset_zero` were failing because `daily_thermal_mode` was OFF (default from fixture). This caused `async_apply_climate_control` to return early before the setpoint tracking logic could execute.

## Changes Made
- Added `coordinator_data.daily_thermal_mode = ThermalMode.COOL` to both failing tests
- This properly simulates real usage where thermal control is active

## Testing
All 34 tests in test_thermal_manager.py pass:
```
tests/test_thermal_manager.py::TestClimateControl::test_tracks_original_setpoint PASSED
tests/test_thermal_manager.py::TestClimateControl::test_clears_tracking_when_offset_zero PASSED
```

Fixes #240