### PR TITLE
fix: Correct load forecast decay logic with hours_ahead parameter

### DIFF
--- a/custom_components/localshift/computation_engine.py
+++ b/custom_components/localshift/computation_engine.py
@@ -638,12 +638,16 @@ class ComputationEngine:
         for i in range(TOTAL_SLOTS):
             slot_start = base_slot + timedelta(minutes=15 * i)
             slot_hour = slot_start.hour
+            hours_ahead = i / 4.0
+            temperature = data.weather_temperature_forecast.get(slot_hour)
             load_kw, _ = self._load_forecaster.estimate_hourly_consumption_kw(
                 hourly_avg_kw=historical_avg_kw,
                 slot_hour=slot_hour,
                 current_hour=current_hour,
                 current_load_kw=data.load_power_kw,
                 recent_load_kw=recent_load_kw,
+                temperature=temperature,
+                hours_ahead=hours_ahead,
             )
             slots.append(load_kw)
 

--- a/custom_components/localshift/computation_engine_lib/excess_solar.py
+++ b/custom_components/localshift/computation_engine_lib/excess_solar.py
@@ -77,6 +77,7 @@ class ExcessSolarEngine:
         for offset in range(16):  # 4 hours = 16 slots
             slot_start = base_slot + timedelta(minutes=15 * offset)
             slot_hour = slot_start.hour
+            hours_ahead = offset / 4.0
 
             solar_kwh = get_solar_for_15min_slot(all_solcast, slot_start)
             load_kw, _ = self._estimate_hourly_consumption_kw(
@@ -85,6 +86,7 @@ class ExcessSolarEngine:
                 current_hour,
                 current_load_kw,
                 recent_load_kw,
+                hours_ahead=hours_ahead,
             )
             consumption_kwh = load_kw * slot_fraction
             net_kwh = solar_kwh - consumption_kwh
@@ -200,6 +202,7 @@ class ExcessSolarEngine:
         for offset in range(slots_until_fit):
             slot_start = base_slot + timedelta(minutes=15 * offset)
             slot_hour = slot_start.hour
+            hours_ahead = offset / 4.0
 
             solar_kwh = get_solar_for_15min_slot(all_solcast, slot_start)
             load_kw, _ = self._estimate_hourly_consumption_kw(
@@ -208,6 +211,7 @@ class ExcessSolarEngine:
                 current_hour,
                 current_load_kw,
                 recent_load_kw,
+                hours_ahead=hours_ahead,
             )
             consumption_kwh = load_kw * slot_fraction
             net_kwh = solar_kwh - consumption_kwh

--- a/custom_components/localshift/computation_engine_lib/load_forecaster.py
+++ b/custom_components/localshift/computation_engine_lib/load_forecaster.py
@@ -69,6 +69,7 @@ class LoadForecaster:
         current_load_kw: float,
         recent_load_kw: float = 0.0,
         temperature: float | None = None,
+        hours_ahead: float | None = None,
     ) -> tuple[float, str]:
         """Estimate hourly household consumption with exponential decay weighting.
 
@@ -82,6 +83,17 @@ class LoadForecaster:
 
         When temperature is provided and weather correlation is available with
         sufficient confidence, applies temperature-based adjustments for heating/cooling.
+
+        Args:
+            hourly_avg_kw: Historical hourly averages (hour -> kW)
+            slot_hour: The hour of the slot being estimated (for historical lookup)
+            current_hour: Current hour of day (for legacy distance calc), or None to skip blending
+            current_load_kw: Instantaneous live load in kW
+            recent_load_kw: 1-hour rolling average load in kW
+            temperature: Optional temperature for weather correlation
+            hours_ahead: Actual hours ahead for decay weighting (fixes midnight wrap bug).
+                        When provided, overrides clock-hour distance calculation.
+                        Pass i/4.0 where i is the slot index (15-min slots).
 
         Returns tuple of (kW, source_tag).
         """
@@ -100,9 +112,14 @@ class LoadForecaster:
         # EXPONENTIAL DECAY WEIGHTING (Issue #381)
         # When current_hour is None (simulations without time context), skip blending
         if current_hour is not None:
-            # Calculate distance from current hour (handles midnight wrap)
-            hour_distance = abs(slot_hour - current_hour)
-            hour_distance = min(hour_distance, 24 - hour_distance)
+            # Calculate distance for decay weighting
+            # Prefer hours_ahead (actual time distance) over clock-hour distance
+            # This fixes the midnight wrap bug where slots 20-23h away appeared "close"
+            if hours_ahead is not None:
+                hour_distance = int(hours_ahead)
+            else:
+                hour_distance = abs(slot_hour - current_hour)
+                hour_distance = min(hour_distance, 24 - hour_distance)
 
             # CURRENT SLOT: Use live load directly
             # This ensures immediate accuracy for the current time slot
