### PR TITLE
fix: skip boost charging when SOC >= 80%

### DIFF
--- a/custom_components/localshift/computation_engine_lib/forecast_computer.py
+++ b/custom_components/localshift/computation_engine_lib/forecast_computer.py
@@ -12,6 +12,7 @@ from homeassistant.util import dt as dt_util
 
 from ..const import (
     BATTERY_CAPACITY_KWH,
+    BOOST_CHARGE_MAX_SOC,
     CHARGE_RATE_BOOST_KW,
     CHARGE_RATE_GRID_KW,
     CHARGE_RATE_SOLAR_KW,
@@ -948,13 +949,25 @@ class ForecastComputer:
                 target_pct,
             )
             # Check if we should boost (very cheap price)
+            # Issue #309: Skip boost if SOC >= 80% (Powerwall throttles charge rate)
             if price_is_very_cheap:
+                if predicted_soc >= BOOST_CHARGE_MAX_SOC:
+                    return True, False  # Continue at normal rate
                 return True, True
             return True, False
 
         # SAFETY NET: Charge if very cheap (forecast could be wrong)
         # IMPORTANT: only applies when solar *cannot* meet the target before DW.
+        # Issue #309: Skip boost charging if SOC >= 80% (Powerwall throttles charge rate)
         if price_is_very_cheap:
+            if predicted_soc >= BOOST_CHARGE_MAX_SOC:
+                _LOGGER.info(
+                    "Grid charge: VERY CHEAP price $%.2f at %s (safety net) - SOC %.1f%% >= 80%%, using normal rate instead of boost",
+                    slot_price,
+                    slot_start.strftime("%H:%M"),
+                    predicted_soc,
+                )
+                return True, False  # Grid charge at normal rate, not boost
             _LOGGER.info(
                 "Grid charge: VERY CHEAP price $%.2f at %s (safety net)",
                 slot_price,

--- a/custom_components/localshift/computation_engine_lib/forecast_computer.py
+++ b/custom_components/localshift/computation_engine_lib/forecast_computer.py
@@ -847,6 +847,8 @@ class ForecastComputer:
                         slot_start.minute,
                     )
                     if price_is_very_cheap:
+                        if predicted_soc >= BOOST_CHARGE_MAX_SOC:
+                            return True, False
                         return True, True
                     return False, False
 
@@ -883,7 +885,10 @@ class ForecastComputer:
                     slot_start.minute,
                 )
                 # Only grid charge if price is very cheap (safety net for extreme cases)
+                # Issue #309: Skip boost if SOC >= 80%
                 if price_is_very_cheap:
+                    if predicted_soc >= BOOST_CHARGE_MAX_SOC:
+                        return True, False
                     return True, True
                 return False, False
         else:
@@ -917,6 +922,8 @@ class ForecastComputer:
                     slot_start.minute,
                 )
                 if price_is_very_cheap:
+                    if predicted_soc >= BOOST_CHARGE_MAX_SOC:
+                        return True, False
                     return True, True
                 return False, False
 

--- a/custom_components/localshift/const.py
+++ b/custom_components/localshift/const.py
@@ -76,6 +76,11 @@ BACKUP_RESERVE_MAX_VALID = (
     80  # Maximum reserve that Tesla firmware accepts in backup mode
 )
 
+# Issue #309: Maximum SOC for boost charging
+# Powerwall throttles charge rate above 80%, making boost charging inefficient.
+# When SOC >= 80%, use normal grid charging (3.3kW) instead of boost (5kW).
+BOOST_CHARGE_MAX_SOC = 80.0
+
 # Powerwall capacity
 BATTERY_CAPACITY_KWH = 13.5
 

--- a/tests/test_forecast_computer.py
+++ b/tests/test_forecast_computer.py
@@ -870,6 +870,112 @@ class TestShouldGridChargeAtSlot:
         assert should_charge is True
         assert should_boost is True
 
