### PR TITLE
fix(optimizer): align self-consumption mode config and UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,11 +157,12 @@ All entities are grouped under a single **LocalShift** device in Settings → De
 | `number.localshift_spike_price_percentile` | Price percentile for spike discharge activation |
 | `number.localshift_minimum_target_soc` | Minimum SOC during discharge modes |
 
-### Selects (1)
+### Selects (2)
 
 | Entity ID | Description |
 |---|---|
 | `select.localshift_battery_mode` | Select battery operating mode (self_consumption, grid_charging, boost_charging, spike_discharge, proactive_export). Changing this disables automation and applies manual control. |
+| `select.localshift_optimization_mode` | Select optimizer objective mode (`self_consumption` or `arbitrage`). Changes take effect on the next recompute cycle. |
 
 ### Buttons (3)
 

--- a/custom_components/localshift/computation_engine_lib/optimizer_dp.py
+++ b/custom_components/localshift/computation_engine_lib/optimizer_dp.py
@@ -187,6 +187,19 @@ class OptimizerConfig:
     soc_bins: int = 50
     """Number of SOC bins for DP state space (higher = more precise, slower)."""
 
+    # --- Optimization mode (Issue #406) ---
+    optimization_mode: str = "self_consumption"
+    """Optimization strategy: 'self_consumption' (default) or 'arbitrage'."""
+
+    self_consumption_value_per_kwh: float = 0.15
+    """Value of using battery energy for household load ($/kWh). Auto-derived from average buy price."""
+
+    effective_cheap_price: float = 0.10
+    """Price threshold for grid charging in self-consumption mode ($/kWh)."""
+
+    export_price_margin: float = 0.02
+    """Minimum profit margin for proactive export above self-consumption value ($/kWh)."""
+
 
 # ---------------------------------------------------------------------------
 # Per-slot decision output
@@ -209,12 +222,16 @@ class ObjectiveTerms:
     shortfall_penalty: float = 0.0
     """Terminal penalty applied at demand window boundary (only for terminal slots)."""
 
+    self_consumption_value: float = 0.0
+    """Value of battery energy used for household load (benefit, subtracted from cost)."""
+
     @property
     def net_cost(self) -> float:
-        """Net slot cost = import - revenue + penalties."""
+        """Net slot cost = import - revenue - self_consumption_value + penalties."""
         return (
             self.import_cost
             - self.export_revenue
+            - self.self_consumption_value
             + self.cycle_penalty
             + self.shortfall_penalty
         )
@@ -226,6 +243,7 @@ class ObjectiveTerms:
             "export_revenue": self.export_revenue,
             "cycle_penalty": self.cycle_penalty,
             "shortfall_penalty": self.shortfall_penalty,
+            "self_consumption_value": self.self_consumption_value,
             "net_cost": self.net_cost,
         }
 
@@ -812,7 +830,8 @@ class DPPlanner:
         Constraints checked:
         - SOC floor/ceiling
         - Demand window entry requirements
-        - Slot duration vs transfer limits (TODO: implement fully in Phase C)
+        - Optimization mode (self_consumption vs arbitrage)
+        - Price thresholds for self-consumption mode
         """
         actions = []
 
@@ -821,12 +840,37 @@ class DPPlanner:
 
         actions.append(PlannerAction.HOLD)
 
-        if can_charge:
-            actions.append(PlannerAction.CHARGE_GRID_NORMAL)
-            actions.append(PlannerAction.CHARGE_GRID_BOOST)
+        # Grid charging constraints (Issue #406)
+        if can_charge and not slot.is_demand_window_slot:
+            # In self-consumption mode, only charge if price is cheap
+            if config.optimization_mode == "self_consumption":
+                price_is_cheap = slot.buy_price <= config.effective_cheap_price
+                price_is_very_cheap = (
+                    slot.buy_price <= config.effective_cheap_price * 0.8
+                )
 
-        if can_discharge and slot.sell_price > 0:
-            actions.append(PlannerAction.EXPORT_PROACTIVE)
+                if price_is_cheap:
+                    actions.append(PlannerAction.CHARGE_GRID_NORMAL)
+                    if price_is_very_cheap:
+                        actions.append(PlannerAction.CHARGE_GRID_BOOST)
+            else:
+                # Arbitrage mode: charge whenever below max
+                actions.append(PlannerAction.CHARGE_GRID_NORMAL)
+                actions.append(PlannerAction.CHARGE_GRID_BOOST)
+
+        # Export constraints (Issue #406)
+        if can_discharge:
+            # In self-consumption mode, only export if profitable vs keeping energy for load
+            if config.optimization_mode == "self_consumption":
+                min_profitable_sell = (
+                    config.self_consumption_value_per_kwh + config.export_price_margin
+                )
+                if slot.sell_price >= min_profitable_sell:
+                    actions.append(PlannerAction.EXPORT_PROACTIVE)
+            else:
+                # Arbitrage mode: export if positive price
+                if slot.sell_price > 0:
+                    actions.append(PlannerAction.EXPORT_PROACTIVE)
 
         return actions
 
@@ -981,17 +1025,39 @@ class DPPlanner:
         """
         Compute per-slot stage cost terms for an action.
 