@@ -138,10 +155,27 @@ class LoadForecaster:
             base_load_kw = historical_kw
             base_source = "profile_hour"
 
-        # Fallback to current load
+        # Fallback: no historical for this specific hour, no live-load blending applicable
         if not base_source:
-            base_load_kw = current_load_kw if current_load_kw > 0 else 0.6
-            base_source = "live_load_fallback"
+            # Try mean of available historical hours first
+            if hourly_avg_kw:
+                values = [v for v in hourly_avg_kw.values() if v > 0]
+                if values:
+                    base_load_kw = sum(values) / len(values)
+                    base_source = "live_load_fallback"
+            # Then try current live load
+            if not base_source and current_load_kw > 0:
+                base_load_kw = current_load_kw
+                base_source = "live_load_fallback"
+            # No data available - log warning and return 0.0
+            if not base_source:
+                _LOGGER.warning(
+                    "NO_LOAD_DATA: No historical or live load data available for slot_hour=%d. "
+                    "Check load sensor availability and recorder history.",
+                    slot_hour,
+                )
+                base_load_kw = 0.0
+                base_source = "live_load_fallback"
 
         # WEATHER CORRELATION: Apply temperature-based adjustment if available
         # Only apply when:

--- a/custom_components/localshift/computation_engine_lib/soc_simulator.py
+++ b/custom_components/localshift/computation_engine_lib/soc_simulator.py
@@ -161,6 +161,7 @@ class SocSimulator:
                     break
 
                 slot_hour = slot_start.hour
