### PR TITLE
fix: suppress BATTERY_PRESERVE when grid charging is planned before DW start

### DIFF
--- a/custom_components/localshift/computation_engine.py
+++ b/custom_components/localshift/computation_engine.py
@@ -411,7 +411,7 @@ class ComputationEngine:
 
         self._run_dp_optimizer_inline(data, now_dt)
 
-        self._compute_active_mode(data, now_dt)
+        self._compute_active_mode(data, now_dt, dw_start_time)
 
         # ---- Step 15: decision_log ----
         # Add entry when mode changes OR periodically for status updates
@@ -1298,7 +1298,12 @@ class ComputationEngine:
             data.active_mode = _BatteryMode.SELF_CONSUMPTION
             data.optimizer_last_apply_status = "fallback"
 
-    def _compute_active_mode(self, data: CoordinatorData, now_dt: datetime) -> None:
+    def _compute_active_mode(
+        self,
+        data: CoordinatorData,
+        now_dt: datetime,
+        dw_start_time: time | None = None,
+    ) -> None:
         """Compute active battery mode.
 
         Phase F (#403): In active mode, check if optimizer apply plan is ready
@@ -1310,7 +1315,7 @@ class ComputationEngine:
             return  # active_mode already set by active mode handler
 
         # Fall back to legacy mode decision
-        self._mode_decision.compute_active_mode(data, now_dt)
+        self._mode_decision.compute_active_mode(data, now_dt, dw_start_time)
 
     def _check_active_mode_optimizer_override(self, data: CoordinatorData) -> bool:
         """Check if active mode should override legacy with optimizer decision.

--- a/custom_components/localshift/computation_engine_lib/mode_decision.py
+++ b/custom_components/localshift/computation_engine_lib/mode_decision.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable
-from datetime import datetime
+from datetime import datetime, time, timedelta
 
 from ..const import DISCHARGE_EARLIEST_HOUR, BatteryMode
 from ..coordinator_data import CoordinatorData
@@ -133,7 +133,12 @@ class ModeDecisionEngine:
         )
         return True, False
 
-    def compute_active_mode(self, data: CoordinatorData, now_dt: datetime) -> None:
+    def compute_active_mode(
+        self,
+        data: CoordinatorData,
+        now_dt: datetime,
+        dw_start_time: time | None = None,
+    ) -> None:
         """Compute active battery mode from forecast and current constraints."""
         automation_enabled = self._get_switch_state("automation_enabled")
         spike_discharge_enabled = self._get_switch_state("spike_discharge_enabled")
@@ -285,9 +290,14 @@ class ModeDecisionEngine:
         # If solar cannot reach the target, we need to preserve the battery
         # to avoid discharging energy that will need to be replaced via grid charging.
         # This is determined by solar_can_reach_target which uses solar-only simulation.
-        self._compute_preserve_soc(data, now_dt)
+        self._compute_preserve_soc(data, now_dt, dw_start_time)
 
-    def _compute_preserve_soc(self, data: CoordinatorData, now_dt: datetime) -> None:
+    def _compute_preserve_soc(
+        self,
+        data: CoordinatorData,
+        now_dt: datetime,
+        dw_start_time: time | None = None,
+    ) -> None:
         """Compute battery preservation SOC when charging is needed.
 
         Issue #350: When solar cannot reach the target, we need to preserve
@@ -295,9 +305,20 @@ class ModeDecisionEngine:
         by setting a raised backup reserve that prevents discharge below
         the current SOC (minus a small buffer).
 
+        Issue #457: Guard against activating when the forecast already has grid
+        charging planned before the demand window. In that case the SOC gap will
+        be filled by scheduled grid charging — preserving the battery by drawing
+        from the grid *now* (at non-cheap rates) achieves nothing and may cost more.
+
+        The lookahead window is derived dynamically from the configured DW start
+        time so it always covers exactly the pre-DW period regardless of how the
+        user has configured the demand window.
+
         Args:
             data: CoordinatorData to update with preserve_soc
-            now_dt: Current datetime
+            now_dt: Current datetime (timezone-aware)
+            dw_start_time: Configured demand-window start time (e.g. time(15, 0)).
+                           When None the guard falls back to a 8-hour fixed window.
         """
         # Reset preserve_soc by default
         data.preserve_soc = None
@@ -310,35 +331,77 @@ class ModeDecisionEngine:
         if data.demand_window_active:
             return
 