-        Returns ObjectiveTerms with all applicable cost components.
+        In self-consumption mode, adds value for battery energy used to cover load.
+        This makes the optimizer prefer keeping energy for household use over exporting
+        unless the export price exceeds the self-consumption value + margin.
         """
         import_cost = grid_import_kwh * slot.buy_price
         export_revenue = grid_export_kwh * max(0.0, slot.sell_price)
         cycle_kwh = grid_import_kwh + grid_export_kwh
         cycle_penalty = cycle_kwh * config.cycle_penalty_per_kwh
 
+        # Calculate self-consumption value (Issue #406)
+        # Battery energy used to cover household load has value because it avoids
+        # buying from grid at retail price
+        self_consumption_value = 0.0
+        if config.optimization_mode == "self_consumption":
+            # Net load that battery covers = consumption - solar - grid_import
+            # (If positive, battery discharges for load; if negative, battery is being charged)
+            net_load = slot.consumption_kwh - slot.solar_kwh
+            if net_load > 0:
+                # Household needs energy beyond what solar provides
+                # Battery covers some of this (the rest would be grid import)
+                # Grid export takes energy away from load coverage
+                battery_for_load = max(
+                    0.0, net_load - grid_import_kwh - grid_export_kwh
+                )
+                self_consumption_value = (
+                    battery_for_load * config.self_consumption_value_per_kwh
+                )
+
         return ObjectiveTerms(
             import_cost=import_cost,
             export_revenue=export_revenue,
             cycle_penalty=cycle_penalty,
+            self_consumption_value=self_consumption_value,
         )
 
     @staticmethod

--- a/custom_components/localshift/computation_engine_lib/optimizer_shadow_runner.py
+++ b/custom_components/localshift/computation_engine_lib/optimizer_shadow_runner.py
@@ -254,9 +254,13 @@ def _build_optimizer_config(
         CHARGE_RATE_BOOST_KW,
         CHARGE_RATE_GRID_KW,
         CONF_BATTERY_TARGET,
+        CONF_EXPORT_PRICE_MARGIN,
         CONF_MINIMUM_TARGET_SOC,
+        CONF_OPTIMIZATION_MODE,
         DEFAULT_BATTERY_TARGET,
+        DEFAULT_EXPORT_PRICE_MARGIN,
         DEFAULT_MINIMUM_TARGET_SOC,
+        DEFAULT_OPTIMIZATION_MODE,
     )
 
     # User-configurable target SOC for demand window
@@ -265,6 +269,21 @@ def _build_optimizer_config(
     # User-configurable minimum SOC (floor for discharge modes)
     min_soc = float(
         config_options.get(CONF_MINIMUM_TARGET_SOC, DEFAULT_MINIMUM_TARGET_SOC)
+    )
+
+    optimization_mode = str(
+        config_options.get(CONF_OPTIMIZATION_MODE, DEFAULT_OPTIMIZATION_MODE)
+    )
+
+    effective_cheap_price = float(getattr(data, "effective_cheap_price", 0.10))
+    self_consumption_value_per_kwh = float(
+        getattr(data, "general_price", effective_cheap_price)
+    )
+    if self_consumption_value_per_kwh <= 0.0:
+        self_consumption_value_per_kwh = max(0.10, effective_cheap_price)
+
+    export_price_margin = float(
+        config_options.get(CONF_EXPORT_PRICE_MARGIN, DEFAULT_EXPORT_PRICE_MARGIN)
     )
 
     return OptimizerConfig(
@@ -288,6 +307,11 @@ def _build_optimizer_config(
         cycle_penalty_per_kwh=0.005,
         # --- SOC discretization ---
         soc_bins=50,
+        # --- Optimization mode ---
+        optimization_mode=optimization_mode,
+        self_consumption_value_per_kwh=self_consumption_value_per_kwh,
+        effective_cheap_price=effective_cheap_price,
+        export_price_margin=export_price_margin,
     )
 
 

--- a/custom_components/localshift/config_flow/__init__.py
+++ b/custom_components/localshift/config_flow/__init__.py
@@ -26,6 +26,7 @@ from ..const import (
     CONF_MAX_PRECHARGE_PRICE,
     CONF_MINIMUM_TARGET_SOC,
     CONF_NOTIFY_SERVICE,
+    CONF_OPTIMIZATION_MODE,
     CONF_OPTIMIZER_CONTROL_MODE,
     CONF_OPTIMIZER_ENABLED,
     CONF_PRICING_FEED_IN_FORECAST,
@@ -56,6 +57,7 @@ from ..const import (
     DEFAULT_MANUAL_OVERRIDE_TIMEOUT,
     DEFAULT_MAX_PRECHARGE_PRICE,
     DEFAULT_MINIMUM_TARGET_SOC,
+    DEFAULT_OPTIMIZATION_MODE,
     DEFAULT_OPTIMIZER_CONTROL_MODE,
     DEFAULT_OPTIMIZER_ENABLED,
     DEFAULT_WEATHER_ENTITY,
@@ -397,6 +399,11 @@ class LocalShiftOptionsFlow(OptionsFlow):
                     CONF_OPTIMIZER_CONTROL_MODE: current.get(
                         CONF_OPTIMIZER_CONTROL_MODE,
                         DEFAULT_OPTIMIZER_CONTROL_MODE,
+                    ),
+                    # Optimization mode (Issue #406)
+                    CONF_OPTIMIZATION_MODE: current.get(
+                        CONF_OPTIMIZATION_MODE,
+                        DEFAULT_OPTIMIZATION_MODE,
                     ),
                 },
                 notify_services,

--- a/custom_components/localshift/config_flow/schemas.py
+++ b/custom_components/localshift/config_flow/schemas.py
@@ -22,6 +22,7 @@ from ..const import (
     CONF_MAX_PRECHARGE_PRICE,
     CONF_MINIMUM_TARGET_SOC,
     CONF_NOTIFY_SERVICE,
+    CONF_OPTIMIZATION_MODE,
     CONF_OPTIMIZER_CONTROL_MODE,
     CONF_OPTIMIZER_ENABLED,
     CONF_PRICING_FEED_IN_FORECAST,
@@ -52,11 +53,13 @@ from ..const import (
     DEFAULT_MANUAL_OVERRIDE_TIMEOUT,
     DEFAULT_MAX_PRECHARGE_PRICE,
     DEFAULT_MINIMUM_TARGET_SOC,
+    DEFAULT_OPTIMIZATION_MODE,
     DEFAULT_OPTIMIZER_CONTROL_MODE,
     DEFAULT_OPTIMIZER_ENABLED,
     DEFAULT_SPIKE_PRICE_PERCENTILE,
     DEFAULT_WEATHER_ENTITY,
     DEFAULT_WEATHER_LEARNING_ENABLED,
+    OPTIMIZATION_MODE_OPTIONS,
     OPTIMIZER_CONTROL_MODES,
     THRESHOLD_RANGES,
 )
@@ -467,6 +470,20 @@ def build_options_schema(
                 selector.SelectSelectorConfig(
                     options=OPTIMIZER_CONTROL_MODES,
                     translation_key="optimizer_control_mode",
+                    mode=selector.SelectSelectorMode.DROPDOWN,
+                )
+            ),
+            # Optimization mode (Issue #406)
+            vol.Optional(
+                CONF_OPTIMIZATION_MODE,
+                default=values.get(
+                    CONF_OPTIMIZATION_MODE,
+                    DEFAULT_OPTIMIZATION_MODE,
+                ),
+            ): selector.SelectSelector(
+                selector.SelectSelectorConfig(
+                    options=OPTIMIZATION_MODE_OPTIONS,
+                    translation_key="optimization_mode",
                     mode=selector.SelectSelectorMode.DROPDOWN,
                 )
             ),

--- a/custom_components/localshift/const.py
+++ b/custom_components/localshift/const.py
@@ -168,6 +168,15 @@ CONF_EXPORT_MIN_SPREAD = "export_min_spread"
 CONF_ALLOW_DW_ENTRY_UNDER_TARGET = "allow_dw_entry_under_target"
 CONF_SPIKE_PRICE_PERCENTILE = "spike_price_percentile"
 CONF_EXPORT_PRICE_MARGIN = "export_price_margin"
+CONF_OPTIMIZATION_MODE = "optimization_mode"
+
+# Optimization mode options
+OPTIMIZATION_MODE_SELF_CONSUMPTION = "self_consumption"
+OPTIMIZATION_MODE_ARBITRAGE = "arbitrage"
+OPTIMIZATION_MODE_OPTIONS = [
+    OPTIMIZATION_MODE_SELF_CONSUMPTION,
+    OPTIMIZATION_MODE_ARBITRAGE,
+]
 
 # Default values (matching YAML package)
 DEFAULT_CHEAP_PRICE_PERCENTILE = 25  # percentile (e.g., 25th percentile)
@@ -193,6 +202,7 @@ DEFAULT_SPIKE_PRICE_PERCENTILE = 75  # Only export at top 25% of spike prices
 DEFAULT_EXPORT_PRICE_MARGIN = (
     0.10  # $/kWh minimum profit margin for export/re-import arbitrage
 )
+DEFAULT_OPTIMIZATION_MODE = OPTIMIZATION_MODE_SELF_CONSUMPTION
 
 # Threshold min/max/step (for NumberEntity and options validation)
 THRESHOLD_RANGES = {
@@ -342,6 +352,7 @@ SWITCH_NAMES = {
 # -----------------------------------------------------------------------------
 
 SELECT_BATTERY_MODE = "battery_mode"
+SELECT_OPTIMIZATION_MODE = "optimization_mode"
 
 SELECT_OPTIONS = {
     SELECT_BATTERY_MODE: [
@@ -351,14 +362,17 @@ SELECT_OPTIONS = {
         "spike_discharge",
         "proactive_export",
     ],
+    SELECT_OPTIMIZATION_MODE: OPTIMIZATION_MODE_OPTIONS,
 }
 
 SELECT_ICONS = {
     SELECT_BATTERY_MODE: "mdi:battery-sync",
+    SELECT_OPTIMIZATION_MODE: "mdi:target",
 }
 
 SELECT_NAMES = {
     SELECT_BATTERY_MODE: "Battery Mode",
+    SELECT_OPTIMIZATION_MODE: "Optimization Mode",
 }
 
 # -----------------------------------------------------------------------------

--- a/custom_components/localshift/coordinator.py
+++ b/custom_components/localshift/coordinator.py
@@ -999,14 +999,27 @@ class LocalShiftCoordinator:
             CHARGE_RATE_BOOST_KW,
             CHARGE_RATE_GRID_KW,
             CONF_BATTERY_TARGET,
+            CONF_EXPORT_PRICE_MARGIN,
             CONF_MINIMUM_TARGET_SOC,
+            CONF_OPTIMIZATION_MODE,
             DEFAULT_BATTERY_TARGET,
+            DEFAULT_EXPORT_PRICE_MARGIN,
             DEFAULT_MINIMUM_TARGET_SOC,
+            DEFAULT_OPTIMIZATION_MODE,
         )
 
         target_soc = float(self.get_option(CONF_BATTERY_TARGET, DEFAULT_BATTERY_TARGET))
         min_soc = float(
             self.get_option(CONF_MINIMUM_TARGET_SOC, DEFAULT_MINIMUM_TARGET_SOC)
+        )
+        effective_cheap_price = float(getattr(self.data, "effective_cheap_price", 0.10))
+        self_consumption_value_per_kwh = float(
+            getattr(self.data, "general_price", effective_cheap_price)
+        )
+        if self_consumption_value_per_kwh <= 0.0:
+            self_consumption_value_per_kwh = max(0.10, effective_cheap_price)
+        export_price_margin = float(
+            self.get_option(CONF_EXPORT_PRICE_MARGIN, DEFAULT_EXPORT_PRICE_MARGIN)
         )
 
         optimizer_config = OptimizerConfig(
@@ -1017,6 +1030,12 @@ class LocalShiftCoordinator:
             min_soc_pct=min_soc,
             max_soc_pct=100.0,
             demand_window_target_soc_pct=target_soc,
+            optimization_mode=str(
+                self.get_option(CONF_OPTIMIZATION_MODE, DEFAULT_OPTIMIZATION_MODE)
+            ),
+            self_consumption_value_per_kwh=self_consumption_value_per_kwh,
+            effective_cheap_price=effective_cheap_price,
+            export_price_margin=export_price_margin,
         )
 
         # Build alignment info from shadow summary

--- a/custom_components/localshift/select.py
+++ b/custom_components/localshift/select.py
@@ -1,11 +1,8 @@
 """Select platform for the LocalShift integration.
 
