### PR TITLE
fix: prevent overcharging from multiple grid charging windows (Issue #283)

### DIFF
--- a/custom_components/localshift/computation_engine_lib/forecast_computer.py
+++ b/custom_components/localshift/computation_engine_lib/forecast_computer.py
@@ -1514,6 +1514,12 @@ class ForecastComputer:
         remaining_export_budget = export_budget_kwh
         slot_fraction = 15 / 60.0  # 0.25 hours
 
+        # Issue #283: Cumulative grid import tracking to prevent overcharging
+        # Each slot makes independent decisions, but we need to track total planned
+        # import to avoid scheduling more charging than needed across multiple windows.
+        cumulative_grid_import_kwh = 0.0
+        max_grid_import_kwh = max(0, (target_pct - current_soc) / 100 * BATTERY_CAPACITY_KWH * 1.05)  # 5% buffer
+
         for slot_idx in range(TOTAL_SLOTS):
             slot_start = base_slot + timedelta(minutes=15 * slot_idx)
             is_first_slot = slot_idx == 0
@@ -1725,6 +1731,19 @@ class ForecastComputer:
                 baseline_avg_kw=baseline_avg_kw,
             )
 
+            # Issue #283: Check if we've already planned enough grid import
+            # This prevents multiple charging windows from over-scheduling
+            if should_grid_charge and cumulative_grid_import_kwh >= max_grid_import_kwh:
+                _LOGGER.info(
+                    "GRID_CHARGE_SKIP[%02d:%02d]: cumulative %.2f kWh >= max %.2f kWh (target already covered)",
+                    slot_hour,
+                    slot_minute,
+                    cumulative_grid_import_kwh,
+                    max_grid_import_kwh,
+                )
+                should_grid_charge = False
+                should_boost = False
+
             # Debug logging for charging decision
             _LOGGER.debug(
                 "GRID_CHARGE[15min]: %02d:%02d in_dw=%s before_dw=%s soc=%.1f<%d gap=%d -> charge=%s boost=%s",
@@ -1802,6 +1821,8 @@ class ForecastComputer:
                 )
                 battery_delta_kwh += grid_charge_amount
                 grid_import_kwh = grid_charge_amount / 0.92
+                # Issue #283: Track cumulative grid import
+                cumulative_grid_import_kwh += grid_import_kwh
             else:
                 grid_import_kwh = 0.0
 


### PR DESCRIPTION
## Summary

Add cumulative grid import tracking to prevent multiple cheap price windows from scheduling more charging than needed.

## Problem

Each slot made independent grid charging decisions without considering total planned import. This caused overcharging when multiple cheap price windows existed before the demand window.

For example, with a 10 kWh battery at 50% SOC targeting 90%:
- Window 1 (00:00-02:00): Cheap prices → schedules 4 kWh charging
- Window 2 (04:00-06:00): Cheap prices → schedules another 4 kWh charging
- Result: 8 kWh scheduled, but only 4 kWh needed (50% → 90%)

## Solution

Track cumulative grid import across all slots and skip charging when target is already covered by earlier windows.

## Changes

- Add `cumulative_grid_import_kwh` tracking variable
- Add `max_grid_import_kwh` limit (target gap + 5% buffer)
- Skip grid charging when cumulative >= max
- Log skipped slots for debugging

## Testing

- Deployed to live Home Assistant instance
- Integration reloaded successfully
- No errors in logs

Closes #283