### PR TITLE
fix: Control grid charging switch in battery modes

### DIFF
--- a/custom_components/localshift/battery_controller.py
+++ b/custom_components/localshift/battery_controller.py
@@ -144,6 +144,49 @@ class BatteryController:
             )
             return False
 
+    async def _set_grid_charging_allowed(self, allowed: bool) -> bool:
+        """Set whether grid charging is allowed.
+
+        Controls the switch.my_home_allow_charging_from_grid entity.
+        This must be OFF in self-consumption mode to prevent unwanted grid charging.
+        This must be ON in force_charge/boost_charge modes to enable grid charging.
+
+        Args:
+            allowed: True to allow grid charging, False to disable.
+
+        Returns:
+            True if successful, False otherwise.
+        """
+        entity_id = self._get_entity_id("teslemetry_allow_charging_from_grid")
+        start_time = time.monotonic()
+        service = "turn_on" if allowed else "turn_off"
+        _LOGGER.info(
+            "[TRANSITION] Setting grid charging allowed: %s → %s", entity_id, allowed
+        )
+
+        try:
+            await self.hass.services.async_call(
+                "switch",
+                service,
+                {"entity_id": entity_id},
+                blocking=True,
+            )
+            elapsed = time.monotonic() - start_time
+            _LOGGER.info(
+                "[TRANSITION] Grid charging allowed set to %s in %.2fs", allowed, elapsed
+            )
+            return True
+        except Exception as e:
+            elapsed = time.monotonic() - start_time
+            _LOGGER.error(
+                "[TRANSITION] Failed to set grid charging allowed to %s after %.2fs: %s",
+                allowed,
+                elapsed,
+                e,
+                exc_info=True,
+            )
+            return False
+
     async def set_self_consumption(
         self, data: CoordinatorData, dry_run: bool = False
     ) -> bool:
@@ -160,6 +203,14 @@ class BatteryController:
             return True
 
         _LOGGER.info("Setting battery to self consumption mode")
+
+        # Disable grid charging first - this is critical for self-consumption mode
+        # Without this, the battery will charge from grid even in self-consumption mode
+        if not await self._set_grid_charging_allowed(False):
+            _LOGGER.error(
+                "Aborting self_consumption mode: Failed to disable grid charging"
+            )
+            return False
 
         # Set allow_export to pv_only first (don't allow battery to export)
         if not await self._set_export_mode(TESLEMETRY_EXPORT_PV_ONLY):
@@ -183,6 +234,7 @@ class BatteryController:
             expected_operation_mode="self_consumption",
             expected_backup_reserve=10,
             expected_export_mode=TESLEMETRY_EXPORT_PV_ONLY,
+            expected_grid_charging_allowed=False,
             timeout=10,
         ):
             _LOGGER.error("Self consumption mode validation failed")
@@ -265,13 +317,19 @@ class BatteryController:
         initial_state = self._get_hardware_state_snapshot()
         transition_start = time.monotonic()
         _LOGGER.info(
-            "[TRANSITION] Starting force charge mode (target=%.0f%%, reserve=%d%%) | Initial state: op=%s, reserve=%s, export=%s",
+            "[TRANSITION] Starting force charge mode (target=%.0f%%, reserve=%d%%) | Initial state: op=%s, reserve=%s, export=%s, grid_charging=%s",
             target_soc,
             reserve,
             initial_state["operation_mode"],
             initial_state["backup_reserve"],
             initial_state["export_mode"],
+            initial_state.get("grid_charging_allowed", "unknown"),
         )
+
+        # Enable grid charging first - required for force charge mode
+        if not await self._set_grid_charging_allowed(True):
+            _LOGGER.error("Aborting force charge mode: Failed to enable grid charging")
+            return False
 
         # Set allow_export to pv_only first (don't allow battery to export)
         if not await self._set_export_mode(TESLEMETRY_EXPORT_PV_ONLY):