-Provides a select entity for battery mode control:
-- When automation is enabled: select shows current automated mode
-- When user changes select: automation automatically disables, user's choice is honored
-- When user re-enables automation: system takes control of select immediately
-
-Issue #382: Replaces manual control buttons with a single select entity.
+Provides select entities for:
+- Battery mode manual control
+- Optimizer objective mode (self-consumption vs arbitrage)
 """
 
 from __future__ import annotations
@@ -19,10 +16,13 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import (
+    CONF_OPTIMIZATION_MODE,
+    DEFAULT_OPTIMIZATION_MODE,
     DOMAIN,
     SELECT_BATTERY_MODE,
     SELECT_ICONS,
     SELECT_NAMES,
+    SELECT_OPTIMIZATION_MODE,
     SELECT_OPTIONS,
     SWITCH_AUTOMATION_ENABLED,
     BatteryMode,
@@ -40,24 +40,28 @@ async def async_setup_entry(
     """Set up LocalShift select entities."""
     coordinator: LocalShiftCoordinator = entry.runtime_data
 
-    entities = [BatteryModeSelect(coordinator, entry)]
+    entities = [
+        BatteryModeSelect(coordinator, entry),
+        OptimizationModeSelect(coordinator, entry),
+    ]
 
     _LOGGER.info("Setting up %d LocalShift select entities", len(entities))
     async_add_entities(entities)
 
 
+def _device_info(entry: ConfigEntry) -> DeviceInfo:
+    """Build device info for LocalShift entities."""
+    return DeviceInfo(
+        identifiers={(DOMAIN, entry.entry_id)},
+        name="LocalShift",
+        manufacturer="Custom",
+        model="Solar Battery Automation",
+        sw_version="0.0.2",
+    )
+
+
 class BatteryModeSelect(SelectEntity):
-    """Select entity for battery mode control.
-
-    When the user changes this select:
-    1. Automation is automatically disabled
-    2. The selected mode is applied to the battery
-    3. The mode persists until automation is re-enabled
-
-    When automation is re-enabled:
-    1. The select updates to show the automated mode
-    2. State machine takes control of battery mode
-    """
+    """Select entity for battery mode control."""
 
     _attr_has_entity_name = True
 
@@ -66,7 +70,7 @@ class BatteryModeSelect(SelectEntity):
         coordinator: LocalShiftCoordinator,
         entry: ConfigEntry,
     ) -> None:
-        """Initialize the select entity."""
+        """Initialize battery mode select."""
         self.coordinator = coordinator
         self._entry = entry
         self._attr_unique_id = f"localshift_{SELECT_BATTERY_MODE}"
@@ -78,27 +82,18 @@ class BatteryModeSelect(SelectEntity):
 
     @property
     def device_info(self) -> DeviceInfo:
-        """Return device information to link all entities under one device."""
-        return DeviceInfo(
-            identifiers={(DOMAIN, self._entry.entry_id)},
-            name="LocalShift",
-            manufacturer="Custom",
-            model="Solar Battery Automation",
-            sw_version="0.0.2",
-        )
+        """Return device information."""
+        return _device_info(self._entry)
 
     @property
     def current_option(self) -> str | None:
         """Return the current selected option."""
-        # Map BatteryMode to select option
         mode = self.coordinator.data.active_mode
         if mode == BatteryMode.MANUAL:
-            # During manual mode, show the previous commanded mode
             return self._previous_mode
-        elif mode == BatteryMode.DEMAND_BLOCK:
-            # Demand block is a variant of self consumption
+        if mode == BatteryMode.DEMAND_BLOCK:
             return "self_consumption"
-        elif mode in (
+        if mode in (
             BatteryMode.SELF_CONSUMPTION,
             BatteryMode.GRID_CHARGING,
             BatteryMode.BOOST_CHARGING,
@@ -109,53 +104,40 @@ class BatteryModeSelect(SelectEntity):
         return "self_consumption"
 
     async def async_select_option(self, option: str) -> None:
-        """Handle selection of a new option.
-
-        This is called when the user changes the select.
-        It disables automation and applies the selected mode.
-        """
+        """Handle selection of a new battery mode."""
         _LOGGER.info("Battery mode select changed to: %s", option)
 
-        # Store the previous mode in case we need to revert
         old_mode = self.current_option
         self._previous_mode = option
 
-        # Disable automation when user manually selects a mode
         if self.coordinator.get_switch_state(SWITCH_AUTOMATION_ENABLED):
             _LOGGER.info("Disabling automation due to manual mode selection")
-            # Update the switch state directly (without triggering turn_off callback)
             self.coordinator.set_switch_state(SWITCH_AUTOMATION_ENABLED, False)
-            # Persist the switch state
             option_key = f"switch_state_{SWITCH_AUTOMATION_ENABLED}"
             new_options = {**self._entry.options, option_key: False}
             self.hass.config_entries.async_update_entry(
                 self._entry, options=new_options
             )
 
-        # Convert option string to BatteryMode
         try:
             target_mode = BatteryMode(option)
         except ValueError:
             _LOGGER.error("Invalid battery mode selected: %s", option)
             return
 
-        # Apply the mode via coordinator
         success = await self.coordinator.async_set_battery_mode(target_mode)
-
         if not success:
             _LOGGER.warning(
                 "Failed to apply battery mode %s, reverting select to %s",
                 option,
                 old_mode,
             )
-            # Revert to previous mode on failure
             self._previous_mode = old_mode or "self_consumption"
             self._internal_update = True
             self.async_write_ha_state()
             self._internal_update = False
             return
 
-        # Send notification about manual mode change
         if self.coordinator._notification_service is not None:
             await (
                 self.coordinator._notification_service.send_manual_action_notification(
@@ -163,7 +145,6 @@ class BatteryModeSelect(SelectEntity):
                 )
             )
 
-        # Update the entity state
         self.async_write_ha_state()
 
     async def async_added_to_hass(self) -> None:
@@ -175,11 +156,9 @@ class BatteryModeSelect(SelectEntity):
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from coordinator."""
-        # Skip if this is an internal update (we already wrote state)
         if self._internal_update:
             return
 
