### PR TITLE
feat: add duplicate code detection to CI pipeline

### DIFF
--- a/.github/workflows/duplicate-check.yml
+++ b/.github/workflows/duplicate-check.yml
@@ -1,0 +1,16 @@
+name: Duplicate Code Check
+on: [push, pull_request]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+
+      - name: Run jscpd
+        run: npx jscpd custom_components/ --min-lines 20 --min-tokens 50 --reporters console

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,3 +25,11 @@ repos:
     rev: v1.1.408
     hooks:
       - id: pyright
+
+  - repo: local
+    hooks:
+      - id: jscpd
+        name: Duplicate Code Check
+        entry: npx jscpd custom_components/ --min-lines 20 --min-tokens 50 --reporters console
+        language: system
+        pass_filenames: false


### PR DESCRIPTION
## Summary

Add automated duplicate code detection using jscpd to catch code duplication before it causes maintenance issues like #237 and #246.

## Changes Made

- Added jscpd to pre-commit hooks for local duplicate detection
- Created GitHub workflow for CI duplicate code checking
- Configured with `--min-lines 20 --min-tokens 50` thresholds

## Configuration Rationale

| Parameter | Value | Reason |
|-----------|-------|--------|
| `--min-lines` | 20 | Ignore small duplications (imports, boilerplate) |
| `--min-tokens` | 50 | Semantic similarity threshold |
| `--reporters` | console | Simple output for CI/pre-commit |

## Would This Have Caught #246?

Yes. The two `_simulate_future_soc_with_solar_only` implementations share ~30-40 lines of nearly identical code. jscpd uses token-based detection (not exact string matching), so it would have flagged this duplication before the return signatures diverged.

## Benefits

1. **Early detection** - Catch duplicates before they diverge
2. **CI enforcement** - Block PRs with significant duplication
3. **Code review aid** - Automated check reduces manual effort

## Testing

The CI workflow will run on this PR and verify the configuration works correctly.

Closes #247