### PR TITLE
fix(optimizer): align DP solar handling with legacy model (#410)

### DIFF
--- a/custom_components/localshift/computation_engine_lib/optimizer_dp.py
+++ b/custom_components/localshift/computation_engine_lib/optimizer_dp.py
@@ -157,11 +157,14 @@ class OptimizerConfig:
     boost_charge_rate_kw: float = 5.0
     """Maximum battery charge rate in boost mode in kW."""
 
+    solar_charge_rate_kw: float = 5.0
+    """Maximum solar-to-battery charge rate in kW (Powerwall 3 inverter limit)."""
+
     discharge_rate_kw: float = 5.0
     """Maximum battery discharge rate in kW."""
 
-    charge_efficiency: float = 0.95
-    """Round-trip charging efficiency (0–1)."""
+    charge_efficiency: float = 0.92
+    """Charging efficiency (energy lost going into battery)."""
 
     discharge_efficiency: float = 0.95
     """Round-trip discharging efficiency (0–1)."""
@@ -855,7 +858,20 @@ class DPPlanner:
             # Battery absorbs surplus or supplies deficit from solar/consumption balance
             # Net positive = charge from solar surplus
             # Net negative = discharge to meet consumption
-            delta_soc = (net_kwh / capacity_kwh) * 100.0
+            # Apply solar charge rate limit and efficiency (aligns with legacy soc_simulator.py)
+            max_transfer_kwh = config.solar_charge_rate_kw * slot_hours
+            if net_kwh >= 0:
+                # Solar surplus → charge battery (lose efficiency)
+                effective_kwh = (
+                    min(net_kwh, max_transfer_kwh) * config.charge_efficiency
+                )
+                delta_soc = (effective_kwh / capacity_kwh) * 100.0
+            else:
+                # Consumption deficit → discharge battery (lose efficiency)
+                effective_kwh = (
+                    max(net_kwh, -max_transfer_kwh) / config.discharge_efficiency
+                )
+                delta_soc = (effective_kwh / capacity_kwh) * 100.0
             next_soc = soc_pct + delta_soc
             # Clip to valid range
             next_soc = max(config.min_soc_pct, min(config.max_soc_pct, next_soc))

--- a/custom_components/localshift/computation_engine_lib/optimizer_shadow_runner.py
+++ b/custom_components/localshift/computation_engine_lib/optimizer_shadow_runner.py
@@ -253,6 +253,7 @@ def _build_optimizer_config(
         BATTERY_CAPACITY_KWH,
         CHARGE_RATE_BOOST_KW,
         CHARGE_RATE_GRID_KW,
+        CHARGE_RATE_SOLAR_KW,
         CONF_BATTERY_TARGET,
         CONF_MINIMUM_TARGET_SOC,
         DEFAULT_BATTERY_TARGET,
@@ -272,10 +273,11 @@ def _build_optimizer_config(
         battery_capacity_kwh=BATTERY_CAPACITY_KWH,
         charge_rate_kw=CHARGE_RATE_GRID_KW,  # 3.3 kW normal grid charge
         boost_charge_rate_kw=CHARGE_RATE_BOOST_KW,  # 5.0 kW boost charge
+        solar_charge_rate_kw=CHARGE_RATE_SOLAR_KW,  # 5.0 kW solar->battery cap
         discharge_rate_kw=CHARGE_RATE_BOOST_KW,  # 5.0 kW (Powerwall symmetric)
         # --- Efficiency defaults (Powerwall typical) ---
         # TODO (#403 Phase C): Consider exposing via config if needed
-        charge_efficiency=0.95,
+        charge_efficiency=0.92,
         discharge_efficiency=0.95,
         # --- SOC constraints ---
         min_soc_pct=min_soc,  # User-configured minimum

--- a/tests/test_optimizer_shadow_runner_integration.py
+++ b/tests/test_optimizer_shadow_runner_integration.py
@@ -102,6 +102,7 @@ class TestBuildOptimizerConfig:
         config = _build_optimizer_config(mock_coordinator_data, config_options)
         assert config.charge_rate_kw == 3.3  # CHARGE_RATE_GRID_KW
         assert config.boost_charge_rate_kw == 5.0  # CHARGE_RATE_BOOST_KW
+        assert config.solar_charge_rate_kw == 5.0  # CHARGE_RATE_SOLAR_KW
 
     def test_config_maps_user_target_soc(self, mock_coordinator_data, config_options):
         """Verify user-configured target SOC is mapped."""
@@ -122,7 +123,7 @@ class TestBuildOptimizerConfig:
     def test_config_efficiency_defaults(self, mock_coordinator_data, config_options):
         """Verify efficiency defaults are set."""
         config = _build_optimizer_config(mock_coordinator_data, config_options)
-        assert config.charge_efficiency == 0.95
+        assert config.charge_efficiency == 0.92
         assert config.discharge_efficiency == 0.95
 
     def test_config_objective_weights_default(


### PR DESCRIPTION
## Summary
- align DP HOLD SOC transitions with legacy `soc_simulator.py` by applying solar transfer caps and asymmetric charge/discharge efficiencies
- add `solar_charge_rate_kw` to optimizer config and map it from `CHARGE_RATE_SOLAR_KW` in shadow runner config construction
- update shadow runner integration tests to assert the new solar cap mapping and 0.92 charge efficiency default

## Validation
- `uv run pytest tests/test_optimizer_shadow_runner_integration.py tests/test_optimizer_dp_solve.py`
- `uv run pytest tests/test_optimizer_*.py`
- `uv run ruff check custom_components/localshift/computation_engine_lib/optimizer_shadow_runner.py tests/test_optimizer_shadow_runner_integration.py`