### PR TITLE
Phase 7 (#449): Wire learning system into DP optimizer medium tick

### DIFF
--- a/custom_components/localshift/computation_engine_lib/decision_outcome_tracker.py
+++ b/custom_components/localshift/computation_engine_lib/decision_outcome_tracker.py
@@ -3,6 +3,8 @@
 Issue #170 Phase 1: Records mode decisions and backfills outcomes to create
 a ground-truth dataset for optimization. This phase is observation-only —
 no behavioral changes.
+
+Issue #449 Phase 7: Updated to use DP-native PlannerAction instead of legacy BatteryMode.
 """
 
 from __future__ import annotations
@@ -18,6 +20,7 @@ from homeassistant.util import dt as dt_util
 
 from ..const import BatteryMode
 from ..coordinator_data import PerformanceMetrics
+from .optimizer_dp import PlannerAction
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
@@ -25,6 +28,23 @@ if TYPE_CHECKING:
     from ..coordinator_data import CoordinatorData
 
 _LOGGER = logging.getLogger(__name__)
+
+# Legacy mode to DP action mapping for backward compatibility
+LEGACY_MODE_TO_ACTION = {
+    BatteryMode.SELF_CONSUMPTION: PlannerAction.HOLD,
+    BatteryMode.GRID_CHARGING: PlannerAction.CHARGE_GRID_NORMAL,
+    BatteryMode.BOOST_CHARGING: PlannerAction.CHARGE_GRID_BOOST,
+    BatteryMode.SPIKE_DISCHARGE: PlannerAction.EXPORT_PROACTIVE,
+    BatteryMode.PROACTIVE_EXPORT: PlannerAction.EXPORT_PROACTIVE,
+}
+
+# DP action to legacy mode mapping for observability
+ACTION_TO_LEGACY_MODE = {
+    PlannerAction.HOLD: BatteryMode.SELF_CONSUMPTION,
+    PlannerAction.CHARGE_GRID_NORMAL: BatteryMode.GRID_CHARGING,
+    PlannerAction.CHARGE_GRID_BOOST: BatteryMode.BOOST_CHARGING,
+    PlannerAction.EXPORT_PROACTIVE: BatteryMode.PROACTIVE_EXPORT,
+}
 
 # Maximum number of completed decisions to keep in memory
 MAX_COMPLETED_DECISIONS = 500
@@ -39,12 +59,14 @@ class DecisionRecord:
 
     Context is captured at decision time. Outcomes are backfilled after
     the decision period ends (mode changes or max duration elapsed).
+
+    Issue #449 Phase 7: Uses DP-native PlannerAction instead of legacy BatteryMode.
     """
 
     # Context at decision time
     timestamp: datetime
-    mode_chosen: BatteryMode
-    previous_mode: BatteryMode
+    mode_chosen: PlannerAction
+    previous_mode: PlannerAction
     soc_at_decision: float
     general_price_at_decision: float
     feed_in_price_at_decision: float
@@ -63,7 +85,7 @@ class DecisionRecord:
     actual_export_kwh: float | None = None
     actual_import_kwh: float | None = None
     duration_minutes: float | None = None
-    next_mode: BatteryMode | None = None
+    next_mode: PlannerAction | None = None
     outcome_score: float | None = None  # 0.0-1.0, computed quality score
 
     def to_dict(self) -> dict[str, Any]:
@@ -93,12 +115,36 @@ class DecisionRecord:
         }
 
     @classmethod
