### PR TITLE
Wire up Solar Accuracy Tracking (Issue #513)

### DIFF
--- a/custom_components/localshift/computation_engine.py
+++ b/custom_components/localshift/computation_engine.py
@@ -156,6 +156,9 @@ class ComputationEngine:
         # DP Planner for Phase 3 (#441) - eliminates one-cycle lag
         self._dp_planner = DPPlanner()
 
+        # Solar accuracy tracker for Issue #378/#513 - bias correction
+        self._solar_accuracy_tracker: Any = None
+
         # Local cache properties (delegated to history_fetcher for storage)
         self._previous_active_mode = None
         self._last_forecast_hour: int | None = None
@@ -163,6 +166,107 @@ class ComputationEngine:
 
         # Baseline load profile for Issue #137 (set by coordinator)
         self._baseline_avg_kw: dict[int, float] = {}
+
+    def set_solar_accuracy_tracker(self, tracker: Any) -> None:
+        """Set the solar accuracy tracker for bias correction.
+
+        Args:
+            tracker: SolarAccuracyTracker instance
+        """
+        self._solar_accuracy_tracker = tracker
+        _LOGGER.info("Solar accuracy tracker connected to computation engine")
+
+    def _record_forecasts_for_slots(
+        self,
+        slots: list[Any],
+        weather_condition: str,
+    ) -> None:
+        """Record solar forecasts for all slots with solar production.
+
+        Called after building slots to track forecasts for later bias analysis.
+
+        Args:
+            slots: List of SlotContext objects from slot_builder
+            weather_condition: Current weather condition string
+        """
+        if self._solar_accuracy_tracker is None:
+            return
+
+        recorded = 0
+        for slot in slots:
+            if slot.solar_kwh > 0.01:
+                period_start = datetime.fromisoformat(slot.timestamp_iso)
+                self._solar_accuracy_tracker.record_forecast(
+                    period_start=period_start,
+                    forecast_kwh=slot.solar_kwh,
+                    weather_condition=weather_condition,
+                )
+                recorded += 1
+
+        if recorded > 0:
+            _LOGGER.debug("Recorded %d solar forecasts for accuracy tracking", recorded)
+
+    def _apply_bias_correction_to_slots(
+        self,
+        slots: list[Any],
+        weather_condition: str,
+    ) -> None:
+        """Apply bias correction to solar forecasts for each slot.
+
+        Uses the solar accuracy tracker to get context-specific bias
+        and adjusts solar_kwh accordingly. Rounds down to avoid over-charging.
+
+        Args:
+            slots: List of SlotContext objects from slot_builder
+            weather_condition: Current weather condition string
+        """
+        if self._solar_accuracy_tracker is None:
+            return
+
+        from homeassistant.util import dt as dt_util
+
+        now = dt_util.now()
+        hour = now.hour
+        if 6 <= hour < 12:
+            time_of_day = "morning"
+        elif 12 <= hour < 18:
+            time_of_day = "afternoon"
+        elif 18 <= hour < 21:
+            time_of_day = "evening"
+        else:
+            time_of_day = "night"
+
+        month = now.month
+        if month in (12, 1, 2):
+            season = "summer"
+        elif month in (3, 4, 5):
+            season = "autumn"
+        elif month in (6, 7, 8):
+            season = "winter"
+        else:
+            season = "spring"
+
+        bias_multiplier = self._solar_accuracy_tracker.get_bias_correction(
+            time_of_day, weather_condition, season
+        )
+
+        if bias_multiplier != 1.0:
+            corrected = 0
+            for slot in slots:
+                if slot.solar_kwh > 0.01:
+                    original = slot.solar_kwh
+                    slot.solar_kwh = max(0.0, slot.solar_kwh * bias_multiplier)
+                    if abs(slot.solar_kwh - original) > 0.001:
+                        corrected += 1
+            if corrected > 0:
+                _LOGGER.info(
+                    "Applied bias correction: multiplier=%.2f (%s/%s/%s), corrected %d slots",
+                    bias_multiplier,
+                    time_of_day,
+                    weather_condition,
+                    season,
+                    corrected,
+                )
 
     # ========================================================================
     # MAIN ENTRY POINT
@@ -840,6 +944,13 @@ class ComputationEngine:
             slots, slot_metadata = slot_builder.build_slots(
                 data, data.adaptive_params, now_dt=now_dt
             )
+
+            # Record forecasts for solar accuracy tracking (Issue #513)
+            weather_condition = getattr(data, "weather_condition", None) or "unknown"
+            self._record_forecasts_for_slots(slots, weather_condition)
+
+            # Apply bias correction to solar forecasts if tracker has data (Issue #513)
+            self._apply_bias_correction_to_slots(slots, weather_condition)
 
             if not slots:
                 _LOGGER.warning("DP optimizer: no slots available, skipping")

--- a/custom_components/localshift/computation_engine_lib/solar_accuracy.py
+++ b/custom_components/localshift/computation_engine_lib/solar_accuracy.py
@@ -377,3 +377,39 @@ class SolarAccuracyTracker:
             return "foggy"
         else:
             return "unknown"
+
+    def get_bias_correction(
+        self,
+        time_of_day: str,
+        weather: str,
+        season: str | None = None,
+    ) -> float:
+        """Get bias correction factor for given context.
+
+        Returns a multiplier (0.0 to 2.0) to apply to forecasts.
+        A positive bias means forecasts overestimate, so we reduce solar_kwh.
+        A negative bias means forecasts underestimate, so we increase solar_kwh.
+
+        Args:
+            time_of_day: Time bucket ('morning', 'afternoon', 'evening', 'night')
+            weather: Weather condition ('sunny', 'cloudy', 'rainy', etc.)
+            season: Season ('summer', 'autumn', 'winter', 'spring'), optional for coarser granularity
+
+        Returns:
+            Bias correction factor. Returns 1.0 if no historical data available.
+            Values < 1.0 reduce forecast (overestimate), > 1.0 increase (underestimate).
+        """
+        result = self._compute_context_bias(time_of_day, weather, season)
+        if result is None:
+            return 1.0
+
+        weighted_bias, sample_count = result
+        _LOGGER.debug(
+            "Bias correction for %s/%s/%s: bias=%.2f%%, samples=%d",
+            time_of_day,
+            weather,
+            season or "any",
+            weighted_bias * 100,
+            sample_count,
+        )
+        return 1.0 - weighted_bias

--- a/custom_components/localshift/coordinator.py
+++ b/custom_components/localshift/coordinator.py
@@ -136,6 +136,10 @@ class LocalShiftCoordinator:
         self._solcast_ready: bool = False
         self._forecast_computed_on_startup: bool = False
 
+        # Solar energy tracking for backfill (Issue #513)
+        self._last_solar_power_kw: float = 0.0
+        self._last_solar_power_timestamp: datetime | None = None
+
     # ------------------------------------------------------------------
     # Entity ID helpers (read from config entry data)
     # ------------------------------------------------------------------
@@ -264,6 +268,12 @@ class LocalShiftCoordinator:
             self.hass, self.entry.entry_id
         )
         await self.solar_accuracy_tracker.async_load()
