### PR TITLE
fix: include tomorrow's solar forecast for demand window calculations

### DIFF
--- a/custom_components/localshift/computation_engine.py
+++ b/custom_components/localshift/computation_engine.py
@@ -451,8 +451,10 @@ class ComputationEngine:
                 )
 
                 # Solar forecast: pessimistic estimate between now and DW
+                # Include tomorrow's forecast when target is tomorrow morning
+                all_solcast = [*data.solcast_today, *data.solcast_tomorrow]
                 solar_kwh = self._sum_solar_before_target(
-                    data.solcast_today, now_dt, target_hour
+                    all_solcast, now_dt, target_hour
                 )
 
                 # Hours remaining until DW start
@@ -499,8 +501,10 @@ class ComputationEngine:
                 )
 
                 # Solar forecast: pessimistic estimate between now and DW
+                # Include tomorrow's forecast when target is tomorrow morning
+                all_solcast = [*data.solcast_today, *data.solcast_tomorrow]
                 solar_kwh = self._sum_solar_before_target(
-                    data.solcast_today, now_dt, target_hour
+                    all_solcast, now_dt, target_hour
                 )
 
                 # Consumption estimate: current load extrapolated

--- a/custom_components/localshift/computation_engine_lib/price_calculator.py
+++ b/custom_components/localshift/computation_engine_lib/price_calculator.py
@@ -378,9 +378,9 @@ class PriceCalculator:
         )
 
         try:
-            solar_kwh = self._sum_solar_before_target(
-                data.solcast_today, now_dt, target_hour
-            )
+            # Include tomorrow's forecast when target is tomorrow morning
+            all_solcast = [*data.solcast_today, *data.solcast_tomorrow]
+            solar_kwh = self._sum_solar_before_target(all_solcast, now_dt, target_hour)
         except (AttributeError, TypeError):
             solar_kwh = 0.0
 
@@ -487,7 +487,10 @@ class PriceCalculator:
         weighted_sum = 0.0
         total_solar = 0.0
 
-        for period in data.solcast_today:
+        # Include tomorrow's forecast when target is tomorrow morning
+        all_solcast = [*data.solcast_today, *data.solcast_tomorrow]
+
+        for period in all_solcast:
             period_start = self._parse_forecast_dt(period.get("period_start"))
             if period_start is None:
                 continue


### PR DESCRIPTION
## Summary
Fixes a bug where solar forecast calculations for demand windows only used today's solcast data, missing overnight/early morning solar when the demand window is tomorrow morning.

## Changes Made
- **computation_engine.py**: Use combined `solcast_today + solcast_tomorrow` when calculating solar before demand window
- **price_calculator.py**: Use combined forecasts in `_sum_solar_before_target` and weighted solar calculations

## Problem
When calculating solar generation expected before a demand window, the system only used `data.solcast_today`. This caused incorrect predictions when the target time is tomorrow morning (e.g., a 6 AM demand window) because overnight and early morning solar from tomorrow's forecast was not included.

## Solution
Combine both today and tomorrow's solcast forecasts before calculating solar generation:
```python
all_solcast = [*data.solcast_today, *data.solcast_tomorrow]
```

## Testing
- Unit tests pass (76 tests in computation_engine and forecast_computer)
- Deployed to HA and verified no errors in logs
- Lint checks pass

## Origin
These were orphaned changes found on main from a previous crashed session.