@@ -321,17 +379,26 @@ class BatteryController:
         """Capture current hardware state for diagnostic logging.
 
         Returns:
-            Dict with operation_mode, backup_reserve, and export_mode.
+            Dict with operation_mode, backup_reserve, export_mode, and grid_charging_allowed.
         """
         operation_mode_entity = self._get_entity_id("teslemetry_operation_mode")
         backup_reserve_entity = self._get_entity_id("teslemetry_backup_reserve")
         export_mode_entity = self._get_entity_id("teslemetry_allow_export")
+        grid_charging_entity = self._get_entity_id("teslemetry_allow_charging_from_grid")
 
         return {
             "operation_mode": self._read_str(operation_mode_entity),
             "backup_reserve": self._read_float(backup_reserve_entity, -1),
             "export_mode": self._read_str(export_mode_entity),
+            "grid_charging_allowed": self._read_bool(grid_charging_entity),
         }
+
+    def _read_bool(self, entity_id: str, default: bool = False) -> bool:
+        """Read a boolean value from an entity's state (switch on/off)."""
+        state = self.hass.states.get(entity_id)
+        if state is None or state.state in ("unknown", "unavailable"):
+            return default
+        return state.state == "on"
 
     async def set_boost_charge(
         self, data: CoordinatorData, dry_run: bool = False
@@ -352,11 +419,17 @@ class BatteryController:
         initial_state = self._get_hardware_state_snapshot()
         transition_start = time.monotonic()
         _LOGGER.info(
-            "[TRANSITION] Starting boost charge mode | Initial state: op=%s, reserve=%s, export=%s",
+            "[TRANSITION] Starting boost charge mode | Initial state: op=%s, reserve=%s, export=%s, grid_charging=%s",
             initial_state["operation_mode"],
             initial_state["backup_reserve"],
             initial_state["export_mode"],
+            initial_state.get("grid_charging_allowed", "unknown"),
         )
+
+        # Enable grid charging first - required for boost charge mode
+        if not await self._set_grid_charging_allowed(True):
+            _LOGGER.error("Aborting boost charge mode: Failed to enable grid charging")
+            return False
 
         # Set allow_export to pv_only first (don't allow battery to export)
         if not await self._set_export_mode(TESLEMETRY_EXPORT_PV_ONLY):
@@ -592,6 +665,7 @@ class BatteryController:
         expected_operation_mode: str,
         expected_backup_reserve: float | int,
         expected_export_mode: str | None = None,
+        expected_grid_charging_allowed: bool | None = None,
         timeout: int = 10,
     ) -> bool:
         """Validate that hardware state matches expected values after transition.
@@ -600,6 +674,7 @@ class BatteryController:
             expected_operation_mode: Expected Teslemetry operation mode
             expected_backup_reserve: Expected backup reserve percentage
             expected_export_mode: Optional expected allow_export mode
+            expected_grid_charging_allowed: Optional expected grid charging switch state
             timeout: Maximum seconds to wait for validation (default: 10)
 
         Returns:
@@ -607,16 +682,18 @@ class BatteryController:
         """
         validation_start = time.monotonic()
         _LOGGER.info(
-            "[VALIDATION] Starting validation: op=%s, reserve=%s, export=%s, timeout=%ds",
+            "[VALIDATION] Starting validation: op=%s, reserve=%s, export=%s, grid_charging=%s, timeout=%ds",
             expected_operation_mode,
             expected_backup_reserve,
             expected_export_mode,
+            expected_grid_charging_allowed,
             timeout,
         )
 
         operation_mode_entity = self._get_entity_id("teslemetry_operation_mode")
         backup_reserve_entity = self._get_entity_id("teslemetry_backup_reserve")
         export_mode_entity = self._get_entity_id("teslemetry_allow_export")
+        grid_charging_entity = self._get_entity_id("teslemetry_allow_charging_from_grid")
 
         first_failure_logged = False
         last_operation_mode = None
@@ -629,6 +706,11 @@ class BatteryController:
             current_backup_reserve = self._read_float(backup_reserve_entity, -1)
             current_export_mode = (
                 self._read_str(export_mode_entity) if expected_export_mode else None
+            )
+            current_grid_charging = (
+                self._read_bool(grid_charging_entity)
+                if expected_grid_charging_allowed is not None
+                else None
             )
 
             # Track operation mode changes for diagnostics
