### PR TITLE
feat: Replace manual control buttons with select entity for battery mode

### DIFF
--- a/custom_components/localshift/button.py
+++ b/custom_components/localshift/button.py
@@ -1,11 +1,11 @@
 """Button platform for the LocalShift integration.
 
-Provides manual mode control buttons:
-- Force Charge
-- Force Discharge
-- Boost Charge (5kW)
-- Return to Self Consumption
+Provides utility buttons:
 - Update Forecast
+- Reset Learning Data
+- Learn HVAC Power
+
+Issue #382: Mode control buttons removed - replaced by select entity.
 """
 
 from __future__ import annotations
@@ -19,17 +19,12 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import (
-    BUTTON_BOOST_CHARGE,
-    BUTTON_FORCE_CHARGE,
-    BUTTON_FORCE_DISCHARGE,
     BUTTON_ICONS,
     BUTTON_LEARN_HVAC_POWER,
     BUTTON_NAMES,
     BUTTON_RESET_LEARNING,
-    BUTTON_SELF_CONSUMPTION,
     BUTTON_UPDATE_FORECAST,
     DOMAIN,
-    BatteryMode,
 )
 from .coordinator import LocalShiftCoordinator
 
@@ -45,10 +40,6 @@ async def async_setup_entry(
     coordinator: LocalShiftCoordinator = entry.runtime_data
 
     entities = [
-        ForceChargeButton(coordinator, entry),
-        ForceDischargeButton(coordinator, entry),
-        BoostChargeButton(coordinator, entry),
-        SelfConsumptionButton(coordinator, entry),
         UpdateForecastButton(coordinator, entry),
         ResetLearningDataButton(coordinator, entry),
         LearnHVACPowerButton(coordinator, entry),
@@ -62,7 +53,7 @@ async def async_setup_entry(
 
 
 class LocalShiftButtonBase(ButtonEntity):
-    """Base class for manual mode buttons."""
+    """Base class for utility buttons."""
 
     _attr_has_entity_name = True
 
@@ -89,105 +80,6 @@ class LocalShiftButtonBase(ButtonEntity):
             model="Solar Battery Automation",
             sw_version="0.0.2",
         )
-
-
-class ForceChargeButton(LocalShiftButtonBase):
-    """Manually force charge the battery."""
-
-    def __init__(self, coordinator, entry):
-        super().__init__(coordinator, entry, BUTTON_FORCE_CHARGE)
-
-    async def async_press(self) -> None:
-        """Handle button press."""
-        self.coordinator.data.manual_override = True
-        if self.coordinator._state_machine is not None:
-            self.coordinator._state_machine.set_manual_override_timestamp()
-            # Update commanded mode to prevent health check "correction"
-            self.coordinator._state_machine.set_commanded_mode(
-                BatteryMode.GRID_CHARGING
-            )
-        await self.coordinator.async_set_force_charge()
-        if self.coordinator._notification_service is not None:
-            await (
-                self.coordinator._notification_service.send_manual_action_notification(
-                    "Manual Force Charge", self.coordinator.data
-                )
-            )
-
-
-class ForceDischargeButton(LocalShiftButtonBase):
-    """Manually force discharge the battery."""
-
-    def __init__(self, coordinator, entry):
-        super().__init__(coordinator, entry, BUTTON_FORCE_DISCHARGE)
-
-    async def async_press(self) -> None:
-        """Handle button press."""
-        self.coordinator.data.manual_override = True
-        if self.coordinator._state_machine is not None:
-            self.coordinator._state_machine.set_manual_override_timestamp()
-            # Update commanded mode to prevent health check "correction"
-            self.coordinator._state_machine.set_commanded_mode(
-                BatteryMode.SPIKE_DISCHARGE
-            )
-        await self.coordinator.async_set_force_discharge()
-        if self.coordinator._notification_service is not None:
-            await (
-                self.coordinator._notification_service.send_manual_action_notification(
-                    "Manual Force Discharge", self.coordinator.data
-                )
-            )
-
-
-class BoostChargeButton(LocalShiftButtonBase):
-    """Manually boost charge the battery at 5kW."""
-
-    def __init__(self, coordinator, entry):
-        super().__init__(coordinator, entry, BUTTON_BOOST_CHARGE)
-
-    async def async_press(self) -> None:
-        """Handle button press."""
-        self.coordinator.data.manual_override = True
-        if self.coordinator._state_machine is not None:
-            self.coordinator._state_machine.set_manual_override_timestamp()
-            # Update commanded mode to prevent health check "correction"
-            self.coordinator._state_machine.set_commanded_mode(
-                BatteryMode.BOOST_CHARGING
-            )
-        await self.coordinator.async_set_boost_charge()
-        if self.coordinator._notification_service is not None:
-            await (
-                self.coordinator._notification_service.send_manual_action_notification(
-                    "Manual Boost Charge", self.coordinator.data
-                )
-            )
-
-
-class SelfConsumptionButton(LocalShiftButtonBase):
-    """Return to normal self consumption mode."""
-
-    def __init__(self, coordinator, entry):
-        super().__init__(coordinator, entry, BUTTON_SELF_CONSUMPTION)
-
-    async def async_press(self) -> None:
-        """Handle button press."""
-        # Set manual override to prevent state machine from immediately overriding
-        # the user's choice. After manual_override_timeout hours, it will return
-        # to automated control. This matches the behavior of other manual buttons.
-        self.coordinator.data.manual_override = True
-        if self.coordinator._state_machine is not None:
-            self.coordinator._state_machine.set_manual_override_timestamp()
-            # Update commanded mode to prevent health check "correction"
-            self.coordinator._state_machine.set_commanded_mode(
-                BatteryMode.SELF_CONSUMPTION
-            )
-        await self.coordinator.async_set_self_consumption()
-        if self.coordinator._notification_service is not None:
-            await (
-                self.coordinator._notification_service.send_manual_action_notification(
-                    "Manual Self Consumption", self.coordinator.data
-                )
-            )
 
 
 class UpdateForecastButton(LocalShiftButtonBase):

--- a/custom_components/localshift/const.py
+++ b/custom_components/localshift/const.py
@@ -492,32 +492,44 @@ SWITCH_NAMES = {
 }
 
 # -----------------------------------------------------------------------------
-# Button Keys (manual mode controls)
+# Select Keys (battery mode selection)
 # -----------------------------------------------------------------------------
 
-BUTTON_FORCE_CHARGE = "force_charge"
-BUTTON_FORCE_DISCHARGE = "force_discharge"
-BUTTON_BOOST_CHARGE = "boost_charge"
-BUTTON_SELF_CONSUMPTION = "self_consumption"
+SELECT_BATTERY_MODE = "battery_mode"
+
+SELECT_OPTIONS = {
+    SELECT_BATTERY_MODE: [
+        "self_consumption",
+        "grid_charging",
+        "boost_charging",
+        "spike_discharge",
+        "proactive_export",
+    ],
+}
+
+SELECT_ICONS = {
+    SELECT_BATTERY_MODE: "mdi:battery-sync",
+}
+
+SELECT_NAMES = {
+    SELECT_BATTERY_MODE: "Battery Mode",
+}
+
+# -----------------------------------------------------------------------------
+# Button Keys (utility controls - mode control moved to select entity)
+# -----------------------------------------------------------------------------
+
 BUTTON_UPDATE_FORECAST = "update_forecast"
 BUTTON_RESET_LEARNING = "reset_learning"
 BUTTON_LEARN_HVAC_POWER = "learn_hvac_power"
 
 BUTTON_ICONS = {
-    BUTTON_FORCE_CHARGE: "mdi:battery-charging",
-    BUTTON_FORCE_DISCHARGE: "mdi:battery-arrow-down",
-    BUTTON_BOOST_CHARGE: "mdi:battery-charging-high",
-    BUTTON_SELF_CONSUMPTION: "mdi:battery-sync",
     BUTTON_UPDATE_FORECAST: "mdi:refresh",
     BUTTON_RESET_LEARNING: "mdi:brain-off",
     BUTTON_LEARN_HVAC_POWER: "mdi:air-conditioner",
 }
 
 BUTTON_NAMES = {
-    BUTTON_FORCE_CHARGE: "Force Charge",
-    BUTTON_FORCE_DISCHARGE: "Force Discharge",
-    BUTTON_BOOST_CHARGE: "Boost Charge",
-    BUTTON_SELF_CONSUMPTION: "Self Consumption",
     BUTTON_UPDATE_FORECAST: "Update Forecast",
     BUTTON_RESET_LEARNING: "Reset Learning Data",
     BUTTON_LEARN_HVAC_POWER: "Learn HVAC Power",
@@ -635,4 +647,4 @@ EXTENDED_HISTORY_MAX_DAYS = 365  # Maximum days (1 year)
 # Platforms
 # -----------------------------------------------------------------------------
 
-PLATFORMS = ["sensor", "binary_sensor", "number", "switch", "button"]
+PLATFORMS = ["sensor", "binary_sensor", "number", "switch", "button", "select"]

--- a/custom_components/localshift/coordinator.py
+++ b/custom_components/localshift/coordinator.py
@@ -42,6 +42,7 @@ from .const import (
     DEFAULT_DEMAND_WINDOW_END,
     DEFAULT_THERMAL_MODE_DECISION_TIME,
     SWITCH_DEFAULTS,
+    BatteryMode,
 )
 from .coordinator_data import CoordinatorData
 
@@ -1185,37 +1186,70 @@ class LocalShiftCoordinator:
             )
 
     # ------------------------------------------------------------------
-    # Button handlers (delegated to battery_controller)
+    # Battery mode control (for select entity - Issue #382)
     # ------------------------------------------------------------------
 
+    async def async_set_battery_mode(self, mode: BatteryMode) -> bool:
+        """Set battery to a specific mode.
+
+        Used by the select entity for manual mode control.
+        Returns True if successful, False otherwise.
+
+        Args:
+            mode: The BatteryMode to set.
+
+        Returns:
+            True if the mode was set successfully, False otherwise.
+        """
+        if self._battery_controller is None:
+            _LOGGER.error("Battery controller not available")
+            return False
+
+        dry_run = self.get_switch_state("dry_run")
+        success = False
+
+        if mode == BatteryMode.SELF_CONSUMPTION:
+            success = await self._battery_controller.set_self_consumption(self.data, dry_run)
+        elif mode == BatteryMode.GRID_CHARGING:
+            battery_target = float(
+                self.get_option(CONF_BATTERY_TARGET, DEFAULT_BATTERY_TARGET)
+            )
+            success = await self._battery_controller.set_force_charge(
+                self.data, dry_run, target_soc=battery_target
+            )
+        elif mode == BatteryMode.BOOST_CHARGING:
+            success = await self._battery_controller.set_boost_charge(self.data, dry_run)
+        elif mode == BatteryMode.SPIKE_DISCHARGE:
+            # Check if conservative mode is enabled and use spike_reserve_soc if available
+            reserve_soc = (
+                self.data.spike_reserve_soc if self.data.spike_in_conservative_mode else None
+            )
+            success = await self._battery_controller.set_force_discharge(
+                self.data, dry_run, reserve_soc=reserve_soc
+            )
+        elif mode == BatteryMode.PROACTIVE_EXPORT:
+            success = await self._battery_controller.set_proactive_export(self.data, dry_run)
+        else:
+            _LOGGER.warning("Unsupported battery mode: %s", mode)
+            return False
+
+        if success:
+            _LOGGER.info("Battery mode set to %s (dry_run=%s)", mode.value, dry_run)
+            # Update commanded mode in state machine
+            if self._state_machine is not None:
+                self._state_machine.set_commanded_mode(mode)
+        else:
+            _LOGGER.error("Failed to set battery mode to %s", mode.value)
+
+        return success
+
     async def async_set_self_consumption(self) -> None:
-        """Set battery to self consumption mode."""
+        """Set battery to self consumption mode.
+
+        Used by automation switch when automation is disabled.
+        """
         if self._battery_controller is not None:
             await self._battery_controller.set_self_consumption(self.data, False)
-
-    async def async_set_force_charge(self) -> None:
-        """Set battery to force charge mode."""
-        if self._battery_controller is not None:
-            await self._battery_controller.set_force_charge(self.data, False)
-
-    async def async_set_boost_charge(self) -> None:
-        """Set battery to boost charge mode."""
-        if self._battery_controller is not None:
-            await self._battery_controller.set_boost_charge(self.data, False)
-
-    async def async_set_force_discharge(self) -> None:
-        """Set battery to force discharge mode."""
-        if self._battery_controller is not None:
-            await self._battery_controller.set_force_discharge(self.data, False)
-
-    async def async_set_manual_override(self) -> None:
-        """Set manual override mode."""
-        self.data.manual_override = True
-        if self._state_machine is not None:
-            self._state_machine.set_manual_override_timestamp()
-        if self._battery_controller is not None:
-            # Don't issue any commands in manual override
-            _LOGGER.info("Manual override activated - user controls battery")
 
     # ------------------------------------------------------------------
     # Helper methods

--- a/custom_components/localshift/dashboard.yaml
+++ b/custom_components/localshift/dashboard.yaml
@@ -115,7 +115,7 @@ views:
             heading_style: title
 
           - type: tile
-            entity: sensor.localshift_battery_mode
+            entity: select.localshift_battery_mode
             name: Mode
 
           - type: gauge
@@ -326,44 +326,18 @@ views:
             heading: Quick Actions
             heading_style: title
 
-          - type: button
-            name: Self Consumption
-            icon: mdi:battery-sync
-            tap_action:
-              action: call-service
-              service: button.press
-              target:
-                entity_id: button.localshift_self_consumption
-            icon_height: 40px
+          - type: tile
+            entity: select.localshift_battery_mode
+            name: Battery Mode
 
           - type: button
-            name: Force Charge
-            icon: mdi:battery-charging
+            name: Update Forecast
+            icon: mdi:refresh
             tap_action:
               action: call-service
               service: button.press
               target:
-                entity_id: button.localshift_force_charge
-            icon_height: 40px
-
-          - type: button
-            name: Boost Charge
-            icon: mdi:battery-charging-high
-            tap_action:
-              action: call-service
-              service: button.press
-              target:
-                entity_id: button.localshift_boost_charge
-            icon_height: 40px
-
-          - type: button
-            name: Force Discharge
-            icon: mdi:flash-alert
-            tap_action:
-              action: call-service
-              service: button.press
-              target:
-                entity_id: button.localshift_force_discharge
+                entity_id: button.localshift_update_forecast
             icon_height: 40px
 
       # Thermal Status
@@ -530,45 +504,9 @@ views:
             heading: Manual Actions
             heading_style: title
 
-          - type: button
-            name: Self Consumption
-            icon: mdi:battery-sync
-            tap_action:
-              action: call-service
-              service: button.press
-              target:
-                entity_id: button.localshift_self_consumption
-            icon_height: 40px
-
-          - type: button
-            name: Force Charge
-            icon: mdi:battery-charging
-            tap_action:
-              action: call-service
-              service: button.press
-              target:
-                entity_id: button.localshift_force_charge
-            icon_height: 40px
-
-          - type: button
-            name: Boost Charge
-            icon: mdi:battery-charging-high
-            tap_action:
-              action: call-service
-              service: button.press
-              target:
-                entity_id: button.localshift_boost_charge
-            icon_height: 40px
-
-          - type: button
-            name: Force Discharge
-            icon: mdi:flash-alert
-            tap_action:
-              action: call-service
-              service: button.press
-              target:
-                entity_id: button.localshift_force_discharge
-            icon_height: 40px
+          - type: tile
+            entity: select.localshift_battery_mode
+            name: Battery Mode
 
           - type: button
             name: Update Forecast
@@ -578,6 +516,26 @@ views:
               service: button.press
               target:
                 entity_id: button.localshift_update_forecast
+            icon_height: 40px
+
+          - type: button
+            name: Reset Learning
+            icon: mdi:brain
+            tap_action:
+              action: call-service
+              service: button.press
+              target:
+                entity_id: button.localshift_reset_learning
+            icon_height: 40px
+
+          - type: button
+            name: Learn HVAC Power
+            icon: mdi:air-conditioner
+            tap_action:
+              action: call-service
+              service: button.press
+              target:
+                entity_id: button.localshift_learn_hvac_power
             icon_height: 40px
 
       # Live System (Tesla Controls)

--- a/custom_components/localshift/select.py
+++ b/custom_components/localshift/select.py
@@ -1,0 +1,202 @@
+"""Select platform for the LocalShift integration.
+
+Provides a select entity for battery mode control:
+- When automation is enabled: select shows current automated mode
+- When user changes select: automation automatically disables, user's choice is honored
+- When user re-enables automation: system takes control of select immediately
+
+Issue #382: Replaces manual control buttons with a single select entity.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from homeassistant.components.select import SelectEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import (
+    DOMAIN,
+    SELECT_BATTERY_MODE,
+    SELECT_ICONS,
+    SELECT_NAMES,
+    SELECT_OPTIONS,
+    SWITCH_AUTOMATION_ENABLED,
+    BatteryMode,
+)
+from .coordinator import LocalShiftCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up LocalShift select entities."""
+    coordinator: LocalShiftCoordinator = entry.runtime_data
+
+    entities = [BatteryModeSelect(coordinator, entry)]
+
+    _LOGGER.info("Setting up %d LocalShift select entities", len(entities))
+    async_add_entities(entities)
+
+
+class BatteryModeSelect(SelectEntity):
+    """Select entity for battery mode control.
+
+    When the user changes this select:
+    1. Automation is automatically disabled
+    2. The selected mode is applied to the battery
+    3. The mode persists until automation is re-enabled
+
+    When automation is re-enabled:
+    1. The select updates to show the automated mode
+    2. State machine takes control of battery mode
+    """
+
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: LocalShiftCoordinator,
+        entry: ConfigEntry,
+    ) -> None:
+        """Initialize the select entity."""
+        self.coordinator = coordinator
+        self._entry = entry
+        self._attr_unique_id = f"localshift_{SELECT_BATTERY_MODE}"
+        self._attr_name = SELECT_NAMES[SELECT_BATTERY_MODE]
+        self._attr_icon = SELECT_ICONS[SELECT_BATTERY_MODE]
+        self._attr_options = SELECT_OPTIONS[SELECT_BATTERY_MODE]
+        self._previous_mode: str = "self_consumption"
+        self._internal_update: bool = False
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device information to link all entities under one device."""
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._entry.entry_id)},
+            name="LocalShift",
+            manufacturer="Custom",
+            model="Solar Battery Automation",
+            sw_version="0.0.2",
+        )
+
+    @property
+    def current_option(self) -> str | None:
+        """Return the current selected option."""
+        # Map BatteryMode to select option
+        mode = self.coordinator.data.active_mode
+        if mode == BatteryMode.MANUAL:
+            # During manual mode, show the previous commanded mode
+            return self._previous_mode
+        elif mode == BatteryMode.DEMAND_BLOCK:
+            # Demand block is a variant of self consumption
+            return "self_consumption"
+        elif mode in (
+            BatteryMode.SELF_CONSUMPTION,
+            BatteryMode.GRID_CHARGING,
+            BatteryMode.BOOST_CHARGING,
+            BatteryMode.SPIKE_DISCHARGE,
+            BatteryMode.PROACTIVE_EXPORT,
+        ):
+            return mode.value
+        return "self_consumption"
+
+    async def async_select_option(self, option: str) -> None:
+        """Handle selection of a new option.
+
+        This is called when the user changes the select.
+        It disables automation and applies the selected mode.
+        """
+        _LOGGER.info("Battery mode select changed to: %s", option)
+
+        # Store the previous mode in case we need to revert
+        old_mode = self.current_option
+        self._previous_mode = option
+
+        # Disable automation when user manually selects a mode
+        if self.coordinator.get_switch_state(SWITCH_AUTOMATION_ENABLED):
+            _LOGGER.info("Disabling automation due to manual mode selection")
+            # Update the switch state directly (without triggering turn_off callback)
+            self.coordinator.set_switch_state(SWITCH_AUTOMATION_ENABLED, False)
+            # Persist the switch state
+            option_key = f"switch_state_{SWITCH_AUTOMATION_ENABLED}"
+            new_options = {**self._entry.options, option_key: False}
+            self.hass.config_entries.async_update_entry(self._entry, options=new_options)
+
+        # Convert option string to BatteryMode
+        try:
+            target_mode = BatteryMode(option)
+        except ValueError:
+            _LOGGER.error("Invalid battery mode selected: %s", option)
+            return
+
+        # Apply the mode via coordinator
+        success = await self.coordinator.async_set_battery_mode(target_mode)
+
+        if not success:
+            _LOGGER.warning(
+                "Failed to apply battery mode %s, reverting select to %s",
+                option,
+                old_mode,
+            )
+            # Revert to previous mode on failure
+            self._previous_mode = old_mode or "self_consumption"
+            self._internal_update = True
+            self.async_write_ha_state()
+            self._internal_update = False
+            return
+
+        # Send notification about manual mode change
+        if self.coordinator._notification_service is not None:
+            await self.coordinator._notification_service.send_manual_action_notification(
+                f"Manual {target_mode.display_name}", self.coordinator.data
+            )
+
+        # Update the entity state
+        self.async_write_ha_state()
+
+    async def async_added_to_hass(self) -> None:
+        """Subscribe to coordinator updates."""
+        self.async_on_remove(
+            self.coordinator.async_add_listener(self._handle_coordinator_update)
+        )
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from coordinator."""
+        # Skip if this is an internal update (we already wrote state)
+        if self._internal_update:
+            return
+
+        # Update the previous mode tracking when automation is active
+        if self.coordinator.get_switch_state(SWITCH_AUTOMATION_ENABLED):
+            mode = self.coordinator.data.active_mode
+            if mode != BatteryMode.MANUAL and mode != BatteryMode.DEMAND_BLOCK:
+                self._previous_mode = mode.value
+
+        self.async_write_ha_state()
+
+    def set_mode_from_automation(self, mode: BatteryMode) -> None:
+        """Update the select to show the automated mode.
+
+        Called by the state machine when automation changes the mode.
+        This is an internal update that should not trigger async_select_option.
+        """
+        if mode in (
+            BatteryMode.SELF_CONSUMPTION,
+            BatteryMode.GRID_CHARGING,
+            BatteryMode.BOOST_CHARGING,
+            BatteryMode.SPIKE_DISCHARGE,
+            BatteryMode.PROACTIVE_EXPORT,
+        ):
+            self._previous_mode = mode.value
+            self._internal_update = True
+            self.async_write_ha_state()
+            self._internal_update = False

--- a/custom_components/localshift/sensor.py
+++ b/custom_components/localshift/sensor.py
@@ -29,7 +29,7 @@ async def async_setup_entry(
         EffectiveCheapPriceSensor(coordinator, entry),
         CheapChargeStopPriceSensor(coordinator, entry),
         SolarWeightedAvgFITSensor(coordinator, entry),
-        ActiveModeSensor(coordinator, entry),
+        # ActiveModeSensor removed - replaced by select entity (Issue #382)
         SolarBatteryForecastSensor(coordinator, entry),
         NetElectricityCostSensor(coordinator, entry),
         DecisionLogSensor(coordinator, entry),
@@ -176,17 +176,6 @@ class SolarWeightedAvgFITSensor(LocalShiftSensorBase):
                 self.coordinator.data.solar_remaining_kwh, 2
             ),
         }
