### PR TITLE
fix: Use live spot price for current slot mode decision

### DIFF
--- a/custom_components/localshift/computation_engine_lib/mode_decision.py
+++ b/custom_components/localshift/computation_engine_lib/mode_decision.py
@@ -11,6 +11,9 @@ from ..coordinator_data import CoordinatorData
 
 _LOGGER = logging.getLogger(__name__)
 
+# Threshold for "very cheap" price (80% of effective cheap price)
+VERY_CHEAP_PRICE_FACTOR = 0.8
+
 
 class ModeDecisionEngine:
     """Compute active battery mode and maintain decision logs."""
@@ -23,6 +26,109 @@ class ModeDecisionEngine:
         """Initialize decision engine dependencies."""
         self._get_switch_state = get_switch_state
         self._get_forecast_entry_for_now = get_forecast_entry_for_now
+
+    def _should_grid_charge_with_live_price(
+        self,
+        data: CoordinatorData,
+        now_dt: datetime,
+        forecast_entry: dict,
+    ) -> tuple[bool, bool]:
+        """Validate grid charging decision using live spot price.
+
+        Issue #341: The forecast stores grid_charge_boost based on forecast prices,
+        but for the current slot we should validate with the actual live spot price
+        to avoid mode flapping when forecast and live prices differ.
+
+        This method VALIDATES the forecast decision with live prices:
+        - If forecast says charge but live price is NOT cheap → don't charge (fixes #341)
+        - If forecast says charge and live price IS cheap → charge (normal case)
+        - If forecast says boost and live price is VERY cheap → boost
+        - If forecast says boost but live price is only cheap → regular charge
+
+        Args:
+            data: CoordinatorData with live prices and state
+            now_dt: Current datetime
+            forecast_entry: The forecast entry for the current slot
+
+        Returns:
+            Tuple of (should_charge, should_boost)
+        """
+        # Get live values
+        live_price = data.general_price
+        effective_cheap_price = data.effective_cheap_price
+        is_currently_grid_charging = data.force_charge_active
+
+        # Get forecast flags
+        forecast_says_charge = forecast_entry.get("grid_charge", False)
+        forecast_says_boost = forecast_entry.get("grid_charge_boost", False)
+
+        # Price thresholds
+        price_is_cheap = live_price <= effective_cheap_price
+        price_is_very_cheap = live_price <= (
+            effective_cheap_price * VERY_CHEAP_PRICE_FACTOR
+        )
+
+        # HYSTERESIS: If currently grid charging and price is still cheap,
+        # continue charging to avoid flip-flopping
+        if is_currently_grid_charging and price_is_cheap:
+            _LOGGER.info(
+                "LIVE_PRICE HYSTERESIS: Continuing grid charge at %s (live_price=$%.2f, threshold=$%.2f, SOC=%.1f%%)",
+                now_dt.strftime("%H:%M"),
+                live_price,
+                effective_cheap_price,
+                data.soc,
+            )
+            if price_is_very_cheap:
+                return True, True
+            return True, False
+
+        # If forecast didn't plan to charge, don't start based on live price alone
+        # (The forecast has already done solar simulation to determine if charging is needed)
+        if not forecast_says_charge and not forecast_says_boost:
+            return False, False
+
+        # Forecast says to charge - validate with live price
+        if not price_is_cheap:
+            # Issue #341 fix: Forecast said charge based on forecast price,
+            # but live price is NOT cheap - don't charge
+            _LOGGER.info(
+                "LIVE_PRICE BLOCK: Forecast said charge at %s but live_price=$%.2f > threshold=$%.2f - NOT charging",
+                now_dt.strftime("%H:%M"),
+                live_price,
+                effective_cheap_price,
+            )
+            return False, False
+
+        # Live price IS cheap - proceed with charging
+        # Determine boost vs regular based on live price, not forecast flag
+        if forecast_says_boost:
+            if price_is_very_cheap:
+                _LOGGER.info(
+                    "LIVE_PRICE BOOST: Forecast boost confirmed at %s (live_price=$%.2f <= $%.2f)",
+                    now_dt.strftime("%H:%M"),
+                    live_price,
+                    effective_cheap_price * VERY_CHEAP_PRICE_FACTOR,
+                )
+                return True, True
+            else:
+                # Forecast said boost, but live price is only cheap (not very cheap)
+                # Downgrade to regular charge
+                _LOGGER.info(
+                    "LIVE_PRICE DOWNGRADE: Forecast boost at %s but live_price=$%.2f not very cheap (threshold=$%.2f) - regular charge",
+                    now_dt.strftime("%H:%M"),
+                    live_price,
+                    effective_cheap_price * VERY_CHEAP_PRICE_FACTOR,
+                )
+                return True, False
+
+        # Forecast said regular charge, live price confirms it's cheap
+        _LOGGER.info(
+            "LIVE_PRICE CHARGE: Forecast charge confirmed at %s (live_price=$%.2f <= threshold=$%.2f)",
+            now_dt.strftime("%H:%M"),
+            live_price,
+            effective_cheap_price,
+        )
+        return True, False
 
     def compute_active_mode(self, data: CoordinatorData, now_dt: datetime) -> None:
         """Compute active battery mode from forecast and current constraints."""
