### PR TITLE
fix: prefer later cheap slots for just-in-time charging

### DIFF
--- a/custom_components/localshift/computation_engine_lib/forecast_computer.py
+++ b/custom_components/localshift/computation_engine_lib/forecast_computer.py
@@ -1900,10 +1900,14 @@ class ForecastComputer:
 
         # ========================================================================
         # Pass 2: Sort candidates by price and schedule cheapest first
+        # Issue #344: When prices are equal, prefer LATER slots to maximize
+        # solar contribution during earlier hours (just-in-time charging).
         # ========================================================================
 
-        # Sort by price (cheapest first)
-        grid_charge_candidates.sort(key=lambda x: x["price"])
+        # Sort by (price ASC, slot_idx DESC) - cheapest first, but later slots
+        # preferred when prices are equal. This allows solar to contribute during
+        # morning hours before grid charging kicks in.
+        grid_charge_candidates.sort(key=lambda x: (x["price"], -x["slot_idx"]))
 
         # Track which slots are scheduled for grid charging
         scheduled_grid_charges: dict[int, dict] = {}


### PR DESCRIPTION
## Summary
When multiple slots have the same cheap price, the algorithm now prefers later slots to maximize solar contribution during earlier hours.

## Problem
The charging plan was hitting 100% SOC early (at 12:40) when the target was 95% at DW start (15:00). This happened because the algorithm scheduled the earliest cheap slots first, not allowing solar to contribute during morning hours.

## Solution
Changed the sort key in Pass 2 of the price-optimized grid charging algorithm:
- Before: sort by price ASC (earliest slots scheduled first)
- After: sort by (price ASC, slot_idx DESC) - later slots preferred when prices are equal

## Results
**Before:**
- Grid charge slots: 10:45, 11:00, 11:45, 12:00, 12:15, 12:30
- SOC hit 100% at 12:40
- Total grid import: 7.796 kWh

**After:**
- Grid charge slots: 11:45, 12:00, 12:15, 12:30, 12:45, 13:00
- Slots 10:45-11:30 now skipped (solar contributes)
- Total grid import: 7.125 kWh (8% reduction)

## Testing
- All 28 tests pass
- Deployed and verified via logs

Closes #344