### PR TITLE
fix: thermal management switch not respected

### DIFF
--- a/custom_components/localshift/thermal_manager.py
+++ b/custom_components/localshift/thermal_manager.py
@@ -267,18 +267,19 @@ class ThermalManager:
     # ------------------------------------------------------------------
 
     def is_enabled(self) -> bool:
-        """Check if thermal management is enabled."""
-        return self._get_switch_state(
-            CONF_THERMAL_MANAGEMENT_ENABLED
-        ) or self._get_option(
-            CONF_THERMAL_MANAGEMENT_ENABLED, DEFAULT_THERMAL_MANAGEMENT_ENABLED
-        )
+        """Check if thermal management is enabled.
+        
+        The switch state is the authoritative source, initialized from
+        SWITCH_DEFAULTS and persisted when toggled by the user.
+        """
+        return self._get_switch_state(CONF_THERMAL_MANAGEMENT_ENABLED)
 
     def is_solar_taper_enabled(self) -> bool:
-        """Check if solar tapering is enabled."""
-        return self._get_switch_state(CONF_SOLAR_TAPER_ENABLED) or self._get_option(
-            CONF_SOLAR_TAPER_ENABLED, DEFAULT_SOLAR_TAPER_ENABLED
-        )
+        """Check if solar tapering is enabled.
+        
+        The switch state is the authoritative source.
+        """
+        return self._get_switch_state(CONF_SOLAR_TAPER_ENABLED)
 
     def get_cooling_trigger_temp(self) -> float:
         """Get cooling trigger temperature threshold."""

--- a/tests/test_thermal_manager.py
+++ b/tests/test_thermal_manager.py
@@ -569,7 +569,10 @@ class TestSolarTaper:
         self, thermal_manager, coordinator_data
     ):
         """Solar taper active with sufficient excess and INCREASE_LOAD signal."""
-        thermal_manager._get_switch_state = lambda k: k == "thermal_management_enabled"
+        thermal_manager._get_switch_state = lambda k: k in (
+            "thermal_management_enabled",
+            "solar_taper_enabled",
+        )
         coordinator_data.daily_thermal_mode = ThermalMode.COOL
 
         is_active, offset = thermal_manager.evaluate_solar_taper(
@@ -583,7 +586,10 @@ class TestSolarTaper:
 
     def test_taper_scales_with_excess(self, thermal_manager, coordinator_data):
         """Solar taper offset scales with excess solar amount."""
-        thermal_manager._get_switch_state = lambda k: k == "thermal_management_enabled"
+        thermal_manager._get_switch_state = lambda k: k in (
+            "thermal_management_enabled",
+            "solar_taper_enabled",
+        )
         coordinator_data.daily_thermal_mode = ThermalMode.COOL
 
         # 1 kW excess = half max offset
@@ -614,7 +620,10 @@ class TestSolarTaper:
 
     def test_taper_heat_mode_positive_offset(self, thermal_manager, coordinator_data):
         """Solar taper in HEAT mode uses positive offset (raise setpoint)."""
-        thermal_manager._get_switch_state = lambda k: k == "thermal_management_enabled"
+        thermal_manager._get_switch_state = lambda k: k in (
+            "thermal_management_enabled",
+            "solar_taper_enabled",
+        )
         coordinator_data.daily_thermal_mode = ThermalMode.HEAT
 
         is_active, offset = thermal_manager.evaluate_solar_taper(
@@ -727,13 +736,21 @@ class TestConfigurationAccessors:
         thermal_manager._get_switch_state = lambda k: k == "thermal_management_enabled"
         assert thermal_manager.is_enabled() is True
 
-    def test_is_enabled_from_option(self, thermal_manager):
-        """is_enabled returns True from options when switch is False."""
+    def test_is_enabled_switch_is_authoritative(self, thermal_manager):
+        """is_enabled only checks switch state, not config options.
+        
+        This verifies the fix for the bug where config options could
+        override the switch state, causing thermal management to run
+        even when disabled via the UI switch.
+        """
+        # Switch is OFF
         thermal_manager._get_switch_state = lambda k: False
+        # Config option is ON (should be ignored)
         thermal_manager._get_option = lambda k, d: (
             True if k == "thermal_management_enabled" else d
         )
-        assert thermal_manager.is_enabled() is True
+        # Should return False because switch is the authoritative source
+        assert thermal_manager.is_enabled() is False
 
     def test_is_solar_taper_enabled(self, thermal_manager):
         """is_solar_taper_enabled returns correct value."""


### PR DESCRIPTION
## Summary

Fixed a bug where the thermal management switch was not being respected. The `is_enabled()` and `is_solar_taper_enabled()` methods were checking config options as a fallback when the switch was disabled, causing thermal management to run even when explicitly disabled via the UI switch.

## Changes Made

- **`is_enabled()`**: Now only checks switch state, no fallback to options
- **`is_solar_taper_enabled()`**: Now only checks switch state, no fallback
- Updated tests to verify switch is the authoritative source

## Root Cause

The original implementation had this logic:
```python
def is_enabled(self) -> bool:
    return self._get_switch_state("thermal_management_enabled") or self._get_option(
        "thermal_management_enabled", False
    )
```

This meant that if the switch was OFF but the config option was ON (from a previous setup), thermal management would still run. The switch should be the authoritative source.

## Testing

- All 34 thermal manager tests pass
- Deployed and verified via logs - no errors
- Integration running correctly

## Verification

To verify the fix works:
1. Disable thermal management via the UI switch
2. Check that thermal management does NOT run (no climate control changes)
3. Enable the switch
4. Verify thermal management resumes normal operation