### PR TITLE
fix: update high-solar-negative-fit scenario expected min_soc value

### DIFF
--- a/simulations/scenarios/high-solar-negative-fit.json
+++ b/simulations/scenarios/high-solar-negative-fit.json
@@ -1,6 +1,6 @@
 {
   "name": "High Solar with Negative FIT - Replacement Cost Check",
-  "description": "Tests the replacement cost check feature (Issue #70). High solar morning, negative FIT midday, zero solar overnight. Should NOT export overnight when replacement would require expensive grid import. At 20:00 with SOC=46%, FIT=$0.08, grid_import=$0.15 (effective_cheap_price), margin=$0.10. Replacement cost check should block overnight exports.",
+  "description": "Tests the replacement cost check feature (Issue #70). High solar morning, negative FIT midday, zero solar overnight. Should NOT export overnight when replacement would require expensive grid import. At 20:00 with SOC=46%, FIT=$0.08, grid_import=$0.15 (effective_cheap_price), margin=$0.10. Replacement cost check should block overnight exports. NOTE: min_soc=28.1% (not 15.6%) because grid charging triggers at very cheap prices ($0.07-0.08/kWh at 02:00-04:00) when Solcast horizon is truncated (Issue #226 safety net).",
   "input": {
     "test_time": "2026-02-16T20:00:00+11:00",
     "soc": 46.0,
@@ -121,6 +121,6 @@
     "demand_window_block": true
   },
   "expected": {
-    "daily_forecast_min_soc": 15.6
+    "daily_forecast_min_soc": 28.1
   }
 }


### PR DESCRIPTION
## Summary
Update the expected min_soc value in the high-solar-negative-fit scenario test to match the current algorithm behavior.

## Root Cause
The expected value (15.6%) was set before PR #226 which introduced the "Solcast horizon truncation" fix. This fix changed grid charging behavior when the solar simulation cannot see far enough ahead.

## What Changed
When the solar simulation is truncated (Solcast horizon doesn't reach the next demand window), grid charging triggers at "very cheap" prices (≤ 80% of effective cheap price) as a safety net.

In this scenario:
- Test time: 20:00 with SOC=46%
- Solcast horizon ends at 09:30 tomorrow (doesn't reach next DW at 18:00)
- Prices at 02:00-04:00 are $0.07-$0.08/kWh (very cheap threshold)
- Grid charging triggers, raising min_soc from ~15.6% to ~28.1%

## Why 28.1% is Correct
The algorithm is working correctly:
1. It detects the simulation is truncated
2. It finds very cheap prices overnight
3. It grid charges as a safety net to prevent battery draining too low
4. This is conservative and safe behavior

## Changes Made
- Updated expected min_soc from 15.6 to 28.1
- Updated scenario description to explain the expected value

## Testing
- This IS the test fix - the scenario now matches the algorithm

Fixes #239