### PR TITLE
Use expected solar forecast instead of pessimistic

### DIFF
--- a/custom_components/localshift/computation_engine_lib/price_calculator.py
+++ b/custom_components/localshift/computation_engine_lib/price_calculator.py
@@ -496,7 +496,7 @@ class PriceCalculator:
                 continue
             period_start_local = dt_util.as_local(period_start)
             if period_start_local >= now_dt and period_start_local.hour <= target_hour:
-                solar_kwh_val = float(period.get("pv_estimate10", 0))
+                solar_kwh_val = float(period.get("pv_estimate", 0))
                 if solar_kwh_val <= 0:
                     continue
 

--- a/custom_components/localshift/computation_engine_lib/solar_utils.py
+++ b/custom_components/localshift/computation_engine_lib/solar_utils.py
@@ -453,9 +453,9 @@ def sum_solar_before_target(
     now_dt: datetime,
     target_hour: int,
 ) -> float:
-    """Sum pessimistic solar kWh (pv_estimate10) from now until target_hour.
+    """Sum expected solar kWh (pv_estimate) from now until target_hour.
 
-    NOTE: pv_estimate10 values represent average power (kWh per hour),
+    NOTE: pv_estimate values represent average power (kWh per hour),
     NOT energy per period. We need to multiply by the time fraction.
     """
     target_dt = now_dt.replace(hour=target_hour, minute=0, second=0, microsecond=0)
@@ -467,8 +467,8 @@ def sum_solar_before_target(
             continue
         ps_local = dt_util.as_local(period_start)
         period_end = ps_local + period_duration
-        # pv_estimate10 is kWh per HOUR (average power)
-        kwh_per_hour = float(period.get("pv_estimate10", 0))
+        # pv_estimate is kWh per HOUR (average power)
+        kwh_per_hour = float(period.get("pv_estimate", 0))
 
         if ps_local >= target_dt:
             # Period starts at or after target — skip


### PR DESCRIPTION
## Summary

Changed from `pv_estimate10` (10th percentile pessimistic) to `pv_estimate` (50th percentile expected) for solar forecasting.

## Changes Made

- `solar_utils.py`: `sum_solar_before_target()` now uses `pv_estimate`
- `price_calculator.py`: `compute_solar_weighted_avg_fit()` now uses `pv_estimate`
- Updated docstrings from 'pessimistic' to 'expected'

## Why This Matters

| Field | Percentile | Meaning |
|-------|------------|---------|
| `pv_estimate` | 50th | Expected - 50% chance actual exceeds this |
| `pv_estimate10` | 10th | Pessimistic - 90% chance actual exceeds this |

**Before**: System planned for worst-case solar, leading to over-charging "just in case"
**After**: System plans for expected solar, more accurate on average

## Testing

- Deployed and verified via logs - no errors
- Lint checks passed

Related to #378 (full learning system for forecast bias)