### PR TITLE
Add deep nesting detection and refactor violations

### DIFF
--- a/custom_components/localshift/computation_engine.py
+++ b/custom_components/localshift/computation_engine.py
@@ -1306,54 +1306,87 @@ class ComputationEngine:
 
         try:
             stored_data = await self._forecast_history_store.async_load()
-            if stored_data and isinstance(stored_data, dict):
-                history = stored_data.get("forecast_history", [])
-                first_prediction = stored_data.get("first_prediction_time", "")
+            if not stored_data or not isinstance(stored_data, dict):
+                return
 
-                if history:
-                    # Filter out entries with target_time in the past (older than 4 hours)
-                    # These are no longer useful for accuracy tracking
-                    now_dt = dt_util.now()
-                    cutoff = now_dt - timedelta(hours=4)
+            history = stored_data.get("forecast_history", [])
+            first_prediction = stored_data.get("first_prediction_time", "")
 
-                    valid_entries = []
-                    for entry in history:
-                        if "target_time" not in entry:
-                            continue
-                        try:
-                            target_dt = datetime.fromisoformat(entry["target_time"])
-                            if target_dt.tzinfo is None:
-                                target_dt = dt_util.as_local(dt_util.as_utc(target_dt))
-                            else:
-                                target_dt = dt_util.as_local(target_dt)
+            if history:
+                now_dt = dt_util.now()
+                cutoff = now_dt - timedelta(hours=4)
+                valid_entries = self._filter_valid_history_entries(history, cutoff)
 
-                            if target_dt >= cutoff:
-                                valid_entries.append(entry)
-                        except (ValueError, TypeError):
-                            continue
+                data.forecast_history = valid_entries
+                data.forecast_first_prediction_time = first_prediction
+                data.forecast_history_count = len(valid_entries)
 
-                    data.forecast_history = valid_entries
-                    data.forecast_first_prediction_time = first_prediction
-                    data.forecast_history_count = len(valid_entries)
+                _LOGGER.info(
+                    "Loaded %d forecast history entries from storage (filtered from %d)",
+                    len(valid_entries),
+                    len(history),
+                )
 
-                    _LOGGER.info(
-                        "Loaded %d forecast history entries from storage (filtered from %d)",
-                        len(valid_entries),
-                        len(history),
-                    )
+                if not first_prediction and valid_entries:
+                    self._find_first_prediction_time(data, valid_entries)
 
-                    # Find first prediction time from loaded entries if not stored
-                    if not first_prediction and valid_entries:
-                        for entry in valid_entries:
-                            if entry.get("prediction_time"):
-                                data.forecast_first_prediction_time = entry[
-                                    "prediction_time"
-                                ]
-                                break
-
-                self._forecast_history_loaded = True
+            self._forecast_history_loaded = True
         except Exception as e:
             _LOGGER.warning("Failed to load forecast history: %s", e)