@@ -643,12 +725,13 @@ class BatteryController:
                 last_operation_mode = current_operation_mode
 
             _LOGGER.debug(
-                "Validation attempt %d/%d: operation_mode=%s, backup_reserve=%s, export_mode=%s",
+                "Validation attempt %d/%d: operation_mode=%s, backup_reserve=%s, export_mode=%s, grid_charging=%s",
                 attempt + 1,
                 timeout,
                 current_operation_mode,
                 current_backup_reserve,
                 current_export_mode,
+                current_grid_charging,
             )
 
             # Check if state matches expectations
@@ -659,8 +742,18 @@ class BatteryController:
                 if expected_export_mode
                 else True
             )
+            matches_grid_charging = (
+                current_grid_charging == expected_grid_charging_allowed
+                if expected_grid_charging_allowed is not None
+                else True
+            )
 
-            if matches_operation and matches_reserve and matches_export:
+            if (
+                matches_operation
+                and matches_reserve
+                and matches_export
+                and matches_grid_charging
+            ):
                 elapsed = time.monotonic() - validation_start
                 _LOGGER.info(
                     "[VALIDATION] SUCCESS after %.1fs (attempt %d/%d)",
@@ -674,15 +767,17 @@ class BatteryController:
             if not first_failure_logged:
                 _LOGGER.warning(
                     "[VALIDATION] State mismatch at attempt %d: "
-                    "expected (op=%s, reserve=%s, export=%s), "
-                    "actual (op=%s, reserve=%s, export=%s)",
+                    "expected (op=%s, reserve=%s, export=%s, grid_charging=%s), "
+                    "actual (op=%s, reserve=%s, export=%s, grid_charging=%s)",
                     attempt + 1,
                     expected_operation_mode,
                     expected_backup_reserve,
                     expected_export_mode,
+                    expected_grid_charging_allowed,
                     current_operation_mode,
                     current_backup_reserve,
                     current_export_mode,
+                    current_grid_charging,
                 )
                 first_failure_logged = True
 
@@ -706,13 +801,14 @@ class BatteryController:
 
         _LOGGER.error(
             "[VALIDATION] FAILED after %.1fs (%d attempts): "
-            "expected (op=%s, reserve=%s, export=%s), "
+            "expected (op=%s, reserve=%s, export=%s, grid_charging=%s), "
             "actual (op=%s)",
             elapsed,
             timeout,
             expected_operation_mode,
             expected_backup_reserve,
             expected_export_mode,
+            expected_grid_charging_allowed,
             final_operation_mode,
         )
         return False
@@ -722,6 +818,7 @@ class BatteryController:
         expected_operation_mode: str,
         expected_backup_reserve: float | int,
         expected_export_mode: str | None = None,
+        expected_grid_charging_allowed: bool | None = None,
     ) -> bool:
         """Verify current hardware state matches expected values.
 
@@ -731,6 +828,7 @@ class BatteryController:
             expected_operation_mode: Expected Teslemetry operation mode
             expected_backup_reserve: Expected backup reserve percentage
             expected_export_mode: Optional expected allow_export mode
+            expected_grid_charging_allowed: Optional expected grid charging switch state
 
         Returns:
             True if state matches expectations, False otherwise.
@@ -738,12 +836,18 @@ class BatteryController:
         operation_mode_entity = self._get_entity_id("teslemetry_operation_mode")
         backup_reserve_entity = self._get_entity_id("teslemetry_backup_reserve")
         export_mode_entity = self._get_entity_id("teslemetry_allow_export")
+        grid_charging_entity = self._get_entity_id("teslemetry_allow_charging_from_grid")
 
         # Read current hardware state
         current_operation_mode = self._read_str(operation_mode_entity)
         current_backup_reserve = self._read_float(backup_reserve_entity, -1)
         current_export_mode = (
             self._read_str(export_mode_entity) if expected_export_mode else None
+        )
+        current_grid_charging = (
+            self._read_bool(grid_charging_entity)
+            if expected_grid_charging_allowed is not None
+            else None
         )
 
         # Check if state matches expectations
@@ -754,32 +858,46 @@ class BatteryController:
             if expected_export_mode
             else True
         )
+        matches_grid_charging = (
+            current_grid_charging == expected_grid_charging_allowed
+            if expected_grid_charging_allowed is not None
+            else True
+        )
 
         # DIAGNOSTIC: Always log at INFO level for visibility
         _LOGGER.info(
-            "Health check verify: expected=(op=%s, reserve=%s, export=%s), actual=(op=%s, reserve=%s, export=%s), match=%s",
+            "Health check verify: expected=(op=%s, reserve=%s, export=%s, grid_charging=%s), actual=(op=%s, reserve=%s, export=%s, grid_charging=%s), match=%s",
             expected_operation_mode,
             expected_backup_reserve,
             expected_export_mode,
+            expected_grid_charging_allowed,
             current_operation_mode,
             current_backup_reserve,
             current_export_mode,
-            matches_operation and matches_reserve and matches_export,
+            current_grid_charging,
+            matches_operation and matches_reserve and matches_export and matches_grid_charging,
         )
 
-        if matches_operation and matches_reserve and matches_export:
+        if (
+            matches_operation
+            and matches_reserve
+            and matches_export
+            and matches_grid_charging
+        ):
             return True
 
         # State mismatch detected
         _LOGGER.warning(
             "State mismatch detected: "
-            "expected (operation_mode=%s, backup_reserve=%s, export_mode=%s), "
-            "actual (operation_mode=%s, backup_reserve=%s, export_mode=%s)",
+            "expected (operation_mode=%s, backup_reserve=%s, export_mode=%s, grid_charging=%s), "
+            "actual (operation_mode=%s, backup_reserve=%s, export_mode=%s, grid_charging=%s)",
             expected_operation_mode,
             expected_backup_reserve,
             expected_export_mode,
+            expected_grid_charging_allowed,
             current_operation_mode,
             current_backup_reserve,
             current_export_mode,
+            current_grid_charging,
         )
         return False

--- a/custom_components/localshift/const.py
+++ b/custom_components/localshift/const.py
@@ -106,6 +106,7 @@ CONF_TESLEMETRY_BATTERY_POWER = "teslemetry_battery_power"
 CONF_TESLEMETRY_SOLAR_POWER = "teslemetry_solar_power"
 CONF_TESLEMETRY_LOAD_POWER = "teslemetry_load_power"
 CONF_TESLEMETRY_ALLOW_EXPORT = "teslemetry_allow_export"
+CONF_TESLEMETRY_ALLOW_CHARGING_FROM_GRID = "teslemetry_allow_charging_from_grid"
 
 # Pricing entities
 CONF_PRICING_GENERAL_PRICE = "pricing_general_price"
@@ -219,6 +220,7 @@ DEFAULT_ENTITY_IDS = {
     CONF_TESLEMETRY_SOLAR_POWER: "sensor.my_home_solar_power",
     CONF_TESLEMETRY_LOAD_POWER: "sensor.my_home_load_power",
     CONF_TESLEMETRY_ALLOW_EXPORT: "select.my_home_allow_export",
+    CONF_TESLEMETRY_ALLOW_CHARGING_FROM_GRID: "switch.my_home_allow_charging_from_grid",
     CONF_PRICING_GENERAL_PRICE: "sensor.100h_general_price",
     CONF_PRICING_FEED_IN_PRICE: "sensor.100h_feed_in_price",
     CONF_PRICING_GENERAL_FORECAST: "sensor.100h_general_forecast",

--- a/custom_components/localshift/state_machine.py
+++ b/custom_components/localshift/state_machine.py
@@ -578,31 +578,37 @@ class StateMachine:
 
         return transition_success
 
-    def _get_expected_state_for_mode(self, mode: BatteryMode) -> tuple[str, int, str]:
+    def _get_expected_state_for_mode(
+        self, mode: BatteryMode
+    ) -> tuple[str, int, str, bool]:
         """Get the expected hardware state for a given mode.
 
         Returns:
