### PR TITLE
Fix startup log flooding - set grace period before any evaluation

### DIFF
--- a/custom_components/localshift/coordinator.py
+++ b/custom_components/localshift/coordinator.py
@@ -207,6 +207,11 @@ class LocalShiftCoordinator:
             decision_tracker=None,  # Will be set after tracker is initialized
         )
 
+        # Issue #551: Set startup grace period IMMEDIATELY after creating state machine
+        # This prevents state machine evaluation during startup before entities populate
+        # The grace period must be set before ANY computation that might trigger evaluation
+        self._state_machine.set_startup_grace(30)
+
         self._learning_orchestrator = LearningOrchestrator(
             self.hass,
             self.entry,
@@ -343,8 +348,8 @@ class LocalShiftCoordinator:
         # Refresh weather forecast (startup catch-up)
         await self._refresh_weather_forecast()
 
-        # Startup grace: wait 30 s for entities to populate before acting
-        self._state_machine.set_startup_grace(30)
+        # Note: Startup grace period was set earlier (line 213) immediately after
+        # state machine creation to prevent evaluation during startup computation
 
         inferred_mode = self._state_machine.infer_current_hardware_mode(self.data)
 


### PR DESCRIPTION
## Problem

After merging PRs #556 and #557, the startup warning still appears:

```
WARNING Automation not ready - missing inputs: SOC (current: 0.0), Operation mode (current: '')
```

## Root Cause

The state machine was evaluating during the startup process **before** the grace period was set:

1. State machine created at line 201
2. Forecast computation triggers state machine evaluation
3. Grace period set at line 352 (too late!)

The grace period was set after forecast computation, but forecast computation itself triggers state machine evaluation.

## Solution

Move grace period setup to **immediately after** creating the state machine (line 213), before ANY computation that might trigger evaluation.

```python
self._state_machine = StateMachine(...)

# Issue #551: Set startup grace period IMMEDIATELY after creating state machine
# This prevents state machine evaluation during startup before entities populate
self._state_machine.set_startup_grace(30)

# Now safe to do computation that might trigger evaluation
await self._learning_orchestrator.async_initialize()
...
```

## Impact

This completes the fix for Issue #551 startup log flooding:

1. **PR #556**: Added grace checks in periodic handlers
2. **PR #557**: Suppress warnings during grace period  
3. **This PR**: Set grace period BEFORE any evaluation can occur

This fixes the root cause - the timing issue where evaluation happened before the grace period was active.

## Testing

All existing tests pass. Ready for deployment testing to verify startup logs are clean.