+                hours_ahead = (slot_start - base_slot).total_seconds() / 3600
 
                 # Use variable-duration solar function
                 solar_kwh = get_solar_for_slot_by_interval(
@@ -169,11 +170,12 @@ class SocSimulator:
 
                 # ISSUE #137: Use baseline load profile when provided
                 load_kw, _ = self._estimate_hourly_consumption_kw(
-                    load_profile,  # Uses baseline_avg_kw if provided
+                    load_profile,
                     slot_hour,
                     current_hour,
                     current_load_kw,
                     recent_load_kw,
+                    hours_ahead=hours_ahead,
                 )
                 consumption_kwh = load_kw * slot_fraction
                 net_kwh = solar_kwh - consumption_kwh
@@ -202,17 +204,19 @@ class SocSimulator:
             while slot_time < sim_end:
                 slot_time += timedelta(minutes=15)
                 slot_hour = slot_time.hour
+                hours_ahead = (slot_time - base_slot).total_seconds() / 3600
 
                 # Get solar and load for this 15-min slot
                 solar_kwh = get_solar_for_15min_slot(all_solcast, slot_time)
 
                 # ISSUE #137: Use baseline load profile when provided
                 load_kw, _ = self._estimate_hourly_consumption_kw(
-                    load_profile,  # Uses baseline_avg_kw if provided
+                    load_profile,
                     slot_hour,
                     current_hour,
                     current_load_kw,
                     recent_load_kw,
+                    hours_ahead=hours_ahead,
                 )
                 consumption_kwh = load_kw * slot_fraction
                 net_kwh = solar_kwh - consumption_kwh
@@ -282,6 +286,7 @@ class SocSimulator:
         slot_time = base_slot
         while slot_time < solar_start:
             slot_hour = slot_time.hour
+            hours_ahead = (slot_time - base_slot).total_seconds() / 3600
 
             # Get solar (should be ~0 overnight) and load
             solar_kwh = get_solar_for_15min_slot(all_solcast, slot_time)
@@ -289,9 +294,10 @@ class SocSimulator:
             load_kw, _ = self._estimate_hourly_consumption_kw(
                 historical_avg_kw,
                 slot_hour,
-                None,  # current_hour - not available in this simulation
+                None,
                 current_load_kw,
                 recent_load_kw,
+                hours_ahead=hours_ahead,
             )
             consumption_kwh = load_kw * slot_fraction
             net_kwh = solar_kwh - consumption_kwh
@@ -356,6 +362,7 @@ class SocSimulator:
         for i in range(total_slots):
             slot_time = base_slot + timedelta(minutes=15 * i)
             slot_hour = slot_time.hour
+            hours_ahead = i / 4.0
 
             # Get solar and load for this 15-min slot
             solar_kwh = get_solar_for_15min_slot(all_solcast, slot_time)
@@ -363,9 +370,10 @@ class SocSimulator:
             load_kw, _ = self._estimate_hourly_consumption_kw(
                 historical_avg_kw,
                 slot_hour,
-                None,  # current_hour - not available in this simulation
+                None,
                 current_load_kw,
                 recent_load_kw,
+                hours_ahead=hours_ahead,
             )
             consumption_kwh = load_kw * slot_fraction
             net_kwh = solar_kwh - consumption_kwh
@@ -443,6 +451,7 @@ class SocSimulator:
         slot_time = base_slot
         while slot_time < solar_start_slot:
             slot_hour = slot_time.hour
+            hours_ahead = (slot_time - base_slot).total_seconds() / 3600
 
             # Get solar (should be ~0 overnight) and load
             solar_kwh = get_solar_for_15min_slot(all_solcast, slot_time)
@@ -450,9 +459,10 @@ class SocSimulator:
             load_kw, _ = self._estimate_hourly_consumption_kw(
                 historical_avg_kw,
                 slot_hour,
-                None,  # current_hour - not available in this simulation
+                None,
                 current_load_kw,
                 recent_load_kw,
+                hours_ahead=hours_ahead,
             )
             consumption_kwh = load_kw * slot_fraction
             net_kwh = solar_kwh - consumption_kwh
@@ -535,6 +545,7 @@ class SocSimulator:
         for offset in range(slots_to_simulate):
             slot_start = base_slot + timedelta(minutes=15 * offset)
             slot_hour = slot_start.hour
+            hours_ahead = offset / 4.0
 
             solar_kwh = get_solar_for_15min_slot(all_solcast, slot_start)
             load_kw, _ = self._estimate_hourly_consumption_kw(
@@ -543,6 +554,7 @@ class SocSimulator:
                 current_hour,
                 current_load_kw,
                 recent_load_kw,
+                hours_ahead=hours_ahead,
             )
 
             # Add the additional load we're testing
@@ -629,6 +641,7 @@ class SocSimulator:
                 interval_minutes = slot["interval_minutes"]
                 slot_fraction = interval_minutes / 60.0
                 slot_hour = slot_start.hour
+                hours_ahead = (slot_start - base_slot).total_seconds() / 3600
 
                 # Use variable-duration solar function
                 solar_kwh = get_solar_for_slot_by_interval(
@@ -640,6 +653,7 @@ class SocSimulator:
                     current_hour,
                     current_load_kw,
                     recent_load_kw,
+                    hours_ahead=hours_ahead,
                 )
                 # Scale consumption to slot duration
                 consumption_kwh = load_kw * slot_fraction
@@ -669,6 +683,7 @@ class SocSimulator:
             for i in range(TOTAL_SLOTS):
                 slot_start = base_slot + timedelta(minutes=15 * i)
                 slot_hour = slot_start.hour
+                hours_ahead = i / 4.0
 
                 solar_kwh = get_solar_for_15min_slot(all_solcast, slot_start)
                 load_kw, _ = self._estimate_hourly_consumption_kw(
@@ -677,6 +692,7 @@ class SocSimulator:
                     current_hour,
                     current_load_kw,
                     recent_load_kw,
+                    hours_ahead=hours_ahead,
                 )
                 consumption_kwh = load_kw * slot_fraction
                 net_kwh = solar_kwh - consumption_kwh

--- a/tests/test_load_forecaster.py
+++ b/tests/test_load_forecaster.py
@@ -176,20 +176,24 @@ class TestLoadForecasterExponentialDecay:
         assert source == "live_load_fallback"
         assert kw == 0.45
 
-    def test_no_historical_no_live_fallback(self):
-        """Test when no historical and no live load, uses 0.6 default."""
+    def test_no_historical_no_live_fallback(self, caplog):
+        """Test when no historical and no live load, returns 0.0 with warning."""
+        import logging
+
         forecaster = _create_load_forecaster()
 
-        kw, source = forecaster.estimate_hourly_consumption_kw(
-            hourly_avg_kw={},
-            slot_hour=10,
-            current_hour=11,
-            current_load_kw=0.0,
-            recent_load_kw=0.0,
-        )
+        with caplog.at_level(logging.WARNING):
+            kw, source = forecaster.estimate_hourly_consumption_kw(
+                hourly_avg_kw={},
+                slot_hour=10,
+                current_hour=11,
+                current_load_kw=0.0,
+                recent_load_kw=0.0,
+            )
 
         assert source == "live_load_fallback"
-        assert kw == 0.6
+        assert kw == 0.0
+        assert "NO_LOAD_DATA" in caplog.text
 
     def test_weather_correlation_applied(self, mock_weather_correlation):
         """Test weather correlation adjustment when confidence is high.
@@ -271,6 +275,85 @@ class TestLoadForecasterExponentialDecay:
         expected_kw = round(max(0.0, base_kw + 0.1), 3)
 
         assert abs(kw - expected_kw) < 0.001
+
+    def test_midnight_wrap_far_future_uses_historical(self):
+        """Test hours_ahead prevents spurious live-blending for distant slots.
+
+        Without hours_ahead, slot_hour=21 with current_hour=22 would appear
+        1 hour away due to midnight wrap (24 - 22 + 21 = wrong).
+        With hours_ahead=23, correctly uses historical profile only.
+        """
+        forecaster = _create_load_forecaster()
+        hourly_avg = {21: 0.5, 22: 0.6, 23: 0.7, 0: 0.4, 1: 0.3}
+
+        kw, source = forecaster.estimate_hourly_consumption_kw(
+            hourly_avg_kw=hourly_avg,
+            slot_hour=21,
+            current_hour=22,
+            current_load_kw=1.0,
+            recent_load_kw=1.0,
+            hours_ahead=23.0,
+        )
+
+        assert source == "profile_hour"
+        assert kw == 0.5
+
+    def test_hours_ahead_near_slots_decay_correctly(self):
+        """Test hours_ahead correctly controls decay for near-term slots."""
+        forecaster = _create_load_forecaster()
+        hourly_avg = {10: 0.5, 11: 0.6, 12: 0.7}
+
+        for hours_ahead_val, expected_source in [
+            (0.0, "live_load"),
+            (1.0, "decay_load_d1"),
+            (2.0, "decay_load_d2"),
+            (3.0, "decay_load_d3"),
+            (4.0, "profile_hour"),
+        ]:
+            kw, source = forecaster.estimate_hourly_consumption_kw(
+                hourly_avg_kw=hourly_avg,
+                slot_hour=10,
+                current_hour=11,
+                current_load_kw=1.0,
+                recent_load_kw=1.0,
+                hours_ahead=hours_ahead_val,
+            )
+            assert source == expected_source, f"Failed at hours_ahead={hours_ahead_val}"
+
+    def test_fallback_uses_historical_mean_when_available(self):
+        """Test fallback uses mean of available historical hours when slot_hour missing."""
+        forecaster = _create_load_forecaster()
+        hourly_avg = {8: 0.4, 9: 0.6}
+
+        kw, source = forecaster.estimate_hourly_consumption_kw(
+            hourly_avg_kw=hourly_avg,
+            slot_hour=15,
+            current_hour=15,
+            current_load_kw=0.0,
+            recent_load_kw=0.0,
+        )
+
+        assert source == "live_load_fallback"
+        assert kw == 0.5
+
+    def test_cold_start_returns_zero_with_warning(self, caplog):
+        """Test cold start returns 0.0 and logs warning when no data available."""
+        import logging
+
+        forecaster = _create_load_forecaster()
+
+        with caplog.at_level(logging.WARNING):
+            kw, source = forecaster.estimate_hourly_consumption_kw(
+                hourly_avg_kw={},
+                slot_hour=10,
+                current_hour=10,
+                current_load_kw=0.0,
+                recent_load_kw=0.0,
+            )
+
+        assert source == "live_load_fallback"
+        assert kw == 0.0
+        assert "NO_LOAD_DATA" in caplog.text
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

Fixes critical issues in the load forecast decay logic identified during investigation.

## Problems Fixed

### 1. Midnight Wrap Bug (Critical)
The symmetric clock-hour distance calculation caused slots 20-23 hours in the future to incorrectly blend live load data. For example, at 10 PM, a slot at 9 PM tomorrow (+23 hours) appeared only 1 hour away due to clock wrap, resulting in 64% live-weighted forecasts for data that should use pure historical patterns.

**Fix**: Added  parameter that uses actual time distance from now instead of clock-hour distance.

### 2. Weather Correlation Never Applied
The  parameter was never passed to the forecaster in the slot-building loop, making weather correlation dead code.

**Fix**: Now passes  for each slot.

### 3. Hardcoded 0.6 kW Fallback
When no historical data existed for a specific hour and live load was unavailable, the code returned an arbitrary 0.6 kW constant.

**Fix**: Tiered fallback:
1. Mean of available historical hours (if any exist)
2. Current live load (if > 0)
3. 0.0 kW with WARNING log for true cold-start/sensor failure cases

## Changes

- : Add  parameter, fix fallback logic
- : Pass  and  in slot loop
- : Pass  for all relevant calls
- : Pass  for decay-enabled calls
- : Add 4 new tests (midnight wrap, hours_ahead decay, fallback behaviors)

## Testing

- All 605 tests pass
- 4 new tests specifically validate the fixes
- Linting and formatting clean

## Impact

- Load forecasts for distant future slots now correctly use historical data
- Weather correlation adjustments are now active in the optimizer
- Cold-start behavior is more transparent (warning log) and data-driven