### PR TITLE
fix(optimizer): correct discharge efficiency in EXPORT_PROACTIVE

### DIFF
--- a/custom_components/localshift/computation_engine_lib/optimizer_dp.py
+++ b/custom_components/localshift/computation_engine_lib/optimizer_dp.py
@@ -928,7 +928,9 @@ class DPPlanner:
                 # Surplus solar can be sent to battery subject to rate + headroom.
                 solar_surplus_kwh = net_kwh
                 solar_by_rate_kwh = min(solar_surplus_kwh, max_transfer_kwh)
-                headroom_kwh = max(0.0, (config.max_soc_pct - soc_pct) / 100.0 * capacity_kwh)
+                headroom_kwh = max(
+                    0.0, (config.max_soc_pct - soc_pct) / 100.0 * capacity_kwh
+                )
 
                 if config.charge_efficiency <= 0:
                     solar_to_battery_kwh = 0.0
@@ -951,7 +953,9 @@ class DPPlanner:
                 max_load_from_battery_kwh = (
                     available_battery_kwh * config.discharge_efficiency
                 )
-                battery_to_load_kwh = min(discharge_by_rate_kwh, max_load_from_battery_kwh)
+                battery_to_load_kwh = min(
+                    discharge_by_rate_kwh, max_load_from_battery_kwh
+                )
 
                 if config.discharge_efficiency <= 0:
                     battery_delta_kwh = 0.0
@@ -1044,7 +1048,7 @@ class DPPlanner:
             # Discharge to grid at max rate
             max_discharge_kwh = config.discharge_rate_kw * slot_hours
             # Effective export accounts for discharge efficiency loss
-            effective_export_kwh = max_discharge_kwh / config.discharge_efficiency
+            effective_export_kwh = max_discharge_kwh * config.discharge_efficiency
 
             # Account for solar/consumption net
             # Solar goes directly to export (not through battery)
@@ -1057,7 +1061,7 @@ class DPPlanner:
                 # Consumption deficit reduces export
                 net_export = max(0.0, net_export + net_kwh)
 
-            delta_soc = -(effective_export_kwh / capacity_kwh) * 100.0
+            delta_soc = -(max_discharge_kwh / capacity_kwh) * 100.0
             next_soc = soc_pct + delta_soc
 
             # Clip to min SOC


### PR DESCRIPTION
## Problem

The `EXPORT_PROACTIVE` transition in `optimizer_dp.py` incorrectly **divides** by `discharge_efficiency` instead of **multiplying**, causing:

- Grid export to exceed physical battery discharge limits (overstated by ~5%)
- SOC to drain faster than actual battery discharge
- Export revenue to be inflated
- Optimizer to over-favor export actions

## Root Cause

Line 1073 (original): `effective_export_kwh = max_discharge_kwh / config.discharge_efficiency`

This is physically incorrect. When a battery discharges, the energy reaching the grid is **less** than what leaves the battery due to efficiency loss. Therefore, we should multiply, not divide.

## Fix

Changed two lines in `optimizer_dp.py`:

1. Line 1051: `effective_export_kwh = max_discharge_kwh * config.discharge_efficiency` (was `/`)
2. Line 1064: `delta_soc = -(max_discharge_kwh / capacity_kwh) * 100.0` (uses raw discharge instead of inflated export)

## Verification

- All optimizer tests pass (111 tests)
- Full test suite: 695 passed (7 pre-existing failures unrelated)
- Lint and format checks pass

## Physics Check

With `discharge_rate_kw=5.0`, `slot_hours=0.5`, `discharge_efficiency=0.95`, `capacity_kwh=13.5`:

**Before (buggy):**
- max_discharge_kwh = 2.5 kWh
- effective_export_kwh = 2.5 / 0.95 = 2.632 kWh (exceeds physical limit!)
- SOC delta = -2.632/13.5*100 = -19.5%

**After (fixed):**
- effective_export_kwh = 2.5 * 0.95 = 2.375 kWh (correct)
- SOC delta = -(2.5/13.5)*100 = -18.5% (correct, based on actual discharge)

The fix ensures consistency with the HOLD and CHARGE_GRID actions which already use correct efficiency handling.

Fixes #421