### PR TITLE
Fix #505: allow_dw_entry_under_target checks max SOC during DW

### DIFF
--- a/custom_components/localshift/computation_engine_lib/optimizer_dp.py
+++ b/custom_components/localshift/computation_engine_lib/optimizer_dp.py
@@ -380,6 +380,9 @@ class OptimizerResult:
     can_solar_reach_target: bool = False
     """True if solar alone can reach DW target (no grid charge, no export). Phase 4, #441."""
 
+    can_solar_reach_target_in_dw: bool = False
+    """True if solar alone reaches target at any point during DW (allow_dw_entry_under_target mode). Issue #505."""
+
     error_message: str | None = None
     """Error description if success=False."""
 
@@ -612,6 +615,17 @@ class DPPlanner:
         if in_demand_window and demand_window_end_idx is None:
             demand_window_end_idx = n_slots - 1
 
+        # Pre-compute whether solar can reach target during DW (Issue #505)
+        # Used to conditionally zero out terminal penalty when allow_dw_entry_under_target=True
+        solar_can_reach_target_in_dw = False
+        if config.allow_dw_entry_under_target and demand_window_entry_idx is not None:
+            max_soc_in_dw = _simulate_max_soc_in_demand_window(
+                inputs.initial_soc_pct, slots, config
+            )
+            solar_can_reach_target_in_dw = (
+                max_soc_in_dw >= config.demand_window_target_soc_pct
+            )
+
         # Determine where to apply terminal penalty
         # If allow_dw_entry_under_target is True, apply at DW end (allows solar during DW)
         # Otherwise, apply at DW entry (must meet target by DW start)
@@ -633,7 +647,12 @@ class DPPlanner:
             # Apply shortfall penalty at terminal penalty index
             target = config.demand_window_target_soc_pct
             for bin_idx, soc in enumerate(soc_grid):
-                shortfall_penalty = DPPlanner.terminal_cost(soc, target, config)
+                # Issue #505: When allow_dw_entry_under_target=True and solar can reach
+                # target during DW, zero out the terminal penalty (trust solar)
+                if config.allow_dw_entry_under_target and solar_can_reach_target_in_dw:
+                    shortfall_penalty = 0.0
+                else:
+                    shortfall_penalty = DPPlanner.terminal_cost(soc, target, config)
                 dp[n_slots][bin_idx] = (
                     shortfall_penalty,
                     PlannerAction.HOLD,
@@ -823,10 +842,18 @@ class DPPlanner:
 
         # Calculate terminal shortfall at the terminal penalty index
         terminal_shortfall = 0.0
-        if terminal_penalty_idx is not None and terminal_penalty_idx < len(decisions):
-            terminal_soc = decisions[terminal_penalty_idx].predicted_soc_pct
+        if terminal_penalty_idx is not None:
             target = config.demand_window_target_soc_pct
-            terminal_shortfall = max(0.0, target - terminal_soc)
+            if config.allow_dw_entry_under_target:
+                # Issue #505: Shortfall based on max SOC during DW
+                max_soc_in_dw = _simulate_max_soc_in_demand_window(
+                    inputs.initial_soc_pct, slots, config
+                )
+                terminal_shortfall = max(0.0, target - max_soc_in_dw)
+            elif terminal_penalty_idx < len(decisions):
+                # Original: shortfall at fixed checkpoint
+                terminal_soc = decisions[terminal_penalty_idx].predicted_soc_pct
+                terminal_shortfall = max(0.0, target - terminal_soc)
 
         # Determine if solar alone can reach the DW target (Phase 4, #441)
         can_solar = (
@@ -850,6 +877,7 @@ class DPPlanner:
             projected_net_cost=total_net_cost,
             terminal_shortfall_pct=terminal_shortfall,
             can_solar_reach_target=can_solar,
+            can_solar_reach_target_in_dw=solar_can_reach_target_in_dw,
             reason_code_histogram=reason_histogram,
         )
 
@@ -1010,14 +1038,23 @@ class DPPlanner:
         ):
             soc_deficit_pct = config.demand_window_target_soc_pct - soc_pct
             if soc_deficit_pct > 0:
