### PR TITLE
fix: entity availability false positives

### DIFF
--- a/custom_components/localshift/config_flow/defaults.py
+++ b/custom_components/localshift/config_flow/defaults.py
@@ -25,7 +25,7 @@ DEFAULT_ENTITY_IDS: dict[str, str] = {
     "solcast_forecast_today": "sensor.solcast_forecast_today",
     "solcast_forecast_tomorrow": "sensor.solcast_forecast_tomorrow",
     "sun_entity": "sun.sun",
-    "weather_entity": "weather.home",
+    "weather_entity": "",  # No default - user must configure
 }
 
 # Default option values
@@ -40,7 +40,7 @@ DEFAULT_MANUAL_OVERRIDE_TIMEOUT = 4
 DEFAULT_LOAD_WEIGHT_RECENT = 0.7
 DEFAULT_MINIMUM_TARGET_SOC = 20.0
 DEFAULT_ALLOW_DW_ENTRY_UNDER_TARGET = True
-DEFAULT_WEATHER_ENTITY = "weather.home"
+DEFAULT_WEATHER_ENTITY = ""  # No default - user must configure
 DEFAULT_WEATHER_LEARNING_ENABLED = False
 DEFAULT_COOLING_THRESHOLD = 28.0
 DEFAULT_HEATING_THRESHOLD = 18.0

--- a/custom_components/localshift/const.py
+++ b/custom_components/localshift/const.py
@@ -126,7 +126,7 @@ CONF_SUN_ENTITY = "sun_entity"
 
 # Weather entity (for temperature-based consumption prediction)
 CONF_WEATHER_ENTITY = "weather_entity"
-DEFAULT_WEATHER_ENTITY = "weather.home"
+DEFAULT_WEATHER_ENTITY = ""  # No default - user must configure
 
 # Temperature thresholds for degree-day model
 CONF_COOLING_THRESHOLD = "cooling_threshold"

--- a/custom_components/localshift/entity_validator.py
+++ b/custom_components/localshift/entity_validator.py
@@ -317,15 +317,16 @@ class EntityValidator:
             self._check_failure_thresholds(health, config_key)
             return health
 
-        # Check for staleness
+        # Check for staleness using entity's actual last_updated time
+        # (not our internal last_valid_time which tracks when we last validated it)
         staleness_threshold = STALENESS_THRESHOLDS.get(config_key)
-        if staleness_threshold and health.last_valid_time:
-            time_since_valid = dt_util.now() - health.last_valid_time
-            if time_since_valid > staleness_threshold:
+        if staleness_threshold:
+            time_since_update = dt_util.now() - state.last_updated
+            if time_since_update > staleness_threshold:
                 health.status = EntityStatus.STALE
                 health.error_message = (
                     f"Entity '{entity_id}' data is stale "
-                    f"({time_since_valid.total_seconds():.0f}s old)"
+                    f"({time_since_update.total_seconds():.0f}s old)"
                 )
                 # Don't increment failures for stale - it still has a value
                 return health


### PR DESCRIPTION
## Summary
Fixes two issues causing false entity availability warnings:

1. **Staleness detection bug**: The validator was checking its internal `last_valid_time` instead of the entity's actual `last_updated` timestamp, causing false "data is stale" warnings for entities that were updating normally.

2. **Weather entity default**: Removed hardcoded `weather.home` default that doesn't exist in most Home Assistant installations. The weather entity is optional, so an empty default prevents false "missing entity" errors.

## Changes Made
- `entity_validator.py`: Use `state.last_updated` for staleness detection instead of `health.last_valid_time`
- `const.py`: Change `DEFAULT_WEATHER_ENTITY` from "weather.home" to empty string
- `config_flow/defaults.py`: Change weather_entity default from "weather.home" to empty string

## Testing
- Deployed and verified via logs
- Integration loads successfully without errors

Fixes #311