### PR TITLE
fix: prevent state machine from overriding self consumption button

### DIFF
--- a/custom_components/localshift/button.py
+++ b/custom_components/localshift/button.py
@@ -156,10 +156,12 @@ class SelfConsumptionButton(LocalShiftButtonBase):
 
     async def async_press(self) -> None:
         """Handle button press."""
-        # Clear manual override flag and timestamp to return to automated control
-        self.coordinator.data.manual_override = False
+        # Set manual override to prevent state machine from immediately overriding
+        # the user's choice. After manual_override_timeout hours, it will return
+        # to automated control. This matches the behavior of other manual buttons.
+        self.coordinator.data.manual_override = True
         if self.coordinator._state_machine is not None:
-            self.coordinator._state_machine.clear_manual_override_timestamp()
+            self.coordinator._state_machine.set_manual_override_timestamp()
         await self.coordinator.async_set_self_consumption()
         if self.coordinator._notification_service is not None:
             await (


### PR DESCRIPTION
## Summary
Fixes a race condition where the Self Consumption button was immediately overridden by the state machine.

## Root Cause
The `SelfConsumptionButton.async_press()` method was setting `manual_override = False`, which told the state machine to "return to automated control". The state machine then immediately evaluated and decided the appropriate mode based on current conditions, overriding the user's self-consumption request.

## Evidence from Logs
```
09:50:56.323 - Self-consumption mode started being set
09:50:57.238 - Self-consumption validation started (expecting op=self_consumption, reserve=10)
09:50:57.556 - Boost charge started setting op=autonomous, reserve=100
09:50:59.442 - Boost charge SUCCESS
09:51:07.248 - ERROR: Self-consumption validation FAILED
```

## Fix
Changed the Self Consumption button to set `manual_override = True` (like the other manual buttons) to prevent the state machine from immediately overriding the user's choice.

## Behavior After Fix
1. User clicks "Self Consumption" button
2. `manual_override = True` prevents state machine interference
3. Battery goes to self-consumption mode and stays there
4. After `manual_override_timeout` hours (configurable), it returns to automated control

## Testing
- Deployed and verified integration reloads without errors
- Fix tested in production

Fixes #289