### PR TITLE
optimizer: solar-aware feasibility gate and recalibrated shortfall penalty (#439)

### DIFF
--- a/custom_components/localshift/computation_engine_lib/optimizer_dp.py
+++ b/custom_components/localshift/computation_engine_lib/optimizer_dp.py
@@ -183,8 +183,23 @@ class OptimizerConfig:
     """If True, allow reaching target during DW via solar (instead of by DW start)."""
 
     # --- Objective weights ---
-    target_shortfall_penalty_per_pct: float = 1.0
-    """Penalty applied per % SOC below target at demand-window entry."""
+    target_shortfall_penalty_per_pct: float = 0.030
+    """Penalty applied per % SOC below target at demand-window entry ($/%-point).
+
+    This should be calibrated to the actual cost of importing 1% SOC from the grid
+    at the cheapest available price, with a small safety multiplier:
+
+        penalty = effective_cheap_price ($/kWh) * battery_capacity_kwh / 100 * safety_factor
+
+    Example: 0.15 $/kWh * 13.5 kWh / 100 * 1.5 = $0.030 per %-point
+
+    Do NOT use the original default of 1.0 — it is ~53x the actual remediation cost
+    and causes the optimizer to grid-charge compulsively. See issue #438.
+
+    In production, this value is computed in optimizer_shadow_runner._build_optimizer_config()
+    from the live tariff data; the dataclass default here is a reasonable fallback
+    for unit tests and standalone use.
+    """
 
     cycle_penalty_per_kwh: float = 0.005
     """Mild penalty per kWh cycled to discourage unnecessary grid arbitrage."""
@@ -637,7 +652,14 @@ class DPPlanner:
 
             for bin_idx, soc in enumerate(soc_grid):
                 # Get feasible actions for this state
-                actions = DPPlanner.feasible_actions(soc, slot, config)
+                actions = DPPlanner.feasible_actions(
+                    soc,
+                    slot,
+                    config,
+                    slot_idx=slot_idx,
+                    slots=slots,
+                    terminal_penalty_idx=terminal_penalty_idx,
+                )
 
                 best_cost = float("inf")
                 best_action = PlannerAction.HOLD
@@ -856,14 +878,13 @@ class DPPlanner:
             if terminal_penalty_idx is not None and slot_idx < terminal_penalty_idx:
                 soc_deficit = config.demand_window_target_soc_pct - soc
                 if soc_deficit > 0:
-                    # Use real future slots (no repeated-current-slot approximation).
-                    projected_net_kwh = sum(
-                        s.solar_kwh - s.consumption_kwh
-                        for s in slots[slot_idx:terminal_penalty_idx]
+                    # Use shared helper (same calculation as feasible_actions solar gate).
+                    potential_soc_gain_pct = DPPlanner._projected_solar_soc_gain_pct(
+                        slot_idx=slot_idx,
+                        slots=slots,
+                        terminal_penalty_idx=terminal_penalty_idx,
+                        battery_capacity_kwh=config.battery_capacity_kwh,
                     )
-                    potential_soc_gain_pct = (
-                        projected_net_kwh / config.battery_capacity_kwh
-                    ) * 100.0
                     if potential_soc_gain_pct < soc_deficit:
                         return PlannerReasonCode.TARGET_SHORTFALL_RISK
 
@@ -902,10 +923,36 @@ class DPPlanner:
     # ------------------------------------------------------------------
 
     @staticmethod
+    def _projected_solar_soc_gain_pct(
+        slot_idx: int,
+        slots: list[SlotContext],
+        terminal_penalty_idx: int,
+        battery_capacity_kwh: float,
+    ) -> float:
+        """
+        Estimate the net SOC gain (%) achievable from solar between slot_idx
+        (inclusive) and terminal_penalty_idx (exclusive), after subtracting
+        household consumption.
+
+        A positive return value means solar surplus exceeds consumption over the
+        window; negative means consumption exceeds solar (net grid draw expected).
+
+        Used by feasible_actions() to decide whether to suppress grid charging.
+        """
+        projected_net_kwh = sum(
+            s.solar_kwh - s.consumption_kwh
+            for s in slots[slot_idx:terminal_penalty_idx]
+        )
+        return (projected_net_kwh / battery_capacity_kwh) * 100.0
+
+    @staticmethod
     def feasible_actions(
         soc_pct: float,
         slot: SlotContext,
         config: OptimizerConfig,
+        slot_idx: int = 0,
+        slots: list[SlotContext] | None = None,
+        terminal_penalty_idx: int | None = None,
     ) -> list[PlannerAction]:
         """
         Return list of actions feasible from given SOC and slot context.
@@ -915,7 +962,18 @@ class DPPlanner:
         - Demand window: no grid import during DW slots
         - Optimization mode (self_consumption vs arbitrage)
         - Price thresholds for self-consumption mode
+        - Solar surplus gate: suppresses grid charging when solar will cover
+          the full SOC deficit before the demand window (self_consumption mode only)
         - Slot duration vs transfer limits (TODO: implement fully in Phase C)
+
+        Args:
+            soc_pct: Current battery SOC percentage.
+            slot: Per-slot context (price, solar, consumption, flags).
+            config: Optimizer configuration and constraints.
+            slot_idx: Index of the current slot in the planning horizon (default 0).
+            slots: Full list of planning slots (None disables solar gate).
+            terminal_penalty_idx: Index at which the shortfall penalty is applied
+                (None disables solar gate).
         """
         actions = []
 
@@ -924,8 +982,30 @@ class DPPlanner:
 
         actions.append(PlannerAction.HOLD)
 
+        # Solar surplus gate: if projected solar can cover the full SOC deficit
+        # before the demand window, suppress grid charging entirely.
+        # This prevents the solver from grid-charging during solar-peak hours
+        # when solar will naturally fill the battery at zero cost.
+        _solar_covers_deficit = False
+        if (
+            config.optimization_mode == "self_consumption"
+            and slots is not None
+            and terminal_penalty_idx is not None
+            and slot_idx < terminal_penalty_idx
+        ):
+            soc_deficit_pct = config.demand_window_target_soc_pct - soc_pct
+            if soc_deficit_pct > 0:
+                solar_gain_pct = DPPlanner._projected_solar_soc_gain_pct(
+                    slot_idx=slot_idx,
+                    slots=slots,
+                    terminal_penalty_idx=terminal_penalty_idx,
+                    battery_capacity_kwh=config.battery_capacity_kwh,
+                )
+                if solar_gain_pct >= soc_deficit_pct:
+                    _solar_covers_deficit = True
+
         # Grid charging constraints (Issue #406)
-        if can_charge and not slot.is_demand_window_slot:
+        if can_charge and not slot.is_demand_window_slot and not _solar_covers_deficit:
             # In self-consumption mode, only charge if price is cheap
             if config.optimization_mode == "self_consumption":
                 price_is_cheap = slot.buy_price <= config.effective_cheap_price
@@ -938,7 +1018,7 @@ class DPPlanner:
                     if price_is_very_cheap:
                         actions.append(PlannerAction.CHARGE_GRID_BOOST)
             else:
-                # Arbitrage mode: charge whenever below max
+                # Arbitrage mode: charge whenever below max (no solar gate)
                 actions.append(PlannerAction.CHARGE_GRID_NORMAL)
                 actions.append(PlannerAction.CHARGE_GRID_BOOST)
 

--- a/custom_components/localshift/computation_engine_lib/optimizer_shadow_runner.py
+++ b/custom_components/localshift/computation_engine_lib/optimizer_shadow_runner.py
@@ -36,6 +36,14 @@ from .planner_comparator import PlannerComparator
 
 _LOGGER = logging.getLogger(__name__)
 
+# Safety multiplier for shortfall penalty calibration.
+# The penalty is set to (cheapest_grid_price * battery_kwh / 100) * this factor.
+# A value of 1.5 means the optimizer mildly prefers pre-charging over risking
+# a shortfall, but won't pay more than 1.5x the remediation cost to do so.
+# Do not set above 3.0 without careful testing — higher values cause compulsive
+# pre-charging even when solar will cover the deficit.
+_SHORTFALL_PENALTY_SAFETY_FACTOR = 1.5
+
 
 # ---------------------------------------------------------------------------
 # Public entry point
@@ -311,9 +319,18 @@ def _build_optimizer_config(
         # --- Demand window target ---
         demand_window_target_soc_pct=target_soc,  # User-configured target
         allow_dw_entry_under_target=allow_dw_entry_under_target,
-        # --- Objective weights (conservative defaults) ---
-        # TODO (#403 Phase C): Expose for tuning if comparison analytics suggest
-        target_shortfall_penalty_per_pct=1.0,
+        # --- Objective weights ---
+        # Calibrated to the actual cost of buying 1% SOC at the cheapest grid price,
+        # with a safety margin so the optimizer mildly prefers pre-charging over shortfall.
+        # Formula: effective_cheap_price ($/kWh) * battery_kwh / 100 * safety_factor
+        # Example at typical Amber overnight rates: 0.15 * 13.5 / 100 * 1.5 = $0.030/%-pt
+        # (Fixes #438 — original hardcoded 1.0 was ~53x the actual remediation cost)
+        target_shortfall_penalty_per_pct=(
+            effective_cheap_price
+            * BATTERY_CAPACITY_KWH
+            / 100.0
+            * _SHORTFALL_PENALTY_SAFETY_FACTOR
+        ),
         cycle_penalty_per_kwh=0.005,
         # --- SOC discretization ---
         soc_bins=50,

--- a/tests/test_optimizer_dp_solve.py
+++ b/tests/test_optimizer_dp_solve.py
@@ -863,7 +863,11 @@ def test_classify_reason_target_shortfall_uses_future_slots():
 
 
 def test_classify_reason_cheap_import_when_target_can_be_met():
-    """Cheap price should classify as CHEAP_IMPORT_WINDOW when shortfall risk test does not trigger."""
+    """Cheap price should classify as CHEAP_IMPORT_WINDOW when shortfall risk test does not trigger.
+
+    Uses a very cheap price (≤ effective_cheap_price * 0.8) so the blind-horizon guard
+    still allows the CHEAP_IMPORT_WINDOW classification (only 3 slots — horizon is short).
+    """
     planner = DPPlanner()
     config = OptimizerConfig(
         battery_capacity_kwh=13.5, demand_window_target_soc_pct=80.0
@@ -874,7 +878,7 @@ def test_classify_reason_cheap_import_when_target_can_be_met():
             slot_index=0,
             timestamp_iso="2026-01-03T10:00:00",
             slot_interval_minutes=30,
-            buy_price=0.10,
+            buy_price=0.07,  # very cheap: ≤ effective_cheap_price * 0.8 (0.10 * 0.8 = 0.08)
             sell_price=0.06,
             solar_kwh=1.5,
             consumption_kwh=0.2,
@@ -883,7 +887,7 @@ def test_classify_reason_cheap_import_when_target_can_be_met():
             slot_index=1,
             timestamp_iso="2026-01-03T10:30:00",
             slot_interval_minutes=30,
-            buy_price=0.10,
+            buy_price=0.07,
             sell_price=0.06,
             solar_kwh=1.5,
             consumption_kwh=0.2,
@@ -892,7 +896,7 @@ def test_classify_reason_cheap_import_when_target_can_be_met():
             slot_index=2,
             timestamp_iso="2026-01-03T11:00:00",
             slot_interval_minutes=30,
-            buy_price=0.10,
+            buy_price=0.07,
             sell_price=0.06,
             solar_kwh=1.0,
             consumption_kwh=0.2,
@@ -912,3 +916,281 @@ def test_classify_reason_cheap_import_when_target_can_be_met():
     )
 
     assert reason == PlannerReasonCode.CHEAP_IMPORT_WINDOW
+
+
+# ---------------------------------------------------------------------------
+# Tests: solar gate in feasible_actions() (#437 / #439)
+# ---------------------------------------------------------------------------
+
+
+def _make_slot(
+    slot_index: int = 0,
+    buy_price: float = 0.08,
+    solar_kwh: float = 0.0,
+    consumption_kwh: float = 0.3,
+    is_demand_window_slot: bool = False,
+) -> SlotContext:
+    """Helper to create a minimal SlotContext for feasibility tests."""
+    return SlotContext(
+        slot_index=slot_index,
+        timestamp_iso=f"2026-01-03T10:{slot_index * 5:02d}:00",
+        slot_interval_minutes=30,
+        buy_price=buy_price,
+        sell_price=0.06,
+        solar_kwh=solar_kwh,
+        consumption_kwh=consumption_kwh,
+        is_demand_window_slot=is_demand_window_slot,
+    )
+
+
+def test_feasible_actions_suppresses_grid_charge_when_solar_covers_deficit():
+    """Solar surplus >= SOC deficit: no CHARGE_GRID_* in feasible actions (self_consumption mode)."""
+    # SOC=70, target=80 → deficit=10%
+    # 10% of 13.5 kWh = 1.35 kWh needed
+    # Slots: 6 slots each with solar=0.5 kWh, consumption=0.2 kWh → net=0.3 kWh/slot → 1.8 kWh total
+    # 1.8 / 13.5 * 100 = 13.3% solar gain >= 10% deficit → gate fires
+    slots = [
+        _make_slot(slot_index=i, buy_price=0.08, solar_kwh=0.5, consumption_kwh=0.2)
+        for i in range(6)
+    ]
+    config = OptimizerConfig(
+        battery_capacity_kwh=13.5,
+        demand_window_target_soc_pct=80.0,
+        effective_cheap_price=0.10,
+        optimization_mode="self_consumption",
+        soc_bins=20,
+    )
+
+    actions = DPPlanner.feasible_actions(
+        soc_pct=70.0,
+        slot=slots[0],
+        config=config,
+        slot_idx=0,
+        slots=slots,
+        terminal_penalty_idx=6,
+    )
+
+    assert PlannerAction.HOLD in actions
+    assert PlannerAction.CHARGE_GRID_NORMAL not in actions
+    assert PlannerAction.CHARGE_GRID_BOOST not in actions
+
+
+def test_feasible_actions_allows_grid_charge_when_solar_insufficient():
+    """Solar surplus < SOC deficit: CHARGE_GRID_* remains feasible (price-gated)."""
+    # SOC=70, target=80 → deficit=10% (1.35 kWh needed)
+    # Slots: 6 slots each solar=0.1 kWh, consumption=0.2 kWh → net=-0.1/slot → -0.6 kWh total
+    # -0.6 / 13.5 * 100 = -4.4% solar gain < 10% deficit → gate does NOT fire
+    # buy_price=0.08 < effective_cheap_price=0.10 → charge actions available
+    slots = [
+        _make_slot(slot_index=i, buy_price=0.08, solar_kwh=0.1, consumption_kwh=0.2)
+        for i in range(6)
+    ]
+    config = OptimizerConfig(
+        battery_capacity_kwh=13.5,
+        demand_window_target_soc_pct=80.0,
+        effective_cheap_price=0.10,
+        optimization_mode="self_consumption",
+        soc_bins=20,
+    )
+
+    actions = DPPlanner.feasible_actions(
+        soc_pct=70.0,
+        slot=slots[0],
+        config=config,
+        slot_idx=0,
+        slots=slots,
+        terminal_penalty_idx=6,
+    )
+
+    assert PlannerAction.HOLD in actions
+    assert PlannerAction.CHARGE_GRID_NORMAL in actions
+    # buy_price=0.08 = effective_cheap_price * 0.8 = 0.08 → very_cheap → boost also offered
+    assert PlannerAction.CHARGE_GRID_BOOST in actions
+
+
+def test_feasible_actions_no_context_behaves_as_before():
+    """When slot_idx/slots/terminal_penalty_idx not provided, no solar gate (original behaviour)."""
+    # This checks the 3-argument call still works identically to pre-fix.
+    # SOC=70, target=80, cheap price, no solar — without context the gate is disabled.
+    slot = _make_slot(buy_price=0.08, solar_kwh=0.0, consumption_kwh=0.3)
+    config = OptimizerConfig(
+        battery_capacity_kwh=13.5,
+        demand_window_target_soc_pct=80.0,
+        effective_cheap_price=0.10,
+        optimization_mode="self_consumption",
+        soc_bins=20,
+    )
+
+    # 3-argument form: no solar context → gate disabled → grid charge offered normally
+    actions = DPPlanner.feasible_actions(70.0, slot, config)
+
+    assert PlannerAction.HOLD in actions
+    # Price is cheap, no gate in effect → grid charge should be available
+    assert PlannerAction.CHARGE_GRID_NORMAL in actions
+
+
+def test_feasible_actions_gate_disabled_in_arbitrage_mode():
+    """Solar gate does not apply in arbitrage mode — grid charge always available."""
+    # Solar more than covers deficit, but mode='arbitrage' → gate is skipped
+    slots = [
+        _make_slot(slot_index=i, buy_price=0.08, solar_kwh=2.0, consumption_kwh=0.1)
+        for i in range(6)
+    ]
+    config = OptimizerConfig(
+        battery_capacity_kwh=13.5,
+        demand_window_target_soc_pct=80.0,
+        effective_cheap_price=0.10,
+        optimization_mode="arbitrage",
+        soc_bins=20,
+    )
+
+    actions = DPPlanner.feasible_actions(
+        soc_pct=70.0,
+        slot=slots[0],
+        config=config,
+        slot_idx=0,
+        slots=slots,
+        terminal_penalty_idx=6,
+    )
+
+    # Arbitrage mode skips gate — both charge actions always available (below max_soc)
+    assert PlannerAction.CHARGE_GRID_NORMAL in actions
+    assert PlannerAction.CHARGE_GRID_BOOST in actions
+
+
+def test_feasible_actions_gate_not_fired_when_soc_already_at_target():
+    """When SOC >= target (no deficit), gate should not suppress grid charging."""
+    # SOC=85 >= target=80 → deficit=0 → gate does not fire
+    slots = [
+        _make_slot(slot_index=i, buy_price=0.08, solar_kwh=0.0, consumption_kwh=0.3)
+        for i in range(4)
+    ]
+    config = OptimizerConfig(
+        battery_capacity_kwh=13.5,
+        demand_window_target_soc_pct=80.0,
+        effective_cheap_price=0.10,
+        optimization_mode="self_consumption",
+        soc_bins=20,
+    )
+
+    actions = DPPlanner.feasible_actions(
+        soc_pct=85.0,
+        slot=slots[0],
+        config=config,
+        slot_idx=0,
+        slots=slots,
+        terminal_penalty_idx=4,
+    )
+
+    # No deficit → gate does not fire → price-gated grid charge offered
+    assert PlannerAction.HOLD in actions
+    assert PlannerAction.CHARGE_GRID_NORMAL in actions
+
+
+def test_projected_solar_soc_gain_pct_positive_surplus():
+    """_projected_solar_soc_gain_pct returns positive when solar > consumption."""
+    slots = [
+        _make_slot(slot_index=i, solar_kwh=1.0, consumption_kwh=0.3) for i in range(4)
+    ]
+    # 4 slots * (1.0 - 0.3) = 2.8 kWh net; 2.8/13.5 * 100 = ~20.7%
+    result = DPPlanner._projected_solar_soc_gain_pct(  # noqa: SLF001
+        slot_idx=0,
+        slots=slots,
+        terminal_penalty_idx=4,
+        battery_capacity_kwh=13.5,
+    )
+    assert result == pytest.approx((4 * 0.7 / 13.5) * 100.0, rel=1e-6)
+
+
+def test_projected_solar_soc_gain_pct_negative_when_consumption_dominates():
+    """_projected_solar_soc_gain_pct returns negative when consumption > solar."""
+    slots = [
+        _make_slot(slot_index=i, solar_kwh=0.1, consumption_kwh=0.5) for i in range(4)
+    ]
+    result = DPPlanner._projected_solar_soc_gain_pct(  # noqa: SLF001
+        slot_idx=0,
+        slots=slots,
+        terminal_penalty_idx=4,
+        battery_capacity_kwh=13.5,
+    )
+    assert result < 0.0
+
+
+def test_projected_solar_soc_gain_pct_respects_slot_range():
+    """Only slots in [slot_idx, terminal_penalty_idx) are counted."""
+    slots = [
+        _make_slot(slot_index=0, solar_kwh=3.0, consumption_kwh=0.1),  # large surplus
+        _make_slot(slot_index=1, solar_kwh=0.0, consumption_kwh=0.5),  # deficit
+        _make_slot(slot_index=2, solar_kwh=0.0, consumption_kwh=0.5),  # deficit
+        _make_slot(slot_index=3, solar_kwh=3.0, consumption_kwh=0.1),  # ignored
+    ]
+    # Only slots 1–2 (slot_idx=1, terminal=3); both are net deficit
+    result = DPPlanner._projected_solar_soc_gain_pct(  # noqa: SLF001
+        slot_idx=1,
+        slots=slots,
+        terminal_penalty_idx=3,
+        battery_capacity_kwh=13.5,
+    )
+    # 2 slots * (0.0 - 0.5) = -1.0 kWh; -1.0/13.5*100 = -7.4%
+    assert result < 0.0
+    assert result == pytest.approx((2 * -0.5 / 13.5) * 100.0, rel=1e-6)
+
+
+def test_optimizer_does_not_grid_charge_during_solar_peak_with_sufficient_solar():
+    """Integration: on a sunny day with enough solar, no grid charging before demand window."""
+    # 8 pre-DW slots (09:00–13:00) with strong solar; DW entry at slot 8
+    # SOC deficit: 80% - 70% = 10% (1.35 kWh)
+    # Solar surplus: 8 slots * (0.6 kWh solar - 0.2 kWh consumption) = 3.2 kWh net
+    # 3.2 / 13.5 * 100 = 23.7% solar gain >> 10% deficit → gate fires on all pre-DW slots
+    pre_dw_slots = [
+        SlotContext(
+            slot_index=i,
+            timestamp_iso=f"2026-01-03T{9 + i // 2:02d}:{(i % 2) * 30:02d}:00",
+            slot_interval_minutes=30,
+            buy_price=0.08,  # cheap — would grid-charge without the gate
+            sell_price=0.06,
+            solar_kwh=0.6,
+            consumption_kwh=0.2,
+        )
+        for i in range(8)
+    ]
+    dw_slots = [
+        SlotContext(
+            slot_index=8 + i,
+            timestamp_iso=f"2026-01-03T1{3 + i // 2}:{(i % 2) * 30:02d}:00",
+            slot_interval_minutes=30,
+            buy_price=0.30,
+            sell_price=0.06,
+            solar_kwh=0.0,
+            consumption_kwh=0.5,
+            is_demand_window_entry=(i == 0),
+            is_demand_window_slot=True,
+        )
+        for i in range(4)
+    ]
+    slots = pre_dw_slots + dw_slots
+
+    config = OptimizerConfig(
+        battery_capacity_kwh=13.5,
+        demand_window_target_soc_pct=80.0,
+        effective_cheap_price=0.10,
+        optimization_mode="self_consumption",
+        soc_bins=30,
+        target_shortfall_penalty_per_pct=0.030,
+    )
+    inputs = OptimizerInputs(
+        cycle_id="test-solar-gate-integration",
+        initial_soc_pct=70.0,
+        slots=slots,
+        config=config,
+    )
+
+    result = DPPlanner().plan(inputs)
+    assert result.success
+
+    # No grid charging actions in the pre-DW solar window (slots 0–7)
+    for decision in result.decisions[:8]:
+        assert decision.action not in (
+            PlannerAction.CHARGE_GRID_NORMAL,
+            PlannerAction.CHARGE_GRID_BOOST,
+        ), f"Unexpected grid charge at slot {decision.slot_index}: {decision.action}"

--- a/tests/test_optimizer_shadow_runner_integration.py
+++ b/tests/test_optimizer_shadow_runner_integration.py
@@ -132,10 +132,41 @@ class TestBuildOptimizerConfig:
     def test_config_objective_weights_default(
         self, mock_coordinator_data, config_options
     ):
-        """Verify objective weight defaults."""
+        """Verify objective weight defaults (calibrated formula, not hardcoded 1.0)."""
         config = _build_optimizer_config(mock_coordinator_data, config_options)
-        assert config.target_shortfall_penalty_per_pct == 1.0
+        # Penalty must be calibrated: effective_cheap_price * battery_kwh / 100 * factor
+        # With effective_cheap_price=0.12, battery=13.5 kWh, safety_factor=1.5:
+        # 0.12 * 13.5 / 100 * 1.5 = 0.02430
+        assert config.target_shortfall_penalty_per_pct != 1.0
+        assert 0.010 <= config.target_shortfall_penalty_per_pct <= 0.100
         assert config.cycle_penalty_per_kwh == 0.005
+
+    def test_config_penalty_calibrated_to_tariff(
+        self, mock_coordinator_data, config_options
+    ):
+        """target_shortfall_penalty_per_pct is calibrated from effective_cheap_price."""
+        # mock_coordinator_data has effective_cheap_price=0.12
+        config = _build_optimizer_config(mock_coordinator_data, config_options)
+        expected = pytest.approx(0.12 * 13.5 / 100.0 * 1.5, rel=1e-4)
+        assert config.target_shortfall_penalty_per_pct == expected
+
+    def test_config_penalty_not_hardcoded_to_1(
+        self, mock_coordinator_data, config_options
+    ):
+        """The penalty must not be 1.0 (the original miscalibrated value). Fixes #438."""
+        config = _build_optimizer_config(mock_coordinator_data, config_options)
+        assert config.target_shortfall_penalty_per_pct != 1.0
+
+    def test_config_penalty_scales_with_cheap_price(self, mock_coordinator_data):
+        """Penalty scales proportionally with effective_cheap_price."""
+        mock_coordinator_data.effective_cheap_price = 0.20
+        config_high = _build_optimizer_config(mock_coordinator_data, {})
+        mock_coordinator_data.effective_cheap_price = 0.10
+        config_low = _build_optimizer_config(mock_coordinator_data, {})
+        # Higher cheap price → higher penalty (2x cheap price → 2x penalty)
+        assert config_high.target_shortfall_penalty_per_pct == pytest.approx(
+            config_low.target_shortfall_penalty_per_pct * 2.0, rel=1e-4
+        )
 
     def test_config_uses_default_allow_dw_entry_under_target(
         self, mock_coordinator_data


### PR DESCRIPTION
## Summary

Two-part fix for the optimizer's tendency to import from the grid during hours naturally covered by solar. Implements the complete fix described in #439, closing #437 and #438.

- **Part 1 (#437):** Solar-aware feasibility gate in `feasible_actions()` — when projected solar surplus ≥ SOC deficit before the demand window, `CHARGE_GRID_NORMAL` and `CHARGE_GRID_BOOST` are suppressed entirely (self-consumption mode only; arbitrage mode unaffected).
- **Part 2 (#438):** Recalibrate `target_shortfall_penalty_per_pct` from the hardcoded `1.0` (~53× actual remediation cost) to `effective_cheap_price × battery_kwh / 100 × 1.5`, computed live from tariff data in `_build_optimizer_config()`.

## Changes

| File | Change |
|------|--------|
| `optimizer_dp.py` | Add `_projected_solar_soc_gain_pct()` shared helper; extend `feasible_actions()` with solar gate; update backward induction call site; refactor `_classify_reason()` to use shared helper; update `OptimizerConfig` default + docstring |
| `optimizer_shadow_runner.py` | Add `_SHORTFALL_PENALTY_SAFETY_FACTOR = 1.5`; replace hardcoded `1.0` with calibrated formula |
| `tests/test_optimizer_dp_solve.py` | 9 new solar gate tests + integration test; fix pre-existing broken classify-reason test |
| `tests/test_optimizer_shadow_runner_integration.py` | 4 new/updated penalty calibration tests |

## Test results

- 715 tests pass, 0 new failures
- 2 pre-existing failures in `test_forecast_computer.py` (unrelated, present on `main`)
- Ruff lint and format: clean
- Deployed to HA: no errors in logs

Closes #437
Closes #438
Closes #439