-            Tuple of (operation_mode, backup_reserve, export_mode)
+            Tuple of (operation_mode, backup_reserve, export_mode, grid_charging_allowed)
         """
         if mode == BatteryMode.SELF_CONSUMPTION:
-            return ("self_consumption", 10, TESLEMETRY_EXPORT_PV_ONLY)
+            return ("self_consumption", 10, TESLEMETRY_EXPORT_PV_ONLY, False)
         elif mode == BatteryMode.DEMAND_BLOCK:
-            return ("self_consumption", 10, TESLEMETRY_EXPORT_PV_ONLY)
+            return ("self_consumption", 10, TESLEMETRY_EXPORT_PV_ONLY, False)
         elif mode == BatteryMode.GRID_CHARGING:
             # Grid charging uses backup mode for 3.3 kW rate.
             # Reserve is clamped for Tesla firmware compatibility (81-99% → 80).
             # The actual reserve is tracked in _grid_charging_reserve.
-            return ("backup", -1, TESLEMETRY_EXPORT_PV_ONLY)  # reserve is dynamic
+            # Grid charging must be enabled for this mode.
+            return ("backup", -1, TESLEMETRY_EXPORT_PV_ONLY, True)  # reserve is dynamic
         elif mode == BatteryMode.BOOST_CHARGING:
-            return ("autonomous", 100, TESLEMETRY_EXPORT_PV_ONLY)
+            # Boost charging needs grid charging enabled for fast charging
+            return ("autonomous", 100, TESLEMETRY_EXPORT_PV_ONLY, True)
         elif mode == BatteryMode.SPIKE_DISCHARGE:
-            return ("autonomous", 10, TESLEMETRY_EXPORT_BATTERY_OK)
+            # Discharge modes don't need grid charging
+            return ("autonomous", 10, TESLEMETRY_EXPORT_BATTERY_OK, False)
         elif mode == BatteryMode.PROACTIVE_EXPORT:
             # Reserve is dynamic (max(4, SOC-5)), so use 10 as expected for health check
             # The actual reserve will be set based on current SOC
-            return ("autonomous", 10, TESLEMETRY_EXPORT_BATTERY_OK)
+            # Export modes don't need grid charging
+            return ("autonomous", 10, TESLEMETRY_EXPORT_BATTERY_OK, False)
         else:  # MANUAL or unknown
-            return ("", -1, "")
+            return ("", -1, "", False)
 
     async def _perform_health_check(self, data: CoordinatorData) -> None:
         """Verify hardware state matches commanded mode.