-                solar_gain_pct = DPPlanner._projected_solar_soc_gain_pct(
-                    slot_idx=slot_idx,
-                    slots=slots,
-                    terminal_penalty_idx=terminal_penalty_idx,
-                    battery_capacity_kwh=config.battery_capacity_kwh,
-                )
-                if solar_gain_pct >= soc_deficit_pct:
-                    _solar_covers_deficit = True
+                if config.allow_dw_entry_under_target:
+                    # Issue #505: Check if solar reaches target at any point during DW
+                    max_soc_in_dw = _simulate_max_soc_in_demand_window(
+                        soc_pct, slots, config
+                    )
+                    if max_soc_in_dw >= config.demand_window_target_soc_pct:
+                        _solar_covers_deficit = True
+                else:
+                    # Original: solar must cover deficit to DW entry
+                    solar_gain_pct = DPPlanner._projected_solar_soc_gain_pct(
+                        slot_idx=slot_idx,
+                        slots=slots,
+                        terminal_penalty_idx=terminal_penalty_idx,
+                        battery_capacity_kwh=config.battery_capacity_kwh,
+                    )
+                    if solar_gain_pct >= soc_deficit_pct:
+                        _solar_covers_deficit = True
 
         # Grid charging constraints (Issue #406)
         if can_charge and not slot.is_demand_window_slot and not _solar_covers_deficit:
