### PR TITLE
fix(dp): use discharge_rate_kw for HOLD discharge rate limit

### DIFF
--- a/custom_components/localshift/computation_engine_lib/optimizer_dp.py
+++ b/custom_components/localshift/computation_engine_lib/optimizer_dp.py
@@ -944,12 +944,12 @@ class DPPlanner:
             # - Surplus solar charges battery first, then remaining surplus exports.
             # - Net load discharges battery first, then remaining deficit imports.
             # Rate limits, efficiency, and SOC bounds are applied in both directions.
-            max_transfer_kwh = config.solar_charge_rate_kw * slot_hours
 
             if net_kwh >= 0:
                 # Surplus solar can be sent to battery subject to rate + headroom.
+                limit_kwh = config.solar_charge_rate_kw * slot_hours
                 solar_surplus_kwh = net_kwh
-                solar_by_rate_kwh = min(solar_surplus_kwh, max_transfer_kwh)
+                solar_by_rate_kwh = min(solar_surplus_kwh, limit_kwh)
                 headroom_kwh = max(
                     0.0, (config.max_soc_pct - soc_pct) / 100.0 * capacity_kwh
                 )
@@ -967,8 +967,9 @@ class DPPlanner:
                 return next_soc, 0.0, grid_export_kwh
             else:
                 # Net load can be supplied by battery subject to rate + floor.
+                limit_kwh = config.discharge_rate_kw * slot_hours
                 load_deficit_kwh = -net_kwh
-                discharge_by_rate_kwh = min(load_deficit_kwh, max_transfer_kwh)
+                discharge_by_rate_kwh = min(load_deficit_kwh, limit_kwh)
                 available_battery_kwh = max(
                     0.0, (soc_pct - config.min_soc_pct) / 100.0 * capacity_kwh
                 )

--- a/tests/test_optimizer_dp_solve.py
+++ b/tests/test_optimizer_dp_solve.py
@@ -192,6 +192,37 @@ def test_transition_hold_at_soc_ceiling_emits_passive_grid_export(default_config
     assert terms.export_revenue == pytest.approx(slot.sell_price * grid_export)
 
 
+def test_transition_hold_respects_separate_rates():
+    """Issue #422: HOLD must use solar_charge_rate_kw for charge and discharge_rate_kw for discharge."""
+    config = OptimizerConfig(solar_charge_rate_kw=2.0, discharge_rate_kw=4.0)
+    slot = SlotContext(
+        slot_index=0,
+        timestamp_iso="2026-01-01T12:00:00",
+        slot_interval_minutes=60,
+        buy_price=0.1,
+        sell_price=0.05,
+        solar_kwh=0,
+        consumption_kwh=0,
+    )
+
+    # 1. Discharge (net_kwh = -10): should be capped by discharge_rate_kw (4.0 kW * 1h = 4.0 kWh)
+    slot.consumption_kwh = 10.0
+    _, grid_import, _ = DPPlanner.transition(
+        soc_pct=50.0, action=PlannerAction.HOLD, slot=slot, config=config
+    )
+    assert grid_import == pytest.approx(6.0)  # 10.0 - 4.0
+
+    # 2. Charge (net_kwh = 10): should be capped by solar_charge_rate_kw (2.0 kW * 1h = 2.0 kWh)
+    slot.consumption_kwh = 0.0
+    slot.solar_kwh = 10.0
+    _, _, grid_export = DPPlanner.transition(
+        soc_pct=50.0, action=PlannerAction.HOLD, slot=slot, config=config
+    )
+    assert grid_export == pytest.approx(8.0)  # 10.0 - 2.0
+
+
+# ---------------------------------------------------------------------------
+# DPPlanner core tests
 # ---------------------------------------------------------------------------
 # DPPlanner core tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Corrected `DPPlanner.transition` logic for `PlannerAction.HOLD` to use `config.discharge_rate_kw` when handling net load deficits.
- Previously, `config.solar_charge_rate_kw` was used for both charge and discharge, which was semantically incorrect and led to wrong behavior if the two rates were configured differently.
- Added a concise regression test in `tests/test_optimizer_dp_solve.py` verifying both rate limits under `HOLD`.

Closes #422