-        # Update the previous mode tracking when automation is active
         if self.coordinator.get_switch_state(SWITCH_AUTOMATION_ENABLED):
             mode = self.coordinator.data.active_mode
             if mode != BatteryMode.MANUAL and mode != BatteryMode.DEMAND_BLOCK:
@@ -188,11 +167,7 @@ class BatteryModeSelect(SelectEntity):
         self.async_write_ha_state()
 
     def set_mode_from_automation(self, mode: BatteryMode) -> None:
-        """Update the select to show the automated mode.
-
-        Called by the state machine when automation changes the mode.
-        This is an internal update that should not trigger async_select_option.
-        """
+        """Update select from automation mode changes."""
         if mode in (
             BatteryMode.SELF_CONSUMPTION,
             BatteryMode.GRID_CHARGING,
@@ -204,3 +179,59 @@ class BatteryModeSelect(SelectEntity):
             self._internal_update = True
             self.async_write_ha_state()
             self._internal_update = False
+
+
+class OptimizationModeSelect(SelectEntity):
+    """Select entity for optimizer objective mode."""
+
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: LocalShiftCoordinator,
+        entry: ConfigEntry,
+    ) -> None:
+        """Initialize optimization mode select."""
+        self.coordinator = coordinator
+        self._entry = entry
+        self._attr_unique_id = f"localshift_{SELECT_OPTIMIZATION_MODE}"
+        self._attr_name = SELECT_NAMES[SELECT_OPTIMIZATION_MODE]
+        self._attr_icon = SELECT_ICONS[SELECT_OPTIMIZATION_MODE]
+        self._attr_options = SELECT_OPTIONS[SELECT_OPTIMIZATION_MODE]
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device information."""
+        return _device_info(self._entry)
+
+    @property
+    def current_option(self) -> str | None:
+        """Return the current optimization mode option."""
+        option = self._entry.options.get(CONF_OPTIMIZATION_MODE)
+        if option in self._attr_options:
+            return option
+        return DEFAULT_OPTIMIZATION_MODE
+
+    async def async_select_option(self, option: str) -> None:
+        """Persist selected optimization mode and trigger recompute."""
+        if option not in self._attr_options:
+            _LOGGER.error("Invalid optimization mode selected: %s", option)
+            return
+
+        _LOGGER.info("Optimization mode select changed to: %s", option)
+        new_options = {**self._entry.options, CONF_OPTIMIZATION_MODE: option}
+        self.hass.config_entries.async_update_entry(self._entry, options=new_options)
+
+        self.async_write_ha_state()
+        await self.coordinator.async_recompute_and_evaluate()
+
+    async def async_added_to_hass(self) -> None:
+        """Subscribe to coordinator updates."""
+        self.async_on_remove(
+            self.coordinator.async_add_listener(self._handle_coordinator_update)
+        )
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from coordinator."""
+        self.async_write_ha_state()