@@ -1396,3 +1433,44 @@ def _simulate_solar_only_terminal_soc(
         if terminal_penalty_idx is not None and i == terminal_penalty_idx:
             return soc
     return soc
+
+
+def _simulate_max_soc_in_demand_window(
+    initial_soc_pct: float,
+    slots: list[SlotContext],
+    config: OptimizerConfig,
+) -> float:
+    """Simulate solar-only SOC and return max SOC within demand window slots.
+
+    Used when allow_dw_entry_under_target=True to determine if solar
+    will reach target at any point during DW (Issue #505).
+
+    Args:
+        initial_soc_pct: Starting SOC percentage.
+        slots: List of slot contexts to simulate.
+        config: Optimizer configuration.
+
+    Returns:
+        Maximum SOC percentage reached within any demand window slot.
+        Returns initial_soc_pct if no DW slots exist.
+    """
+    soc = initial_soc_pct
+    max_soc_in_dw = soc
+
+    for slot in slots:
+        net_kwh = slot.solar_kwh - slot.consumption_kwh
+        slot_hours = slot.slot_interval_minutes / 60.0
+        max_transfer_kwh = config.charge_rate_kw * slot_hours
+
+        if net_kwh >= 0:
+            delta = min(net_kwh, max_transfer_kwh) * config.charge_efficiency
+        else:
+            delta = max(net_kwh, -max_transfer_kwh) / config.discharge_efficiency
+
+        soc += delta / config.battery_capacity_kwh * 100
+        soc = max(config.min_soc_pct, min(100.0, soc))
+
+        if slot.is_demand_window_slot:
+            max_soc_in_dw = max(max_soc_in_dw, soc)
+
+    return max_soc_in_dw

--- a/tests/test_optimizer_dp_solve.py
+++ b/tests/test_optimizer_dp_solve.py
@@ -23,6 +23,7 @@ from custom_components.localshift.computation_engine_lib.optimizer_dp import (
     SlotContext,
     _build_soc_grid,
     _map_soc_to_bin,
+    _simulate_max_soc_in_demand_window,
 )
 
 # ---------------------------------------------------------------------------
@@ -1194,3 +1195,217 @@ def test_optimizer_does_not_grid_charge_during_solar_peak_with_sufficient_solar(
             PlannerAction.CHARGE_GRID_NORMAL,
             PlannerAction.CHARGE_GRID_BOOST,
         ), f"Unexpected grid charge at slot {decision.slot_index}: {decision.action}"
+
+
+def test_allow_dw_entry_under_target_suppresses_charge_when_solar_reaches_target_mid_dw():
+    """Issue #505: When allow_dw_entry_under_target=True, no grid charging if solar
+    reaches target at ANY point during DW (not just at DW end)."""
+    # Scenario:
+    # - Initial SOC: 50%
+    # - Target: 80%
+    # - Pre-DW (slots 0-3): Low solar, cheap prices - could charge
+    # - DW (slots 4-7): High solar - will reach target at slot 5
+    # - Expected: NO grid charging because solar reaches target mid-DW
+
+    pre_dw_slots = [
+        SlotContext(
+            slot_index=i,
+            timestamp_iso=f"2026-01-03T{10 + i}:00:00",
+            slot_interval_minutes=60,
+            buy_price=0.10,  # cheap enough to grid charge
+            sell_price=0.05,
+            solar_kwh=0.5,  # low solar
+            consumption_kwh=0.5,
+        )
+        for i in range(4)
+    ]
+    dw_slots = [
+        SlotContext(
+            slot_index=4 + i,
+            timestamp_iso=f"2026-01-03T{14 + i}:00:00",
+            slot_interval_minutes=60,
+            buy_price=0.15,
+            sell_price=0.05,
+            solar_kwh=3.0 if i < 2 else 1.0,  # high solar early in DW
+            consumption_kwh=0.5,
+            is_demand_window_entry=(i == 0),
+            is_demand_window_slot=True,
+        )
+        for i in range(4)
+    ]
+    slots = pre_dw_slots + dw_slots
+
+    config = OptimizerConfig(
+        battery_capacity_kwh=13.5,
+        demand_window_target_soc_pct=80.0,
+        effective_cheap_price=0.12,
+        allow_dw_entry_under_target=True,  # Enable the new behavior
+        optimization_mode="self_consumption",
+        soc_bins=20,
+        target_shortfall_penalty_per_pct=0.030,
+    )
+    inputs = OptimizerInputs(
+        cycle_id="test-dw-target-anywhere",
+        initial_soc_pct=50.0,
+        slots=slots,
+        config=config,
+    )
+
+    result = DPPlanner().plan(inputs)
+    assert result.success
+
+    # Solar should reach ~80%+ during DW, so no grid charging needed
+    # Check pre-DW slots (0-3) don't grid charge
+    for decision in result.decisions[:4]:
+        assert decision.action not in (
+            PlannerAction.CHARGE_GRID_NORMAL,
+            PlannerAction.CHARGE_GRID_BOOST,
+        ), (
+            f"Pre-DW slot {decision.slot_index} should not grid-charge when solar will reach target in DW"
+        )
+
+    # Verify solar reaches target in DW
+    assert result.can_solar_reach_target_in_dw is True
+
+
+def test_allow_dw_entry_under_target_charges_when_solar_insufficient():
+    """Issue #505: Grid charging still occurs when solar cannot reach target during DW."""
+    # Scenario:
+    # - Initial SOC: 50%
+    # - Target: 80%
+    # - Pre-DW (slots 0-3): Cheap prices
+    # - DW (slots 4-7): Low solar - will NOT reach target
+    # - Expected: Grid charging occurs because solar insufficient
+
+    pre_dw_slots = [
+        SlotContext(
+            slot_index=i,
+            timestamp_iso=f"2026-01-03T{10 + i}:00:00",
+            slot_interval_minutes=60,
+            buy_price=0.10,  # cheap
+            sell_price=0.05,
+            solar_kwh=0.3,  # low solar
+            consumption_kwh=0.5,
+        )
+        for i in range(4)
+    ]
+    dw_slots = [
+        SlotContext(
+            slot_index=4 + i,
+            timestamp_iso=f"2026-01-03T{14 + i}:00:00",
+            slot_interval_minutes=60,
+            buy_price=0.20,
+            sell_price=0.05,
+            solar_kwh=0.3,  # consistently low solar
+            consumption_kwh=0.5,
+            is_demand_window_entry=(i == 0),
+            is_demand_window_slot=True,
+        )
+        for i in range(4)
+    ]
+    slots = pre_dw_slots + dw_slots
+
+    config = OptimizerConfig(
+        battery_capacity_kwh=13.5,
+        demand_window_target_soc_pct=80.0,
+        effective_cheap_price=0.12,
+        allow_dw_entry_under_target=True,
+        optimization_mode="self_consumption",
+        soc_bins=20,
+        target_shortfall_penalty_per_pct=0.030,
+    )
+    inputs = OptimizerInputs(
+        cycle_id="test-dw-target-anywhere-insufficient",
+        initial_soc_pct=50.0,
+        slots=slots,
+        config=config,
+    )
+
+    result = DPPlanner().plan(inputs)
+    assert result.success
+
+    # Solar cannot reach target, so grid charging should occur
+    grid_charge_actions = [
+        d.action
+        for d in result.decisions
+        if d.action
+        in (PlannerAction.CHARGE_GRID_NORMAL, PlannerAction.CHARGE_GRID_BOOST)
+    ]
+    assert len(grid_charge_actions) > 0, "Should grid-charge when solar insufficient"
+
+    # Verify solar cannot reach target in DW
+    assert result.can_solar_reach_target_in_dw is False
+
+
+def test_allow_dw_entry_under_target_false_uses_original_behavior():
+    """Issue #505: When allow_dw_entry_under_target=False, use original gate logic.
+
+    This test verifies the two modes behave differently:
+    - allow_dw_entry_under_target=False: Target must be reached BY DW ENTRY
+    - allow_dw_entry_under_target=True: Target must be reached AT ANY POINT in DW
+
+    With False mode, high terminal penalty, and pre-DW discharge, optimizer
+    grid-charges to meet target by DW entry.
+    """
+    # Pre-DW: Net discharge (solar < consumption) to create SOC deficit
+    pre_dw_slots = [
+        SlotContext(
+            slot_index=i,
+            timestamp_iso=f"2026-01-03T{10 + i}:00:00",
+            slot_interval_minutes=60,
+            buy_price=0.10,  # cheap enough to grid charge
+            sell_price=0.05,
+            solar_kwh=0.0,  # No solar pre-DW
+            consumption_kwh=1.0,  # Net discharge
+        )
+        for i in range(4)
+    ]
+    # DW: High solar that would reach target mid-DW (but not by DW entry)
+    dw_slots = [
+        SlotContext(
+            slot_index=4 + i,
+            timestamp_iso=f"2026-01-03T{14 + i}:00:00",
+            slot_interval_minutes=60,
+            buy_price=0.15,
+            sell_price=0.05,
+            solar_kwh=3.0 if i < 2 else 1.0,  # High solar early in DW
+            consumption_kwh=0.5,
+            is_demand_window_entry=(i == 0),
+            is_demand_window_slot=True,
+        )
+        for i in range(4)
+    ]
+    slots = pre_dw_slots + dw_slots
+
+    config = OptimizerConfig(
+        battery_capacity_kwh=13.5,
+        demand_window_target_soc_pct=80.0,
+        effective_cheap_price=0.12,
+        allow_dw_entry_under_target=False,  # Must reach target BY DW entry
+        optimization_mode="self_consumption",
+        soc_bins=20,
+        target_shortfall_penalty_per_pct=0.150,  # High penalty to incentivize charging
+    )
+    inputs = OptimizerInputs(
+        cycle_id="test-dw-target-at-entry",
+        initial_soc_pct=50.0,
+        slots=slots,
+        config=config,
+    )
+
+    result = DPPlanner().plan(inputs)
+    assert result.success
+
+    # With allow_dw_entry_under_target=False, target must be met BY DW entry.
+    # Pre-DW discharge creates deficit, high penalty forces grid charging.
+    pre_dw_grid_charges = [
+        d.action
+        for d in result.decisions[:4]
+        if d.action
+        in (PlannerAction.CHARGE_GRID_NORMAL, PlannerAction.CHARGE_GRID_BOOST)
+    ]
+    assert len(pre_dw_grid_charges) > 0, (
+        "With allow_dw_entry_under_target=False and high penalty, "
+        "should grid-charge when solar won't reach target by DW entry. "
+        f"Got decisions: {[d.action.name for d in result.decisions[:4]]}"
+    )


### PR DESCRIPTION
## Summary

Fixes issue #505 where the optimizer would grid-charge unnecessarily even when solar alone would reach the target SOC during the demand window.

## Problem

When `allow_dw_entry_under_target=True`, the optimizer was only checking if solar reaches target at DW END. This caused unnecessary grid charging when solar would reach target mid-DW (e.g., solar reaches 95% at 16:00, then drains to 70% by 20:00).

## Solution

The optimizer now checks if solar reaches target at **any point** during the demand window:
- Pre-computes maximum SOC achievable during DW with solar-only
- Zeroes terminal penalty when solar will reach target (trusts solar)
- Updates solar surplus gate to check max SOC during DW
- Adds `can_solar_reach_target_in_dw` diagnostic field

## Changes

- **optimizer_dp.py**: Add `_simulate_max_soc_in_demand_window()` helper, modify terminal penalty logic, update solar surplus gate
- **test_optimizer_dp_solve.py**: Add 3 tests covering both modes

## Testing

All 45 optimizer tests pass:
- ✅ No grid charge when solar reaches target mid-DW
- ✅ Grid charge still occurs when solar insufficient  
- ✅ Original behavior preserved when `allow_dw_entry_under_target=False`

## Impact

Users with `allow_dw_entry_under_target=True` will see:
- Less unnecessary grid charging
- More accurate solar utilization
- Better economic optimization