+    def _parse_action(cls, value: str) -> PlannerAction:
+        """Parse a PlannerAction from a stored string value.
+
+        Handles both current DP action strings and legacy BatteryMode strings,
+        mapping the latter to their DP equivalents for backward compatibility
+        with records stored before Issue #449.
+        """
+        # Try PlannerAction first (current format)
+        try:
+            return PlannerAction(value)
+        except ValueError:
+            pass
+        # Fall back: try as legacy BatteryMode and map to PlannerAction
+        try:
+            legacy = BatteryMode(value)
+            return LEGACY_MODE_TO_ACTION.get(legacy, PlannerAction.HOLD)
+        except ValueError:
+            _LOGGER.warning(
+                "Unknown mode/action value %r in stored record; defaulting to HOLD",
+                value,
+            )
+            return PlannerAction.HOLD
+
+    @classmethod
     def from_dict(cls, data: dict[str, Any]) -> DecisionRecord:
         """Create from dictionary (deserialization)."""
         return cls(
             timestamp=datetime.fromisoformat(data["timestamp"]),
-            mode_chosen=BatteryMode(data["mode_chosen"]),
-            previous_mode=BatteryMode(data["previous_mode"]),
+            mode_chosen=cls._parse_action(data["mode_chosen"]),
+            previous_mode=cls._parse_action(data["previous_mode"]),
             soc_at_decision=data["soc_at_decision"],
             general_price_at_decision=data["general_price_at_decision"],
             feed_in_price_at_decision=data["feed_in_price_at_decision"],
@@ -117,7 +163,9 @@ class DecisionRecord:
             actual_export_kwh=data.get("actual_export_kwh"),
             actual_import_kwh=data.get("actual_import_kwh"),
             duration_minutes=data.get("duration_minutes"),
-            next_mode=BatteryMode(data["next_mode"]) if data.get("next_mode") else None,
+            next_mode=cls._parse_action(data["next_mode"])
+            if data.get("next_mode")
+            else None,
             outcome_score=data.get("outcome_score"),
         )
 
@@ -165,30 +213,45 @@ class DecisionOutcomeTracker:
     def record_decision(
         self,
         data: CoordinatorData,
-        mode: BatteryMode,
-        prev_mode: BatteryMode,
+        mode: PlannerAction | BatteryMode,
+        prev_mode: PlannerAction | BatteryMode,
     ) -> None:
         """Record a mode transition with full context.
 
         Called by StateMachine on every mode transition. Also triggers
         backfill of any pending decision that just ended.
 
+        Accepts either PlannerAction (DP-native, preferred) or legacy BatteryMode,
+        mapping BatteryMode to PlannerAction automatically.
+
         Args:
             data: Current coordinator data with context
-            mode: New mode being transitioned to
-            prev_mode: Previous mode before transition
+            mode: New mode being transitioned to (PlannerAction or BatteryMode)
+            prev_mode: Previous mode before transition (PlannerAction or BatteryMode)
         """
         now = dt_util.now()
 
+        # Normalise to PlannerAction
+        action = (
+            mode
+            if isinstance(mode, PlannerAction)
+            else LEGACY_MODE_TO_ACTION.get(mode, PlannerAction.HOLD)
+        )
+        prev_action = (
+            prev_mode
+            if isinstance(prev_mode, PlannerAction)
+            else LEGACY_MODE_TO_ACTION.get(prev_mode, PlannerAction.HOLD)
+        )
+
         # First, backfill any pending decision (this transition ends it)
         if self._pending_decisions:
-            self._backfill_pending_decision(data, mode, now)
+            self._backfill_pending_decision(data, action, now)
 
         # Capture context for the new decision
         record = DecisionRecord(
             timestamp=now,
-            mode_chosen=mode,
-            previous_mode=prev_mode,
+            mode_chosen=action,
+            previous_mode=prev_action,
             soc_at_decision=data.soc,
             general_price_at_decision=data.general_price,
             feed_in_price_at_decision=data.feed_in_price,
@@ -232,14 +295,14 @@ class DecisionOutcomeTracker:
     def _backfill_pending_decision(
         self,
         data: CoordinatorData,
-        next_mode: BatteryMode,
+        next_mode: PlannerAction,
         now: datetime,
     ) -> None:
         """Backfill outcome for a pending decision that just ended.
 
         Args:
             data: Current coordinator data
-            next_mode: The mode being transitioned to (ends the pending decision)
+            next_mode: The DP action being transitioned to (ends the pending decision)
             now: Current timestamp
         """
         if not self._pending_decisions:
@@ -264,7 +327,10 @@ class DecisionOutcomeTracker:
         if soc_change < 0:  # Battery discharged
             cost = 0.0  # Discharging is "free"
         else:  # Battery charged
-            if pending.mode_chosen == BatteryMode.GRID_CHARGING:
+            if pending.mode_chosen in (
+                PlannerAction.CHARGE_GRID_NORMAL,
+                PlannerAction.CHARGE_GRID_BOOST,
+            ):
                 cost = (
                     -soc_change / 100.0 * 13.5 * pending.general_price_at_decision / 100
                 )
@@ -386,21 +452,17 @@ class DecisionOutcomeTracker:
         # 1. Cost Score (weight: 40%)
         # Lower cost = better score
         if record.actual_cost_during_period is not None:
-            if record.mode_chosen == BatteryMode.GRID_CHARGING:
+            if record.mode_chosen in (
+                PlannerAction.CHARGE_GRID_NORMAL,
+                PlannerAction.CHARGE_GRID_BOOST,
+            ):
                 # Grid charging: positive cost is expected
                 # Penalize if we charged and then exported (waste)
                 if record.actual_export_kwh and record.actual_export_kwh > 0.5:
                     cost_score = 0.2  # Penalize grid-charge-then-export
                 else:
                     cost_score = 0.7  # Normal grid charge
-            elif record.mode_chosen == BatteryMode.SPIKE_DISCHARGE:
-                # Spike discharge: should save money
-                # Negative cost (revenue) is good
-                if record.actual_cost_during_period < 0:
-                    cost_score = 0.9  # Made money
-                else:
-                    cost_score = 0.5  # Neutral
-            elif record.mode_chosen == BatteryMode.PROACTIVE_EXPORT:
+            elif record.mode_chosen == PlannerAction.EXPORT_PROACTIVE:
                 # Proactive export: should make money
                 if (
                     record.actual_cost_during_period
@@ -410,7 +472,7 @@ class DecisionOutcomeTracker:
                 else:
                     cost_score = 0.4  # Didn't make expected profit
             else:
-                # Self consumption, demand block: neutral on cost
+                # HOLD / self-consumption: neutral on cost
                 cost_score = 0.6
             score = score * 0.6 + cost_score * 0.4
 
@@ -422,16 +484,16 @@ class DecisionOutcomeTracker:
             grid_imported = (
                 record.actual_import_kwh is not None and record.actual_import_kwh > 0.1
             )
-            if record.mode_chosen == BatteryMode.GRID_CHARGING:
+            if record.mode_chosen in (
+                PlannerAction.CHARGE_GRID_NORMAL,
+                PlannerAction.CHARGE_GRID_BOOST,
+            ):
                 if grid_imported:
                     # Bad: imported from grid then exported
                     score -= 0.15
                 # else: solar-driven export is acceptable, no penalty
-            elif record.mode_chosen in (
-                BatteryMode.PROACTIVE_EXPORT,
-                BatteryMode.SPIKE_DISCHARGE,
-            ):
-                # Good: these modes are supposed to export
+            elif record.mode_chosen == PlannerAction.EXPORT_PROACTIVE:
+                # Good: this mode is supposed to export
                 score += 0.05
 
         # 3. Target Score (weight: 25%)

--- a/custom_components/localshift/computation_engine_lib/optimization_controller.py
+++ b/custom_components/localshift/computation_engine_lib/optimization_controller.py
@@ -618,10 +618,15 @@ class OptimizationController:
 
         # Export score
         if record.actual_export_kwh is not None and record.actual_export_kwh > 0.1:
-            if record.mode_chosen.value in ("proactive_export", "spike_discharge"):
-                # These modes are supposed to export
+            from .optimizer_dp import PlannerAction  # noqa: PLC0415
+
+            if record.mode_chosen == PlannerAction.EXPORT_PROACTIVE:
+                # This mode is supposed to export
                 scores["export"] = 0.8
-            elif record.mode_chosen.value == "grid_charging":
+            elif record.mode_chosen in (
+                PlannerAction.CHARGE_GRID_NORMAL,
+                PlannerAction.CHARGE_GRID_BOOST,
+            ):
                 # Bad: grid charged then exported
                 scores["export"] = 0.2
             else:

--- a/custom_components/localshift/computation_engine_lib/pattern_analyzer.py
+++ b/custom_components/localshift/computation_engine_lib/pattern_analyzer.py
@@ -18,6 +18,7 @@ from homeassistant.helpers.storage import Store
 from homeassistant.util import dt as dt_util
 
 from ..const import DOMAIN, OPTIMIZABLE_PARAMS
+from .optimizer_dp import PlannerAction
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
@@ -405,13 +406,18 @@ class PatternAnalyzer:
             std_score = 0.0
 
         # Over-charge rate: grid charge decisions that resulted in export
+        # Issue #449 Phase 7: compare against PlannerAction (DP-native) values
+        _grid_charge_actions = {
+            PlannerAction.CHARGE_GRID_NORMAL,
+            PlannerAction.CHARGE_GRID_BOOST,
+        }
         grid_charge_count = sum(
-            1 for d in decisions if d.mode_chosen.value == "grid_charging"
+            1 for d in decisions if d.mode_chosen in _grid_charge_actions
         )
         over_charge_count = sum(
             1
             for d in decisions
-            if d.mode_chosen.value == "grid_charging"
+            if d.mode_chosen in _grid_charge_actions
             and d.actual_export_kwh is not None
             and d.actual_export_kwh > 0.5
         )

--- a/custom_components/localshift/coordinator.py
+++ b/custom_components/localshift/coordinator.py
@@ -791,6 +791,22 @@ class LocalShiftCoordinator:
                         decisions, current_7d_score
                     )
 
+        # Apply contextual overrides from OptimizationController (Issue #449 Phase 7)
+        # This merges real-time adjustments on top of Thompson-sampled base params
+        if self.optimization_controller is not None:
+            self.data.adaptive_params = self.optimization_controller.evaluate(self.data)
+            # Update observability fields for sensors
+            self.data.optimization_weights = (
+                self.optimization_controller.weights.to_dict()
+            )
+            active_adjustments = self.optimization_controller.get_active_adjustments()
+            self.data.contextual_adjustments_active = active_adjustments
+            if active_adjustments:
+                _LOGGER.debug(
+                    "Contextual overrides applied: %d adjustments active",
+                    len(active_adjustments),
+                )
+
         # Learn from current temperature/load for weather correlation
         if self._computation_engine is not None:
             self.hass.async_create_task(
@@ -1212,16 +1228,3 @@ class LocalShiftCoordinator:
             report.data_points_analyzed,
             len(report.biases_detected),
         )
-
-        # Run optimization controller cycle (Issue #170 Phase 4)
-        # This computes contextual adjustments and returns adaptive parameters
-        if self.optimization_controller is not None:
-            # Evaluate returns AdaptiveParameters, which updates the data
-            self.optimization_controller.evaluate(self.data)
-            # Update coordinator data with optimization state
-            self.data.optimization_weights = (
-                self.optimization_controller.weights.to_dict()
-            )
-            self.data.contextual_adjustments_active = (
-                self.optimization_controller.get_active_adjustments()
-            )

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -748,3 +748,157 @@ class TestShadowOptimizerConfigPlumbing:
         assert captured.get(CONF_ALLOW_DW_ENTRY_UNDER_TARGET) is True, (
             "allow_dw_entry_under_target=True in options must propagate to config_options"
         )
+
+
+# =============================================================================
+# MEDIUM TICK OPTIMIZATION CONTROLLER WIRING TESTS (Issue #449 Phase 7)
+# =============================================================================
+
+
+class TestMediumTickOptimizationController:
+    """Tests that _handle_medium_tick() wires OptimizationController.evaluate()
+    correctly (Issue #449 Phase 7).
+
+    Verifies:
+    - evaluate() is called when optimization_controller is set
+    - data.adaptive_params is updated with the returned AdaptiveParameters
+    - data.optimization_weights is populated from controller.weights.to_dict()
+    - data.contextual_adjustments_active is populated from get_active_adjustments()
+    - evaluate() is NOT called when optimization_controller is None
+    """
+
+    @pytest.fixture
+    def coordinator_with_data(self, coordinator, coordinator_data):
+        """Coordinator with data pre-set and minimal mocks for medium tick."""
+        coordinator.data = coordinator_data
+
+        # Stub out methods called before the optimization block so we can run
+        # _handle_medium_tick() without a real HA environment.
+        coordinator._read_all_external_state = MagicMock()
+        coordinator._check_entity_health = MagicMock()
+        coordinator._computation_engine = None
+        coordinator.decision_tracker = None
+
+        return coordinator
+
+    def test_medium_tick_calls_evaluate_when_controller_set(
+        self, coordinator_with_data
+    ):
+        """evaluate() is called on every medium tick when controller is present."""
+        from custom_components.localshift.coordinator_data import AdaptiveParameters
+
+        coordinator = coordinator_with_data
+
+        # Build a fake AdaptiveParameters result
+        returned_params = AdaptiveParameters()
+        returned_params.values["cheap_price_bias"] = 2.5
+
+        # Mock OptimizationController
+        mock_controller = MagicMock()
+        mock_controller.evaluate.return_value = returned_params
+        mock_controller.weights.to_dict.return_value = {
+            "cost_minimization": 0.50,
+            "export_avoidance": 0.20,
+            "target_achievement": 0.20,
+            "cycle_reduction": 0.10,
+        }
+        mock_controller.get_active_adjustments.return_value = []
+
+        coordinator.optimization_controller = mock_controller
+
+        now = datetime(2026, 3, 3, 10, 0, 0)
+        coordinator._handle_medium_tick(now)
+
+        mock_controller.evaluate.assert_called_once_with(coordinator.data)
+
+    def test_medium_tick_updates_adaptive_params(self, coordinator_with_data):
+        """data.adaptive_params is replaced with the result of evaluate()."""
+        from custom_components.localshift.coordinator_data import AdaptiveParameters
+
+        coordinator = coordinator_with_data
+
+        returned_params = AdaptiveParameters()
+        returned_params.values["overnight_drain_safety_margin"] = 5.0
+
+        mock_controller = MagicMock()
+        mock_controller.evaluate.return_value = returned_params
+        mock_controller.weights.to_dict.return_value = {}
+        mock_controller.get_active_adjustments.return_value = []
+
+        coordinator.optimization_controller = mock_controller
+
+        coordinator._handle_medium_tick(datetime(2026, 3, 3, 10, 5, 0))
+
+        assert coordinator.data.adaptive_params is returned_params
+        assert (
+            coordinator.data.adaptive_params.values["overnight_drain_safety_margin"]
+            == 5.0
+        )
+
+    def test_medium_tick_updates_optimization_weights(self, coordinator_with_data):
+        """data.optimization_weights is populated from weights.to_dict()."""
+        coordinator = coordinator_with_data
+
+        expected_weights = {
+            "cost_minimization": 0.60,
+            "export_avoidance": 0.15,
+            "target_achievement": 0.15,
+            "cycle_reduction": 0.10,
+        }
+
+        from custom_components.localshift.coordinator_data import AdaptiveParameters
+
+        mock_controller = MagicMock()
+        mock_controller.evaluate.return_value = AdaptiveParameters()
+        mock_controller.weights.to_dict.return_value = expected_weights
+        mock_controller.get_active_adjustments.return_value = []
+
+        coordinator.optimization_controller = mock_controller
+
+        coordinator._handle_medium_tick(datetime(2026, 3, 3, 10, 10, 0))
+
+        assert coordinator.data.optimization_weights == expected_weights
+
+    def test_medium_tick_updates_contextual_adjustments_active(
+        self, coordinator_with_data
+    ):
+        """data.contextual_adjustments_active is populated from get_active_adjustments()."""
+        coordinator = coordinator_with_data
+
+        active_adjustments = [
+            {
+                "param": "cheap_price_bias",
+                "adjustment": 1.5,
+                "reason": "high export rate",
+            }
+        ]
+
+        from custom_components.localshift.coordinator_data import AdaptiveParameters
+
+        mock_controller = MagicMock()
+        mock_controller.evaluate.return_value = AdaptiveParameters()
+        mock_controller.weights.to_dict.return_value = {}
+        mock_controller.get_active_adjustments.return_value = active_adjustments
+
+        coordinator.optimization_controller = mock_controller
+
+        coordinator._handle_medium_tick(datetime(2026, 3, 3, 10, 15, 0))
+
+        assert coordinator.data.contextual_adjustments_active == active_adjustments
+
+    def test_medium_tick_skips_evaluate_when_no_controller(self, coordinator_with_data):
+        """When optimization_controller is None, no evaluate() call is made and
+        adaptive_params/optimization_weights are unchanged."""
+        coordinator = coordinator_with_data
+        coordinator.optimization_controller = None
+
+        # Set a sentinel on data fields so we can verify nothing changes
+        from custom_components.localshift.coordinator_data import AdaptiveParameters
+
+        original_params = AdaptiveParameters()
+        coordinator.data.adaptive_params = original_params
+
+        coordinator._handle_medium_tick(datetime(2026, 3, 3, 10, 20, 0))
+
+        # Unchanged – no controller was present
+        assert coordinator.data.adaptive_params is original_params

--- a/tests/test_decision_outcome_tracker.py
+++ b/tests/test_decision_outcome_tracker.py
@@ -9,6 +9,9 @@ from custom_components.localshift.computation_engine_lib.decision_outcome_tracke
     DecisionOutcomeTracker,
     DecisionRecord,
 )
