### PR TITLE
fix: prevent boost_charging when prices unavailable

### DIFF
--- a/custom_components/localshift/computation_engine_lib/mode_decision.py
+++ b/custom_components/localshift/computation_engine_lib/mode_decision.py
@@ -52,6 +52,18 @@ class ModeDecisionEngine:
             data.active_mode = BatteryMode.SELF_CONSUMPTION
             return
 
+        # Issue #330: Defer grid charging decisions when price data is unavailable
+        # This prevents BOOST mode from being triggered when prices are "unavailable"
+        # which would otherwise be treated as $0 and incorrectly trigger cheap charging.
+        if not data.prices_available:
+            data.debug_mode_source = "prices_unavailable"
+            _LOGGER.warning(
+                "Price data unavailable (prices_available=False), defaulting to self-consumption - "
+                "deferring grid charging decisions until price data is available"
+            )
+            data.active_mode = BatteryMode.SELF_CONSUMPTION
+            return
+
         data.proactive_export_active = False
 
         current_hour = now_dt.hour

--- a/custom_components/localshift/coordinator_data.py
+++ b/custom_components/localshift/coordinator_data.py
@@ -216,6 +216,7 @@ class CoordinatorData:
     general_price: float = 0.0
     feed_in_price: float = 0.0
     price_spike: bool = False
+    prices_available: bool = True  # False when price entities are unavailable (Issue #330)
     general_forecast: list[dict[str, Any]] = field(default_factory=list)
     feed_in_forecast: list[dict[str, Any]] = field(default_factory=list)
     solcast_today: list[dict[str, Any]] = field(default_factory=list)

--- a/custom_components/localshift/state_reader.py
+++ b/custom_components/localshift/state_reader.py
@@ -217,16 +217,21 @@ class StateReader:
         )
 
         # Pricing - read prices with unavailable detection
-        # Log warning if price entities are unavailable (helps diagnose $0 vs unavailable)
+        # Issue #330: Track price availability to prevent incorrect mode decisions
         general_price_entity = self._get_entity_id(CONF_PRICING_GENERAL_PRICE)
         feed_in_price_entity = self._get_entity_id(CONF_PRICING_FEED_IN_PRICE)
 
         general_price_raw = self._read_float_optional(general_price_entity)
         feed_in_price_raw = self._read_float_optional(feed_in_price_entity)
 
+        # Track if prices are available (Issue #330)
+        # If either price is unavailable, we should not make grid charging decisions
+        data.prices_available = general_price_raw is not None and feed_in_price_raw is not None
+
         if general_price_raw is None:
             _LOGGER.warning(
-                "General price entity '%s' is unavailable - treating as $0. Check entity configuration.",
+                "General price entity '%s' is unavailable - prices_available=False. "
+                "Grid charging decisions will be deferred. Check entity configuration.",
                 general_price_entity,
             )
             data.general_price = 0.0
@@ -235,12 +240,20 @@ class StateReader:
 
         if feed_in_price_raw is None:
             _LOGGER.warning(
-                "Feed-in price entity '%s' is unavailable - treating as $0. Check entity configuration.",
+                "Feed-in price entity '%s' is unavailable - prices_available=False. "
+                "Grid charging decisions will be deferred. Check entity configuration.",
                 feed_in_price_entity,
             )
             data.feed_in_price = 0.0
         else:
             data.feed_in_price = feed_in_price_raw
+
+        if data.prices_available:
+            _LOGGER.debug(
+                "Price entities available: buy=$%.3f/kWh, sell=$%.3f/kWh",
+                data.general_price,
+                data.feed_in_price,
+            )
         data.price_spike = self._read_bool(
             self._get_entity_id(CONF_PRICING_PRICE_SPIKE)
         )

--- a/tests/test_state_reader.py
+++ b/tests/test_state_reader.py
@@ -480,3 +480,123 @@ class TestReadAllExternalState:
         assert coordinator_data.general_price == 0.0
         assert coordinator_data.feed_in_price == 0.0
         assert coordinator_data.price_spike is False