@@ -94,30 +200,42 @@ class ModeDecisionEngine:
         grid_import_kwh = forecast_entry.get("grid_import_kwh", 0)
         grid_import_threshold = 0.01
 
-        if forecast_entry.get("grid_charge_boost"):
+        # Issue #341: Use live spot price for current slot mode decision
+        # The forecast stores grid_charge_boost based on forecast prices, but for
+        # the current slot we should use the actual live spot price to avoid
+        # mode flapping when forecast and live prices differ.
+        should_charge, should_boost = self._should_grid_charge_with_live_price(
+            data, now_dt, forecast_entry
+        )
+
+        if should_boost:
             if grid_import_kwh > grid_import_threshold:
                 data.active_mode = BatteryMode.BOOST_CHARGING
+                data.debug_mode_source = "live_price_boost"
                 _LOGGER.info(
-                    "Forecast-driven: BOOST_CHARGING at %s, import=%.3f kWh",
+                    "Live-price-driven: BOOST_CHARGING at %s, import=%.3f kWh (live_price=$%.2f)",
                     now_dt.strftime("%H:%M"),
                     grid_import_kwh,
+                    data.general_price,
                 )
                 return
             _LOGGER.debug(
-                "grid_charge_boost=True but grid_import_kwh=0, checking grid_charge"
+                "should_boost=True but grid_import_kwh=0, checking regular charge"
             )
 
-        if forecast_entry.get("grid_charge"):
+        if should_charge:
             if grid_import_kwh > grid_import_threshold:
                 data.active_mode = BatteryMode.GRID_CHARGING
+                data.debug_mode_source = "live_price_charge"
                 _LOGGER.info(
-                    "Forecast-driven: GRID_CHARGING at %s, import=%.3f kWh",
+                    "Live-price-driven: GRID_CHARGING at %s, import=%.3f kWh (live_price=$%.2f)",
                     now_dt.strftime("%H:%M"),
                     grid_import_kwh,
+                    data.general_price,
                 )
                 return
             _LOGGER.debug(
-                "grid_charge=True but grid_import_kwh=%.3f, staying in self-consumption",
+                "should_charge=True but grid_import_kwh=%.3f, staying in self-consumption",
                 grid_import_kwh,
             )
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -62,6 +62,8 @@ class TestFullStateMachineFlow:
         integration_data.soc = 40.0
         integration_data.general_price = 0.10  # Cheap price
         integration_data.feed_in_price = 0.05
+        # Issue #341: Set effective_cheap_price so live price validation passes
+        integration_data.effective_cheap_price = 0.15  # Price threshold
 
         # Mock forecast with grid charging flag
         test_time = dt_aware(2026, 2, 16, 10, 0, 0)


### PR DESCRIPTION
## Summary
Fixes mode flapping when live spot price differs from forecast price.

## Problem
The mode decision for the current time slot was using pre-computed forecast flags (grid_charge_boost) which were calculated using forecast prices. This caused mode flapping when the live spot price differed from the forecast price.

## Solution
- Add _should_grid_charge_with_live_price() helper method that validates the forecast decision with live prices
- Modify compute_active_mode() to use live prices for current slot

## Decision Logic
- If forecast says charge but live price is NOT cheap → don't charge (fixes #341)
- If forecast says charge and live price IS cheap → charge (normal case)
- If forecast says boost and live price is VERY cheap → boost
- If forecast says boost but live price is only cheap → regular charge

## Testing
- All relevant tests pass
- Lint checks pass

Closes #341