### PR TITLE
Fix optimizer demand-window import blocking and target timing

### DIFF
--- a/custom_components/localshift/computation_engine_lib/optimizer_dp.py
+++ b/custom_components/localshift/computation_engine_lib/optimizer_dp.py
@@ -176,6 +176,9 @@ class OptimizerConfig:
     demand_window_target_soc_pct: float = 80.0
     """Required SOC (%) at demand window entry."""
 
+    allow_dw_entry_under_target: bool = False
+    """If True, allow reaching target during DW via solar (instead of by DW start)."""
+
     # --- Objective weights ---
     target_shortfall_penalty_per_pct: float = 1.0
     """Penalty applied per % SOC below target at demand-window entry."""
@@ -531,12 +534,31 @@ class DPPlanner:
         soc_grid = _build_soc_grid(config)
         n_bins = len(soc_grid)
 
-        # Find demand window entry slot (if any)
+        # Find demand window entry and end slots (if any)
         demand_window_entry_idx = None
+        demand_window_end_idx = None
+        in_demand_window = False
         for i, slot in enumerate(slots):
             if slot.is_demand_window_entry:
                 demand_window_entry_idx = i
+            if slot.is_demand_window_slot:
+                in_demand_window = True
+            # DW ends when we see the first slot that's not in DW after being in DW
+            if in_demand_window and not slot.is_demand_window_slot:
+                demand_window_end_idx = i - 1
                 break
+
+        # If DW extends to end of horizon, set end to last slot
+        if in_demand_window and demand_window_end_idx is None:
+            demand_window_end_idx = n_slots - 1
+
+        # Determine where to apply terminal penalty
+        # If allow_dw_entry_under_target is True, apply at DW end (allows solar during DW)
+        # Otherwise, apply at DW entry (must meet target by DW start)
+        if config.allow_dw_entry_under_target and demand_window_end_idx is not None:
+            terminal_penalty_idx = demand_window_end_idx
+        else:
+            terminal_penalty_idx = demand_window_entry_idx
 
         # ------------------------------------------------------------------
         # Forward pass: compute cost-to-go tables
@@ -547,8 +569,8 @@ class DPPlanner:
         ]
 
         # Initialize terminal costs (after last slot)
-        if demand_window_entry_idx is not None:
-            # Apply shortfall penalty at demand window entry
+        if terminal_penalty_idx is not None:
+            # Apply shortfall penalty at terminal penalty index
             target = config.demand_window_target_soc_pct
             for bin_idx, soc in enumerate(soc_grid):
                 shortfall_penalty = DPPlanner.terminal_cost(soc, target, config)
@@ -678,7 +700,7 @@ class DPPlanner:
                 soc=current_soc,
                 next_soc=next_soc,
                 config=config,
-                demand_window_entry_idx=demand_window_entry_idx,
+                terminal_penalty_idx=terminal_penalty_idx,
             )
 
             # Record decision
@@ -706,12 +728,10 @@ class DPPlanner:
             current_soc = next_soc
             current_bin = _map_soc_to_bin(current_soc, soc_grid)
 
-        # Calculate terminal shortfall (at demand window entry if applicable)
+        # Calculate terminal shortfall at the terminal penalty index
         terminal_shortfall = 0.0
-        if demand_window_entry_idx is not None and demand_window_entry_idx < len(
-            decisions
-        ):
-            terminal_soc = decisions[demand_window_entry_idx].predicted_soc_pct
+        if terminal_penalty_idx is not None and terminal_penalty_idx < len(decisions):
+            terminal_soc = decisions[terminal_penalty_idx].predicted_soc_pct
             target = config.demand_window_target_soc_pct
             terminal_shortfall = max(0.0, target - terminal_soc)
 
@@ -737,7 +757,7 @@ class DPPlanner:
         soc: float,
         next_soc: float,
         config: OptimizerConfig,