@@ -702,7 +708,7 @@ class StateMachine:
                 )
                 return
 
-        expected_op, expected_reserve, expected_export = (
+        expected_op, expected_reserve, expected_export, expected_grid_charging = (
             self._get_expected_state_for_mode(self._commanded_mode)
         )
 
@@ -729,6 +735,7 @@ class StateMachine:
             expected_operation_mode=expected_op,
             expected_backup_reserve=expected_reserve,
             expected_export_mode=expected_export,
+            expected_grid_charging_allowed=expected_grid_charging,
         )
 
         if not is_valid:


### PR DESCRIPTION
## Summary
Fixes unwanted grid charging during self-consumption mode by controlling the Teslemetry `allow_charging_from_grid` switch.

## Problem
In self-consumption mode, the battery was charging from the grid even though this mode should only use solar to charge the battery. The root cause was that the `switch.my_home_allow_charging_from_grid` entity was not being controlled by LocalShift.

## Changes Made
- Add `teslemetry_allow_charging_from_grid` entity to configuration (const.py)
- Turn OFF grid charging in `set_self_consumption()` mode
- Turn ON grid charging in `set_force_charge()` and `set_boost_charge()` modes
- Update `validate_transition()` and `verify_current_state()` to verify grid charging switch state
- Add `_read_bool()` helper for reading switch states
- Update `_get_expected_state_for_mode()` to return grid charging expected state

## Testing
- Deployed and verified grid charging switch is now OFF in self-consumption mode
- Grid power dropped from 2.335 kW to 0.0 kW
- Battery stopped charging from grid

Fixes #333