### PR TITLE
fix: skip staleness check for select entities (Issue #342)

### DIFF
--- a/custom_components/localshift/entity_validator.py
+++ b/custom_components/localshift/entity_validator.py
@@ -321,8 +321,13 @@ class EntityValidator:
 
         # Check for staleness using entity's actual last_updated time
         # (not our internal last_valid_time which tracks when we last validated it)
+        #
+        # IMPORTANT: Skip staleness check for select entities (Issue #342)
+        # Select entities only update last_updated when the VALUE changes, not periodically.
+        # If a battery stays in "autonomous" mode for hours, the entity is still valid -
+        # the data is NOT stale, it's just unchanged.
         staleness_threshold = STALENESS_THRESHOLDS.get(config_key)
-        if staleness_threshold:
+        if staleness_threshold and not entity_id.startswith("select."):
             time_since_update = dt_util.now() - state.last_updated
             if time_since_update > staleness_threshold:
                 health.status = EntityStatus.STALE


### PR DESCRIPTION
## Summary

Fixed false 'data stale' warnings for select entities by skipping staleness checks for entities that start with `select.`.

## Problem

The integration status was showing `degraded` with warnings:
- "Battery operation mode: data stale"
- "Today's solar forecast: data stale"

## Root Cause

Select entities (like `select.my_home_operation_mode`) only update their `last_updated` timestamp when the **value changes**, not periodically. If a battery stays in "autonomous" mode for hours, the entity is still valid - the data is NOT stale, it's just unchanged.

The staleness detection was incorrectly treating unchanged select entities as stale.

## Solution

Modified the staleness check in `entity_validator.py` to skip select entities.

## Testing

- Deployed to Home Assistant
- Verified integration status changed from `degraded` to `ok`
- No more false stale warnings

Closes #342