### PR TITLE
Fix: Align base_slot in slot_builder.py to 5-min boundary (#492)

### DIFF
--- a/custom_components/localshift/computation_engine_lib/slot_builder.py
+++ b/custom_components/localshift/computation_engine_lib/slot_builder.py
@@ -174,7 +174,8 @@ class SlotBuilder:
         all_solcast = [*data.solcast_today, *data.solcast_tomorrow]
 
         # Step 5: Compute base slot for load_forecast_slots indexing
-        base_slot = now_local.replace(second=0, microsecond=0)
+        current_5min = (now_local.minute // 5) * 5
+        base_slot = now_local.replace(minute=current_5min, second=0, microsecond=0)
 
         # Resolve local timezone object once for DW time comparisons.
         # DW start/end times are always in the HA local timezone, so we must


### PR DESCRIPTION
## Summary
Fixes bug where first forecast slot always had zero consumption due to base_slot alignment mismatch.

## Changes
- Align `base_slot` in `slot_builder.py:177` to 5-minute boundary
- Matches producer alignment in `computation_engine.py:633-634`

## Root Cause
Producer aligned to 5-min boundary, consumer did not → negative elapsed time → `consumption_kwh = 0.0`

## Testing
- ✅ Lint passed
- ✅ Format passed  
- ✅ All 601 tests passed

Fixes #492