### PR TITLE
Strengthen worktree enforcement via opencode instructions

### DIFF
--- a/.agents/rules/worktrees.md
+++ b/.agents/rules/worktrees.md
@@ -6,14 +6,32 @@ trigger: always_on
 
 **This applies to ALL tasks, no matter how simple. Failure to follow this is a process violation.**
 
-1. **FIRST ACTION:** Run `git worktree list` to check current worktree status
-2. **If output shows only the main repo (no worktree path matches current directory):**
-   - For GitHub issues: `git worktree add /Users/jackmcintyre/worktrees/issue-{NNN} -b issue/{NNN}`
-   - For ad-hoc tasks: `git worktree add /Users/jackmcintyre/worktrees/{task-name} -b task/{task-name}`
-3. **Change directory to the worktree before making ANY file changes**
-4. **Only then proceed with the actual task**
+## Why Worktrees?
 
-This ensures isolation between tasks and prevents changes to the main repo.
+Git hooks block all commits on `main`. Editing on main wastes time - you'll be forced to move changes anyway. Start in a worktree from the beginning.
+
+## Required Workflow
+
+1. **FIRST ACTION:** Run `git branch --show-current` to verify you're NOT on main
+2. **If output is "main":**
+   - **STOP** - Do not make ANY file edits
+   - Create worktree: `git worktree add worktrees/issue-{NNN} -b issue/{NNN}`
+   - Change to worktree: `cd worktrees/issue-{NNN}`
+3. **If output is NOT "main":**
+   - Verify with `git worktree list` that current directory is a worktree
+   - Proceed with the task
+
+## Quick Verification
+
+```bash
+# Should show branch name (NOT "main")
+git branch --show-current
+
+# Should show your current path as a worktree entry
+git worktree list
+```
+
+---
 
 ## ⚠️ FOUND CHANGES ON MAIN (Crashed Session / Orphaned Changes)
 
@@ -29,10 +47,10 @@ This ensures isolation between tasks and prevents changes to the main repo.
    git stash push -m "orphaned changes from crashed session"
    
    # Create worktree
-   git worktree add /Users/jackmcintyre/worktrees/{task-name} -b task/{task-name}
+   git worktree add worktrees/{task-name} -b task/{task-name}
    
    # In worktree, apply the stash
-   cd /Users/jackmcintyre/worktrees/{task-name}
+   cd worktrees/{task-name}
    git stash pop
    ```
 4. **Only commit directly on main** if:
@@ -40,4 +58,13 @@ This ensures isolation between tasks and prevents changes to the main repo.
    - Changes are trivial (typo fixes, documentation)
    - You have explained the process violation
 
-**This prevents accidental commits on main from orphaned changes.**
+---
+
+## Why This Matters
+
+- **Git hooks block main commits** - No exceptions (unless emergency bypass)
+- **Time saved** - Editing on main means re-doing work in a worktree
+- **Traceability** - Each task has its own branch and history
+- **Safety** - Main always reflects production-ready code
+
+**The enforcement is real. Work with it, not against it.**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,37 @@
 # AGENTS.md - Agent Coding Guidelines for LocalShift
 
-LocalShift is a Home Assistant integration for automated Tesla Powerwall battery control. This document provides guidelines for agentic coding agents.
+---
+
+# ⚠️ STOP: MANDATORY FIRST ACTION
+
+**You MUST verify you're NOT on the `main` branch before ANY file edit.**
+
+## Verification Steps
+
+1. Run: `git branch --show-current`
+2. If output is `"main"`: **STOP HERE**
+   - Create worktree: `git worktree add worktrees/issue-{NNN} -b issue/{NNN}`
+   - Change directory: `cd worktrees/issue-{NNN}`
+   - Then proceed with edits
+3. If output is NOT `"main"`: Proceed with the task
+
+## Why This Matters
+
+- **Git hooks block all commits on main** - No exceptions
+- **Editing on main wastes time** - You'll be forced to move changes anyway
+- **Main is read-only** - All changes go through PR
+
+**The enforcement is real. Start in a worktree.**
+
+---
+
+## Project Overview
+
+LocalShift is a Home Assistant integration for automated Tesla Powerwall battery control.
 
 **Python**: 3.13+ | **Main code**: `custom_components/localshift/` | **Tests**: `tests/`
+
+**Verify protection is active:** `.githooks/scripts/verify-safety.sh`
 
 ---
 
@@ -10,20 +39,22 @@ LocalShift is a Home Assistant integration for automated Tesla Powerwall battery
 
 **Git hooks in `.githooks/` block all main branch commits and pushes.**
 
-Before starting ANY task:
+### Before Starting ANY Task
+
 1. Run `git worktree list` - verify you're in a worktree
 2. Run `git branch --show-current` - must NOT be `main`
 3. If on main, create worktree: `git worktree add worktrees/issue-{NNN} -b issue/{NNN}`
 
-**Verify protection is active:** `.githooks/scripts/verify-safety.sh`
+### Emergency Bypass
 
-**Emergency bypass (logged, audit required):** `GIT_EMERGENCY_PUSH=1 git push origin main`
+**Only in emergencies (logged, audit required):** `GIT_EMERGENCY_PUSH=1 git push origin main`
 
 See `.opencode/rules` and `.githooks/README.md` for full workflow.
 
 ---
 
 ### After Making Changes
+
 1. Lint: `uv run ruff check custom_components/localshift`
 2. Format check: `uv run ruff format --check custom_components/localshift`
 3. Test: `uv run pytest`
@@ -31,12 +62,14 @@ See `.opencode/rules` and `.githooks/README.md` for full workflow.
 5. Check logs: `tail -100 /homeassistant/home-assistant.log | grep -i localshift`
 
 ### Deployment Protocol
+
 - **Agents do NOT run deploy.sh directly** - always ask the user to deploy
 - When ready to test: "Ready to deploy. Please run: `./deploy.sh --reserve && ./deploy.sh`"
 - For HA restart: "Restart recommended. Please run: `./deploy.sh --restart` (you'll be prompted to confirm)"
 - User controls all deployments - ensures human-in-the-loop before HA changes
 
 ### Commit Guidelines
+
 - Reference issue: `Fixes #NNN` or `Closes #NNN`
 - Ask user to commit; do not auto-commit
 - Open PR after commit