+
+    def _filter_valid_history_entries(
+        self, history: list[dict], cutoff: datetime
+    ) -> list[dict]:
+        """Filter history entries to only valid ones within cutoff time.
+
+        Args:
+            history: List of history entry dictionaries
+            cutoff: Cutoff datetime for filtering
+
+        Returns:
+            List of valid entries
+        """
+        valid_entries = []
+        for entry in history:
+            if "target_time" not in entry:
+                continue
+            if self._is_history_entry_valid(entry, cutoff):
+                valid_entries.append(entry)
+        return valid_entries
+
+    def _is_history_entry_valid(self, entry: dict, cutoff: datetime) -> bool:
+        """Check if a history entry is valid and within cutoff time.
+
+        Args:
+            entry: History entry dictionary
+            cutoff: Cutoff datetime
+
+        Returns:
+            True if entry is valid and within cutoff
+        """
+        try:
+            target_dt = datetime.fromisoformat(entry["target_time"])
+            if target_dt.tzinfo is None:
+                target_dt = dt_util.as_local(dt_util.as_utc(target_dt))
+            else:
+                target_dt = dt_util.as_local(target_dt)
+            return target_dt >= cutoff
+        except (ValueError, TypeError):
+            return False
+
+    def _find_first_prediction_time(
+        self, data: CoordinatorData, entries: list[dict]
+    ) -> None:
+        """Find first prediction time from loaded entries.
+
+        Args:
+            data: CoordinatorData to update
+            entries: List of valid history entries
+        """
+        for entry in entries:
+            if entry.get("prediction_time"):
+                data.forecast_first_prediction_time = entry["prediction_time"]
+                break
 
     async def async_save_forecast_history(self, data: CoordinatorData) -> None:
         """Persist forecast history to storage.

--- a/custom_components/localshift/cost_tracker.py
+++ b/custom_components/localshift/cost_tracker.py
@@ -240,7 +240,6 @@ class CostTracker:
             return 0.0
 
         try:
-            # Use statistics_during_period which is the correct API
             stats = statistics_during_period(
                 self.hass,
                 start_time,
@@ -250,29 +249,43 @@ class CostTracker:
                 ["sum"],
             )
 
-            if not stats:
+            if not stats or not isinstance(stats, dict):
                 return 0.0
 
-            if isinstance(stats, dict) and entity_id in stats:
-                rows = stats[entity_id]
-                if isinstance(rows, list):
-                    # Sum all 'sum' values
-                    total = 0.0
-                    for row in rows:
-                        if isinstance(row, dict):
-                            val = row.get("sum")
-                            if val is not None:
-                                try:
-                                    total += float(val)
-                                except (TypeError, ValueError):
-                                    pass
-                    return total
+            if entity_id not in stats:
+                return 0.0
 
-            return 0.0
+            rows = stats[entity_id]
+            if not isinstance(rows, list):
+                return 0.0
+
+            return self._sum_statistics_rows(rows)
 
         except Exception as e:
             _LOGGER.warning("Error fetching statistics: %s", e)
             return 0.0
+
+    def _sum_statistics_rows(self, rows: list) -> float:
+        """Sum 'sum' values from statistics rows.
+
+        Args:
+            rows: List of statistics row dictionaries
+
+        Returns:
+            Total sum of 'sum' values
+        """
+        total = 0.0
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            val = row.get("sum")
+            if val is None:
+                continue
+            try:
+                total += float(val)
+            except (TypeError, ValueError):
+                pass
+        return total
 
     def _calculate_variance_pct(self, estimated: float, actual: float) -> float:
         """Calculate variance percentage between estimated and actual.

--- a/custom_components/localshift/weather_correlation.py
+++ b/custom_components/localshift/weather_correlation.py
@@ -364,7 +364,6 @@ class WeatherCorrelation:
 
         forecasts: list[TemperatureForecast] = []
 
-        # Try modern service call first (HA 2024.3+)
         try:
             response = await self.hass.services.async_call(
                 "weather",
@@ -381,144 +380,9 @@ class WeatherCorrelation:
             )
 
             if response and weather_entity in response:
-                forecast_data = response[weather_entity]
-                _LOGGER.info(
-                    "forecast_data type=%s, len=%s, keys=%s",
-                    type(forecast_data).__name__,
-                    len(forecast_data) if isinstance(forecast_data, list) else "N/A",
-                    list(forecast_data.keys())
-                    if isinstance(forecast_data, dict)
-                    else "N/A",
-                )
-
-                # Handle different response formats
-                if isinstance(forecast_data, dict):
-                    # Some integrations return {"forecast": [...]} or {"hourly": [...]}
-                    _LOGGER.info(
-                        "forecast_data is dict, checking for forecast/hourly keys"
-                    )
-                    if "forecast" in forecast_data:
-                        forecast_data = forecast_data["forecast"]
-                        _LOGGER.info(
-                            "Found 'forecast' key with %d entries",
-                            len(forecast_data)
-                            if isinstance(forecast_data, list)
-                            else 0,
-                        )
-                    elif "hourly" in forecast_data:
-                        forecast_data = forecast_data["hourly"]
-                        _LOGGER.info(
-                            "Found 'hourly' key with %d entries",
-                            len(forecast_data)
-                            if isinstance(forecast_data, list)
-                            else 0,
-                        )
-
-                if isinstance(forecast_data, list):
-                    parse_failed_count = 0
-                    skipped_no_datetime = 0
-                    filtered_count = 0
-                    _LOGGER.info(
-                        "Processing %d forecast entries, first entry keys: %s",
-                        len(forecast_data),
-                        list(forecast_data[0].keys()) if forecast_data else "empty",
-                    )
-                    for i, forecast_entry in enumerate(forecast_data):
-                        # Skip if not a dict (handles 'str' object error)
-                        if not isinstance(forecast_entry, dict):
-                            continue
-
-                        # Parse forecast datetime - HA uses "datetime" key
-                        forecast_time_str = forecast_entry.get("datetime")
-                        if not forecast_time_str:
-                            skipped_no_datetime += 1
-                            if skipped_no_datetime <= 2:
-                                _LOGGER.info(
-                                    "Entry missing 'datetime', keys: %s",
-                                    list(forecast_entry.keys()),
-                                )
-                            continue
-
-                        try:
-                            forecast_time = dt_util.parse_datetime(forecast_time_str)
-                            if forecast_time is None:
-                                # Try parsing as naive datetime and localize it
-                                try:
-                                    from datetime import datetime as dt
-
-                                    naive_dt = dt.fromisoformat(forecast_time_str)
-                                    forecast_time = dt_util.as_local(naive_dt)
-                                    if i == 0:
-                                        _LOGGER.info(
-                                            "First entry: datetime='%s' parsed as naive=%s, localized=%s",
-                                            forecast_time_str,
-                                            naive_dt,
-                                            forecast_time,
-                                        )
-                                except (ValueError, TypeError) as e:
-                                    parse_failed_count += 1
-                                    if parse_failed_count <= 3:
-                                        _LOGGER.info(
-                                            "Failed to parse datetime '%s': %s",
-                                            forecast_time_str,
-                                            e,
-                                        )
-                                    continue
-                            else:
-                                # dt_util.parse_datetime may return naive datetime
-                                # Ensure it's timezone-aware
-                                if forecast_time.tzinfo is None:
-                                    forecast_time = dt_util.as_local(forecast_time)
-                                if i == 0:
-                                    _LOGGER.info(
-                                        "First entry: datetime='%s' parsed as %s (tzinfo=%s)",
-                                        forecast_time_str,
-                                        forecast_time,
-                                        forecast_time.tzinfo,
-                                    )
-                        except (ValueError, TypeError) as e:
-                            parse_failed_count += 1
-                            if parse_failed_count <= 3:
-                                _LOGGER.info(
-                                    "Exception parsing datetime '%s': %s",
-                                    forecast_time_str,
-                                    e,
-                                )
-                            continue
-
-                        # Only include forecasts for the next 24 hours
-                        hours_ahead = (forecast_time - now).total_seconds() / 3600
-                        if hours_ahead < 0 or hours_ahead > 24:
-                            filtered_count += 1
-                            if filtered_count <= 3:
-                                _LOGGER.info(
-                                    "Filtering out forecast: time=%s, now=%s, hours_ahead=%.1f",
-                                    forecast_time.isoformat(),
-                                    now.isoformat(),
-                                    hours_ahead,
-                                )
-                            continue
-
-                        temperature = forecast_entry.get("temperature")
-                        condition = forecast_entry.get("condition", "unknown")
-
-                        forecasts.append(
-                            TemperatureForecast(
-                                slot_time=forecast_time,
-                                temperature=temperature,
-                                condition=condition,
-                            )
-                        )
-
-                    _LOGGER.info(
-                        "Fetched %d temperature forecasts via weather.get_forecasts service",
-                        len(forecasts),
-                    )
-                else:
-                    _LOGGER.debug(
-                        "Unexpected forecast_data format: %s",
-                        type(forecast_data).__name__,
-                    )
+                forecast_data = self._extract_forecast_list(response, weather_entity)
+                if forecast_data:
+                    forecasts = self._parse_forecast_entries(forecast_data, now)
             else:
                 _LOGGER.debug(
                     "No response from weather.get_forecasts for entity %s, "
@@ -533,15 +397,224 @@ class WeatherCorrelation:
                 e,
             )
 
-        # If no forecasts from modern service, try legacy attribute
         if not forecasts:
             forecasts = self.get_temperature_forecast()
 
-        # Update cache
         self._cached_forecasts = forecasts
         self._forecast_cache_time = now
 
         return forecasts