-        # Check if charging is needed to meet the target
-        # solar_can_reach_target is True if solar alone can reach the target
+        # Check if charging is needed to meet the target.
+        # solar_can_reach_target is True if solar alone can reach the target.
         charging_needed = not data.solar_can_reach_target
-
-        if charging_needed:
-            # Preserve current SOC (minus buffer) to avoid discharging
-            # energy that will need to be replaced via grid charging
-            preserve_level = max(
-                data.backup_reserve,  # Don't go below existing reserve
-                data.soc - PRESERVE_BUFFER_PERCENT,  # Current SOC minus buffer
-            )
-            data.preserve_soc = preserve_level
-
-            _LOGGER.info(
-                "BATTERY_PRESERVE: Charging needed for target, preserving SOC at %.1f%% "
-                "(current=%.1f%%, buffer=%.1f%%, solar_can_reach=%s)",
-                preserve_level,
-                data.soc,
-                PRESERVE_BUFFER_PERCENT,
-                data.solar_can_reach_target,
-            )
-        else:
-            # Solar can reach target - no preservation needed
+        if not charging_needed:
             _LOGGER.debug(
                 "BATTERY_PRESERVE: Solar can reach target, no preservation needed "
                 "(solar_can_reach=%s, SOC=%.1f%%)",
                 data.solar_can_reach_target,
                 data.soc,
             )
