### PR TITLE
fix: set automation_ready=True in test fixtures

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -157,6 +157,8 @@ def coordinator_data():
     # Issue #319: Mark forecast as ready for tests
     data.forecast_ready = True
     data.forecast_status = "ready"
+    # Issue #349: Mark automation as ready for tests
+    data.automation_ready = True
     return data
 
 

--- a/tests/test_state_machine.py
+++ b/tests/test_state_machine.py
@@ -133,6 +133,8 @@ def coordinator_data():
     data.decision_log = []
     data.daily_forecast = []
     data.daily_forecast_soc_15min = []
+    # Issue #349: Mark automation as ready for tests
+    data.automation_ready = True
     return data
 
 


### PR DESCRIPTION
## Summary
Fix failing tests on PR #357 caused by missing automation_ready attribute in test fixtures.

## Root Cause
Issue #349 added automation_ready checks to state_machine, but test fixtures were not updated to set automation_ready=True. This caused tests to fail with 'automation not ready - missing: unknown' errors.

## Changes Made
- Added automation_ready=True to tests/conftest.py coordinator_data fixture
- Added automation_ready=True to tests/test_state_machine.py coordinator_data fixture

## Testing
All 43 tests in test_state_machine.py now pass:
```
======================== 43 passed, 1 warning in 0.17s =========================
```

Closes #357