### PR TITLE
Fix allow_dw_entry_under_target switch not syncing to optimizer

### DIFF
--- a/custom_components/localshift/computation_engine.py
+++ b/custom_components/localshift/computation_engine.py
@@ -54,7 +54,6 @@ from .const import (
     CONF_OPTIMIZATION_MODE,
     CONF_SUN_ENTITY,
     CONF_WEATHER_LEARNING_ENABLED,
-    DEFAULT_ALLOW_DW_ENTRY_UNDER_TARGET,
     DEFAULT_BATTERY_TARGET,
     DEFAULT_CHEAP_PRICE_DEADBAND,
     DEFAULT_DEMAND_WINDOW_END,
@@ -777,8 +776,8 @@ class ComputationEngine:
             CONF_BATTERY_TARGET: self.entry.options.get(
                 CONF_BATTERY_TARGET, DEFAULT_BATTERY_TARGET
             ),
-            CONF_ALLOW_DW_ENTRY_UNDER_TARGET: self.entry.options.get(
-                SWITCH_ALLOW_DW_ENTRY_UNDER_TARGET, DEFAULT_ALLOW_DW_ENTRY_UNDER_TARGET
+            CONF_ALLOW_DW_ENTRY_UNDER_TARGET: self._get_switch_state(
+                SWITCH_ALLOW_DW_ENTRY_UNDER_TARGET
             ),
             CONF_OPTIMIZATION_MODE: self.entry.options.get(
                 CONF_OPTIMIZATION_MODE, DEFAULT_OPTIMIZATION_MODE


### PR DESCRIPTION
## Summary
- Fix bug where `allow_dw_entry_under_target` switch state was not being read correctly by the optimizer
- The switch state was stored as `switch_state_allow_dw_entry_under_target` but the optimizer looked for `allow_dw_entry_under_target` (always returning the default `False`)
- Changed `_build_optimizer_config_options()` to use `self._get_switch_state()` for consistency with the rest of the codebase

## Root Cause
Two conflicting sources of truth existed:
1. Switch state bridge (coordinator): Used `self._get_switch_state("allow_dw_entry_under_target")`
2. Config entry options: Incorrectly looked for key without `switch_state_` prefix

This caused the optimizer to ignore the user's switch setting, resulting in:
- Terminal penalty applied at DW ENTRY (15:00) instead of DW END (21:00)
- Solar gate only considering solar before 15:00, not the full day
- Unnecessary grid charging when solar would have covered the deficit

## Testing
- All 601 tests pass
- Lint and format checks pass

Fixes the planning issue discussed where battery was charging in the morning then exceeding SOC target and exporting.