### PR TITLE
Raise cycle_penalty_per_kwh to /usr/sbin/bash.05 to discourage marginal arbitrage

### DIFF
--- a/custom_components/localshift/computation_engine_lib/optimizer_dp.py
+++ b/custom_components/localshift/computation_engine_lib/optimizer_dp.py
@@ -201,8 +201,20 @@ class OptimizerConfig:
     for unit tests and standalone use.
     """
 
-    cycle_penalty_per_kwh: float = 0.005
-    """Mild penalty per kWh cycled to discourage unnecessary grid arbitrage."""
+    cycle_penalty_per_kwh: float = 0.05
+    """Penalty per kWh cycled to reflect true battery cycling cost.
+
+    True cost components:
+    - Efficiency loss (13% round-trip × avg price): ~$0.02/kWh
+    - Battery degradation: ~$0.01-0.03/kWh
+    - Total: $0.03-0.05/kWh
+
+    Using the upper bound ($0.05) ensures cheap-import arbitrage is only
+    attractive for spreads > 5¢/kWh, eliminating marginal trades that waste
+    cycle life for minimal savings.
+
+    Fixes #516.
+    """
 
     # --- SOC discretization ---
     soc_bins: int = 50

--- a/custom_components/localshift/computation_engine_lib/optimizer_runner.py
+++ b/custom_components/localshift/computation_engine_lib/optimizer_runner.py
@@ -316,7 +316,7 @@ def _build_optimizer_config(
             / 100.0
             * _SHORTFALL_PENALTY_SAFETY_FACTOR
         ),
-        cycle_penalty_per_kwh=0.005,
+        cycle_penalty_per_kwh=0.05,  # True cycle cost (Fixes #516)
         # --- SOC discretization ---
         soc_bins=50,
         # --- Optimization mode ---

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -78,6 +78,23 @@ The state machine uses debounce timers to prevent rapid mode switching:
 | Grid charging | 5 minutes |
 | Self consumption | 5 minutes |
 
+### Objective Function Calibration
+
+The optimizer's objective function balances multiple cost terms. The calibration
+reflects physical and economic realities, not user preferences.
+
+| Parameter | Value | Rationale | Issue |
+|-----------|-------|-----------|-------|
+| `target_shortfall_penalty_per_pct` | `effective_cheap_price × battery_kwh / 100 × 1.5` | Cost to import 1% SOC at cheapest price | #438 |
+| `cycle_penalty_per_kwh` | `$0.05/kWh` | Efficiency loss + battery degradation | #516 |
+
+The cycle penalty represents the true cost of cycling battery energy through the grid:
+- **Round-trip efficiency loss**: ~13% (92% charge × 95% discharge) at average prices
+- **Battery degradation**: Each cycle reduces lifespan; amortized cost per kWh
+
+These values prevent the optimizer from making marginal trades that appear profitable
+but result in net losses after accounting for wear and inefficiency.
+
 ## Core Classes
 
 ### Coordinator (`coordinator.py`)

--- a/tests/test_optimizer_runner_integration.py
+++ b/tests/test_optimizer_runner_integration.py
@@ -198,7 +198,7 @@ class TestBuildOptimizerConfig:
         # 0.12 * 13.5 / 100 * 1.5 = 0.02430
         assert config.target_shortfall_penalty_per_pct != 1.0
         assert 0.010 <= config.target_shortfall_penalty_per_pct <= 0.100
-        assert config.cycle_penalty_per_kwh == 0.005
+        assert config.cycle_penalty_per_kwh == 0.05
 
     def test_config_penalty_calibrated_to_tariff(
         self, mock_coordinator_data, config_options


### PR DESCRIPTION
## Summary

Raises `cycle_penalty_per_kwh` from $0.005 to $0.05 to prevent the optimizer from triggering `CHEAP_IMPORT_WINDOW` for marginal price spreads that don't justify the battery cycle cost.

## Problem

The optimizer was recommending grid charging for price spreads of 1-2¢/kWh, which results in net losses after accounting for:
- Round-trip efficiency loss (~13% = ~$0.02/kWh)
- Battery degradation (~$0.01-0.03/kWh)

## Solution

Set `cycle_penalty_per_kwh = $0.05` to reflect the true cost of cycling. This ensures:
- Arbitrage only attractive for spreads >5¢/kWh
- Reduced unnecessary battery cycling
- Still allows charging when genuinely needed for demand window coverage

## Changes

| File | Change |
|------|--------|
| `optimizer_dp.py` | Default value + expanded docstring |
| `optimizer_runner.py` | Runtime config value |
| `test_optimizer_runner_integration.py` | Test assertion update |
| `docs/DEVELOPER_GUIDE.md` | New calibration section |

## Testing

- ✅ All 68 optimizer tests pass
- ✅ Lint and format checks pass

Fixes #516