### PR TITLE
Implement worktree enforcement and hard-stop signals (Issue #527)

### DIFF
--- a/.agents/rules/worktrees.md
+++ b/.agents/rules/worktrees.md
@@ -33,6 +33,29 @@ git worktree list
 
 ---
 
+## ⚠️ HARD STOP SIGNALS
+
+**When user issues any of these commands, IMMEDIATELY stop all work and respond:**
+
+| Trigger Phrase | Action |
+|---------------|--------|
+| "wrong branch" | Stop editing, check git branch, create worktree if needed |
+| "stop" | Halt all operations, await further instructions |
+| "wait" | Pause operations, ask user for clarification |
+| "hold on" | Stop and confirm what to do next |
+| "not on main" | Verify branch immediately, create worktree if on main |
+| "check branch" | Run `git branch --show-current` and `git worktree list` |
+| ALL CAPS warnings | Treat as urgent - stop and acknowledge |
+
+**Response protocol:**
+1. STOP immediately - no further edits
+2. Acknowledge the signal
+3. Run verification commands
+4. Explain current state and what action will be taken
+5. Wait for user confirmation before proceeding
+
+---
+
 ## ⚠️ FOUND CHANGES ON MAIN (Crashed Session / Orphaned Changes)
 
 **If you discover staged or unstaged changes on main (e.g., from a crashed session):**

--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -1,10 +1,16 @@
 #!/bin/bash
-# Post-checkout hook: Display warning when on main branch
-# Informational only - does not block
+# Post-checkout hook: Enforce worktree-only workflow
+# - Warn when checking out main
+# - Block checkout to main if uncommitted changes exist
 
 PREV_BRANCH="$1"
 NEW_BRANCH="$2"
 CHECKOUT_TYPE="$3"
+
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+GREEN='\033[0;32m'
+NC='\033[0m' # No Color
 
 # Only run on branch checkouts (not file checkouts)
 if [ "$CHECKOUT_TYPE" != "1" ]; then
@@ -13,11 +19,36 @@ fi
 
 if [ "$NEW_BRANCH" = "main" ]; then
     echo ""
-    echo "=========================================="
-    echo "WARNING: You are now on the main branch"
-    echo "=========================================="
+    echo -e "${RED}==========================================${NC}"
+    echo -e "${RED}WARNING: You are now on the main branch${NC}"
+    echo -e "${RED}==========================================${NC}"
     echo ""
-    echo "Direct commits to main are blocked. All changes require a pull request."
+    
+    # Check for uncommitted changes
+    if ! git diff-index --quiet HEAD -- 2>/dev/null; then
+        echo -e "${RED}ERROR: Uncommitted changes detected!${NC}"
+        echo ""
+        echo "You have uncommitted changes that would be stranded on main."
+        echo ""
+        echo "Recommended action:"
+        echo "  1. Stash changes: git stash push -m 'work in progress'"
+        echo "  2. Create worktree: git worktree add worktrees/issue-{NNN} -b issue/{NNN}"
+        echo "  3. Checkout worktree: cd worktrees/issue-{NNN}"
+        echo "  4. Restore changes: git stash pop"
+        echo ""
+        echo -e "${YELLOW}Checkout blocked due to uncommitted changes${NC}"
+        echo -e "${RED}==========================================${NC}"
+        
+        # Attempt to go back to previous branch
+        if [ -n "$PREV_BRANCH" ] && [ "$PREV_BRANCH" != "main" ]; then
+            echo ""
+            echo "Returning to previous branch: $PREV_BRANCH"
+            git checkout "$PREV_BRANCH" 2>/dev/null
+        fi
+        exit 1
+    fi
+    
+    echo -e "${YELLOW}Direct commits to main are blocked. All changes require a pull request.${NC}"
     echo ""
     echo "Recommended workflow:"
     echo "  git worktree add worktrees/issue-{NNN} -b issue/{NNN}"
@@ -25,7 +56,8 @@ if [ "$NEW_BRANCH" = "main" ]; then
     echo "Recent main branch activity:"
     git log --oneline -3 --decorate 2>/dev/null | sed 's/^/  /'
     echo ""
-    echo "=========================================="
+    echo -e "${GREEN}Tip: Create a worktree to continue working${NC}"
+    echo -e "${RED}==========================================${NC}"
 fi
 
 exit 0

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -2,6 +2,10 @@
 # Pre-push hook: Block all pushes from main branch
 # Emergency override: GIT_EMERGENCY_PUSH=1 (logged)
 
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
 REMOTE="$1"
 URL="$2"
 
@@ -11,13 +15,14 @@ if [ "$BRANCH" = "main" ]; then
     # Check for emergency override
     if [ "$GIT_EMERGENCY_PUSH" = "1" ]; then
         echo "$(date -Iseconds) - pre-push EMERGENCY OVERRIDE: push from main to $REMOTE" >> .git-bypass.log
-        echo "WARNING: Emergency push from main branch logged for audit"
+        echo -e "${YELLOW}WARNING: Emergency push from main branch logged for audit${NC}"
         exit 0
     fi
     
-    echo "=========================================="
-    echo "ERROR: Pushes from 'main' branch are blocked!"
-    echo "=========================================="
+    echo ""
+    echo -e "${RED}==========================================${NC}"
+    echo -e "${RED}ERROR: Pushes from 'main' branch are blocked!${NC}"
+    echo -e "${RED}==========================================${NC}"
     echo ""
     echo "The main branch is protected. Push from feature branches only."
     echo ""
@@ -29,7 +34,7 @@ if [ "$BRANCH" = "main" ]; then
     echo "Emergency override (logged, audit required):"
     echo "  GIT_EMERGENCY_PUSH=1 git push origin main"
     echo ""
-    echo "=========================================="
+    echo -e "${RED}==========================================${NC}"
     
     # Log the attempt
     echo "$(date -Iseconds) - pre-push blocked push from main to $REMOTE" >> .git-bypass.log

--- a/.opencode/rules
+++ b/.opencode/rules
@@ -7,6 +7,7 @@
 Git hooks in `.githooks/` automatically block:
 - Direct commits on main (pre-commit hook)
 - Pushes from main branch (pre-push hook)
+- Checkout to main with uncommitted changes (post-checkout hook)
 
 Bypass attempts are logged to `.git-bypass.log` for audit.
 
@@ -39,6 +40,19 @@ Before any git operation, check:
 git branch --show-current  # Should show issue/* or feature/*, NOT main
 git worktree list          # Should show you're in a worktree
 ```
+
+## HARD STOP SIGNALS
+
+**When user issues any of these commands, IMMEDIATELY stop all work:**
+
+| Trigger | Response |
+|---------|----------|
+| "wrong branch" | Check git branch immediately |
+| "stop" / "wait" / "hold on" | Halt all operations |
+| "not on main" | Verify branch status |
+| ALL CAPS warnings | Treat as urgent hard stop |
+
+**Protocol:** Acknowledge → Verify → Wait for direction
 
 ## Emergency Bypass
 


### PR DESCRIPTION
## Summary

Implements stronger worktree enforcement to prevent editing on main branch and ensures user interruptions are honored as hard stops.

### Changes

1. **`.githooks/post-checkout`** - Enhanced:
   - Added ANSI colors (red/yellow/green)
   - Added detection of uncommitted changes when checking out main
   - Blocks checkout if uncommitted changes exist, auto-returns to previous branch

2. **`.githooks/pre-push`** - Enhanced:
   - Added ANSI colors for better visibility

3. **`.agents/rules/worktrees.md`** - Added:
   - New "HARD STOP SIGNALS" section with trigger phrases table
   - Response protocol: STOP → Acknowledge → Verify → Wait

4. **`.opencode/rules`** - Added:
   - New "HARD STOP SIGNALS" section with table and protocol

### Related
- Fixes #527