### PR TITLE
Suppress warnings during state machine grace period

### DIFF
--- a/custom_components/localshift/state_machine.py
+++ b/custom_components/localshift/state_machine.py
@@ -506,8 +506,10 @@ class StateMachine:
             # Issue #468: Re-check automation ready after reading fresh state
             # If automation_ready was set False from stale startup data,
             # re-checking now ensures we use fresh values after state refresh
+            # Issue #551: Suppress warning during startup grace period
             if not data.automation_ready and check_automation_ready_func is not None:
-                check_automation_ready_func(data)
+                in_grace = self._startup_grace_until is not None
+                check_automation_ready_func(data, suppress_warning=in_grace)
             computation_engine.compute_derived_values(data)
 
             # Notify listeners with fresh computed data regardless of which


### PR DESCRIPTION
## Problem

After PR #556 was merged, the startup warning was still appearing:

```
WARNING Automation not ready - missing inputs: SOC (current: 0.0), Operation mode (current: '')
```

This warning appears during state machine evaluation, not during the initial startup check.

## Root Cause

The state machine's `evaluate_state_machine()` method calls `check_automation_ready_func(data)` to re-check automation readiness after reading fresh state. This call was made **without** the `suppress_warning` parameter, causing the warning to appear during the grace period.

## Solution

**state_machine.py** (line 509-512):
```python
# Issue #551: Suppress warning during startup grace period
if not data.automation_ready and check_automation_ready_func is not None:
    in_grace = self._startup_grace_until is not None
    check_automation_ready_func(data, suppress_warning=in_grace)
```

Now the state machine checks if it's in the grace period and passes `suppress_warning=True` to prevent log flooding.

## Testing

- Follow-up to PR #556
- Completes the fix for startup log flooding
- All existing tests pass

## Impact

This completes the fix started in PR #556. Together, these changes eliminate all startup log flooding:

1. PR #556: Added grace checks in periodic handlers
2. This PR: Suppress warnings during state machine evaluation in grace period