@@ -44,6 +77,7 @@ See `.opencode/rules` and `.githooks/README.md` for full workflow.
 ---
 
 ## Testing Best Practices
+
 - Test files: `test_*.py`, classes: `Test*`, functions: `test_*`
 - Use fixtures defined in `conftest.py`
 - Mock HA with `hass` fixture
@@ -52,6 +86,7 @@ See `.opencode/rules` and `.githooks/README.md` for full workflow.
 ---
 
 ## Notes
+
 - No Cursor or Copilot rules found in repository
 - Follow existing code patterns when modifying files
 - Update documentation (`docs/ENTITY_REFERENCE.md`, `docs/ARCHITECTURE.md`, `docs/DEVELOPER_GUIDE.md`) when adding/removing entities

--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "instructions": [
+    ".opencode/rules",
+    ".agents/rules/worktrees.md"
+  ]
+}


### PR DESCRIPTION
## Summary

- Add `opencode.json` with instructions field to load rules files
- Fix paths in `.agents/rules/worktrees.md` (remove hardcoded user paths)
- Strengthen `AGENTS.md`: move worktree check to top with stronger language
- Add 'Why This Matters' section to worktrees.md explaining enforcement

## Motivation

Agents keep editing files on the `main` branch despite git hooks blocking commits. This wastes time because changes must be moved to a worktree anyway.

## Changes

### 1. Add `opencode.json`
Tells opencode to load both `.opencode/rules` and `.agents/rules/worktrees.md` into the agent's context:

```json
{
  "$schema": "https://opencode.ai/config.json",
  "instructions": [
    ".opencode/rules",
    ".agents/rules/worktrees.md"
  ]
}
```

### 2. Fix `.agents/rules/worktrees.md`
- Remove hardcoded `/Users/jackmcintyre/` paths
- Use relative paths (`worktrees/issue-{NNN}`) instead
- Strengthen language about enforcement
- Add "Why This Matters" section

### 3. Strengthen `AGENTS.md`
- Move worktree verification to the **very top** of the file
- Add "STOP: MANDATORY FIRST ACTION" header
- Make instructions more actionable
- Explain why worktrees matter

## Testing

- JSON validation: `python -m json.tool opencode.json` ✓
- Git hooks still active: Pre-commit hook blocked my attempt to commit on main ✓
- File paths corrected: No more hardcoded user directories ✓

## Expected Outcome

1. Opencode loads both instruction files into agent context
2. Agent sees worktree rules **before** making any edits
3. Agent understands why worktrees are mandatory
4. Fewer wasted edits on main branch

## Alternative Approaches Considered

- **Filesystem enforcement (read-only main)**: More robust but requires hook changes
- **Consolidate all rules into AGENTS.md**: Simpler but loses modularity

This approach uses opencode's native instruction loading mechanism, making it cleaner and more maintainable.