### PR TITLE
Fix Issue #468: Re-check automation_ready after state refresh

### DIFF
--- a/custom_components/localshift/coordinator.py
+++ b/custom_components/localshift/coordinator.py
@@ -1046,6 +1046,9 @@ class LocalShiftCoordinator:
                 self._computation_engine,
                 read_state_func=self._read_all_external_state,
                 notify_func=self._notify_listeners,
+                check_automation_ready_func=self._state_reader.check_automation_ready
+                if self._state_reader is not None
+                else None,
             )
 
     # ------------------------------------------------------------------

--- a/custom_components/localshift/state_machine.py
+++ b/custom_components/localshift/state_machine.py
@@ -173,6 +173,7 @@ class StateMachine:
         computation_engine: ComputationEngine,
         read_state_func: callable | None = None,
         notify_func: callable | None = None,
+        check_automation_ready_func: callable | None = None,
     ) -> None:
         """Compare desired mode with commanded mode and execute transitions.
 
@@ -200,6 +201,11 @@ class StateMachine:
             # the previous evaluation — preventing stale-state reversions.
             if read_state_func is not None:
                 read_state_func()
+            # Issue #468: Re-check automation ready after reading fresh state
+            # If automation_ready was set False from stale startup data,
+            # re-checking now ensures we use fresh values after state refresh
+            if not data.automation_ready and check_automation_ready_func is not None:
+                check_automation_ready_func(data)
             computation_engine.compute_derived_values(data)
 
             # Notify listeners with fresh computed data regardless of which


### PR DESCRIPTION
# Summary

This PR fixes Issue #468 where the automation_ready check would incorrectly show stale, invalid values after HA restart, causing false warnings even when entities had valid, fresh values.

## Problem
- After HA restart, sensor.localshift_automation_ready reported 'not_ready' with stale values (SOC=0.0, operation_mode='')
- Even though entities already contained valid values (SOC=80.5, operation_mode='self_consumption')
- This caused the startup grace warning to fire unnecessarily on every restart

## Root Cause
When startup grace ends, evaluate_state_machine() refreshes entity values via read_state_func() but doesn't re-validate the automation_ready status with the fresh data. The automation_ready status remained stuck with its invalid startup values.

## Fix
- Pass check_automation_ready_func callback from coordinator to state machine 
- Add a re-validation step that runs when automation_ready is currently False (indicating stale startup data)
- Only re-check when needed to avoid unnecessary processing once ready becomes True

## Changes
1. Modified evaluate_state_machine() in state_machine.py to accept new callback parameter
2. Added logic to re-check automation_ready status after state refresh when currently False
3. Updated coordinator.py to pass the required callback function

## Validation
- All existing coordinator/tests pass
- Fix addresses the exact timing issue described in the issue