+
+        # Wire solar accuracy tracker to computation engine for forecasting (Issue #513)
+        if self._computation_engine is not None:
+            self._computation_engine.set_solar_accuracy_tracker(
+                self.solar_accuracy_tracker
+            )
 
         # Wire the decision tracker to the state machine
         self._state_machine._decision_tracker = self.decision_tracker
@@ -874,7 +884,52 @@ class LocalShiftCoordinator:
                 "localshift_save_forecast_history",
             )
 
+        # Backfill actual solar energy for completed periods (Issue #513)
+        self._backfill_solar_actual()
+
         _LOGGER.debug("Slow tick completed: weather forecast and accuracy metrics")
+
+    def _backfill_solar_actual(self) -> None:
+        """Backfill actual solar energy for completed 30-min periods.
+
+        Calculates energy produced since last tick using integrated power,
+        then calls backfill_actual() on the tracker for completed periods.
+        """
+        if not hasattr(self, "solar_accuracy_tracker"):
+            return
+
+        tracker = getattr(self, "solar_accuracy_tracker", None)
+        if tracker is None:
+            return
+
+        from homeassistant.util import dt as dt_util
+
+        now = dt_util.now()
+        current_power = self.data.solar_power_kw
+
+        if self._last_solar_power_timestamp is None:
+            self._last_solar_power_timestamp = now
+            self._last_solar_power_kw = current_power
+            return
+
+        time_delta_hours = (
+            now - self._last_solar_power_timestamp
+        ).total_seconds() / 3600.0
+        if time_delta_hours < 0.01:
+            return
+
+        avg_power_kw = (self._last_solar_power_kw + current_power) / 2.0
+        energy_kwh = avg_power_kw * time_delta_hours
+
+        if energy_kwh > 0.001 and current_power > 0.01:
+            now_local = now.astimezone()
+            period_start = now_local.replace(
+                minute=(now_local.minute // 30) * 30, second=0, microsecond=0
+            )
+            tracker.backfill_actual(period_start, energy_kwh)
+
+        self._last_solar_power_timestamp = now
+        self._last_solar_power_kw = current_power
 
     def _check_stale_price(self) -> bool:
         """Check if price sensor hasn't updated in STALE_PRICE_THRESHOLD.


### PR DESCRIPTION
## Summary

Wires up the Solar Accuracy Tracker (`solar_accuracy.py`) that was instantiated but never used.

### Changes

1. **solar_accuracy.py**: Add `get_bias_correction()` method to expose context-specific bias
2. **computation_engine.py**: 
   - Wire `record_forecast()` after slot building
   - Wire `_apply_bias_correction_to_slots()` to adjust solar forecasts
3. **coordinator.py**:
   - Connect tracker to computation engine
   - Add `_backfill_solar_actual()` in slow tick (30-min) to backfill actual solar energy

### How it works

1. **record_forecast()**: Called after building slots - stores forecast for each 30-min period
2. **backfill_actual()**: Called every 30 min - calculates energy from power integration and compares to forecast
3. **get_bias_correction()**: Called when building slots - applies learned bias to improve forecast accuracy

The tracker learns systematic bias patterns based on time of day, weather, and season, then corrects future forecasts to improve battery planning accuracy.

Fixes #513