### PR TITLE
Add decision-to-implementation lag metric

### DIFF
--- a/custom_components/localshift/computation_engine.py
+++ b/custom_components/localshift/computation_engine.py
@@ -979,7 +979,22 @@ class ComputationEngine:
         # Map battery_mode string → BatteryMode enum
         battery_mode_str = apply_plan.get("battery_mode", "")
         try:
-            data.active_mode = _BatteryMode(battery_mode_str)
+            new_mode = _BatteryMode(battery_mode_str)
+            # Record decision timestamp when mode changes (Issue #501)
+            if new_mode != data.active_mode:
+                from homeassistant.util import dt as dt_util  # noqa: PLC0415
+
+                decision_time = dt_util.now()
+                if decision_time is not None:
+                    data.decision_timestamp = decision_time
+                    data.decision_mode = new_mode
+                    _LOGGER.info(
+                        "Decision lag tracking: mode change %s → %s at %s",
+                        data.active_mode.value,
+                        new_mode.value,
+                        decision_time.isoformat(),
+                    )
+            data.active_mode = new_mode
             data.optimizer_last_apply_status = "ready_to_apply"
             data.optimizer_safety_block_reason = ""
             _LOGGER.info(

--- a/custom_components/localshift/coordinator_data.py
+++ b/custom_components/localshift/coordinator_data.py
@@ -515,3 +515,26 @@ class CoordinatorData:
     """Apply plan derived from optimizer decisions.
     Contains: action, battery_mode, target_soc, reason.
     """
+
+    # ---------------------------------------------------------------------------
+    # --- Decision-to-Implementation Lag Tracking (Issue #501) ---
+    # ---------------------------------------------------------------------------
+    # Measures time from decision made to hardware validation passed.
+
+    decision_timestamp: datetime | None = None
+    """When active_mode was set to a new value (decision made)."""
+
+    decision_mode: BatteryMode | None = None
+    """The mode that was decided (for lag tracking)."""
+
+    implementation_timestamp: datetime | None = None
+    """When validation passed for the decision."""
+
+    decision_lag_seconds: float | None = None
+    """Calculated lag from decision to implementation (seconds)."""
+
+    decision_lag_history: list[dict[str, Any]] = field(default_factory=list)
+    """History of recent decision-to-implementation lag measurements.
+    Each entry: {from_mode, to_mode, lag_seconds, decision_time, implementation_time}.
+    Max 50 entries.
+    """

--- a/custom_components/localshift/sensor.py
+++ b/custom_components/localshift/sensor.py
@@ -53,6 +53,8 @@ async def async_setup_entry(
         LearningStatusSensor(coordinator, entry),
         DecisionQualitySensor(coordinator, entry),
         LearningDecisionHistorySensor(coordinator, entry),
+        # Decision-to-implementation lag sensor (Issue #501)
+        DecisionLagSensor(coordinator, entry),
         # Statistics backfiller sensor (Issue #267)
         BackfillStatusSensor(coordinator, entry),
         # Cost reconciliation sensor (Issue #269)
@@ -863,6 +865,75 @@ class LearningDecisionHistorySensor(LocalShiftSensorBase):
         return {
             "decisions": self.coordinator.data.recent_decision_log[-20:],
         }
+
+
+# ---------------------------------------------------------------------------
+# Decision-to-Implementation Lag Sensor (Issue #501)
+# ---------------------------------------------------------------------------
+
+
+class DecisionLagSensor(LocalShiftSensorBase):
+    """Measures time from decision to validated implementation.
+
+    Shows the lag in seconds between when a battery mode decision is made
+    and when the hardware validates the change.
+    """
+
+    _attr_unique_id = "localshift_decision_lag"
+    _attr_name = "Decision Lag"
+    _attr_icon = "mdi:timer-outline"
+    _attr_native_unit_of_measurement = "s"
+    _attr_state_class = SensorStateClass.MEASUREMENT
+
+    def _update_from_coordinator(self) -> None:
+        """Update with current lag in seconds."""
+        lag = self.coordinator.data.decision_lag_seconds
+        if lag is not None:
+            self._attr_native_value = round(lag, 2)
+        else:
+            self._attr_native_value = None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return lag history and statistics."""
+        d = self.coordinator.data
+        history = d.decision_lag_history or []
+
+        # Calculate statistics from history
+        if history:
+            lag_values = [h["lag_seconds"] for h in history]
+            avg_lag = sum(lag_values) / len(lag_values)
+            max_lag = max(lag_values)
+            min_lag = min(lag_values)
+        else:
+            avg_lag = None
+            max_lag = None
+            min_lag = None
+
+        return {
+            "current_lag": round(d.decision_lag_seconds, 2)
+            if d.decision_lag_seconds is not None
+            else None,
+            "last_transition": history[-1] if history else None,
+            "history": history[-20:],  # Last 20 entries
+            "avg_lag_24h": round(avg_lag, 2) if avg_lag is not None else None,
+            "max_lag_24h": round(max_lag, 2) if max_lag is not None else None,
+            "min_lag_24h": round(min_lag, 2) if min_lag is not None else None,
+            "total_transitions": len(history),
+            "decision_timestamp": d.decision_timestamp.isoformat()
+            if d.decision_timestamp
+            else None,
+            "implementation_timestamp": d.implementation_timestamp.isoformat()
+            if d.implementation_timestamp
+            else None,
+        }
+
+    @property
+    def icon(self) -> str:
+        """Return icon based on lag status."""
+        if self.coordinator.data.decision_timestamp is not None:
+            return "mdi:timer-sand"  # Decision pending
+        return "mdi:timer-outline"  # Completed
 
 
 # ---------------------------------------------------------------------------

--- a/custom_components/localshift/state_machine.py
+++ b/custom_components/localshift/state_machine.py
@@ -609,10 +609,49 @@ class StateMachine:
 
         # Track successful transition time for health check grace period
         if transition_success and not dry_run:
+            from homeassistant.util import dt as dt_util  # noqa: PLC0415
+
             transition_time = dt_util.now()
             self._last_successful_transition = transition_time
             # Track when mode was established for minimum duration check (Issue #279)
             self._mode_established_at = transition_time
+
+            # Issue #501: Record implementation timestamp and calculate lag
+            if data.decision_timestamp is not None and data.decision_mode == target:
+                data.implementation_timestamp = transition_time
+                lag_seconds = (
+                    transition_time - data.decision_timestamp
+                ).total_seconds()
+                data.decision_lag_seconds = lag_seconds
+                from_mode = data.active_mode.value if data.active_mode else "unknown"
+                to_mode = target.value
+                decision_mode_value = (
+                    data.decision_mode.value if data.decision_mode else "unknown"
+                )
+
+                # Add to history
+                history_entry = {
+                    "from_mode": from_mode,
+                    "to_mode": to_mode,
+                    "lag_seconds": round(lag_seconds, 2),
+                    "decision_time": data.decision_timestamp.isoformat(),
+                    "implementation_time": transition_time.isoformat(),
+                }
+                data.decision_lag_history.append(history_entry)
+                if len(data.decision_lag_history) > 50:
+                    data.decision_lag_history = data.decision_lag_history[-50:]
+
+                _LOGGER.info(
+                    "Decision lag: %s → %s completed in %.2fs",
+                    decision_mode_value,
+                    to_mode,
+                    lag_seconds,
+                )
+
+                # Clear decision tracking fields
+                data.decision_timestamp = None
+                data.decision_mode = None
+
             _LOGGER.debug(
                 "Recorded successful transition to %s at %s",
                 target.value,

--- a/tests/test_decision_lag.py
+++ b/tests/test_decision_lag.py
@@ -1,0 +1,45 @@
+"""Tests for decision-to-implementation lag tracking (Issue #501)."""
+
+from datetime import datetime, timedelta
+
+import pytest
+
+from custom_components.localshift.const import BatteryMode
+from custom_components.localshift.coordinator_data import CoordinatorData
+
+
+class TestDecisionLagTracking:
+    """Test decision lag tracking in CoordinatorData."""
+
+    def test_initial_state_no_lag(self):
+        """Test initial state has no lag data."""
+        data = CoordinatorData()
+
+        assert data.decision_timestamp is None
+        assert data.decision_mode is None
+        assert data.implementation_timestamp is None
+        assert data.decision_lag_seconds is None
+        assert len(data.decision_lag_history) == 0
+
+    def test_history_limit(self):
+        """Test history is limited to 50 entries when managed by state machine."""
+        data = CoordinatorData()
+
+        # Simulate what state machine does - adds entries with limit check
+        for i in range(60):
+            entry = {
+                "from_mode": "self_consumption",
+                "to_mode": "grid_charging",
+                "lag_seconds": 5.0 + i,
+                "decision_time": f"2025-01-01T{i:02d}:00:00",
+                "implementation_time": f"2025-01-01T{i:02d}:00:05",
+            }
+            data.decision_lag_history.append(entry)
+            if len(data.decision_lag_history) > 50:
+                data.decision_lag_history = data.decision_lag_history[-50:]
+
+        # Should be limited to 50
+        assert len(data.decision_lag_history) == 50
+        # Should keep the most recent (entries 10-59, lag values 15.0-64.0)
+        assert data.decision_lag_history[0]["lag_seconds"] == 15.0
+        assert data.decision_lag_history[-1]["lag_seconds"] == 64.0


### PR DESCRIPTION
## Summary
Measures time from decision to validated implementation (including debounce).

## Implementation
- Timing fields in CoordinatorData (decision_timestamp, implementation_timestamp, decision_lag_seconds, decision_lag_history)
- Record decision in computation_engine._assign_active_mode()
- Calculate lag in state_machine._execute_mode_transition()
- New sensor sensor.localshift_decision_lag with history and stats

## Tests
- CoordinatorData timing fields
- History limit (50 entries)

Fixes #501