+
+    def _extract_forecast_list(
+        self, response: dict, weather_entity: str
+    ) -> list | None:
+        """Extract forecast list from API response.
+
+        Args:
+            response: Service call response dictionary
+            weather_entity: Weather entity ID
+
+        Returns:
+            List of forecast entries or None
+        """
+        forecast_data = response.get(weather_entity)
+        if forecast_data is None:
+            return None
+
+        _LOGGER.info(
+            "forecast_data type=%s, len=%s, keys=%s",
+            type(forecast_data).__name__,
+            len(forecast_data) if isinstance(forecast_data, list) else "N/A",
+            list(forecast_data.keys()) if isinstance(forecast_data, dict) else "N/A",
+        )
+
+        if isinstance(forecast_data, dict):
+            _LOGGER.info("forecast_data is dict, checking for forecast/hourly keys")
+            if "forecast" in forecast_data:
+                forecast_data = forecast_data["forecast"]
+                _LOGGER.info(
+                    "Found 'forecast' key with %d entries",
+                    len(forecast_data) if isinstance(forecast_data, list) else 0,
+                )
+            elif "hourly" in forecast_data:
+                forecast_data = forecast_data["hourly"]
+                _LOGGER.info(
+                    "Found 'hourly' key with %d entries",
+                    len(forecast_data) if isinstance(forecast_data, list) else 0,
+                )
+
+        if isinstance(forecast_data, list):
+            return forecast_data
+
+        _LOGGER.debug(
+            "Unexpected forecast_data format: %s",
+            type(forecast_data).__name__,
+        )
+        return None
+
+    def _parse_forecast_entries(
+        self, forecast_data: list, now: datetime
+    ) -> list[TemperatureForecast]:
+        """Parse forecast entries into TemperatureForecast objects.
+
+        Args:
+            forecast_data: List of forecast entry dictionaries
+            now: Current datetime for filtering
+
+        Returns:
+            List of TemperatureForecast objects
+        """
+        forecasts: list[TemperatureForecast] = []
+        parse_failed_count = 0
+        skipped_no_datetime = 0
+        filtered_count = 0
+
+        _LOGGER.info(
+            "Processing %d forecast entries, first entry keys: %s",
+            len(forecast_data),
+            list(forecast_data[0].keys()) if forecast_data else "empty",
+        )
+
+        for i, forecast_entry in enumerate(forecast_data):
+            result = self._parse_single_forecast_entry(
+                forecast_entry,
+                now,
+                i,
+                parse_failed_count,
+                skipped_no_datetime,
+                filtered_count,
+            )
+            if result is None:
+                continue
+            forecast, parse_failed_count, skipped_no_datetime, filtered_count = result
+            if forecast:
+                forecasts.append(forecast)
+
+        _LOGGER.info(
+            "Fetched %d temperature forecasts via weather.get_forecasts service",
+            len(forecasts),
+        )
+        return forecasts
+
+    def _parse_single_forecast_entry(
+        self,
+        entry: dict,
+        now: datetime,
+        index: int,
+        parse_failed_count: int,
+        skipped_no_datetime: int,
+        filtered_count: int,
+    ) -> tuple[TemperatureForecast | None, int, int, int] | None:
+        """Parse a single forecast entry.
+
+        Args:
+            entry: Forecast entry dictionary
+            now: Current datetime for filtering
+            index: Entry index for logging
+            parse_failed_count: Running count of parse failures
+            skipped_no_datetime: Running count of entries skipped for missing datetime
+            filtered_count: Running count of filtered entries
+
+        Returns:
+            Tuple of (forecast or None, updated counts) or None if entry invalid
+        """
+        if not isinstance(entry, dict):
+            return None
+
+        forecast_time_str = entry.get("datetime")
+        if not forecast_time_str:
+            skipped_no_datetime += 1
+            if skipped_no_datetime <= 2:
+                _LOGGER.info(
+                    "Entry missing 'datetime', keys: %s",
+                    list(entry.keys()),
+                )
+            return (None, parse_failed_count, skipped_no_datetime, filtered_count)
+
+        forecast_time = self._parse_forecast_datetime(
+            forecast_time_str, index, parse_failed_count
+        )
+        if forecast_time is None:
+            parse_failed_count += 1
+            return (None, parse_failed_count, skipped_no_datetime, filtered_count)
+
+        hours_ahead = (forecast_time - now).total_seconds() / 3600
+        if hours_ahead < 0 or hours_ahead > 24:
+            filtered_count += 1
+            if filtered_count <= 3:
+                _LOGGER.info(
+                    "Filtering out forecast: time=%s, now=%s, hours_ahead=%.1f",
+                    forecast_time.isoformat(),
+                    now.isoformat(),
+                    hours_ahead,
+                )
+            return (None, parse_failed_count, skipped_no_datetime, filtered_count)
+
+        temperature = entry.get("temperature")
+        condition = entry.get("condition", "unknown")
+
+        forecast = TemperatureForecast(
+            slot_time=forecast_time,
+            temperature=temperature,
+            condition=condition,
+        )
+        return (forecast, parse_failed_count, skipped_no_datetime, filtered_count)
+
+    def _parse_forecast_datetime(
+        self, time_str: str, index: int, parse_failed_count: int
+    ) -> datetime | None:
+        """Parse forecast datetime string.
+
+        Args:
+            time_str: Datetime string to parse
+            index: Entry index for logging
+            parse_failed_count: Current parse failure count
+
+        Returns:
+            Parsed datetime or None if parsing failed
+        """
+        try:
+            from datetime import datetime as dt
+
+            forecast_time = dt_util.parse_datetime(time_str)
+            if forecast_time is None:
+                try:
+                    naive_dt = dt.fromisoformat(time_str)
+                    forecast_time = dt_util.as_local(naive_dt)
+                    if index == 0:
+                        _LOGGER.info(
+                            "First entry: datetime='%s' parsed as naive=%s, localized=%s",
+                            time_str,
+                            naive_dt,
+                            forecast_time,
+                        )
+                except (ValueError, TypeError) as e:
+                    if parse_failed_count < 3:
+                        _LOGGER.info(
+                            "Failed to parse datetime '%s': %s",
+                            time_str,
+                            e,
+                        )
+                    return None
+            else:
+                if forecast_time.tzinfo is None:
+                    forecast_time = dt_util.as_local(forecast_time)
+                if index == 0:
+                    _LOGGER.info(
+                        "First entry: datetime='%s' parsed as %s (tzinfo=%s)",
+                        time_str,
+                        forecast_time,
+                        forecast_time.tzinfo,
+                    )
+            return forecast_time
+        except (ValueError, TypeError) as e:
+            if parse_failed_count < 3:
+                _LOGGER.info(
+                    "Exception parsing datetime '%s': %s",
+                    time_str,
+                    e,
+                )
+            return None
 
     def get_current_temperature(self) -> float | None:
         """Get current temperature from weather entity.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ include = ["custom_components.localshift*"]
 [tool.ruff]
 line-length = 88
 target-version = "py313"
+preview = true
 
 [tool.ruff.lint]
 select = [
@@ -28,7 +29,12 @@ select = [
   "I",
   "B",
   "UP",
+  "PLR1702",
+  "C901",
 ]
+
+[tool.ruff.lint.mccabe]
+max-complexity = 15
 
 [tool.ruff.lint.per-file-ignores]
 "custom_components/localshift/*.py" = ["D"]


### PR DESCRIPTION
## Summary
- Add PLR1702 (too-many-nested-blocks) and C901 (mccabe complexity) linter rules to detect deep nesting
- Refactor 3 files to reduce nesting depth from 6-8 levels to 4 levels
- All 53 existing tests pass

## Changes

### pyproject.toml
- Added `preview = true` for PLR1702 support
- Added `PLR1702` (too-many-nested-blocks) rule
- Added `C901` (mccabe complexity) rule with max-complexity=15

### Refactored Files
| File | Before | After | New Methods |
|------|--------|-------|-------------|
| `cost_tracker.py` | 7 levels | 4 levels | `_sum_statistics_rows()` |
| `computation_engine.py` | 6 levels | 4 levels | `_filter_valid_history_entries()`, `_is_history_entry_valid()`, `_find_first_prediction_time()` |
| `weather_correlation.py` | 8 levels | 4 levels | `_extract_forecast_list()`, `_parse_forecast_entries()`, `_parse_single_forecast_entry()`, `_parse_forecast_datetime()` |

### Remaining Work
- `state_machine.py` has 6 levels nesting - being addressed separately
- 11 functions exceed C901 complexity threshold - separate issue

## Testing
- All 53 tests for `test_cost_tracker.py` and `test_computation_engine.py` pass
- Weather correlation tests pass