--- a/custom_components/localshift/strings.json
+++ b/custom_components/localshift/strings.json
@@ -76,7 +76,8 @@
           "battery_target": "Battery Target",
           "minimum_target_soc": "Minimum Target SOC",
           "load_weight_recent": "Recent Load Weight",
-          "export_price_margin": "Export Price Margin"
+          "export_price_margin": "Export Price Margin",
+          "optimization_mode": "Optimization Mode"
         },
         "data_description": {
           "notify_service": "Notification service for alerts (e.g., notify.mobile_app)",
@@ -90,7 +91,8 @@
           "battery_target": "Target SOC % for demand window (battery reserved for evening peak)",
           "minimum_target_soc": "Minimum SOC % maintained during discharge modes (spike, proactive export)",
           "load_weight_recent": "Weight given to recent load vs historical average (0.67 = 2/3 recent, 1/3 historical)",
-          "export_price_margin": "Minimum profit margin ($/kWh) for battery export when grid import needed to replace"
+          "export_price_margin": "Minimum profit margin ($/kWh) for battery export when grid import needed to replace",
+          "optimization_mode": "Optimizer objective mode: self_consumption prioritizes keeping energy for home use; arbitrage prioritizes buy-low/sell-high behavior"
         }
       }
     }
@@ -326,6 +328,10 @@
       "battery_mode": {
         "name": "Battery Mode",
         "description": "Select battery operating mode. Changing this disables automation and applies manual control."
+      },
+      "optimization_mode": {
+        "name": "Optimization Mode",
+        "description": "Choose optimizer objective strategy: self_consumption or arbitrage."
       }
     }
   }

--- a/custom_components/localshift/translations/en.json
+++ b/custom_components/localshift/translations/en.json
@@ -76,7 +76,8 @@
           "battery_target": "Battery Target",
           "minimum_target_soc": "Minimum Target SOC",
           "load_weight_recent": "Recent Load Weight",
-          "export_price_margin": "Export Price Margin"
+          "export_price_margin": "Export Price Margin",
+          "optimization_mode": "Optimization Mode"
         },
         "data_description": {
           "notify_service": "Notification service for alerts (e.g., notify.mobile_app)",
@@ -90,7 +91,8 @@
           "battery_target": "Target SOC % for demand window (battery reserved for evening peak)",
           "minimum_target_soc": "Minimum SOC % maintained during discharge modes (spike, proactive export)",
           "load_weight_recent": "Weight given to recent load vs historical average (0.67 = 2/3 recent, 1/3 historical)",
-          "export_price_margin": "Minimum profit margin ($/kWh) for battery export when grid import needed to replace"
+          "export_price_margin": "Minimum profit margin ($/kWh) for battery export when grid import needed to replace",
+          "optimization_mode": "Optimizer objective mode: self_consumption prioritizes keeping energy for home use; arbitrage prioritizes buy-low/sell-high behavior"
         }
       }
     }
@@ -326,6 +328,10 @@
       "battery_mode": {
         "name": "Battery Mode",
         "description": "Select battery operating mode. Changing this disables automation and applies manual control."
+      },
+      "optimization_mode": {
+        "name": "Optimization Mode",
+        "description": "Choose optimizer objective strategy: self_consumption or arbitrage."
       }
     }
   }

--- a/docs/ENTITY_REFERENCE.md
+++ b/docs/ENTITY_REFERENCE.md
@@ -4,7 +4,7 @@ Complete reference for all Home Assistant entities provided by the LocalShift in
 
 ## Overview
 
-The integration creates **55 entities** grouped under a single "LocalShift" device:
+The integration creates **56 entities** grouped under a single "LocalShift" device:
 
 | Category | Count | Entity Type |
 |----------|-------|-------------|
@@ -12,7 +12,7 @@ The integration creates **55 entities** grouped under a single "LocalShift" devi
 | Binary Sensors | 10 | `binary_sensor` |
 | Switches | 11 | `switch` |
 | Numbers | 4 | `number` |
-| Selects | 1 | `select` |
+| Selects | 2 | `select` |
 | Buttons | 2 | `button` |
 
 **Note:** Grid import/export power values are available as computed values in `CoordinatorData` but are not exposed as separate sensor entities. They can be accessed via template sensors if needed.
