### PR TITLE
feat(notifications): suppress Tesla grid_charging sync alerts

### DIFF
--- a/custom_components/localshift/notification_service.py
+++ b/custom_components/localshift/notification_service.py
@@ -328,17 +328,38 @@ class NotificationService:
         )
 
     async def send_health_correction_notification(
-        self, mode: BatteryMode, data: CoordinatorData
+        self,
+        mode: BatteryMode,
+        data: CoordinatorData,
+        mismatch_details: dict | None = None,
     ) -> None:
         """Notify when health check corrects hardware drift.
 
         Args:
             mode: The commanded mode that was corrected
             data: Current coordinator data
+            mismatch_details: Dict with what mismatched (operation_mode, backup_reserve,
+                            grid_charging_allowed). Used to suppress notifications for
+                            expected Tesla cloud sync behavior (Issue #394).
         """
         # Check if alert notifications are enabled
         if not self._is_notification_enabled(SWITCH_NOTIFY_ALERTS):
             _LOGGER.debug("Alert notifications disabled, skipping health correction")
+            return
+
+        # Issue #394: Suppress notification for Tesla cloud grid_charging sync
+        # Tesla's cloud resets allow_charging_from_grid to True every ~60 minutes.
+        # This is expected behavior - the health check corrects it within seconds.
+        # Only suppress if:
+        # 1. Mode is SELF_CONSUMPTION or DEMAND_BLOCK (where grid_charging should be False)
+        # 2. ONLY grid_charging_allowed mismatched (not operation_mode or backup_reserve)
+        if mismatch_details is not None and self._is_tesla_grid_charging_sync(
+            mode, mismatch_details
+        ):
+            _LOGGER.info(
+                "[HEALTH CHECK] Skipping notification - Tesla cloud sync for grid_charging "
+                "(expected behavior, corrected automatically)"
+            )
             return
 
         dry_run_prefix = self._get_dry_run_prefix()
@@ -349,6 +370,35 @@ class NotificationService:
         )
 
         await self.send_notification(title, message)
+
+    def _is_tesla_grid_charging_sync(
+        self, mode: BatteryMode, mismatch_details: dict
+    ) -> bool:
+        """Check if this is Tesla's periodic grid_charging reset (Issue #394).
+
+        Tesla's cloud resets allow_charging_from_grid to True approximately every
+        60 minutes. This is expected behavior in SELF_CONSUMPTION and DEMAND_BLOCK
+        modes where grid_charging should be False.
+
+        Args:
+            mode: The commanded mode
+            mismatch_details: Dict with what mismatched
+
+        Returns:
+            True if this is just Tesla's grid_charging sync (should suppress notification)
+        """
+        # Only suppress for modes where grid_charging should be False
+        if mode not in (BatteryMode.SELF_CONSUMPTION, BatteryMode.DEMAND_BLOCK):
+            return False
+
+        # Check if ONLY grid_charging_allowed mismatched
+        only_grid_charging_mismatched = (
+            mismatch_details.get("grid_charging_allowed", False)
+            and not mismatch_details.get("operation_mode", False)
+            and not mismatch_details.get("backup_reserve", False)
+        )
+
+        return only_grid_charging_mismatched
 
     async def send_transition_failed_notification(
         self, target_mode: BatteryMode, data: CoordinatorData

--- a/custom_components/localshift/state_machine.py
+++ b/custom_components/localshift/state_machine.py
@@ -837,9 +837,24 @@ class StateMachine:
                     self._commanded_mode.value,
                 )
 
-            # Send notification about health check correction
+            # Collect mismatch details for intelligent notification filtering
+            # Issue #394: Skip notification if only grid_charging flipped (Tesla cloud sync)
+            grid_charging_entity = self._battery_controller._get_entity_id(  # noqa: SLF001
+                "teslemetry_allow_charging_from_grid"
+            )
+            actual_grid_charging = self._battery_controller._read_bool(  # noqa: SLF001
+                grid_charging_entity
+            )
+
+            mismatch_details = {
+                "operation_mode": data.operation_mode != expected_op,
+                "backup_reserve": abs((data.backup_reserve or 0) - expected_reserve) >= 1,
+                "grid_charging_allowed": actual_grid_charging != expected_grid_charging,
+            }
+
+            # Send notification about health check correction (may be suppressed)
             await self._notification_service.send_health_correction_notification(
-                self._commanded_mode, data
+                self._commanded_mode, data, mismatch_details
             )
 
     def set_startup_grace(self, grace_seconds: int = 30) -> None:


### PR DESCRIPTION
## Summary
Suppress notifications for Tesla's periodic grid_charging sync which was causing alert fatigue.

## Problem
Tesla's cloud resets `allow_charging_from_grid` to True every ~60 minutes as part of their periodic sync. This triggers health check corrections which work correctly (correcting within ~5 seconds), but each correction was sending a notification.

## Solution
- Collect mismatch details in `state_machine.py` (operation_mode, backup_reserve, grid_charging_allowed)
- Add `_is_tesla_grid_charging_sync()` in `notification_service.py` to detect Tesla sync scenario
- Skip notification when only grid_charging flips in SELF_CONSUMPTION or DEMAND_BLOCK modes

## Testing
- Deployed and verified integration loads correctly
- Health checks running with `match=True` results

## Changes Made
- `custom_components/localshift/state_machine.py`: Pass mismatch details to notification service
- `custom_components/localshift/notification_service.py`: Add intelligent notification suppression

Closes #394