### PR TITLE
fix: defer grid charging until solar forecast is ready

### DIFF
--- a/custom_components/localshift/computation_engine_lib/mode_decision.py
+++ b/custom_components/localshift/computation_engine_lib/mode_decision.py
@@ -33,6 +33,25 @@ class ModeDecisionEngine:
             data.active_mode = BatteryMode.SELF_CONSUMPTION
             return
 
+        # Always respect manual override - user is in control
+        if data.manual_override:
+            data.active_mode = BatteryMode.MANUAL
+            data.debug_mode_source = "manual_override"
+            return
+
+        # Issue #319: Defer grid charging decisions when forecast data is not ready
+        # This prevents BOOST mode from being triggered at startup when Solcast
+        # data hasn't been received yet.
+        if not data.forecast_ready:
+            data.debug_mode_source = "forecast_not_ready"
+            _LOGGER.info(
+                "Forecast not ready (status=%s), defaulting to self-consumption - "
+                "deferring grid charging decisions until forecast data is available",
+                data.forecast_status,
+            )
+            data.active_mode = BatteryMode.SELF_CONSUMPTION
+            return
+
         data.proactive_export_active = False
 
         current_hour = now_dt.hour

--- a/custom_components/localshift/coordinator.py
+++ b/custom_components/localshift/coordinator.py
@@ -587,6 +587,7 @@ class LocalShiftCoordinator:
         """Check if Solcast forecast data is available and valid.
 
         Returns True if Solcast data is ready, False otherwise.
+        Also updates forecast_ready and forecast_status in CoordinatorData (Issue #319).
         """
         # Check if today's forecast has valid data
         today_entity = self._get_entity_id(CONF_SOLCAST_FORECAST_TODAY)
@@ -594,6 +595,8 @@ class LocalShiftCoordinator:
 
         if today_state is None:
             _LOGGER.debug("Solcast today entity not found: %s", today_entity)
+            self.data.forecast_ready = False
+            self.data.forecast_status = "stale"
             return False
 
         if today_state.state in ("unknown", "unavailable", None, ""):
@@ -601,23 +604,41 @@ class LocalShiftCoordinator:
                 "Solcast today entity state is %s, waiting for data",
                 today_state.state,
             )
+            self.data.forecast_ready = False
+            self.data.forecast_status = "stale"
             return False
 
         # Check if the forecast attribute has actual forecast data
         forecast_data = today_state.attributes.get("detailedForecast")
         if not forecast_data or not isinstance(forecast_data, list):
             _LOGGER.debug("Solcast today forecast attribute is empty or invalid")
+            self.data.forecast_ready = False
+            self.data.forecast_status = "partial"
             return False
 
         # Check if we have at least some forecast entries
         if len(forecast_data) == 0:
             _LOGGER.debug("Solcast today forecast has no entries")
+            self.data.forecast_ready = False
+            self.data.forecast_status = "partial"
             return False
+
+        # Check if we have enough entries for meaningful forecasting (at least 4 hours = 8 entries)
+        if len(forecast_data) < 8:
+            _LOGGER.debug(
+                "Solcast today forecast has only %d entries (need 8+ for full forecast)",
+                len(forecast_data),
+            )
+            self.data.forecast_ready = True  # Partial but usable
+            self.data.forecast_status = "partial"
+            return True
 
         _LOGGER.info(
             "Solcast forecast data is ready (%d entries for today)",
             len(forecast_data),
         )
+        self.data.forecast_ready = True
+        self.data.forecast_status = "ready"
         return True
 
     async def _wait_for_solcast_and_compute(self) -> None:

--- a/custom_components/localshift/coordinator_data.py
+++ b/custom_components/localshift/coordinator_data.py
@@ -302,8 +302,12 @@ class CoordinatorData:
     optimal_charge_end: datetime | None = None  # Latest optimal charging slot
 
     # Debug/diagnostic fields for dashboard troubleshooting
-    forecast_ready: bool = False  # True when Solcast data is available and valid (Issue #319)
-    forecast_status: str = "initializing"  # "ready", "partial", "stale", "initializing" (Issue #319)
+    forecast_ready: bool = (
+        False  # True when Solcast data is available and valid (Issue #319)
+    )
+    forecast_status: str = (
+        "initializing"  # "ready", "partial", "stale", "initializing" (Issue #319)
+    )
     debug_forecast_slot_found: bool = (
         False  # True if current time slot found in forecast
     )

--- a/custom_components/localshift/coordinator_data.py
+++ b/custom_components/localshift/coordinator_data.py
@@ -302,6 +302,8 @@ class CoordinatorData:
     optimal_charge_end: datetime | None = None  # Latest optimal charging slot
 
     # Debug/diagnostic fields for dashboard troubleshooting