-
-
-class ActiveModeSensor(LocalShiftSensorBase):
-    """Current battery automation mode."""
-
-    _attr_unique_id = "localshift_battery_mode"
-    _attr_name = "Battery Mode"
-    _attr_icon = "mdi:battery-sync"
-
-    def _update_from_coordinator(self) -> None:
-        self._attr_native_value = self.coordinator.data.active_mode.value
 
 
 class SolarBatteryForecastSensor(LocalShiftSensorBase):


### PR DESCRIPTION
## Summary

Issue #382: Replace manual control buttons with a single select entity for battery mode control.

## Changes Made

- **Add select.py** with BatteryModeSelect entity for manual mode control
- **Remove ActiveModeSensor** from sensor.py (replaced by select entity)
- **Remove mode control buttons** from button.py (keep utility buttons: Update Forecast, Reset Learning, Learn HVAC Power)
- **Add SELECT constants** to const.py
- **Add async_set_battery_mode()** to coordinator.py for select entity integration

## New Entity

**select.localshift_battery_mode**
- Options: self_consumption, grid_charging, boost_charging, spike_discharge, proactive_export
- Shows current battery mode
- When user changes selection: automation automatically disables, user's choice is honored
- When user re-enables automation: system takes control immediately

## Benefits

1. **Clearer UI**: Single dropdown instead of 5 separate buttons
2. **Better UX**: Current mode is always visible
3. **Simpler interaction**: One click to change mode instead of finding the right button
4. **Consistent with HA patterns**: Select entities are the standard way to choose from options

## Testing

- Deployed to HA and verified select entity is created
- Verified select entity shows current mode correctly
- Verified mode options are available

Closes #382