-        demand_window_entry_idx: int | None,
+        terminal_penalty_idx: int | None,
     ) -> PlannerReasonCode:
         """
         Classify the reason for a decision based on action and context.
@@ -764,16 +784,14 @@ class DPPlanner:
             PlannerAction.CHARGE_GRID_BOOST,
         ):
             # Check if needed for demand window target
-            if (
-                demand_window_entry_idx is not None
-                and slot_idx < demand_window_entry_idx
-            ):
+            # Use terminal_penalty_idx which is DW entry (default) or DW end (if allow_dw_entry_under_target)
+            if terminal_penalty_idx is not None and slot_idx < terminal_penalty_idx:
                 soc_deficit = config.demand_window_target_soc_pct - soc
                 if soc_deficit > 0:
                     # Use real future slots (no repeated-current-slot approximation).
                     projected_net_kwh = sum(
                         s.solar_kwh - s.consumption_kwh
-                        for s in slots[slot_idx:demand_window_entry_idx]
+                        for s in slots[slot_idx:terminal_penalty_idx]
                     )
                     potential_soc_gain_pct = (
                         projected_net_kwh / config.battery_capacity_kwh
@@ -811,7 +829,7 @@ class DPPlanner:
 
         Constraints checked:
         - SOC floor/ceiling
-        - Demand window entry requirements
+        - Demand window: no grid import during DW slots
         - Slot duration vs transfer limits (TODO: implement fully in Phase C)
         """
         actions = []
@@ -821,7 +839,8 @@ class DPPlanner:
 
         actions.append(PlannerAction.HOLD)
 
-        if can_charge:
+        # Block grid charging during demand window (no grid import allowed in DW)
+        if can_charge and not slot.is_demand_window_slot:
             actions.append(PlannerAction.CHARGE_GRID_NORMAL)
             actions.append(PlannerAction.CHARGE_GRID_BOOST)
 

--- a/custom_components/localshift/computation_engine_lib/optimizer_shadow_runner.py
+++ b/custom_components/localshift/computation_engine_lib/optimizer_shadow_runner.py
@@ -253,8 +253,10 @@ def _build_optimizer_config(
         BATTERY_CAPACITY_KWH,
         CHARGE_RATE_BOOST_KW,
         CHARGE_RATE_GRID_KW,
+        CONF_ALLOW_DW_ENTRY_UNDER_TARGET,
         CONF_BATTERY_TARGET,
         CONF_MINIMUM_TARGET_SOC,
+        DEFAULT_ALLOW_DW_ENTRY_UNDER_TARGET,
         DEFAULT_BATTERY_TARGET,
         DEFAULT_MINIMUM_TARGET_SOC,
     )
