### PR TITLE
Fix: forecast accuracy sensor shows 100% with no data (Issue #561)

### DIFF
--- a/custom_components/localshift/computation_engine_lib/forecast_accuracy.py
+++ b/custom_components/localshift/computation_engine_lib/forecast_accuracy.py
@@ -90,9 +90,9 @@ class ForecastAccuracyEngine:
             ("forecast_error_soc_15min", 0.0),
             ("forecast_error_soc_1h", 0.0),
             ("forecast_error_soc_4h", 0.0),
-            ("forecast_accuracy_soc_15min", 100.0),
-            ("forecast_accuracy_soc_1h", 100.0),
-            ("forecast_accuracy_soc_4h", 100.0),
+            ("forecast_accuracy_soc_15min", None),
+            ("forecast_accuracy_soc_1h", None),
+            ("forecast_accuracy_soc_4h", None),
             ("forecast_error_buy_price_1h", 0.0),
             ("forecast_error_sell_price_1h", 0.0),
         ]
@@ -166,7 +166,7 @@ class ForecastAccuracyEngine:
             target_dt = dt_util.as_local(target_dt)
 
         time_diff = abs((target_dt - now_dt).total_seconds())
-        if time_diff > 60:
+        if time_diff > 300:  # 5 minute window to tolerate scheduling drift
             return None
 
         offset = entry.get("offset_minutes")

--- a/custom_components/localshift/computation_engine_lib/forecast_history_store.py
+++ b/custom_components/localshift/computation_engine_lib/forecast_history_store.py
@@ -153,6 +153,7 @@ class ForecastHistoryStore:
         if len(data.forecast_history) > 200:
             data.forecast_history = data.forecast_history[-200:]
 
+        data.forecast_history_count = len(data.forecast_history)
         self._last_forecast_hour = current_hour
 
     def _filter_valid_history_entries(

--- a/custom_components/localshift/computation_engine_lib/optimization_controller.py
+++ b/custom_components/localshift/computation_engine_lib/optimization_controller.py
@@ -270,11 +270,12 @@ class OptimizationController:
 
         # Rule 3: Forecast Confidence
         # If forecast accuracy is low, be more pessimistic about solar
-        avg_accuracy = (
-            (data.forecast_accuracy_soc_1h + data.forecast_accuracy_soc_4h) / 2.0
-            if data.forecast_accuracy_soc_1h > 0
-            else 100.0
-        )
+        acc_1h = data.forecast_accuracy_soc_1h
+        acc_4h = data.forecast_accuracy_soc_4h
+        if acc_1h is not None and acc_4h is not None:
+            avg_accuracy = (acc_1h + acc_4h) / 2.0
+        else:
+            avg_accuracy = 100.0  # Default when no accuracy data available
 
         if avg_accuracy < 50.0:
             # Reduce solar confidence factor (be more pessimistic)

--- a/custom_components/localshift/coordinator_data.py
+++ b/custom_components/localshift/coordinator_data.py
@@ -391,9 +391,9 @@ class CoordinatorData:
     forecast_error_soc_1h: float = 0.0  # Error for 1-hour predictions
     forecast_error_soc_4h: float = 0.0  # Error for 4-hour predictions
     # SOC accuracy percentages (100 - abs error, clamped to 0-100)
-    forecast_accuracy_soc_15min: float = 100.0
-    forecast_accuracy_soc_1h: float = 100.0
-    forecast_accuracy_soc_4h: float = 100.0
+    forecast_accuracy_soc_15min: float | None = None  # None = no data yet
+    forecast_accuracy_soc_1h: float | None = None  # None = no data yet
+    forecast_accuracy_soc_4h: float | None = None  # None = no data yet
     # Price prediction errors
     forecast_error_buy_price_1h: float = 0.0  # Buy price error ($/kWh)
     forecast_error_sell_price_1h: float = 0.0  # Sell price error ($/kWh)

--- a/custom_components/localshift/sensor.py
+++ b/custom_components/localshift/sensor.py
@@ -659,9 +659,8 @@ class ForecastAccuracySensor(LocalShiftSensorBase):
 
     def _update_from_coordinator(self) -> None:
         """Update with overall accuracy percentage."""
-        self._attr_native_value = round(
-            self.coordinator.data.forecast_accuracy_soc_1h, 1
-        )
+        accuracy = self.coordinator.data.forecast_accuracy_soc_1h
+        self._attr_native_value = round(accuracy, 1) if accuracy is not None else None
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
@@ -673,9 +672,15 @@ class ForecastAccuracySensor(LocalShiftSensorBase):
             "soc_error_1h": round(d.forecast_error_soc_1h, 1),
             "soc_error_4h": round(d.forecast_error_soc_4h, 1),
             # SOC accuracy percentages (100 - abs error, clamped)
-            "soc_accuracy_15min": round(d.forecast_accuracy_soc_15min, 1),
-            "soc_accuracy_1h": round(d.forecast_accuracy_soc_1h, 1),
-            "soc_accuracy_4h": round(d.forecast_accuracy_soc_4h, 1),
+            "soc_accuracy_15min": round(d.forecast_accuracy_soc_15min, 1)
+            if d.forecast_accuracy_soc_15min is not None
+            else None,
+            "soc_accuracy_1h": round(d.forecast_accuracy_soc_1h, 1)
+            if d.forecast_accuracy_soc_1h is not None
+            else None,
+            "soc_accuracy_4h": round(d.forecast_accuracy_soc_4h, 1)
+            if d.forecast_accuracy_soc_4h is not None
+            else None,
             # Price prediction errors
             "buy_price_error_1h": round(d.forecast_error_buy_price_1h, 4),
             "sell_price_error_1h": round(d.forecast_error_sell_price_1h, 4),

--- a/tests/test_forecast_accuracy.py
+++ b/tests/test_forecast_accuracy.py
@@ -219,7 +219,7 @@ class TestForecastAccuracyEngine:
 
         # Should set default values
         assert data.forecast_error_soc_15min == 0.0
-        assert data.forecast_accuracy_soc_1h == 100.0
+        assert data.forecast_accuracy_soc_1h is None  # No data available
 
     @pytest.mark.asyncio
     async def test_compute_forecast_accuracy_sets_defaults(self):


### PR DESCRIPTION
## Summary

Fixes issue #561 where the forecast accuracy sensor displayed 100% accuracy even though no comparisons had been made (, ).

## Changes

- **coordinator_data.py**: Change accuracy defaults from  to  (with type )
- **forecast_accuracy.py**: 
  - Update  to set  defaults
  - Increase match window from 60s to 300s to tolerate scheduling drift
- **sensor.py**: Return  state when accuracy data unavailable; attributes show  for accuracy fields
- **optimization_controller.py**: Guard against  values, fallback to 100.0
- **forecast_history_store.py**: Update  after appending entries (was stuck at 0)
- **tests**: Update  to expect 

## Testing

- Ran all forecast accuracy tests: **15 passed**
- Ran forecast history store tests: **2 passed**  
- Ran full test suite: **610 passed, 49 skipped, 2 failures** (unrelated scenario tests)

## Verification

After deployment:
-  should show  until first comparison
-  should correctly reflect number of stored predictions
-  should increment as matches occur within 5-minute window
-  attributes show  until data available

Closes #561