+from custom_components.localshift.computation_engine_lib.optimizer_dp import (
+    PlannerAction,
+)
 from custom_components.localshift.const import BatteryMode
 from custom_components.localshift.coordinator_data import (
     CoordinatorData,
@@ -44,12 +47,12 @@ class TestDecisionRecord:
     """Tests for DecisionRecord dataclass."""
 
     def test_decision_record_creation(self):
-        """Test creating a DecisionRecord."""
+        """Test creating a DecisionRecord (Issue #449: uses PlannerAction)."""
         now = datetime.now()
         record = DecisionRecord(
             timestamp=now,
-            mode_chosen=BatteryMode.GRID_CHARGING,
-            previous_mode=BatteryMode.SELF_CONSUMPTION,
+            mode_chosen=PlannerAction.CHARGE_GRID_NORMAL,
+            previous_mode=PlannerAction.HOLD,
             soc_at_decision=50.0,
             general_price_at_decision=0.25,
             feed_in_price_at_decision=0.05,
@@ -64,18 +67,18 @@ class TestDecisionRecord:
         )
 
         assert record.timestamp == now
-        assert record.mode_chosen == BatteryMode.GRID_CHARGING
-        assert record.previous_mode == BatteryMode.SELF_CONSUMPTION
+        assert record.mode_chosen == PlannerAction.CHARGE_GRID_NORMAL
+        assert record.previous_mode == PlannerAction.HOLD
         assert record.soc_at_decision == 50.0
         assert record.outcome_score is None  # Pending
 
     def test_decision_record_to_dict(self):
-        """Test serializing DecisionRecord to dict."""
+        """Test serializing DecisionRecord to dict (Issue #449: DP action strings)."""
         now = datetime.now()
         record = DecisionRecord(
             timestamp=now,
-            mode_chosen=BatteryMode.GRID_CHARGING,
-            previous_mode=BatteryMode.SELF_CONSUMPTION,
+            mode_chosen=PlannerAction.CHARGE_GRID_NORMAL,
+            previous_mode=PlannerAction.HOLD,
             soc_at_decision=50.0,
             general_price_at_decision=0.25,
             feed_in_price_at_decision=0.05,
@@ -92,18 +95,49 @@ class TestDecisionRecord:
 
         result = record.to_dict()
 
-        assert result["mode_chosen"] == "grid_charging"
-        assert result["previous_mode"] == "self_consumption"
+        assert result["mode_chosen"] == "charge_grid_normal"
+        assert result["previous_mode"] == "hold"
         assert result["soc_at_decision"] == 50.0
         assert result["outcome_score"] == 0.75
 
-    def test_decision_record_from_dict(self):
-        """Test deserializing DecisionRecord from dict."""
+    def test_decision_record_from_dict_dp_action(self):
+        """Test deserializing DecisionRecord from dict with native DP action strings."""
         now = datetime.now()
         data = {
             "timestamp": now.isoformat(),
-            "mode_chosen": "spike_discharge",
-            "previous_mode": "self_consumption",
+            "mode_chosen": "export_proactive",
+            "previous_mode": "hold",
+            "soc_at_decision": 75.0,
+            "general_price_at_decision": 2.50,
+            "feed_in_price_at_decision": 0.05,
+            "forecast_solar_remaining_kwh": 10.0,
+            "forecast_consumption_remaining_kwh": 8.0,
+            "cheap_price_threshold": 0.10,
+            "battery_target_soc": 80.0,
+            "weather_condition": "cloudy",
+            "day_of_week": 2,
+            "hour_of_day": 18,
+            "is_demand_window": True,
+            "actual_soc_change": -5.0,
+            "duration_minutes": 15.0,
+            "next_mode": "hold",
+            "outcome_score": 0.85,
+        }
+
+        record = DecisionRecord.from_dict(data)
+
+        assert record.mode_chosen == PlannerAction.EXPORT_PROACTIVE
+        assert record.previous_mode == PlannerAction.HOLD
+        assert record.soc_at_decision == 75.0
+        assert record.outcome_score == 0.85
+
+    def test_decision_record_from_dict_legacy_mode(self):
+        """Test deserializing DecisionRecord with legacy BatteryMode strings (backward compat)."""
+        now = datetime.now()
+        data = {
+            "timestamp": now.isoformat(),
+            "mode_chosen": "spike_discharge",  # legacy BatteryMode value
+            "previous_mode": "self_consumption",  # legacy BatteryMode value
             "soc_at_decision": 75.0,
             "general_price_at_decision": 2.50,
             "feed_in_price_at_decision": 0.05,
@@ -123,9 +157,11 @@ class TestDecisionRecord:
 
         record = DecisionRecord.from_dict(data)
 
-        assert record.mode_chosen == BatteryMode.SPIKE_DISCHARGE
+        # Legacy spike_discharge → EXPORT_PROACTIVE
+        assert record.mode_chosen == PlannerAction.EXPORT_PROACTIVE
+        # Legacy self_consumption → HOLD
+        assert record.previous_mode == PlannerAction.HOLD
         assert record.soc_at_decision == 75.0
-        assert record.general_price_at_decision == 2.50
         assert record.outcome_score == 0.85
 
 
@@ -193,10 +229,12 @@ class TestDecisionOutcomeTracker:
         )
 
         assert tracker.pending_count == 1
-        assert tracker._pending_decisions[0].mode_chosen == BatteryMode.GRID_CHARGING
+        # record_decision normalises BatteryMode → PlannerAction
         assert (
-            tracker._pending_decisions[0].previous_mode == BatteryMode.SELF_CONSUMPTION
+            tracker._pending_decisions[0].mode_chosen
+            == PlannerAction.CHARGE_GRID_NORMAL
         )
+        assert tracker._pending_decisions[0].previous_mode == PlannerAction.HOLD
 
     def test_backfill_on_next_decision(self, mock_hass, coordinator_data):
         """Test that backfill happens when next decision is recorded."""
@@ -312,13 +350,13 @@ class TestDecisionOutcomeScoring:
     """Tests for decision outcome scoring logic."""
 
     def test_compute_outcome_score_grid_charging(self, mock_hass, coordinator_data):
-        """Test scoring for grid charging decision."""
+        """Test scoring for grid charging decision (Issue #449: uses PlannerAction)."""
         tracker = DecisionOutcomeTracker(mock_hass, "test_entry_id")
 
         record = DecisionRecord(
             timestamp=datetime.now(),
-            mode_chosen=BatteryMode.GRID_CHARGING,
-            previous_mode=BatteryMode.SELF_CONSUMPTION,
+            mode_chosen=PlannerAction.CHARGE_GRID_NORMAL,
+            previous_mode=PlannerAction.HOLD,
             soc_at_decision=50.0,
             general_price_at_decision=0.10,  # Low price
             feed_in_price_at_decision=0.05,
@@ -339,16 +377,16 @@ class TestDecisionOutcomeScoring:
         # Grid charging at low price should score well
         assert 0.5 <= score <= 1.0
 
-    def test_compute_outcome_score_spike_discharge(self, mock_hass, coordinator_data):
-        """Test scoring for spike discharge decision."""
+    def test_compute_outcome_score_proactive_export(self, mock_hass, coordinator_data):
+        """Test scoring for proactive export decision (Issue #449: uses PlannerAction)."""
         tracker = DecisionOutcomeTracker(mock_hass, "test_entry_id")
 
         record = DecisionRecord(
             timestamp=datetime.now(),
-            mode_chosen=BatteryMode.SPIKE_DISCHARGE,
-            previous_mode=BatteryMode.SELF_CONSUMPTION,
+            mode_chosen=PlannerAction.EXPORT_PROACTIVE,
+            previous_mode=PlannerAction.HOLD,
             soc_at_decision=80.0,
-            general_price_at_decision=2.50,  # High price spike
+            general_price_at_decision=2.50,  # High sell price
             feed_in_price_at_decision=0.05,
             forecast_solar_remaining_kwh=0.0,
             forecast_consumption_remaining_kwh=5.0,
@@ -365,7 +403,7 @@ class TestDecisionOutcomeScoring:
 
         score = tracker.compute_outcome_score(record)
 
-        # Spike discharge during high price should score well
+        # Proactive export during high price should score well
         assert 0.5 <= score <= 1.0
 
     def test_compute_outcome_score_short_duration_penalty(
@@ -377,8 +415,8 @@ class TestDecisionOutcomeScoring:
         # Short duration decision
         record_short = DecisionRecord(
             timestamp=datetime.now(),
-            mode_chosen=BatteryMode.GRID_CHARGING,
-            previous_mode=BatteryMode.SELF_CONSUMPTION,
+            mode_chosen=PlannerAction.CHARGE_GRID_NORMAL,
+            previous_mode=PlannerAction.HOLD,
             soc_at_decision=50.0,
             general_price_at_decision=0.10,
             feed_in_price_at_decision=0.05,
@@ -396,8 +434,8 @@ class TestDecisionOutcomeScoring:
         # Long duration decision
         record_long = DecisionRecord(
             timestamp=datetime.now(),
-            mode_chosen=BatteryMode.GRID_CHARGING,
-            previous_mode=BatteryMode.SELF_CONSUMPTION,
+            mode_chosen=PlannerAction.CHARGE_GRID_NORMAL,
+            previous_mode=PlannerAction.HOLD,
             soc_at_decision=50.0,
             general_price_at_decision=0.10,
             feed_in_price_at_decision=0.05,


### PR DESCRIPTION
## Summary

Completes Issue #449 — the final phase of retiring the legacy planner. Wires the full learning loop end-to-end so contextual overrides from `OptimizationController` are applied every 5 minutes on top of Thompson-sampled base parameters.

## Changes

### `coordinator.py`
- `_handle_medium_tick()`: calls `OptimizationController.evaluate()` after Thompson sampling; assigns result to `data.adaptive_params`; updates `data.optimization_weights` and `data.contextual_adjustments_active` for sensor observability
- Removed the old (wrong-cadence) `evaluate()` call from `_run_pattern_analysis()`

### `decision_outcome_tracker.py`
- Full migration from `BatteryMode` to DP-native `PlannerAction` on all `DecisionRecord` fields (`mode_chosen`, `previous_mode`, `next_mode`)
- Added `LEGACY_MODE_TO_ACTION` / `ACTION_TO_LEGACY_MODE` dicts for backward compatibility with stored records
- `_parse_action()` classmethod: tries `PlannerAction` first, falls back to legacy mapping
- `record_decision()` accepts `PlannerAction | BatteryMode`, normalises to `PlannerAction`

### `optimization_controller.py`
- `score_decision()`: comparisons updated from legacy `.value` strings to `PlannerAction` enum members

### `pattern_analyzer.py`
- `_compute_bucket_stats()`: replaced broken `d.mode_chosen.value == "grid_charging"` string comparisons with set-membership check against `{PlannerAction.CHARGE_GRID_NORMAL, PlannerAction.CHARGE_GRID_BOOST}`
- Added `PlannerAction` import

### `tests/test_decision_outcome_tracker.py`
- All tests updated for `PlannerAction`; legacy backward-compat test added (`test_decision_record_from_dict_legacy_mode`)

### `tests/test_coordinator.py`
- New class `TestMediumTickOptimizationController` (5 tests) covering the Phase 7 wiring

## Test results

```
616 passed, 56 skipped, 2 warnings
```
(+5 tests vs pre-PR baseline of 611)

## Deployment verified

Deployed and confirmed live via logs + MCP:
- `optimization_weights` populated in `sensor.localshift_learning_status` attributes
- `contextual_adjustments_active: []` (correct — system in observing phase)
- Decision history shows DP-native mode strings: `charge_grid_boost`, `charge_grid_normal`, `hold`
- No localshift errors in logs

## Related issues opened

- #467 — `sensor.localshift_optimizer_plan_detailed` exceeds 16KB recorder limit
- #468 — Stale SOC/operation_mode on first tick after restart