### PR TITLE
fix: respect user override in pre-conditioning and solar taper

### DIFF
--- a/custom_components/localshift/thermal_manager.py
+++ b/custom_components/localshift/thermal_manager.py
@@ -1255,6 +1255,14 @@ class ThermalManager:
         if not self.is_enabled():
             return False, 0.0
 
+        # Check for user override - suspend control if user manually changed settings
+        if self._user_override_until is not None and now < self._user_override_until:
+            _LOGGER.debug(
+                "Pre-conditioning suspended due to user override: %s",
+                self._user_override_reason,
+            )
+            return False, 0.0
+
         daily_mode = data.daily_thermal_mode
         if daily_mode not in (ThermalMode.HEAT, ThermalMode.COOL):
             return False, 0.0
@@ -1309,6 +1317,15 @@ class ThermalManager:
             Tuple of (is_active, setpoint_offset).
         """
         if not self.is_enabled() or not self.is_solar_taper_enabled():
+            return False, 0.0
+
+        # Check for user override - suspend control if user manually changed settings
+        now = datetime.now()
+        if self._user_override_until is not None and now < self._user_override_until:
+            _LOGGER.debug(
+                "Solar taper suspended due to user override: %s",
+                self._user_override_reason,
+            )
             return False, 0.0
 
         daily_mode = data.daily_thermal_mode


### PR DESCRIPTION
## Summary
Fixed a bug where pre-conditioning and solar taper thermal control layers ignored user manual changes to AC setpoints.

## Problem
The thermal manager has three control layers that can apply setpoint offsets:
1. **Pre-conditioning** (before demand window)
2. **Solar tapering** (excess solar consumption)  
3. **Real-time thermal** (room temperature based)

Only the real-time thermal layer checked for user override before applying changes. This caused pre-conditioning to override user manual changes to AC setpoints within seconds.

## Solution
Added user override check to `evaluate_preconditioning()` and `evaluate_solar_taper()` methods. When a user manually changes AC settings, all three thermal layers now respect the override cooldown period (default 30 minutes).

## Changes Made
- Added user override check in `evaluate_preconditioning()` (lines 819-825)
- Added user override check in `evaluate_solar_taper()` (lines 864-871)

## Testing
- Deployed to live HA instance
- Verified integration reloaded successfully
- Pre-conditioning now respects user override state

## Impact
| Scenario | Before Fix | After Fix |
|----------|-----------|-----------|
| User changes setpoint from 16°C to 21°C | Reverted to 14°C (16-2) within seconds | Respected for 30 min cooldown |
| User turns off AC during pre-conditioning | Turned back on with offset | Respected for 30 min cooldown |
| User changes mode from cool to fan_only | Reverted to cool mode | Respected for 30 min cooldown |