### PR TITLE
Add automatic CI checks for PRs

### DIFF
--- a/.agents/rules/pr-ci-checks.md
+++ b/.agents/rules/pr-ci-checks.md
@@ -1,0 +1,217 @@
+---
+trigger: on_pr_creation
+---
+
+# PR CI Checks Workflow
+
+**Automatically check GitHub Actions status after PR creation.**
+
+## When This Applies
+
+This workflow triggers when creating a pull request using `gh pr create`.
+
+## Required Steps
+
+### 1. After PR Creation
+
+When you create a PR with `gh pr create`:
+
+1. **Extract PR number** from the output (e.g., `https://github.com/owner/repo/pull/123` → PR #123)
+2. **Immediately check CI status:**
+   ```bash
+   gh pr checks <PR_NUMBER>
+   ```
+3. **Report initial status** to user with estimated time
+
+### 2. Monitor CI Progress
+
+**Interactive approach (recommended):**
+
+1. After creating PR, inform user:
+   ```
+   ✅ PR #123 created
+   🔄 CI checks running (typically 2-5 minutes)
+   
+   Options:
+   - [W] Wait for results (I'll monitor and report)
+   - [C] Continue working (I'll check later)
+   ```
+
+2. **If user chooses to wait:**
+   - Poll status every 30 seconds:
+     ```bash
+     while true; do
+       gh pr checks <PR_NUMBER> --watch
+       sleep 30
+     done
+     ```
+   - Or use interactive watch:
+     ```bash
+     gh run watch
+     ```
+   - Report progress for each check
+   - Alert immediately on failure
+   - Confirm success when all pass
+
+3. **If user chooses to continue:**
+   - Note the PR number for later
+   - Continue with other tasks
+   - Check status periodically (every 2-3 minutes)
+   - Notify user when checks complete
+
+### 3. Status Reporting
+
+**Check Status Categories:**
+
+| Status | Icon | Action |
+|--------|------|--------|
+| Pending | ⏳ | Continue monitoring |
+| In Progress | 🔄 | Show progress if available |
+| Success | ✅ | Report success, ready to merge |
+| Failure | ❌ | Alert user, show failure details |
+| Skipped | ⏭️ | Note but continue |
+
+**Detailed Status Command:**
+```bash
+gh pr checks <PR_NUMBER> --watch
+```
+
+Or for more details:
+```bash
+gh run list --branch <BRANCH_NAME>
+gh run view <RUN_ID>
+```
+
+### 4. Failure Handling
+
+**If CI checks fail:**
+
+1. **Stop and alert immediately:**
+   ```
+   ❌ CI checks failed on PR #123
+   
+   Failed checks:
+   - lint: ruff found formatting issues
+   - test: 3 tests failed
+   
+   View details: gh run view <RUN_ID>
+   ```
+
+2. **Fetch failure details:**
+   ```bash
+   gh run view <RUN_ID> --log-failed
+   ```
+
+3. **Ask user:**
+   - Fix issues now?
+   - View full logs?
+   - Continue anyway?
+
+4. **If fixing:**
+   - Make necessary changes
+   - Commit and push
+   - Monitor new CI run
+
+### 5. Success Handling
+
+**When all checks pass:**
+
+1. **Report success:**
+   ```
+   ✅ All CI checks passed on PR #123
+   
+   Checks:
+   - lint: ✅ passed (45s)
+   - test: ✅ passed (1m 23s)
+   - duplicate-check: ✅ passed (12s)
+   
+   PR is ready for review/merge.
+   View PR: gh pr view 123
+   ```
+
+2. **Suggest next steps:**
+   - Ready to merge?
+   - Request review?
+   - Continue working?
+
+## CI Workflows in This Repository
+
+The following workflows run on PRs:
+
+1. **Lint** (`.github/workflows/lint.yml`)
+   - ruff lint check
+   - ruff format check
+   - vulture (dead code)
+   - bandit (security)
+   - pyright (types, non-blocking)
+   - interrogate (docstrings)
+   - deptry (dependencies)
+
+2. **Test** (`.github/workflows/test.yml`)
+   - pytest test suite
+
+3. **Duplicate Check** (`.github/workflows/duplicate-check.yml`)
+   - jscpd duplicate code detection
+
+**Typical duration:** 2-5 minutes total
+
+## Example Workflow
+
+```
+Agent: Creating PR for issue #123...
+Agent: Running: gh pr create --title "Fix widget bug" --body "..."
+Agent: 
+  ✅ PR #456 created
+  https://github.com/owner/repo/pull/456
+  
+  🔄 CI checks starting...
+  
+  Wait for results? [W] or Continue [C]
+
+User: W
+
+Agent: Monitoring CI checks...
+  - lint: ⏳ pending
+  - test: ⏳ pending
+  - duplicate-check: ⏳ pending
+  
+  [30s later]
+  - lint: 🔄 in progress
+  - test: ⏳ pending
+  - duplicate-check: ✅ passed
+  
+  [60s later]
+  - lint: ✅ passed (1m 5s)
+  - test: 🔄 in progress
+  
+  [90s later]
+  - lint: ✅ passed
+  - test: ✅ passed (1m 23s)
+  - duplicate-check: ✅ passed
+  
+  ✅ All CI checks passed!
+  PR #456 is ready for review.
+```
+
+## Integration with Worktree Workflow
+
+**When creating PR from worktree:**
+
+1. Verify you're on issue branch (not main)
+2. Create PR
+3. Run CI checks workflow (this document)
+4. If checks fail:
+   - Make fixes in current worktree
+   - Commit and push (triggers new CI run)
+   - Re-monitor
+5. If checks pass:
+   - PR ready for review
+   - User can merge when approved
+
+## Notes
+
+- CI checks are **blocking** for this repository (branch protection rules)
+- All checks must pass before merge
+- Pre-commit hooks run locally, but CI runs additional checks
+- Use `gh run watch` for detailed real-time progress
+- Use `gh pr checks` for quick status overview

--- a/.opencode/rules
+++ b/.opencode/rules
@@ -27,6 +27,28 @@ Bypass attempts are logged to `.git-bypass.log` for audit.
 
 4. **Push and create a PR** when done
 
+5. **Monitor CI checks** after PR creation (see `.agents/rules/pr-ci-checks.md`)
+
+## PR Creation & CI Monitoring
+
+**After creating a PR with `gh pr create`:**
+
+1. **Extract PR number** from output URL
+2. **Check CI status immediately:**
+   ```bash
+   gh pr checks <PR_NUMBER>
+   ```
+
+3. **Ask user preference:**
+   - Wait for CI results (monitor every 30s)
+   - Continue working (check periodically)
+
+4. **Report results when checks complete:**
+   - ✅ All passed: PR ready for review
+   - ❌ Failed: Show failure details, offer to fix
+
+**See `.agents/rules/pr-ci-checks.md` for full workflow details.**
+
 ## If You See Changes on Main
 
 - DO NOT commit them

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,27 @@ See `.opencode/rules` and `.githooks/README.md` for full workflow.
 - Ask user to commit; do not auto-commit
 - Open PR after commit
 
+### PR Creation & CI Monitoring
+
+**After creating a PR:**
+
+1. **Check CI status immediately:**
+   ```bash
+   ./scripts/check-pr-ci.sh [PR_NUMBER]
+   # Or: gh pr checks <PR_NUMBER>
+   ```
+
+2. **Interactive monitoring:**
+   - Ask user: "Wait for CI results? [W] or Continue [C]"
+   - If wait: Monitor every 30s until complete
+   - If continue: Check periodically, notify when done
+
+3. **Report results:**
+   - ✅ All passed: PR ready for review
+   - ❌ Failed: Show failure details, offer to fix
+
+**Full workflow:** `.agents/rules/pr-ci-checks.md`
+
 ---
 
 ## Testing Best Practices

--- a/scripts/check-pr-ci.sh
+++ b/scripts/check-pr-ci.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+#
+# Check CI status for a pull request
+# Usage: ./scripts/check-pr-ci.sh [PR_NUMBER]
+#
+# If PR_NUMBER is not provided, tries to detect from current branch
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+# Get PR number
+PR_NUMBER="${1:-}"
+
+if [[ -z "$PR_NUMBER" ]]; then
+    # Try to get PR number from current branch
+    BRANCH=$(git branch --show-current)
+    PR_NUMBER=$(gh pr list --head "$BRANCH" --json number --jq '.[0].number' 2>/dev/null || echo "")
+    
+    if [[ -z "$PR_NUMBER" ]]; then
+        echo "❌ No PR number provided and couldn't detect from current branch"
+        echo "Usage: $0 [PR_NUMBER]"
+        exit 1
+    fi
+    
+    echo "📌 Detected PR #$PR_NUMBER from branch '$BRANCH'"
+fi
+
+# Check PR exists
+if ! gh pr view "$PR_NUMBER" &>/dev/null; then
+    echo "❌ PR #$PR_NUMBER not found"
+    exit 1
+fi
+
+echo ""
+echo "🔍 Checking CI status for PR #$PR_NUMBER..."
+echo ""
+
+# Get CI status
+gh pr checks "$PR_NUMBER"
+
+# Get detailed status
+CHECKS_JSON=$(gh pr checks "$PR_NUMBER" --json status,conclusion,name 2>/dev/null || echo "[]")
+
+# Count statuses
+PENDING=$(echo "$CHECKS_JSON" | jq '[.[] | select(.status == "queued" or .status == "in_progress")] | length' 2>/dev/null || echo "0")
+SUCCESS=$(echo "$CHECKS_JSON" | jq '[.[] | select(.status == "completed" and .conclusion == "success")] | length' 2>/dev/null || echo "0")
+FAILED=$(echo "$CHECKS_JSON" | jq '[.[] | select(.status == "completed" and .conclusion == "failure")] | length' 2>/dev/null || echo "0")
+TOTAL=$((PENDING + SUCCESS + FAILED))
+
+echo ""
+echo "📊 Summary:"
+echo "   Total checks: $TOTAL"
+echo "   ✅ Passed: $SUCCESS"
+echo "   ⏳ Pending/Running: $PENDING"
+echo "   ❌ Failed: $FAILED"
+
+# Exit with appropriate code
+if [[ "$FAILED" -gt 0 ]]; then
+    echo ""
+    echo "❌ Some checks failed. View details with: gh pr checks $PR_NUMBER --watch"
+    exit 1
+elif [[ "$PENDING" -gt 0 ]]; then
+    echo ""
+    echo "⏳ Checks still running. Monitor with: gh pr checks $PR_NUMBER --watch"
+    exit 2
+else
+    echo ""
+    echo "✅ All checks passed! PR is ready for review/merge."
+    echo "   View PR: gh pr view $PR_NUMBER"
+    exit 0
+fi


### PR DESCRIPTION
## Summary
- Added comprehensive CI monitoring workflow for PRs
- Automatic status checking after PR creation
- Interactive user preference (wait or continue working)
- Detailed failure handling and success reporting

## Files Changed
- `.agents/rules/pr-ci-checks.md` - Detailed workflow documentation
- `.opencode/rules` - Integrated CI monitoring into PR workflow
- `AGENTS.md` - Added PR creation & CI monitoring section
- `scripts/check-pr-ci.sh` - Automated CI status checking script

## How It Works
1. After creating PR, check CI status immediately
2. Ask user: "Wait for results? [W] or Continue [C]"
3. If wait: Poll every 30s, report progress
4. If continue: Check periodically, notify when done

## Testing
- Script works with auto-detection from current branch
- Exit codes: 0=success, 1=failed, 2=pending
- Color-coded output for easy reading