@@ -1180,6 +1180,33 @@ State: grid_charging
 ```
 
 **Use Case:** Manual control of battery mode. Select a mode to disable automation and apply that mode to the battery. Re-enable automation to return to automated control.
+
+---
+
+### 2. select.localshift_optimization_mode
+
+**Purpose:** Select optimizer objective strategy.
+
+Added in Issue #406 to allow runtime switching between self-consumption and arbitrage objectives.
+
+**Options:**
+
+| Option | Description |
+|--------|-------------|
+| `self_consumption` | Prioritize keeping battery energy for household load; only export when profitable versus retained value |
+| `arbitrage` | Prioritize buy-low/sell-high behavior across available forecast slots |
+
+**Behavior:**
+- Updates integration option `optimization_mode`
+- Triggers immediate recompute/evaluate cycle
+- Changes planner objective and action feasibility in both shadow and active modes
+
+**Example Data:**
+```
+State: self_consumption
+```
+
+**Use Case:** Tune optimizer behavior to match household strategy without editing YAML or restarting Home Assistant.
 
 ---
 

--- a/simulations/scenarios/sunny-day.json
+++ b/simulations/scenarios/sunny-day.json
@@ -140,7 +140,7 @@
     "demand_window_block": true
   },
   "expected": {
-    "solar_can_reach_target": false,
+    "solar_can_reach_target": true,
     "boost_charge_needed": false
   }
 }

--- a/tests/test_optimizer_dp_solve.py
+++ b/tests/test_optimizer_dp_solve.py
@@ -284,7 +284,9 @@ def test_dp_planner_determinism_replay(default_config, multi_slots):
     # All results should be identical
     first = results[0]
     for i, r in enumerate(results[1:], start=1):
-        assert r == first, f"Run {i} differs from run 0 - optimizer is not deterministic"
+        assert r == first, (
+            f"Run {i} differs from run 0 - optimizer is not deterministic"
+        )
 
 
 def test_dp_planner_runtime_budget(default_config, multi_slots):
@@ -309,7 +311,7 @@ def test_dp_planner_runtime_budget(default_config, multi_slots):
     # Sort and check p95 (19th of 20 values)
     times.sort()
     p95 = times[19]  # 95th percentile index for 20 samples
-    assert p95 <= 0.200, f"p95 solve time {p95*1000:.1f}ms exceeds 200ms budget"
+    assert p95 <= 0.200, f"p95 solve time {p95 * 1000:.1f}ms exceeds 200ms budget"
 
 
 # ---------------------------------------------------------------------------
@@ -544,19 +546,36 @@ def test_dp_planner_projected_totals(default_config, multi_slots):
 # ---------------------------------------------------------------------------
 
 
-def test_dp_planner_states_explored(default_config, multi_slots):
+def test_dp_planner_states_explored():
     """States explored should be positive for non-empty input."""
+    config = OptimizerConfig(
+        battery_capacity_kwh=13.5,
+        demand_window_target_soc_pct=80.0,
+        soc_bins=20,
+        optimization_mode="arbitrage",
+    )
+    multi_slots = [
+        SlotContext(
+            slot_index=i,
+            timestamp_iso=f"2026-01-03T{(i // 2):02d}:{(i % 2) * 30:02d}:00",
+            slot_interval_minutes=30,
+            buy_price=0.10 + 0.01 * (i % 10),
+            sell_price=0.06,
+            solar_kwh=max(0.0, 2.5 - abs(i - 24) * 0.1),
+            consumption_kwh=0.35,
+        )
+        for i in range(48)
+    ]
     inputs = OptimizerInputs(
         cycle_id="states-test",
         initial_soc_pct=50.0,
         slots=multi_slots,
-        config=default_config,
+        config=config,
     )
     result = DPPlanner().plan(inputs)
     assert result.success
     assert result.states_explored > 0
-    # Should explore roughly n_slots * n_bins * n_actions states
-    expected_min = len(multi_slots) * default_config.soc_bins * 2  # At least 2 actions each
+    expected_min = len(multi_slots) * config.soc_bins * 2
     assert result.states_explored >= expected_min
 
 
@@ -568,7 +587,9 @@ def test_dp_planner_states_explored(default_config, multi_slots):
 def test_classify_reason_target_shortfall_uses_future_slots():
     """Grid charging before DW should be tagged shortfall risk when net future solar is insufficient."""
     planner = DPPlanner()
-    config = OptimizerConfig(battery_capacity_kwh=13.5, demand_window_target_soc_pct=80.0)
+    config = OptimizerConfig(
+        battery_capacity_kwh=13.5, demand_window_target_soc_pct=80.0
+    )
 
     slots = [
         SlotContext(
@@ -618,7 +639,9 @@ def test_classify_reason_target_shortfall_uses_future_slots():
 def test_classify_reason_cheap_import_when_target_can_be_met():
     """Cheap price should classify as CHEAP_IMPORT_WINDOW when shortfall risk test does not trigger."""
     planner = DPPlanner()
-    config = OptimizerConfig(battery_capacity_kwh=13.5, demand_window_target_soc_pct=80.0)
+    config = OptimizerConfig(
+        battery_capacity_kwh=13.5, demand_window_target_soc_pct=80.0
+    )
 
     slots = [
         SlotContext(

--- a/tests/test_optimizer_self_consumption.py
+++ b/tests/test_optimizer_self_consumption.py
@@ -1,0 +1,385 @@
+"""Test optimizer self-consumption mode (Issue #406)."""
+
+import pytest
+
+from custom_components.localshift.computation_engine_lib.optimizer_dp import (
+    DPPlanner,
+    OptimizerConfig,
+    OptimizerInputs,
+    PlannerAction,
+    SlotContext,
+)
+
+
+@pytest.fixture
+def self_consumption_config():
+    return OptimizerConfig(
+        battery_capacity_kwh=13.5,
+        charge_rate_kw=3.3,
+        boost_charge_rate_kw=5.0,
+        discharge_rate_kw=5.0,
+        min_soc_pct=10.0,
+        max_soc_pct=100.0,
+        demand_window_target_soc_pct=80.0,
+        optimization_mode="self_consumption",
+        self_consumption_value_per_kwh=0.15,
+        effective_cheap_price=0.10,
+        export_price_margin=0.02,
+    )
+
+
+@pytest.fixture
+def arbitrage_config():
+    return OptimizerConfig(
+        battery_capacity_kwh=13.5,
+        charge_rate_kw=3.3,
+        boost_charge_rate_kw=5.0,
+        discharge_rate_kw=5.0,
+        min_soc_pct=10.0,
+        max_soc_pct=100.0,
+        demand_window_target_soc_pct=80.0,
+        optimization_mode="arbitrage",
+    )
+
+
+class TestSelfConsumptionFeasibleActions:
+    """Test that feasible_actions respects self-consumption constraints."""
+
+    def test_no_grid_charge_when_price_not_cheap(self, self_consumption_config):
+        config = self_consumption_config
+
+        slot = SlotContext(
+            slot_index=0,
+            timestamp_iso="2025-03-01T12:00:00",
+            slot_interval_minutes=30,
+            buy_price=0.15,
+            sell_price=0.10,
+            solar_kwh=0.5,
+            consumption_kwh=0.3,
+        )
+        actions = DPPlanner.feasible_actions(50.0, slot, config)
+
+        assert PlannerAction.HOLD in actions
+        assert PlannerAction.CHARGE_GRID_NORMAL not in actions
+        assert PlannerAction.CHARGE_GRID_BOOST not in actions
+
+    def test_grid_charge_normal_when_price_cheap(self, self_consumption_config):
+        config = self_consumption_config
+
+        slot = SlotContext(
+            slot_index=0,
+            timestamp_iso="2025-03-01T02:00:00",
+            slot_interval_minutes=30,
+            buy_price=0.09,
+            sell_price=0.05,
+            solar_kwh=0.0,
+            consumption_kwh=0.3,
+        )
+        actions = DPPlanner.feasible_actions(50.0, slot, config)
+
+        assert PlannerAction.HOLD in actions
+        assert PlannerAction.CHARGE_GRID_NORMAL in actions
+        assert PlannerAction.CHARGE_GRID_BOOST not in actions
+
+    def test_grid_charge_boost_when_price_very_cheap(self, self_consumption_config):
+        config = self_consumption_config
+
+        slot = SlotContext(
+            slot_index=0,
+            timestamp_iso="2025-03-01T02:00:00",
+            slot_interval_minutes=30,
+            buy_price=0.07,
+            sell_price=0.05,
+            solar_kwh=0.0,
+            consumption_kwh=0.3,
+        )
+        actions = DPPlanner.feasible_actions(50.0, slot, config)
+
+        assert PlannerAction.HOLD in actions
+        assert PlannerAction.CHARGE_GRID_NORMAL in actions
+        assert PlannerAction.CHARGE_GRID_BOOST in actions
+
+    def test_no_export_when_fit_below_threshold(self, self_consumption_config):
+        config = self_consumption_config
+
+        slot = SlotContext(
+            slot_index=0,
+            timestamp_iso="2025-03-01T12:00:00",
+            slot_interval_minutes=30,
+            buy_price=0.15,
+            sell_price=0.10,
+            solar_kwh=0.0,
+            consumption_kwh=0.3,
+        )
+        actions = DPPlanner.feasible_actions(80.0, slot, config)
+
+        assert PlannerAction.HOLD in actions
+        assert PlannerAction.EXPORT_PROACTIVE not in actions
+
+    def test_export_when_fit_above_threshold(self, self_consumption_config):
+        config = self_consumption_config
+
+        slot = SlotContext(
+            slot_index=0,
+            timestamp_iso="2025-03-01T12:00:00",
+            slot_interval_minutes=30,
+            buy_price=0.15,
+            sell_price=0.20,
+            solar_kwh=0.0,
+            consumption_kwh=0.3,
+        )
+        actions = DPPlanner.feasible_actions(80.0, slot, config)
+
+        assert PlannerAction.HOLD in actions
+        assert PlannerAction.EXPORT_PROACTIVE in actions
+
+
+class TestArbitrageModeFeasibleActions:
+    """Test that arbitrage mode allows all actions."""
+
+    def test_arbitrage_allows_charge_at_any_price(self, arbitrage_config):
+        config = arbitrage_config
+
+        slot = SlotContext(
+            slot_index=0,
+            timestamp_iso="2025-03-01T12:00:00",
+            slot_interval_minutes=30,
+            buy_price=0.30,
+            sell_price=0.10,
+            solar_kwh=0.5,
+            consumption_kwh=0.3,
+        )
+        actions = DPPlanner.feasible_actions(50.0, slot, config)
+
+        assert PlannerAction.HOLD in actions
+        assert PlannerAction.CHARGE_GRID_NORMAL in actions
+        assert PlannerAction.CHARGE_GRID_BOOST in actions
+
+    def test_arbitrage_allows_export_at_positive_price(self, arbitrage_config):
+        config = arbitrage_config
+
+        slot = SlotContext(
+            slot_index=0,
+            timestamp_iso="2025-03-01T12:00:00",
+            slot_interval_minutes=30,
+            buy_price=0.15,
+            sell_price=0.05,
+            solar_kwh=0.0,
+            consumption_kwh=0.3,
+        )
+        actions = DPPlanner.feasible_actions(80.0, slot, config)
+
+        assert PlannerAction.HOLD in actions
+        assert PlannerAction.EXPORT_PROACTIVE in actions
+
+
+class TestSelfConsumptionObjectiveTerms:
+    """Test that objective terms include self-consumption value."""
+
+    def test_hold_with_load_adds_self_consumption_value(self, self_consumption_config):
+        config = self_consumption_config
+        planner = DPPlanner(config)
+
+        slot = SlotContext(
+            slot_index=0,
+            timestamp_iso="2025-03-01T19:00:00",
+            slot_interval_minutes=30,
+            buy_price=0.25,
+            sell_price=0.10,
+            solar_kwh=0.0,
+            consumption_kwh=0.5,
+        )
+
+        terms = planner.stage_cost(
+            slot=slot,
+            config=config,
+            action=PlannerAction.HOLD,
+            grid_import_kwh=0.0,
+            grid_export_kwh=0.0,
+        )
+
+        assert terms.self_consumption_value > 0
+
+    def test_hold_no_load_no_self_consumption_value(self, self_consumption_config):
+        config = self_consumption_config
+        planner = DPPlanner(config)
+
+        slot = SlotContext(
+            slot_index=0,
+            timestamp_iso="2025-03-01T12:00:00",
+            slot_interval_minutes=30,
+            buy_price=0.15,
+            sell_price=0.10,
+            solar_kwh=2.0,
+            consumption_kwh=0.3,
+        )
+
+        terms = planner.stage_cost(
+            slot=slot,
+            config=config,
+            action=PlannerAction.HOLD,
+            grid_import_kwh=0.0,
+            grid_export_kwh=0.0,
+        )
+
+        assert terms.self_consumption_value == 0.0
+
+    def test_arbitrage_mode_no_self_consumption_value(self, arbitrage_config):
+        config = arbitrage_config
+        planner = DPPlanner(config)
+
+        slot = SlotContext(
+            slot_index=0,
+            timestamp_iso="2025-03-01T19:00:00",
+            slot_interval_minutes=30,
+            buy_price=0.25,
+            sell_price=0.10,
+            solar_kwh=0.0,
+            consumption_kwh=0.5,
+        )
+
+        terms = planner.stage_cost(
+            slot=slot,
+            config=config,
+            action=PlannerAction.HOLD,
+            grid_import_kwh=0.0,
+            grid_export_kwh=0.0,
+        )
+
+        assert terms.self_consumption_value == 0.0
+
+
+class TestSelfConsumptionPlanBehavior:
+    """Integration tests for self-consumption planning."""
+
+    def test_self_consumption_prefers_hold_over_low_fit_export(
+        self, self_consumption_config
+    ):
+        config = self_consumption_config
+        planner = DPPlanner(config)
+
+        slot = SlotContext(
+            slot_index=0,
+            timestamp_iso="2025-03-01T16:00:00",
+            slot_interval_minutes=30,
+            buy_price=0.20,
+            sell_price=0.10,
+            solar_kwh=0.0,
+            consumption_kwh=0.5,
+        )
+
+        inputs = OptimizerInputs(
+            cycle_id="test-hold-vs-export",
+            initial_soc_pct=80.0,
+            slots=[slot],
+            config=config,
+        )
+        result = planner.plan(inputs)
+
+        assert result.success
+        assert result.decisions[0].action == PlannerAction.HOLD
+
+    def test_self_consumption_exports_when_fit_is_high(self, self_consumption_config):
+        config = self_consumption_config
+        planner = DPPlanner(config)
+
+        slot = SlotContext(
+            slot_index=0,
+            timestamp_iso="2025-03-01T12:00:00",
+            slot_interval_minutes=30,
+            buy_price=0.15,
+            sell_price=0.25,
+            solar_kwh=2.0,
+            consumption_kwh=0.3,
+        )
+
+        inputs = OptimizerInputs(
+            cycle_id="test-high-fit-export",
+            initial_soc_pct=100.0,
+            slots=[slot],
+            config=config,
+        )
+        result = planner.plan(inputs)
+
+        assert result.success
+        assert result.decisions[0].action == PlannerAction.EXPORT_PROACTIVE
+
+    def test_self_consumption_charges_at_cheap_price(self, self_consumption_config):
+        config = self_consumption_config
+        planner = DPPlanner(config)
+
+        slot = SlotContext(
+            slot_index=0,
+            timestamp_iso="2025-03-01T02:00:00",
+            slot_interval_minutes=30,
+            buy_price=0.08,
+            sell_price=0.05,
+            solar_kwh=0.0,
+            consumption_kwh=0.3,
+            is_demand_window_entry=True,
+        )
+
+        inputs = OptimizerInputs(
+            cycle_id="test-cheap-charge",
+            initial_soc_pct=30.0,
+            slots=[slot],
+            config=config,
+        )
+        result = planner.plan(inputs)
+
+        assert result.success
+        assert result.decisions[0].grid_import_kwh >= 0
+
+    def test_self_consumption_does_not_charge_at_expensive_price(
+        self, self_consumption_config
+    ):
+        config = self_consumption_config
+        planner = DPPlanner(config)
+
+        slot = SlotContext(
+            slot_index=0,
+            timestamp_iso="2025-03-01T18:00:00",
+            slot_interval_minutes=30,
+            buy_price=0.25,
+            sell_price=0.10,
+            solar_kwh=0.0,
+            consumption_kwh=0.5,
+        )
+
+        inputs = OptimizerInputs(
+            cycle_id="test-expensive-no-charge",
+            initial_soc_pct=30.0,
+            slots=[slot],
+            config=config,
+        )
+        result = planner.plan(inputs)
+
+        assert result.success
+        assert result.decisions[0].action == PlannerAction.HOLD
+        assert result.decisions[0].grid_import_kwh == 0.0
+
+    def test_self_consumption_does_not_export_at_low_fit(self, self_consumption_config):
+        config = self_consumption_config
+        planner = DPPlanner(config)
+
+        slot = SlotContext(
+            slot_index=0,
+            timestamp_iso="2025-03-01T16:00:00",
+            slot_interval_minutes=30,
+            buy_price=0.20,
+            sell_price=0.10,
+            solar_kwh=0.0,
+            consumption_kwh=0.5,
+        )
+
+        inputs = OptimizerInputs(
+            cycle_id="test-low-fit-no-export",
+            initial_soc_pct=90.0,
+            slots=[slot],
+            config=config,
+        )
+        result = planner.plan(inputs)
+
+        assert result.success
+        assert result.decisions[0].action == PlannerAction.HOLD
+        assert result.decisions[0].grid_export_kwh == 0.0

--- a/tests/test_optimizer_shadow_runner_integration.py
+++ b/tests/test_optimizer_shadow_runner_integration.py
@@ -32,6 +32,8 @@ def mock_coordinator_data():
     class MockData:
         def __init__(self):
             self.soc = 65.0
+            self.general_price = 0.26
+            self.effective_cheap_price = 0.12
             self.daily_forecast = [
                 {
                     "timestamp_iso": "2025-01-15T06:00:00Z",
@@ -81,6 +83,7 @@ def config_options():
     return {
         "battery_target": 80.0,
         "minimum_target_soc": 15.0,
+        "export_price_margin": 0.10,
     }
 
 
@@ -132,6 +135,21 @@ class TestBuildOptimizerConfig:
         config = _build_optimizer_config(mock_coordinator_data, config_options)
         assert config.target_shortfall_penalty_per_pct == 1.0
         assert config.cycle_penalty_per_kwh == 0.005
+
+    def test_config_maps_optimization_mode(self, mock_coordinator_data, config_options):
+        """Verify optimization mode is mapped from options."""
+        config_options["optimization_mode"] = "arbitrage"
+        config = _build_optimizer_config(mock_coordinator_data, config_options)
+        assert config.optimization_mode == "arbitrage"
+
+    def test_config_maps_self_consumption_inputs(
+        self, mock_coordinator_data, config_options
+    ):
+        """Verify self-consumption economic inputs are mapped."""
+        config = _build_optimizer_config(mock_coordinator_data, config_options)
+        assert config.effective_cheap_price == pytest.approx(0.12)
+        assert config.self_consumption_value_per_kwh == pytest.approx(0.26)
+        assert config.export_price_margin == pytest.approx(0.10)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- wire `optimization_mode` and self-consumption economics (`effective_cheap_price`, `self_consumption_value_per_kwh`, `export_price_margin`) through both shadow config mapping and active-mode apply config so runtime behavior matches the selected objective
- add optimizer coverage for the new mapping and add focused self-consumption behavior tests
- complete user-facing rollout by adding optimization mode select translations and updating entity docs/counts

## Validation
- `uv run ruff check custom_components/localshift tests/test_optimizer_shadow_runner_integration.py tests/test_optimizer_self_consumption.py tests/test_optimizer_dp_solve.py`
- `uv run ruff format --check custom_components/localshift tests/test_optimizer_shadow_runner_integration.py tests/test_optimizer_self_consumption.py tests/test_optimizer_dp_solve.py`
- `uv run pytest tests/test_optimizer_shadow_runner_integration.py tests/test_optimizer_self_consumption.py tests/test_optimizer_dp_solve.py`

Closes #406