+    forecast_ready: bool = False  # True when Solcast data is available and valid (Issue #319)
+    forecast_status: str = "initializing"  # "ready", "partial", "stale", "initializing" (Issue #319)
     debug_forecast_slot_found: bool = (
         False  # True if current time slot found in forecast
     )

--- a/custom_components/localshift/sensor.py
+++ b/custom_components/localshift/sensor.py
@@ -65,6 +65,8 @@ async def async_setup_entry(
         CostReconciliationSensor(coordinator, entry),
         # Extended forecast accuracy sensor (Issue #270)
         ExtendedForecastAccuracySensor(coordinator, entry),
+        # Forecast status sensor (Issue #319)
+        ForecastStatusSensor(coordinator, entry),
     ]
 
     async_add_entities(entities)
@@ -1262,3 +1264,54 @@ class ExtendedForecastAccuracySensor(LocalShiftSensorBase):
             "sample_count": m.sample_count,
             "last_updated": m.last_updated.isoformat() if m.last_updated else None,
         }
+
+
+# ---------------------------------------------------------------------------
+# Forecast Status Sensor (Issue #319)
+# ---------------------------------------------------------------------------
+
+
+class ForecastStatusSensor(LocalShiftSensorBase):
+    """Forecast data readiness status.
+
+    Issue #319: Shows whether Solcast forecast data is available and valid.
+    Prevents premature grid charging decisions when forecast data is not ready.
+
+    States:
+    - "ready": Solcast data is available and sufficient for forecasting
+    - "partial": Solcast data is available but incomplete (fewer than 8 entries)
+    - "stale": Solcast entity not found or state is unknown/unavailable
+    - "initializing": Initial state before first check
+    """
+
+    _attr_unique_id = "localshift_forecast_status"
+    _attr_name = "Forecast Status"
+    _attr_icon = "mdi:weather-sunny"
+
+    def _update_from_coordinator(self) -> None:
+        """Update with forecast status."""
+        self._attr_native_value = self.coordinator.data.forecast_status
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return forecast status details."""
+        d = self.coordinator.data
+        return {
+            "forecast_ready": d.forecast_ready,
+            "solcast_today_entries": len(d.solcast_today),
+            "solcast_tomorrow_entries": len(d.solcast_tomorrow),
+            "debug_mode_source": d.debug_mode_source,
+        }
+
+    @property
+    def icon(self) -> str:
+        """Return icon based on status."""
+        status = self._attr_native_value
+        if status == "ready":
+            return "mdi:check-circle"
+        elif status == "partial":
+            return "mdi:alert-circle"
+        elif status == "stale":
+            return "mdi:close-circle"
+        else:  # initializing
+            return "mdi:weather-sunny-alert"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -154,6 +154,9 @@ def coordinator_data():
     data.daily_forecast = []
     data.daily_forecast_soc_15min = []
     data.forecast_consumption_source_counts = {}
+    # Issue #319: Mark forecast as ready for tests
+    data.forecast_ready = True
+    data.forecast_status = "ready"
     return data
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -39,6 +39,9 @@ def integration_data():
     data.daily_forecast = []
     data.daily_forecast_soc_15min = []
     data.target_reached_today = False
+    # Issue #319: Mark forecast as ready for integration tests
+    data.forecast_ready = True
+    data.forecast_status = "ready"
     return data
 
 

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -69,6 +69,10 @@ def setup_coordinator_data(input_data: dict) -> CoordinatorData:
     data.forecast_history = []
     data.target_reached_today = input_data.get("target_reached_today", False)
 
+    # Issue #319: Mark forecast as ready for tests (tests have forecast data)
+    data.forecast_ready = True
+    data.forecast_status = "ready"
+
     return data
 
 


### PR DESCRIPTION
## Summary
Prevent premature grid charging decisions when Solcast forecast data is not yet available at startup.

## Problem
Issue #319: At startup, the integration was making grid charging decisions before the solar forecast data was available from Solcast. This could lead to incorrect early morning charging decisions based on incomplete forecast data.

## Solution
- Added `forecast_ready` flag to `CoordinatorData` to track forecast availability
- Set `forecast_ready` based on Solcast data availability in the coordinator
- Added guard in `mode_decision.py` to defer grid charging when forecast is not ready
- Added `forecast_status` diagnostic sensor for visibility

## Changes Made
- `coordinator_data.py`: Added `forecast_ready` and `forecast_status` attributes
- `coordinator.py`: Set forecast status based on Solcast data availability
- `mode_decision.py`: Guard to defer grid charging when forecast not ready
- `sensor.py`: Added forecast_status diagnostic sensor
- Test fixtures updated to set `forecast_ready=True`

## Testing
- All 528 tests pass
- Deployed and verified via logs

Closes #319