### PR TITLE
Fix #424: Remove SOC fractional-to-percent auto-detection heuristic

### DIFF
--- a/custom_components/localshift/computation_engine_lib/optimizer_runner.py
+++ b/custom_components/localshift/computation_engine_lib/optimizer_runner.py
@@ -337,9 +337,12 @@ def _normalize_initial_soc(
 
     Behavior:
     - Reject non-numeric / non-finite values.
-    - Treat 0 < SOC <= 1 as fractional input and convert to percentage.
+    - Warn if 0 < SOC <= 1.0 (potential misconfiguration, entity should be 0-100 scale).
     - Reject SOC <= 0 as invalid (typically unavailable entity fallback).
     - Clamp out-of-range values to configured bounds.
+
+    Note: Teslemetry always provides SOC in percentage scale (0-100).
+    The fractional-to-percent auto-detection was removed (Issue #424).
     """
     info: dict[str, Any] = {
         "raw_soc": raw_soc,
@@ -357,8 +360,11 @@ def _normalize_initial_soc(
         return None, info
 
     if 0.0 < soc <= 1.0:
-        soc *= 100.0
-        info["normalization"] = "fraction_to_percent"
+        _LOGGER.warning(
+            "SOC value %.3f is unusually low. Teslemetry provides percentage scale (0-100). "
+            "Check that the SOC sensor entity is configured correctly.",
+            soc,
+        )
 
     if soc <= 0.0:
         info["error"] = "non_positive"

--- a/tests/test_optimizer_runner_integration.py
+++ b/tests/test_optimizer_runner_integration.py
@@ -447,14 +447,47 @@ class TestBuildSummary:
 class TestNormalizeInitialSoc:
     """Tests for initial SOC normalization and validation guard."""
 
-    def test_fraction_is_converted_to_percent(self, mock_coordinator_data):
-        """SOC values in 0..1 range should be treated as fractional."""
-        config = _build_optimizer_config(mock_coordinator_data, {})
-        normalized, info = _normalize_initial_soc(0.65, config)
+    def test_percentage_values_not_converted(self, mock_coordinator_data):
+        """SOC values 0 < value <= 1.0 should NOT be multiplied by 100 (Issue #424).
 
-        assert normalized == pytest.approx(65.0)
-        assert info["normalization"] == "fraction_to_percent"
-        assert info["normalized_soc_pct"] == pytest.approx(65.0)
+        Teslemetry always provides percentage scale (0-100). Values like
+        0.5 or 1.0 represent actual low battery percentages, not fractions.
+        They will be clamped to min_soc_pct but NOT converted.
+        """
+        config = _build_optimizer_config(mock_coordinator_data, {})
+
+        normalized, info = _normalize_initial_soc(0.5, config)
+        assert normalized == pytest.approx(config.min_soc_pct)
+        assert info["normalization"] == "clamped_to_bounds"
+        assert info["pre_clamp_soc"] == pytest.approx(0.5)
+
+        normalized, info = _normalize_initial_soc(1.0, config)
+        assert normalized == pytest.approx(config.min_soc_pct)
+        assert info["pre_clamp_soc"] == pytest.approx(1.0)
+
+    def test_normal_percentage_values_unchanged(self, mock_coordinator_data):
+        """Normal percentage values (e.g., 50%, 75%) should pass through unchanged."""
+        config = _build_optimizer_config(mock_coordinator_data, {})
+
+        normalized, info = _normalize_initial_soc(50.0, config)
+        assert normalized == pytest.approx(50.0)
+        assert info["normalization"] == "none"
+
+        normalized, info = _normalize_initial_soc(75.5, config)
+        assert normalized == pytest.approx(75.5)
+        assert info["normalization"] == "none"
+
+    def test_low_soc_warns_about_misconfiguration(self, mock_coordinator_data, caplog):
+        """Values 0 < SOC <= 1.0 should trigger a warning about potential misconfiguration."""
+        import logging
+
+        config = _build_optimizer_config(mock_coordinator_data, {})
+
+        with caplog.at_level(logging.WARNING):
+            normalized, info = _normalize_initial_soc(0.65, config)
+
+        assert "unusually low" in caplog.text
+        assert "percentage scale" in caplog.text
 
     def test_non_positive_soc_is_rejected(self, mock_coordinator_data):
         """SOC <= 0 should be rejected to avoid invalid optimizer runs."""


### PR DESCRIPTION
## Summary

- Removes the incorrect SOC fractional-to-percent auto-detection heuristic from `_normalize_initial_soc()`
- Teslemetry always provides percentage scale (0-100), making the heuristic unnecessary
- Adds warning log for unusually low SOC values (0 < soc <= 1.0) to help detect misconfiguration

## Problem

The heuristic treated any SOC value `0 < soc <= 1.0` as fractional and multiplied by 100. If the battery was actually at 0-1% SOC (nearly depleted), this incorrectly converted it to 100%.

**Example bug:**
- Actual SOC: 0.5% (nearly dead battery)
- Heuristic converts to: 50%
- Optimizer plans for 50% SOC instead of the correct 0.5%

## Solution

Remove the auto-detection entirely. Teslemetry's entity is named `sensor.my_home_percentage_charged` - it always provides 0-100 scale values.

## Test Coverage

- `test_percentage_values_not_converted`: Values 0.5, 1.0 are NOT multiplied by 100
- `test_normal_percentage_values_unchanged`: Values 50%, 75% pass through unchanged
- `test_low_soc_warns_about_misconfiguration`: Warning logged for 0 < soc <= 1.0

Fixes #424