+            return
+
+        # Issue #457: Skip preservation when grid charging is already planned in
+        # the forecast before the demand window starts.  The forecast has already
+        # modelled the discharge between now and the first cheap charge slot — it
+        # is intentional and expected. Blocking it by raising the reserve just
+        # forces the household to draw from the grid at non-cheap rates instead.
+        #
+        # Lookahead window: from now until the next occurrence of dw_start_time.
+        # Floor at now + 1 h so the guard is meaningful even when DW is imminent.
+        if dw_start_time is not None:
+            dw_today = now_dt.replace(
+                hour=dw_start_time.hour,
+                minute=dw_start_time.minute,
+                second=0,
+                microsecond=0,
+            )
+            # If DW start has already passed today, look to tomorrow's occurrence.
+            if dw_today <= now_dt:
+                dw_today = dw_today + timedelta(days=1)
+            lookahead_cutoff = dw_today
+        else:
+            # Fallback when dw_start_time is unavailable (e.g. in tests)
+            lookahead_cutoff = now_dt + timedelta(hours=8)
+
+        # Ensure at least a 1-hour window even when DW is very close.
+        lookahead_cutoff = max(lookahead_cutoff, now_dt + timedelta(hours=1))
+
+        grid_charge_planned_soon = any(
+            (slot.get("grid_charge", False) or slot.get("grid_charge_boost", False))
+            and datetime.fromisoformat(slot["timestamp"]) <= lookahead_cutoff
+            for slot in data.daily_forecast
+            if slot.get("timestamp")
+            and datetime.fromisoformat(slot["timestamp"]) > now_dt
+        )
+
+        if grid_charge_planned_soon:
+            _LOGGER.debug(
+                "BATTERY_PRESERVE: Grid charging already planned before DW start (%s), "
+                "skipping preservation (SOC=%.1f%%)",
+                lookahead_cutoff.strftime("%H:%M"),
+                data.soc,
+            )
+            return
+
+        # No grid charging planned before DW — preserve the current SOC so we
+        # don't discharge energy that would then need expensive make-up charging.
+        preserve_level = max(
+            data.backup_reserve,  # Don't go below existing reserve
+            data.soc - PRESERVE_BUFFER_PERCENT,  # Current SOC minus buffer
+        )
+        data.preserve_soc = preserve_level
+
+        _LOGGER.info(
+            "BATTERY_PRESERVE: Charging needed for target, preserving SOC at %.1f%% "
+            "(current=%.1f%%, buffer=%.1f%%, solar_can_reach=%s)",
+            preserve_level,
+            data.soc,
+            PRESERVE_BUFFER_PERCENT,
+            data.solar_can_reach_target,
+        )
 
     def add_to_decision_log(
         self,

--- a/tests/test_computation_engine.py
+++ b/tests/test_computation_engine.py
@@ -9,6 +9,11 @@ from custom_components.localshift.computation_engine import (
     BatteryMode,
     ForecastChangeTracker,
 )
+from custom_components.localshift.computation_engine_lib.mode_decision import (
+    PRESERVE_BUFFER_PERCENT,
+    ModeDecisionEngine,
+)
+from custom_components.localshift.coordinator_data import CoordinatorData
 
 
 @pytest.mark.parametrize(
@@ -649,6 +654,7 @@ async def test_async_initialize_weather_correlation_updates_forecast_computer(
 
         mock_set_weather.assert_called_once_with(mock_weather)
 
+
 class TestLoadForecastSlots:
     """Tests for load_forecast_slots (Issue #441 Phase 1)."""
 
@@ -664,14 +670,19 @@ class TestLoadForecastSlots:
         coordinator_data.load_power_kw = 0.5
 
         with patch.object(
-            computation_engine, "_get_historical_hourly_averages", return_value={10: 0.5, 11: 0.6}
+            computation_engine,
+            "_get_historical_hourly_averages",
+            return_value={10: 0.5, 11: 0.6},
         ):
             computation_engine.compute_derived_values(coordinator_data)
 
         # Verify load_forecast_slots is populated
         assert hasattr(coordinator_data, "load_forecast_slots")
         assert len(coordinator_data.load_forecast_slots) == TOTAL_SLOTS
-        assert all(isinstance(v, float) and v >= 0 for v in coordinator_data.load_forecast_slots)
+        assert all(
+            isinstance(v, float) and v >= 0
+            for v in coordinator_data.load_forecast_slots
+        )
 
     def test_load_forecast_slots_populated_before_forecast_computer_runs(
         self, computation_engine, coordinator_data
@@ -680,7 +691,9 @@ class TestLoadForecastSlots:
         coordinator_data.load_power_kw = 0.5
 
         with patch.object(
-            computation_engine, "_get_historical_hourly_averages", return_value={10: 0.5, 11: 0.6}
+            computation_engine,
+            "_get_historical_hourly_averages",
+            return_value={10: 0.5, 11: 0.6},
         ):
             with patch.object(
                 computation_engine, "_compute_daily_15min_forecast"
@@ -689,7 +702,10 @@ class TestLoadForecastSlots:
                 def check_slots_on_call(*args, **kwargs):
                     assert hasattr(coordinator_data, "load_forecast_slots")
                     assert len(coordinator_data.load_forecast_slots) > 0
-                    assert all(isinstance(v, float) and v >= 0 for v in coordinator_data.load_forecast_slots)
+                    assert all(
+                        isinstance(v, float) and v >= 0
+                        for v in coordinator_data.load_forecast_slots
+                    )
                     return None
 
                 mock_forecast.side_effect = check_slots_on_call
@@ -697,3 +713,207 @@ class TestLoadForecastSlots:
 
                 # Verify _compute_daily_15min_forecast was called
                 assert mock_forecast.called
+
+
+# =============================================================================
+# Tests for ModeDecisionEngine._compute_preserve_soc (Issue #457)
+# =============================================================================
+
+
+@pytest.fixture
+def mode_engine():
+    """Minimal ModeDecisionEngine instance for preserve_soc unit tests."""
+    engine = ModeDecisionEngine(
+        get_switch_state=MagicMock(return_value=True),
+        get_forecast_entry_for_now=MagicMock(return_value=None),
+    )
+    return engine
+
+
+@pytest.fixture
+def preserve_data():
+    """CoordinatorData pre-configured for preserve_soc tests."""
+    data = CoordinatorData()
+    data.active_mode = BatteryMode.SELF_CONSUMPTION
+    data.demand_window_active = False
+    data.solar_can_reach_target = False
+    data.soc = 60.0
+    data.backup_reserve = 10.0
+    data.daily_forecast = []
+    return data
+
+
+# Helpers -------------------------------------------------------------------
+
+_TZ = timezone(timedelta(hours=11))  # AEDT (same as logs)
+
+
+def _now(hour: int, minute: int = 0) -> datetime:
+    """Return a timezone-aware datetime for the given time today."""
+    return datetime(2026, 3, 3, hour, minute, 0, tzinfo=_TZ)
+
+
+def _slot(
+    hour: int, minute: int = 0, grid_charge: bool = False, boost: bool = False
+) -> dict:
+    """Build a minimal forecast slot dict."""
+    ts = datetime(2026, 3, 3, hour, minute, 0, tzinfo=_TZ)
+    return {
+        "timestamp": ts.isoformat(),
+        "grid_charge": grid_charge,
+        "grid_charge_boost": boost,
+    }
+
+
+# Test: not in SELF_CONSUMPTION → no preservation ---------------------------
+
+
+def test_preserve_soc_skipped_when_not_self_consumption(mode_engine, preserve_data):
+    """preserve_soc must remain None when active_mode is not SELF_CONSUMPTION."""
+    preserve_data.active_mode = BatteryMode.GRID_CHARGING
+    mode_engine._compute_preserve_soc(preserve_data, _now(6), dw_start_time=time(15, 0))
+    assert preserve_data.preserve_soc is None
+
+
+# Test: demand window active → no preservation ------------------------------
+
+
+def test_preserve_soc_skipped_during_demand_window(mode_engine, preserve_data):
+    """preserve_soc must remain None when the demand window is active."""
+    preserve_data.demand_window_active = True
+    mode_engine._compute_preserve_soc(
+        preserve_data, _now(16), dw_start_time=time(15, 0)
+    )
+    assert preserve_data.preserve_soc is None
+
+
+# Test: solar can reach target → no preservation ----------------------------
+
+
+def test_preserve_soc_skipped_when_solar_sufficient(mode_engine, preserve_data):
+    """preserve_soc must remain None when solar alone can reach the target."""
+    preserve_data.solar_can_reach_target = True
+    mode_engine._compute_preserve_soc(preserve_data, _now(9), dw_start_time=time(15, 0))
+    assert preserve_data.preserve_soc is None
+
+
+# Test: Issue #457 — grid charge planned before DW → no preservation --------
+
+
+def test_preserve_soc_skipped_when_grid_charge_planned_before_dw(
+    mode_engine, preserve_data
+):
+    """preserve_soc must not activate when forecast has grid charging before DW start.
+
+    This is the primary regression test for Issue #457: at 06:00 with grid
+    charging scheduled at 09:30, preservation should be suppressed.
+    """
+    now = _now(6, 0)
+    preserve_data.daily_forecast = [
+        _slot(7, 0),  # self-consumption, no charge
+        _slot(9, 30, grid_charge=True),  # cheap grid charge slot
+        _slot(10, 0, grid_charge=True),
+        _slot(14, 30, grid_charge=True),  # still before 15:00 DW
+    ]
+    mode_engine._compute_preserve_soc(preserve_data, now, dw_start_time=time(15, 0))
+    assert preserve_data.preserve_soc is None
+
+
+def test_preserve_soc_skipped_when_boost_planned_before_dw(mode_engine, preserve_data):
+    """preserve_soc must not activate when a boost (grid_charge_boost) is planned before DW."""
+    now = _now(6, 0)
+    preserve_data.daily_forecast = [
+        _slot(10, 30, boost=True),
+    ]
+    mode_engine._compute_preserve_soc(preserve_data, now, dw_start_time=time(15, 0))
+    assert preserve_data.preserve_soc is None
+
+
+# Test: grid charge only after DW start → preservation fires ----------------
+
+
+def test_preserve_soc_fires_when_grid_charge_only_after_dw(mode_engine, preserve_data):
+    """preserve_soc should activate when the only grid charging is after DW start.
+
+    Grid charging inside the DW (e.g. overnight) is outside the lookahead
+    window and must not suppress pre-DW preservation.
+    """
+    now = _now(6, 0)
+    preserve_data.soc = 60.0
+    preserve_data.backup_reserve = 10.0
+    preserve_data.daily_forecast = [
+        _slot(7, 0),  # no charge
+        _slot(22, 0, grid_charge=True),  # overnight — after DW end, well past lookahead
+    ]
+    mode_engine._compute_preserve_soc(preserve_data, now, dw_start_time=time(15, 0))
+    expected = max(10.0, 60.0 - PRESERVE_BUFFER_PERCENT)
+    assert preserve_data.preserve_soc == pytest.approx(expected)
+
+
+# Test: no grid charge at all → preservation fires --------------------------
+
+
+def test_preserve_soc_fires_when_no_grid_charge_planned(mode_engine, preserve_data):
+    """preserve_soc should activate when forecast has no grid charging at all."""
+    now = _now(7, 0)
+    preserve_data.soc = 55.0
+    preserve_data.backup_reserve = 10.0
+    preserve_data.daily_forecast = [
+        _slot(8, 0),
+        _slot(9, 0),
+        _slot(12, 0),
+    ]
+    mode_engine._compute_preserve_soc(preserve_data, now, dw_start_time=time(15, 0))
+    expected = max(10.0, 55.0 - PRESERVE_BUFFER_PERCENT)
+    assert preserve_data.preserve_soc == pytest.approx(expected)
+
+
+# Test: empty forecast → preservation fires ---------------------------------
+
+
+def test_preserve_soc_fires_when_forecast_empty(mode_engine, preserve_data):
+    """preserve_soc should activate when daily_forecast is empty."""
+    preserve_data.daily_forecast = []
+    mode_engine._compute_preserve_soc(preserve_data, _now(7), dw_start_time=time(15, 0))
+    expected = max(
+        preserve_data.backup_reserve, preserve_data.soc - PRESERVE_BUFFER_PERCENT
+    )
+    assert preserve_data.preserve_soc == pytest.approx(expected)
+
+
+# Test: preserve level floored at backup_reserve ----------------------------
+
+
+def test_preserve_soc_floored_at_backup_reserve(mode_engine, preserve_data):
+    """preserve_soc must not fall below the existing backup_reserve."""
+    preserve_data.soc = 13.0  # soc - buffer = 8.0, below backup_reserve=10
+    preserve_data.backup_reserve = 10.0
+    preserve_data.daily_forecast = []
+    mode_engine._compute_preserve_soc(preserve_data, _now(7), dw_start_time=time(15, 0))
+    assert preserve_data.preserve_soc == pytest.approx(10.0)
+
+
+# Test: fallback when dw_start_time is None ---------------------------------
+
+
+def test_preserve_soc_fallback_without_dw_start_time(mode_engine, preserve_data):
+    """When dw_start_time is None the 8-hour fallback window is used.
+
+    Grid charging within 8 hours of now should still suppress preservation.
+    """
+    now = _now(6, 0)
+    preserve_data.daily_forecast = [
+        _slot(12, 0, grid_charge=True),  # 6 hours away — within 8h fallback
+    ]
+    mode_engine._compute_preserve_soc(preserve_data, now, dw_start_time=None)
+    assert preserve_data.preserve_soc is None
+
+
+def test_preserve_soc_fires_outside_fallback_window(mode_engine, preserve_data):
+    """When dw_start_time is None, grid charging >8h away must not suppress preservation."""
+    now = _now(6, 0)
+    preserve_data.daily_forecast = [
+        _slot(16, 0, grid_charge=True),  # 10 hours away — outside 8h fallback
+    ]
+    mode_engine._compute_preserve_soc(preserve_data, now, dw_start_time=None)
+    assert preserve_data.preserve_soc is not None


### PR DESCRIPTION
## Summary

- Fixes #457: `BATTERY_PRESERVE` was firing continuously (e.g. 06:00–07:11) while the forecast already had 11 grid charge slots scheduled from 09:30–14:30, causing unnecessary grid draw and redundant API calls
- Adds a dynamic lookahead guard: before setting `preserve_soc`, scan `data.daily_forecast` for any `grid_charge`/`grid_charge_boost` slot between now and the next DW start — if found, skip preservation
- Lookahead window is derived from `dw_start_time` (respects user-configured demand window), floored at `now + 1h`; falls back to 8h if unavailable
- Threads `dw_start_time` through `_compute_active_mode` → `compute_active_mode` → `_compute_preserve_soc`
- Adds 10 unit tests for `_compute_preserve_soc` (previously zero coverage)

## What changed

| File | Change |
|---|---|
| `computation_engine_lib/mode_decision.py` | Dynamic lookahead guard in `_compute_preserve_soc`; accepts `dw_start_time` param |
| `computation_engine.py` | `_compute_active_mode` forwards `dw_start_time` |
| `tests/test_computation_engine.py` | 10 new unit tests for all `_compute_preserve_soc` branches |

## Test results

58 tests pass in `test_computation_engine.py`. 3 pre-existing failures on `main` are unaffected (`test_config_options_includes_allow_dw_entry_under_target`, `test_config_options_allow_dw_entry_under_target_reflects_option`, `TestPostComputeCallback` × 2).

## Note on `issue/preserve-soc-remove`

That branch takes the nuclear option (full removal, fixed 10% reserve). This PR is the surgical alternative — the feature is preserved for its genuine use case (cloudy day, no grid charging planned, battery at 60% before a peak period) while fixing the false-positive case.