### PR TITLE
feat: Battery preservation mode when charging needed for demand window target

### DIFF
--- a/custom_components/localshift/battery_controller.py
+++ b/custom_components/localshift/battery_controller.py
@@ -192,17 +192,32 @@ class BatteryController:
     ) -> bool:
         """Set battery to self consumption mode (reserve=10, self_consumption).
 
+        Issue #350: When preserve_soc is set, use that as the backup reserve
+        instead of the default 10%. This prevents battery discharge when
+        charging is needed to meet a demand window target.
+
         Returns:
             True if successful, False otherwise.
         """
         # Note: manual_override is managed by button handlers and state machine
         # Self-consumption is the default automated mode, so we don't set manual_override here
 
+        # Determine backup reserve: use preserve_soc if set, otherwise default to 10%
+        reserve = data.preserve_soc if data.preserve_soc is not None else 10
+
         if dry_run:
-            _LOGGER.info("DRY RUN: set_self_consumption")
+            _LOGGER.info(
+                "DRY RUN: set_self_consumption (reserve=%s, preserve_soc=%s)",
+                reserve,
+                data.preserve_soc,
+            )
             return True
 
-        _LOGGER.info("Setting battery to self consumption mode")
+        _LOGGER.info(
+            "Setting battery to self consumption mode (reserve=%s, preserve_soc=%s)",
+            reserve,
+            data.preserve_soc,
+        )
 
         # Disable grid charging first - this is critical for self-consumption mode
         # Without this, the battery will charge from grid even in self-consumption mode
@@ -223,7 +238,7 @@ class BatteryController:
             )
             return False
 
-        if not await self._set_backup_reserve(10):
+        if not await self._set_backup_reserve(reserve):
             _LOGGER.error(
                 "Aborting self_consumption mode: Failed to set backup reserve"
             )
@@ -232,7 +247,7 @@ class BatteryController:
         # Validate transition completed successfully
         if not await self.validate_transition(
             expected_operation_mode="self_consumption",
-            expected_backup_reserve=10,
+            expected_backup_reserve=reserve,
             expected_export_mode=TESLEMETRY_EXPORT_PV_ONLY,
             expected_grid_charging_allowed=False,
             timeout=10,
@@ -241,7 +256,8 @@ class BatteryController:
             return False
 
         _LOGGER.info(
-            "Successfully completed self_consumption mode transition with validation"
+            "Successfully completed self_consumption mode transition with validation (reserve=%s)",
+            reserve,
         )
         return True
 

--- a/custom_components/localshift/computation_engine_lib/mode_decision.py
+++ b/custom_components/localshift/computation_engine_lib/mode_decision.py
@@ -14,6 +14,9 @@ _LOGGER = logging.getLogger(__name__)
 # Threshold for "very cheap" price (80% of effective cheap price)
 VERY_CHEAP_PRICE_FACTOR = 0.8
 
+# Buffer below current SOC for preservation (Issue #350)
+PRESERVE_BUFFER_PERCENT = 5.0
+
 
 class ModeDecisionEngine:
     """Compute active battery mode and maintain decision logs."""
@@ -277,6 +280,65 @@ class ModeDecisionEngine:
                 data.manual_override,
             )
             data.active_mode = BatteryMode.SELF_CONSUMPTION
+
+        # Issue #350: Battery preservation when charging is needed
+        # If solar cannot reach the target, we need to preserve the battery
+        # to avoid discharging energy that will need to be replaced via grid charging.
+        # This is determined by solar_can_reach_target which uses solar-only simulation.
+        self._compute_preserve_soc(data, now_dt)
+
+    def _compute_preserve_soc(self, data: CoordinatorData, now_dt: datetime) -> None:
+        """Compute battery preservation SOC when charging is needed.
+
+        Issue #350: When solar cannot reach the target, we need to preserve
+        the battery charge instead of discharging freely. This is achieved
+        by setting a raised backup reserve that prevents discharge below
+        the current SOC (minus a small buffer).
+
+        Args:
+            data: CoordinatorData to update with preserve_soc
+            now_dt: Current datetime
+        """
+        # Reset preserve_soc by default
+        data.preserve_soc = None
+
+        # Only preserve when in SELF_CONSUMPTION mode (not actively charging/discharging)
+        if data.active_mode != BatteryMode.SELF_CONSUMPTION:
+            return
+
+        # Don't preserve during demand window (handled by DEMAND_BLOCK mode)
+        if data.demand_window_active:
+            return
+
+        # Check if charging is needed to meet the target
+        # solar_can_reach_target is True if solar alone can reach the target
+        charging_needed = not data.solar_can_reach_target
+
+        if charging_needed:
+            # Preserve current SOC (minus buffer) to avoid discharging
+            # energy that will need to be replaced via grid charging
+            preserve_level = max(
+                data.backup_reserve,  # Don't go below existing reserve
+                data.soc - PRESERVE_BUFFER_PERCENT,  # Current SOC minus buffer
+            )
+            data.preserve_soc = preserve_level
+
+            _LOGGER.info(
+                "BATTERY_PRESERVE: Charging needed for target, preserving SOC at %.1f%% "
+                "(current=%.1f%%, buffer=%.1f%%, solar_can_reach=%s)",
+                preserve_level,
+                data.soc,
+                PRESERVE_BUFFER_PERCENT,
+                data.solar_can_reach_target,
+            )
+        else:
+            # Solar can reach target - no preservation needed
+            _LOGGER.debug(
+                "BATTERY_PRESERVE: Solar can reach target, no preservation needed "
+                "(solar_can_reach=%s, SOC=%.1f%%)",
+                data.solar_can_reach_target,
+                data.soc,
+            )
 
     def add_to_decision_log(
         self,

--- a/custom_components/localshift/coordinator_data.py
+++ b/custom_components/localshift/coordinator_data.py
@@ -235,6 +235,9 @@ class CoordinatorData:
     boost_charge_needed: bool = False
     demand_window_active: bool = False
 
+    # Battery preservation (Issue #350)
+    preserve_soc: float | None = None  # SOC to preserve when charging needed
+
     # Extra attributes for binary sensors
     max_forecast_price: float = 0.0
     max_buy_forecast_price: float = 0.0  # Max buy price (general_forecast) for display


### PR DESCRIPTION
## Summary

When the system needs to charge the battery to meet an upcoming demand window target, it previously stayed in self_consumption mode with a 10% reserve. This caused the battery to discharge freely to meet household load, even when:
1. Solar production is insufficient to reach the target SOC
2. Grid charging slots are scheduled at cheap prices
3. The battery should be preserving its charge for the demand window

## Changes Made

- **coordinator_data.py**: Added `preserve_soc: float | None` field
- **mode_decision.py**: Added `_compute_preserve_soc()` method that sets preserve_soc when solar cannot reach target
- **battery_controller.py**: Modified `set_self_consumption()` to use preserve_soc as backup reserve

## Behavior

| Condition | Reserve | Behavior |
|-----------|---------|----------|
| Solar can reach target | 10% | Discharge freely, solar will refill |
| Solar cannot reach target | SOC - 5% | Preserve battery, grid supplies load, solar charges battery |
| In demand window | (handled separately) | Demand block mode |

## Testing

Deployed and verified via logs. System correctly transitions to GRID_CHARGING when price is cheap, and preserve_soc will be applied when in SELF_CONSUMPTION mode with charging needed.

Closes #350