@@ -265,6 +267,11 @@ def _build_optimizer_config(
     # User-configurable minimum SOC (floor for discharge modes)
     min_soc = float(
         config_options.get(CONF_MINIMUM_TARGET_SOC, DEFAULT_MINIMUM_TARGET_SOC)
+    )
+
+    # Allow reaching target during DW via solar (instead of by DW start)
+    allow_dw_entry_under_target = config_options.get(
+        CONF_ALLOW_DW_ENTRY_UNDER_TARGET, DEFAULT_ALLOW_DW_ENTRY_UNDER_TARGET
     )
 
     return OptimizerConfig(
@@ -282,6 +289,7 @@ def _build_optimizer_config(
         max_soc_pct=100.0,  # Hard ceiling
         # --- Demand window target ---
         demand_window_target_soc_pct=target_soc,  # User-configured target
+        allow_dw_entry_under_target=allow_dw_entry_under_target,
         # --- Objective weights (conservative defaults) ---
         # TODO (#403 Phase C): Expose for tuning if comparison analytics suggest
         target_shortfall_penalty_per_pct=1.0,

--- a/tests/test_optimizer_dp_solve.py
+++ b/tests/test_optimizer_dp_solve.py
@@ -284,7 +284,9 @@ def test_dp_planner_determinism_replay(default_config, multi_slots):
     # All results should be identical
     first = results[0]
     for i, r in enumerate(results[1:], start=1):
-        assert r == first, f"Run {i} differs from run 0 - optimizer is not deterministic"
+        assert r == first, (
+            f"Run {i} differs from run 0 - optimizer is not deterministic"
+        )
 
 
 def test_dp_planner_runtime_budget(default_config, multi_slots):
@@ -309,7 +311,7 @@ def test_dp_planner_runtime_budget(default_config, multi_slots):
     # Sort and check p95 (19th of 20 values)
     times.sort()
     p95 = times[19]  # 95th percentile index for 20 samples
-    assert p95 <= 0.200, f"p95 solve time {p95*1000:.1f}ms exceeds 200ms budget"
+    assert p95 <= 0.200, f"p95 solve time {p95 * 1000:.1f}ms exceeds 200ms budget"
 
 
 # ---------------------------------------------------------------------------
@@ -358,6 +360,136 @@ def test_dp_planner_terminal_shortfall_calculation(demand_window_slots):
     assert result.success
     # Terminal shortfall should be >= 0
     assert result.terminal_shortfall_pct >= 0.0
+
+
+def test_feasible_actions_blocks_grid_charging_in_demand_window(default_config):
+    """Grid charging actions should be unavailable during demand window slots."""
+    slot = SlotContext(
+        slot_index=0,
+        timestamp_iso="2026-01-03T18:00:00",
+        slot_interval_minutes=30,
+        buy_price=0.08,
+        sell_price=0.05,
+        solar_kwh=0.0,
+        consumption_kwh=0.5,
+        is_demand_window_slot=True,
+    )
+
+    actions = DPPlanner.feasible_actions(50.0, slot, default_config)
+
+    assert PlannerAction.HOLD in actions
+    assert PlannerAction.CHARGE_GRID_NORMAL not in actions
+    assert PlannerAction.CHARGE_GRID_BOOST not in actions
+
+
+def test_terminal_penalty_applied_at_dw_entry_by_default():
+    """When switch is off, shortfall is measured at demand window entry."""
+    slots = [
+        SlotContext(
+            slot_index=0,
+            timestamp_iso="2026-01-03T18:00:00",
+            slot_interval_minutes=30,
+            buy_price=0.30,
+            sell_price=0.0,
+            solar_kwh=0.0,
+            consumption_kwh=0.0,
+            is_demand_window_entry=True,
+            is_demand_window_slot=True,
+        ),
+        SlotContext(
+            slot_index=1,
+            timestamp_iso="2026-01-03T18:30:00",
+            slot_interval_minutes=30,
+            buy_price=0.30,
+            sell_price=0.0,
+            solar_kwh=2.0,
+            consumption_kwh=0.0,
+            is_demand_window_slot=True,
+        ),
+        SlotContext(
+            slot_index=2,
+            timestamp_iso="2026-01-03T19:00:00",
+            slot_interval_minutes=30,
+            buy_price=0.30,
+            sell_price=0.0,
+            solar_kwh=0.0,
+            consumption_kwh=0.0,
+            is_demand_window_slot=False,
+        ),
+    ]
+
+    config = OptimizerConfig(
+        battery_capacity_kwh=13.5,
+        demand_window_target_soc_pct=60.0,
+        allow_dw_entry_under_target=False,
+        soc_bins=20,
+    )
+    inputs = OptimizerInputs(
+        cycle_id="dw-entry-penalty",
+        initial_soc_pct=50.0,
+        slots=slots,
+        config=config,
+    )
+
+    result = DPPlanner().plan(inputs)
+
+    assert result.success
+    assert result.terminal_shortfall_pct > 0.0
+
+
+def test_terminal_penalty_applied_at_dw_end_when_switch_enabled():
+    """When switch is on, shortfall can be recovered within demand window."""
+    slots = [
+        SlotContext(
+            slot_index=0,
+            timestamp_iso="2026-01-03T18:00:00",
+            slot_interval_minutes=30,
+            buy_price=0.30,
+            sell_price=0.0,
+            solar_kwh=0.0,
+            consumption_kwh=0.0,
+            is_demand_window_entry=True,
+            is_demand_window_slot=True,
+        ),
+        SlotContext(
+            slot_index=1,
+            timestamp_iso="2026-01-03T18:30:00",
+            slot_interval_minutes=30,
+            buy_price=0.30,
+            sell_price=0.0,
+            solar_kwh=2.0,
+            consumption_kwh=0.0,
+            is_demand_window_slot=True,
+        ),
+        SlotContext(
+            slot_index=2,
+            timestamp_iso="2026-01-03T19:00:00",
+            slot_interval_minutes=30,
+            buy_price=0.30,
+            sell_price=0.0,
+            solar_kwh=0.0,
+            consumption_kwh=0.0,
+            is_demand_window_slot=False,
+        ),
+    ]
+
+    config = OptimizerConfig(
+        battery_capacity_kwh=13.5,
+        demand_window_target_soc_pct=60.0,
+        allow_dw_entry_under_target=True,
+        soc_bins=20,
+    )
+    inputs = OptimizerInputs(
+        cycle_id="dw-end-penalty",
+        initial_soc_pct=50.0,
+        slots=slots,
+        config=config,
+    )
+
+    result = DPPlanner().plan(inputs)
+
+    assert result.success
+    assert result.terminal_shortfall_pct == pytest.approx(0.0)
 
 
 # ---------------------------------------------------------------------------
@@ -556,7 +688,9 @@ def test_dp_planner_states_explored(default_config, multi_slots):
     assert result.success
     assert result.states_explored > 0
     # Should explore roughly n_slots * n_bins * n_actions states
-    expected_min = len(multi_slots) * default_config.soc_bins * 2  # At least 2 actions each
+    expected_min = (
+        len(multi_slots) * default_config.soc_bins * 2
+    )  # At least 2 actions each
     assert result.states_explored >= expected_min
 
 
@@ -568,7 +702,9 @@ def test_dp_planner_states_explored(default_config, multi_slots):
 def test_classify_reason_target_shortfall_uses_future_slots():
     """Grid charging before DW should be tagged shortfall risk when net future solar is insufficient."""
     planner = DPPlanner()
-    config = OptimizerConfig(battery_capacity_kwh=13.5, demand_window_target_soc_pct=80.0)
+    config = OptimizerConfig(
+        battery_capacity_kwh=13.5, demand_window_target_soc_pct=80.0
+    )
 
     slots = [
         SlotContext(
@@ -609,7 +745,7 @@ def test_classify_reason_target_shortfall_uses_future_slots():
         soc=40.0,
         next_soc=45.0,
         config=config,
-        demand_window_entry_idx=2,
+        terminal_penalty_idx=2,
     )
 
     assert reason == PlannerReasonCode.TARGET_SHORTFALL_RISK
@@ -618,7 +754,9 @@ def test_classify_reason_target_shortfall_uses_future_slots():
 def test_classify_reason_cheap_import_when_target_can_be_met():
     """Cheap price should classify as CHEAP_IMPORT_WINDOW when shortfall risk test does not trigger."""
     planner = DPPlanner()
-    config = OptimizerConfig(battery_capacity_kwh=13.5, demand_window_target_soc_pct=80.0)
+    config = OptimizerConfig(
+        battery_capacity_kwh=13.5, demand_window_target_soc_pct=80.0
+    )
 
     slots = [
         SlotContext(
@@ -659,7 +797,7 @@ def test_classify_reason_cheap_import_when_target_can_be_met():
         soc=75.0,
         next_soc=78.0,
         config=config,
-        demand_window_entry_idx=2,
+        terminal_penalty_idx=2,
     )
 
     assert reason == PlannerReasonCode.CHEAP_IMPORT_WINDOW

--- a/tests/test_optimizer_shadow_runner_integration.py
+++ b/tests/test_optimizer_shadow_runner_integration.py
@@ -133,6 +133,23 @@ class TestBuildOptimizerConfig:
         assert config.target_shortfall_penalty_per_pct == 1.0
         assert config.cycle_penalty_per_kwh == 0.005
 
+    def test_config_uses_default_allow_dw_entry_under_target(
+        self, mock_coordinator_data
+    ):
+        """Verify allow_dw_entry_under_target defaults to False."""
+        config = _build_optimizer_config(mock_coordinator_data, {})
+        assert config.allow_dw_entry_under_target is False
+
+    def test_config_maps_allow_dw_entry_under_target_override(
+        self, mock_coordinator_data
+    ):
+        """Verify allow_dw_entry_under_target is mapped from options."""
+        config = _build_optimizer_config(
+            mock_coordinator_data,
+            {"allow_dw_entry_under_target": True},
+        )
+        assert config.allow_dw_entry_under_target is True
+
 
 # ---------------------------------------------------------------------------
 # Test: Slot context parity


### PR DESCRIPTION
## Summary
- block optimizer grid-charging actions during demand-window slots to match legacy demand-window import rules
- support `allow_dw_entry_under_target` by shifting terminal shortfall evaluation from demand-window entry to demand-window end when enabled
- plumb the switch through shadow-runner config mapping and add regression tests for action feasibility, terminal-penalty timing, and config defaults/overrides

## Testing
- `uv run pytest tests/test_optimizer_dp_solve.py -q`
- `uv run pytest tests/test_optimizer_shadow_runner_integration.py -q`