+    def test_should_grid_charge_boost_limited_at_80_percent_soc(
+        self, mock_entry, mock_get_entity_id
+    ):
+        """Should use normal grid charging (not boost) when SOC >= 80%.
+
+        Issue #309: Powerwall throttles charge rate above 80% SOC, making
+        boost charging (5kW autonomous mode) inefficient. When SOC >= 80%,
+        use normal grid charging (3.3kW backup mode) instead.
+        """
+        entry = mock_entry
+        entry.options = {
+            "load_weight_recent": 0.7,
+            "battery_target": 100,
+            "minimum_target_soc": 10,
+        }
+
+        computer = ForecastComputer(entry, mock_get_entity_id, lambda x: {10: 0.5})
+
+        slot_start = dt_aware(2026, 2, 16, 10, 0, 0)
+
+        # Create solcast that shows no solar can reach target
+        all_solcast = [
+            {"period_start": "2026-02-16T10:00:00+11:00", "pv_estimate10": 0.0},
+        ]
+
+        # Test at SOC = 80% (exactly at threshold)
+        should_charge, should_boost = computer._should_grid_charge_at_slot(
+            slot_start=slot_start,
+            solar_kwh=0.0,
+            slot_price=0.08,  # Very cheap (< 0.15 * 0.8 = 0.12)
+            predicted_soc=80.0,  # Exactly at threshold
+            target_pct=100.0,
+            effective_cheap_price=0.15,
+            is_before_dw=True,
+            in_demand_window=False,
+            gap_to_target=20.0,
+            is_daylight=False,
+            all_solcast=all_solcast,
+            historical_avg_kw={10: 0.5},
+            current_load_kw=0.5,
+            recent_load_kw=0.5,
+            dw_start_time=time(18, 0),
+            dw_end_time=time(22, 0),
+            allow_dw_entry_under_target=False,
+            general_price_current=0.08,
+            min_soc_pct=10.0,
+        )
+
+        # Should grid charge but NOT boost (SOC >= 80%)
+        assert should_charge is True
+        assert should_boost is False, "Boost should be disabled at 80% SOC"
+
+        # Test at SOC = 85% (above threshold)
+        should_charge2, should_boost2 = computer._should_grid_charge_at_slot(
+            slot_start=slot_start,
+            solar_kwh=0.0,
+            slot_price=0.08,
+            predicted_soc=85.0,  # Above threshold
+            target_pct=100.0,
+            effective_cheap_price=0.15,
+            is_before_dw=True,
+            in_demand_window=False,
+            gap_to_target=15.0,
+            is_daylight=False,
+            all_solcast=all_solcast,
+            historical_avg_kw={10: 0.5},
+            current_load_kw=0.5,
+            recent_load_kw=0.5,
+            dw_start_time=time(18, 0),
+            dw_end_time=time(22, 0),
+            allow_dw_entry_under_target=False,
+            general_price_current=0.08,
+            min_soc_pct=10.0,
+        )
+
+        # Should grid charge but NOT boost
+        assert should_charge2 is True
+        assert should_boost2 is False, "Boost should be disabled above 80% SOC"
+
+        # Test at SOC = 75% (below threshold) - boost should be allowed
+        should_charge3, should_boost3 = computer._should_grid_charge_at_slot(
+            slot_start=slot_start,
+            solar_kwh=0.0,
+            slot_price=0.08,
+            predicted_soc=75.0,  # Below threshold
+            target_pct=100.0,
+            effective_cheap_price=0.15,
+            is_before_dw=True,
+            in_demand_window=False,
+            gap_to_target=25.0,
+            is_daylight=False,
+            all_solcast=all_solcast,
+            historical_avg_kw={10: 0.5},
+            current_load_kw=0.5,
+            recent_load_kw=0.5,
+            dw_start_time=time(18, 0),
+            dw_end_time=time(22, 0),
+            allow_dw_entry_under_target=False,
+            general_price_current=0.08,
+            min_soc_pct=10.0,
+        )
+
+        # Should grid charge WITH boost (SOC < 80%)
+        assert should_charge3 is True
+        assert should_boost3 is True, "Boost should be enabled below 80% SOC"
+
 
 # =============================================================================
 # REPLACEMENT COST CHECK TESTS (Issue #70)


### PR DESCRIPTION
## Summary
Powerwall throttles charge rate above 80% SOC, making boost charging (5kW autonomous mode) inefficient. This PR adds a check to use normal grid charging (3.3kW backup mode) instead of boost charging when SOC >= 80%.

## Changes Made
- Add `BOOST_CHARGE_MAX_SOC = 80.0` constant to `const.py`
- Check SOC before boost charging in `_should_grid_charge_at_slot`
- Apply limit to both safety net and hysteresis boost decisions
- Log when boost is skipped due to SOC threshold

## Testing
- All 28 forecast_computer tests pass
- Ruff linting passes

## Technical Details
When the battery SOC reaches 80%, the Powerwall firmware reduces the maximum charge rate. Using boost charging (5kW) above this threshold is inefficient because:
1. The actual charge rate is throttled
2. Autonomous mode has additional overhead
3. Backup mode (3.3kW) achieves the same effective charge rate

Closes #309