### PR TITLE
Debug view: add Solar, Load, Buy $, Sell $ columns to optimizer forecast table

### DIFF
--- a/custom_components/localshift/computation_engine_lib/optimizer_dp.py
+++ b/custom_components/localshift/computation_engine_lib/optimizer_dp.py
@@ -285,6 +285,19 @@ class PlannedSlotDecision:
     grid_export_kwh: float
     """Grid export energy for this slot (kWh)."""
 
+    # --- Slot context passthroughs (for dashboard debug display) ---
+    solar_kwh: float = 0.0
+    """Forecast solar generation for this slot (kWh), copied from SlotContext."""
+
+    consumption_kwh: float = 0.0
+    """Forecast household consumption for this slot (kWh), copied from SlotContext."""
+
+    buy_price: float = 0.0
+    """Import price ($/kWh), copied from SlotContext."""
+
+    sell_price: float = 0.0
+    """Export (FIT) price ($/kWh), copied from SlotContext."""
+
     # --- Derived compatibility flags (set from action) ---
     @property
     def grid_charge(self) -> bool:
@@ -757,6 +770,10 @@ class DPPlanner:
                 predicted_soc_pct=next_soc,
                 grid_import_kwh=grid_import,
                 grid_export_kwh=grid_export,
+                solar_kwh=slot.solar_kwh,
+                consumption_kwh=slot.consumption_kwh,
+                buy_price=slot.buy_price,
+                sell_price=slot.sell_price,
             )
             decisions.append(decision)
 

--- a/custom_components/localshift/computation_engine_lib/optimizer_shadow_runner.py
+++ b/custom_components/localshift/computation_engine_lib/optimizer_shadow_runner.py
@@ -622,6 +622,11 @@ def _serialize_decision(decision: Any) -> dict[str, Any]:
         "predicted_soc_pct": round(decision.predicted_soc_pct, 2),
         "grid_import_kwh": round(decision.grid_import_kwh, 4),
         "grid_export_kwh": round(decision.grid_export_kwh, 4),
+        # Slot context passthroughs (for dashboard debug display) — see #434
+        "solar_kwh": round(decision.solar_kwh, 3),
+        "consumption_kwh": round(decision.consumption_kwh, 3),
+        "buy_price": round(decision.buy_price, 4),
+        "sell_price": round(decision.sell_price, 4),
         # Derived compatibility flags
         "grid_charge": decision.grid_charge,
         "grid_charge_boost": decision.grid_charge_boost,

--- a/custom_components/localshift/dashboard.yaml
+++ b/custom_components/localshift/dashboard.yaml
@@ -961,12 +961,12 @@ views:
             **Projected Cost:** Legacy: ${{ state_attr('sensor.localshift_optimizer_comparison', 'legacy_projected_net_cost') | default(0) | round(2) }} |
             Optimizer: ${{ state_attr('sensor.localshift_optimizer_comparison', 'optimizer_projected_net_cost') | default(0) | round(2) }}
 
-            | Time | SOC% | Action | Reason | Import | Export |
+            | Time | SOC% | Solar | Load | Buy$ | Sell$ | Action | Reason | Import | Export |
 
-            | :--- | ---: | :--- | :--- | ---: | ---: |
+            | :--- | ---: | ---: | ---: | ---: | ---: | :--- | :--- | ---: | ---: |
 
             {% for d in decisions %}
-            | {{ d.timestamp_iso[11:16] if d.timestamp_iso else '-' }} | {{ "%.1f"|format(d.predicted_soc_pct | float) }} | {{ d.action | replace('_', ' ') | title }} | {{ d.reason_code | replace('_', ' ') | truncate(20) }} | {{ "%.3f"|format(d.grid_import_kwh | float) }} | {{ "%.3f"|format(d.grid_export_kwh | float) }} |
+            | {{ d.timestamp_iso[11:16] if d.timestamp_iso else '-' }} | {{ "%.1f"|format(d.predicted_soc_pct | float) }} | {{ "%.3f"|format(d.solar_kwh | float) }} | {{ "%.3f"|format(d.consumption_kwh | float) }} | {{ "%.3f"|format(d.buy_price | float) }} | {{ "%.3f"|format(d.sell_price | float) }} | {{ d.action | replace('_', ' ') | title }} | {{ d.reason_code | replace('_', ' ') | truncate(20) }} | {{ "%.3f"|format(d.grid_import_kwh | float) }} | {{ "%.3f"|format(d.grid_export_kwh | float) }} |
             
             {% endfor %}
 


### PR DESCRIPTION
Closes #434

## Changes

### `optimizer_dp.py`
- Added `solar_kwh`, `consumption_kwh`, `buy_price`, `sell_price` fields to `PlannedSlotDecision` dataclass (with `0.0` defaults for backward compat)
- Populated from `SlotContext` during the forward pass in `DPPlanner._solve()`

### `optimizer_shadow_runner.py`
- `_serialize_decision()`: serialises the four new fields into the decisions list

### `dashboard.yaml`
- Optimizer forecast table now has: `Time | SOC% | Solar | Load | Buy$ | Sell$ | Action | Reason | Import | Export`
- Matches the column conventions of the legacy forecast table directly above it

## Tests
All 45 computation engine tests pass. The single pre-existing failure in `test_classify_reason_cheap_import_when_target_can_be_met` was present on `main` before this branch.