+
+
+class TestPriceAvailability:
+    """Tests for price availability tracking (Issue #330)."""
+
+    def test_prices_available_when_both_available(
+        self, state_reader, mock_hass, coordinator_data
+    ):
+        """Test prices_available is True when both prices are available."""
+
+        def mock_get_state(entity_id):
+            state = MagicMock()
+            state.state = "0"
+            if "general_price" in entity_id:
+                state.state = "0.25"
+            elif "feed_in_price" in entity_id:
+                state.state = "0.08"
+            state.attributes = {}
+            return state
+
+        mock_hass.states.get = mock_get_state
+
+        state_reader.read_all_external_state(coordinator_data)
+
+        assert coordinator_data.prices_available is True
+        assert coordinator_data.general_price == 0.25
+        assert coordinator_data.feed_in_price == 0.08
+
+    def test_prices_unavailable_when_general_price_missing(
+        self, state_reader, mock_hass, coordinator_data
+    ):
+        """Test prices_available is False when general_price is unavailable."""
+
+        def mock_get_state(entity_id):
+            state = MagicMock()
+            state.state = "0"
+            if "general_price" in entity_id:
+                state.state = "unavailable"  # Simulate unavailable
+            elif "feed_in_price" in entity_id:
+                state.state = "0.08"
+            state.attributes = {}
+            return state
+
+        mock_hass.states.get = mock_get_state
+
+        state_reader.read_all_external_state(coordinator_data)
+
+        assert coordinator_data.prices_available is False
+        assert coordinator_data.general_price == 0.0  # Falls back to 0
+        assert coordinator_data.feed_in_price == 0.08
+
+    def test_prices_unavailable_when_feed_in_price_missing(
+        self, state_reader, mock_hass, coordinator_data
+    ):
+        """Test prices_available is False when feed_in_price is unavailable."""
+
+        def mock_get_state(entity_id):
+            state = MagicMock()
+            state.state = "0"
+            if "general_price" in entity_id:
+                state.state = "0.25"
+            elif "feed_in_price" in entity_id:
+                state.state = "unknown"  # Simulate unknown
+            state.attributes = {}
+            return state
+
+        mock_hass.states.get = mock_get_state
+
+        state_reader.read_all_external_state(coordinator_data)
+
+        assert coordinator_data.prices_available is False
+        assert coordinator_data.general_price == 0.25
+        assert coordinator_data.feed_in_price == 0.0  # Falls back to 0
+
+    def test_prices_unavailable_when_both_missing(
+        self, state_reader, mock_hass, coordinator_data
+    ):
+        """Test prices_available is False when both prices are unavailable."""
+
+        def mock_get_state(entity_id):
+            state = MagicMock()
+            state.state = "0"
+            if "general_price" in entity_id:
+                state.state = "unavailable"
+            elif "feed_in_price" in entity_id:
+                state.state = "unavailable"
+            state.attributes = {}
+            return state
+
+        mock_hass.states.get = mock_get_state
+
+        state_reader.read_all_external_state(coordinator_data)
+
+        assert coordinator_data.prices_available is False
+        assert coordinator_data.general_price == 0.0
+        assert coordinator_data.feed_in_price == 0.0
+
+    def test_prices_available_with_zero_prices(
+        self, state_reader, mock_hass, coordinator_data
+    ):
+        """Test prices_available is True even when prices are legitimately $0."""
+
+        def mock_get_state(entity_id):
+            state = MagicMock()
+            state.state = "0"
+            if "general_price" in entity_id:
+                state.state = "0"  # Legitimate $0 price
+            elif "feed_in_price" in entity_id:
+                state.state = "0"  # Legitimate $0 price
+            state.attributes = {}
+            return state
+
+        mock_hass.states.get = mock_get_state
+
+        state_reader.read_all_external_state(coordinator_data)
+
+        # Both prices are $0 but entities are available
+        assert coordinator_data.prices_available is True
+        assert coordinator_data.general_price == 0.0
+        assert coordinator_data.feed_in_price == 0.0


### PR DESCRIPTION
## Summary

When pricing data entities are unavailable (state='unavailable' or 'unknown'), the system was incorrectly treating prices as $0, which triggered boost_charging mode during potentially expensive periods.

## Problem

From the debug output in issue #330:
- Buy Price: $unavailable/kWh
- Sell Price: $unavailable/kWh
- Mode: boost_charging (incorrect!)

The system was treating unavailable prices as $0.0/kWh, which made prices appear "cheap" ($0 < $0.17 effective_cheap_price), incorrectly triggering boost charging.

## Solution

Added a `prices_available` flag to track when price data is valid:

1. **CoordinatorData**: Added `prices_available: bool = True` field
2. **state_reader.py**: Set `prices_available=False` when either price entity is unavailable
3. **mode_decision.py**: Added guard to fall back to `self_consumption` when prices are unavailable

## Changes Made

- `custom_components/localshift/coordinator_data.py` - Add `prices_available` field
- `custom_components/localshift/state_reader.py` - Set flag when prices unavailable
- `custom_components/localshift/computation_engine_lib/mode_decision.py` - Add guard check
- `tests/test_state_reader.py` - Add 5 unit tests for price availability

## Testing

- All 5 new unit tests pass
- Deployed to Home Assistant and verified integration loads correctly
- Lint checks pass

## Acceptance Criteria

- [x] System does NOT enter boost_charging when prices are unavailable
- [x] System falls back to self_consumption when prices are unavailable
- [x] Warning is logged when prices are unavailable
- [x] Unit tests cover the unavailable price scenario

Fixes #330