### PR TITLE
Fix #372: Add fail-fast check for uv run requirement

### DIFF
--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -640,6 +640,48 @@ def _get_expected_state_for_mode(self, mode):
 
 ## Testing
 
+### Running Tests
+
+Tests must be run using `uv run pytest` because the `homeassistant` package is only installed in the uv virtual environment:
+
+```bash
+# Run all tests
+uv run pytest
+
+# Run specific test file
+uv run pytest tests/test_computation_engine.py
+
+# Run with verbose output
+uv run pytest -v
+
+# Run specific test
+uv run pytest tests/test_computation_engine.py::test_compute_derived_values
+```
+
+**Common Mistakes:**
+
+```bash
+# ❌ WRONG - Uses system Python, homeassistant not available
+pytest
+
+# ❌ WRONG - Same issue
+python -m pytest
+
+# ✅ CORRECT - Uses uv virtual environment with homeassistant
+uv run pytest
+```
+
+If you run tests without `uv run`, you'll see a helpful error message:
+
+```
+ERROR: Tests must be run with 'uv run pytest', not 'pytest' directly.
+
+  Correct:   uv run pytest
+  Incorrect: pytest or python -m pytest
+
+The homeassistant package is only installed in the uv virtual environment.
+```
+
 ### Manual Testing
 
 1. **Dry Run Mode**: Enable `switch.localshift_dry_run` to test without affecting the battery.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,33 @@ For tests that need realistic HA behavior, use:
 - realistic_entity_states: Default entity states for LocalShift
 """
 
+# =============================================================================
+# ENVIRONMENT VALIDATION (Issue #372)
+# =============================================================================
+# Tests must be run with 'uv run pytest' because homeassistant is only
+# installed in the uv virtual environment. This check provides a helpful
+# error message instead of a confusing import error.
+
+import sys
+
+try:
+    import homeassistant  # noqa: F401
+except ImportError:
+    print(
+        "\n"
+        "ERROR: Tests must be run with 'uv run pytest', not 'pytest' directly.\n"
+        "\n"
+        "  Correct:   uv run pytest\n"
+        "  Incorrect: pytest or python -m pytest\n"
+        "\n"
+        "The homeassistant package is only installed in the uv virtual environment.\n"
+    )
+    sys.exit(1)
+
+# =============================================================================
+# IMPORTS
+# =============================================================================
+
 # Import asyncio for sleep mocking
 from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, patch


### PR DESCRIPTION
## Summary

Tests must be run with `uv run pytest` because the `homeassistant` package is only installed in the uv virtual environment. Running tests with bare `python` or `pytest` fails with confusing import errors.

## Changes Made

- **tests/conftest.py**: Add environment validation at top of file that checks if homeassistant is importable. If not, displays a helpful error message explaining the correct command.
- **docs/DEVELOPER_GUIDE.md**: Add "Running Tests" section documenting the `uv run pytest` requirement with examples.

## Testing

Verified the fix works:
- `python -c "import tests.conftest"` → Shows helpful error message and exits
- `uv run pytest` → Works correctly, collects 554 tests

Closes #372