### PR TITLE
fix: correct notification message for charging stopped

### DIFF
--- a/custom_components/localshift/notification_service.py
+++ b/custom_components/localshift/notification_service.py
@@ -228,14 +228,41 @@ class NotificationService:
             BatteryMode.GRID_CHARGING,
             BatteryMode.BOOST_CHARGING,
         ):
-            return (
-                f"{dry_run_prefix}{NOTIFICATION_PREFIX}Charging Stopped",
-                f"Grid price rose to ${data.general_price:.2f}/kWh "
-                f"(above stop threshold "
-                f"${data.cheap_charge_stop_price:.2f}/kWh). "
-                f"Battery at {data.soc:.0f}%. "
-                f"Returning to self consumption.",
-            )
+            # Determine the actual reason for stopping grid charging
+            # Issue #352: Don't assume price rose - check actual conditions
+            price_above_stop = data.general_price > data.cheap_charge_stop_price
+            price_above_effective = data.general_price > data.effective_cheap_price
+
+            if price_above_stop:
+                # Price genuinely rose above stop threshold
+                return (
+                    f"{dry_run_prefix}{NOTIFICATION_PREFIX}Charging Stopped",
+                    f"Grid price rose to ${data.general_price:.2f}/kWh "
+                    f"(above stop threshold "
+                    f"${data.cheap_charge_stop_price:.2f}/kWh). "
+                    f"Battery at {data.soc:.0f}%. "
+                    f"Returning to self consumption.",
+                )
+            elif price_above_effective:
+                # Price above effective threshold but not stop threshold
+                return (
+                    f"{dry_run_prefix}{NOTIFICATION_PREFIX}Charging Stopped",
+                    f"Grid price at ${data.general_price:.2f}/kWh "
+                    f"(above effective threshold "
+                    f"${data.effective_cheap_price:.2f}/kWh). "
+                    f"Battery at {data.soc:.0f}%. "
+                    f"Returning to self consumption.",
+                )
+            else:
+                # Price is still cheap - stopped for other reasons
+                # (forecast complete, SOC target reached, solar sufficient, etc.)
+                return (
+                    f"{dry_run_prefix}{NOTIFICATION_PREFIX}Charging Complete",
+                    f"Grid price at ${data.general_price:.2f}/kWh "
+                    f"(still below threshold ${data.effective_cheap_price:.2f}/kWh). "
+                    f"Battery at {data.soc:.0f}%. "
+                    f"Scheduled charging complete or solar sufficient.",
+                )
         if old_mode == BatteryMode.DEMAND_BLOCK:
             return (
                 f"{dry_run_prefix}{NOTIFICATION_PREFIX}Demand Window Ended",
@@ -442,10 +469,26 @@ class NotificationService:
                 BatteryMode.GRID_CHARGING,
                 BatteryMode.BOOST_CHARGING,
             ):
-                return (
-                    f"Charging ended -- price ${data.general_price:.2f}/kWh "
-                    f"(above ${data.cheap_charge_stop_price:.2f}/kWh)"
-                )
+                # Issue #352: Check actual price vs threshold for accurate reason
+                price_above_stop = data.general_price > data.cheap_charge_stop_price
+                price_above_effective = data.general_price > data.effective_cheap_price
+
+                if price_above_stop:
+                    return (
+                        f"Charging ended -- price ${data.general_price:.2f}/kWh "
+                        f"(above stop threshold ${data.cheap_charge_stop_price:.2f}/kWh)"
+                    )
+                elif price_above_effective:
+                    return (
+                        f"Charging ended -- price ${data.general_price:.2f}/kWh "
+                        f"(above effective threshold ${data.effective_cheap_price:.2f}/kWh)"
+                    )
+                else:
+                    # Price still cheap - stopped for other reasons
+                    return (
+                        f"Charging complete -- price ${data.general_price:.2f}/kWh "
+                        f"(still below threshold). SOC at {data.soc:.0f}%"
+                    )
             if old_mode == BatteryMode.SPIKE_DISCHARGE:
                 return "Price spike cleared"
             if old_mode == BatteryMode.PROACTIVE_EXPORT:


### PR DESCRIPTION
## Summary
Fixes nonsensical notification that claimed price was "above stop threshold" when it was actually below.

## Problem
The notification message for charging stopped always said:
> Grid price rose to $0.08/kWh (above stop threshold $0.12/kWh)

This is mathematically incorrect - $0.08 is below $0.12.

## Root Cause
The  method assumed the transition happened because "price rose above threshold", but transitions can happen for multiple reasons:
1. Price rose above threshold
2. SOC reached target
3. Forecast complete
4. Solar became sufficient
5. grid_import_kwh = 0 (forecast says no charging needed)

## Solution
Now checks actual price vs thresholds and reports correct reason:
- **Price above stop threshold** → "Charging Stopped" (price rose)
- **Price above effective threshold** → "Charging Stopped" (price rose)
- **Price still cheap** → "Charging Complete" (forecast/solar reasons)

## Changes Made
- : Updated  to check actual price conditions
- : Updated  for consistency

## Testing
- Deployed and verified integration loads successfully
- Lint checks pass

Fixes #352