### PR TITLE
fix: prevent grid charge overshoot by calculating solar contribution first

### DIFF
--- a/custom_components/localshift/computation_engine_lib/forecast_computer.py
+++ b/custom_components/localshift/computation_engine_lib/forecast_computer.py
@@ -2372,22 +2372,44 @@ class ForecastComputer:
                 predicted_soc + (net_kwh / BATTERY_CAPACITY_KWH * 100)
             ) >= 100.0
 
-            # Step 1: Calculate base battery delta from solar/load
+            # Step 1: Calculate solar contribution FIRST (Issue #370)
+            # Solar contribution must be calculated before grid charge decision
             if net_kwh >= 0:
-                battery_delta_kwh = min(net_kwh, max_solar_charge_kwh) * 0.92
+                solar_battery_delta_kwh = min(net_kwh, max_solar_charge_kwh) * 0.92
             else:
-                battery_delta_kwh = max(net_kwh, -max_solar_charge_kwh) / 0.95
+                solar_battery_delta_kwh = max(net_kwh, -max_solar_charge_kwh) / 0.95
 
-            # Step 2: Add grid charging if scheduled
+            # Step 2: Add grid charging if scheduled (Issue #370 fix)
+            # Grid charge amount accounts for concurrent solar to prevent overshoot
             if should_grid_charge:
-                current_battery_kwh = predicted_soc / 100 * BATTERY_CAPACITY_KWH
-                space_remaining_kwh = max(target_kwh - current_battery_kwh, 0)
-                grid_charge_amount = min(
-                    max_grid_charge_kwh * 0.92, space_remaining_kwh
+                # Project SOC after solar contribution during this slot
+                projected_soc_after_solar = predicted_soc + (
+                    solar_battery_delta_kwh / BATTERY_CAPACITY_KWH * 100
                 )
-                battery_delta_kwh += grid_charge_amount
-                grid_import_kwh = grid_charge_amount / 0.92
+                projected_battery_kwh = projected_soc_after_solar / 100 * BATTERY_CAPACITY_KWH
+
+                # Grid only fills remaining space AFTER solar
+                space_remaining_kwh = max(target_kwh - projected_battery_kwh, 0)
+
+                if space_remaining_kwh > 0:
+                    grid_charge_amount = min(
+                        max_grid_charge_kwh * 0.92, space_remaining_kwh
+                    )
+                    battery_delta_kwh = solar_battery_delta_kwh + grid_charge_amount
+                    grid_import_kwh = grid_charge_amount / 0.92
+                else:
+                    # Solar alone reaches target - skip grid charge (Issue #370)
+                    _LOGGER.info(
+                        "Skip grid charge at %s: solar will reach target (SOC %.1f%% -> %.1f%%)",
+                        slot_start.strftime("%H:%M"),
+                        predicted_soc,
+                        projected_soc_after_solar,
+                    )
+                    should_grid_charge = False
+                    battery_delta_kwh = solar_battery_delta_kwh
+                    grid_import_kwh = 0.0
             else:
+                battery_delta_kwh = solar_battery_delta_kwh
                 grid_import_kwh = 0.0
 
             # Step 3: Check for proactive export


### PR DESCRIPTION
## Summary

Fixes Issue #370 - Grid charging was overshooting target SOC, causing battery to fill past 100% and require exports.

## Problem

The forecast scheduled grid charging to reach 100% SOC, but during Pass 3 execution:
- Both solar AND grid were contributing to charging in the same slot
- Grid charge amount was calculated based on SOC at slot START
- Concurrent solar contribution was ignored
- Result: overshoot past target, leading to exports (bad outcome)

## Fix

Calculate solar contribution FIRST, then determine grid charge amount based on remaining space AFTER solar. If solar alone reaches target, skip grid charge entirely for that slot.

## Logs Evidence

```
Skip grid charge at 11:30: solar will reach target (SOC 89.5% -> 91.7%)
Skip grid charge at 12:00: solar will reach target (SOC 91.7% -> 94.8%)
Skip grid charge at 12:30: solar will reach target (SOC 94.8% -> 98.7%)
Skip grid charge at 13:00: solar will reach target (SOC 98.7% -> 104.2%)
```

## Testing

- Deployed and verified logs show fix working
- Pre-existing test failure (unrelated - missing Solcast data in test setup)

Closes #370