### PR TITLE
fix: prevent race condition between manual buttons and health check

### DIFF
--- a/custom_components/localshift/button.py
+++ b/custom_components/localshift/button.py
@@ -28,6 +28,7 @@ from .const import (
     BUTTON_SELF_CONSUMPTION,
     BUTTON_UPDATE_FORECAST,
     DOMAIN,
+    BatteryMode,
 )
 from .coordinator import LocalShiftCoordinator
 
@@ -99,6 +100,8 @@ class ForceChargeButton(LocalShiftButtonBase):
         self.coordinator.data.manual_override = True
         if self.coordinator._state_machine is not None:
             self.coordinator._state_machine.set_manual_override_timestamp()
+            # Update commanded mode to prevent health check "correction"
+            self.coordinator._state_machine.set_commanded_mode(BatteryMode.GRID_CHARGING)
         await self.coordinator.async_set_force_charge()
         if self.coordinator._notification_service is not None:
             await (
@@ -119,6 +122,8 @@ class ForceDischargeButton(LocalShiftButtonBase):
         self.coordinator.data.manual_override = True
         if self.coordinator._state_machine is not None:
             self.coordinator._state_machine.set_manual_override_timestamp()
+            # Update commanded mode to prevent health check "correction"
+            self.coordinator._state_machine.set_commanded_mode(BatteryMode.SPIKE_DISCHARGE)
         await self.coordinator.async_set_force_discharge()
         if self.coordinator._notification_service is not None:
             await (
@@ -139,6 +144,8 @@ class BoostChargeButton(LocalShiftButtonBase):
         self.coordinator.data.manual_override = True
         if self.coordinator._state_machine is not None:
             self.coordinator._state_machine.set_manual_override_timestamp()
+            # Update commanded mode to prevent health check "correction"
+            self.coordinator._state_machine.set_commanded_mode(BatteryMode.BOOST_CHARGING)
         await self.coordinator.async_set_boost_charge()
         if self.coordinator._notification_service is not None:
             await (
@@ -162,6 +169,8 @@ class SelfConsumptionButton(LocalShiftButtonBase):
         self.coordinator.data.manual_override = True
         if self.coordinator._state_machine is not None:
             self.coordinator._state_machine.set_manual_override_timestamp()
+            # Update commanded mode to prevent health check "correction"
+            self.coordinator._state_machine.set_commanded_mode(BatteryMode.SELF_CONSUMPTION)
         await self.coordinator.async_set_self_consumption()
         if self.coordinator._notification_service is not None:
             await (

--- a/custom_components/localshift/state_machine.py
+++ b/custom_components/localshift/state_machine.py
@@ -611,7 +611,15 @@ class StateMachine:
 
         If drift is detected, we attempt to correct it, unless Tesla
         has taken control (Storm Watch, Grid Event, VPP).
+
+        SKIPPED when manual_override is True - user is in control and
+        health checks would fight against their manual commands.
         """
+        # Skip health check during manual override - user is in control
+        if data.manual_override:
+            _LOGGER.debug("[HEALTH CHECK] Skipping - manual override active")
+            return
+
         now = dt_util.now()
 
         # --- Tesla Override Detection ---
@@ -784,6 +792,23 @@ class StateMachine:
     def clear_manual_override_timestamp(self) -> None:
         """Clear manual override timestamp when returning to automated control."""
         self._manual_override_set_at = None
+
+    def set_commanded_mode(self, mode: BatteryMode) -> None:
+        """Set the commanded mode directly (used by manual button presses).
+
+        This prevents race conditions where the health check might try to
+        "correct" the mode after a button press changes hardware state
+        but before the next evaluation cycle.
+
+        Args:
+            mode: The battery mode to set as commanded.
+        """
+        self._commanded_mode = mode
+        self._mode_desired_since.clear()
+        _LOGGER.info(
+            "Commanded mode set directly to %s (manual button press)",
+            mode.value,
+        )
 
     @property
     def in_mode_transition(self) -> bool:


### PR DESCRIPTION
## Summary
Fixes a race condition where the self-consumption button (and other manual buttons) would fail validation due to the health check trying to "correct" the mode back.

## Root Cause
The health check was running even when  was True, causing it to fight against the user's manual button press. The sequence was:

1. User presses button → Sets  → Changes hardware
2. Health check sees hardware changed but  unchanged → Tries to "correct"
3. Validation fails because hardware is being pulled in two directions

## Changes Made

### state_machine.py
- Added early return in  when  is True
- Added new  method to allow buttons to update the state machine's commanded mode directly

### button.py
- Updated all manual mode buttons to call  after setting manual override:
  -  → sets 
  -  → sets 
  -  → sets 
  -  → sets 

## Testing
- Deployed and verified via logs
- Integration running correctly with no errors
- Health checks now skip when manual override is active