### PR TITLE
Expand entity health sensor to monitor all LocalShift entities

### DIFF
--- a/custom_components/localshift/computation_engine_lib/price_calculator.py
+++ b/custom_components/localshift/computation_engine_lib/price_calculator.py
@@ -508,12 +508,15 @@ class PriceCalculator:
         # Include tomorrow's forecast when target is tomorrow morning
         all_solcast = [*data.solcast_today, *data.solcast_tomorrow]
 
+        # Compute target datetime (demand window start)
+        target_dt = now_dt.replace(hour=target_hour, minute=0, second=0, microsecond=0)
+
         for period in all_solcast:
             period_start = self._parse_forecast_dt(period.get("period_start"))
             if period_start is None:
                 continue
             period_start_local = dt_util.as_local(period_start)
-            if period_start_local >= now_dt and period_start_local.hour <= target_hour:
+            if period_start_local >= now_dt and period_start_local < target_dt:
                 solar_kwh_val = float(period.get("pv_estimate", 0))
                 if solar_kwh_val <= 0:
                     continue

--- a/custom_components/localshift/coordinator.py
+++ b/custom_components/localshift/coordinator.py
@@ -447,7 +447,7 @@ class LocalShiftCoordinator:
         if self._entity_validator is None:
             return
 
-        # Check all entities
+        # Check all entities (external dependencies)
         self._entity_validator.check_all_entities()
 
         # Update coordinator data with health status
@@ -465,6 +465,11 @@ class LocalShiftCoordinator:
         health_summary = self._entity_validator.get_health_summary()
         self.data.entity_health = health_summary.get("entities", {})
         self.data.last_entity_check = health_summary.get("last_check", "")
+
+        # Check LocalShift internal entities
+        self.data.localshift_entity_health = (
+            self._entity_validator.check_all_localshift_entities()
+        )
 
         # Log any new errors
         if self.data.entity_errors:

--- a/custom_components/localshift/coordinator_data.py
+++ b/custom_components/localshift/coordinator_data.py
@@ -413,6 +413,9 @@ class CoordinatorData:
     )  # Per-entity health status
     last_entity_check: str = ""  # ISO timestamp of last health check
     required_entities_healthy: bool = True  # Are all required entities available?
+    localshift_entity_health: dict[str, Any] = field(
+        default_factory=dict
+    )  # Health status for LocalShift internal entities
 
     # --- Learning system (Issue #170 Phase 1) ---
     performance_metrics: PerformanceMetrics = field(default_factory=PerformanceMetrics)

--- a/custom_components/localshift/entity_validator.py
+++ b/custom_components/localshift/entity_validator.py
@@ -214,6 +214,277 @@ STALENESS_THRESHOLDS: dict[str, timedelta] = {
 FAILURE_THRESHOLD_WARNING = 3  # After 3 failures, log warning
 FAILURE_THRESHOLD_ERROR = 10  # After 10 failures, consider entity broken
 
+# LocalShift internal entity health configuration
+# Maps entity_id to validation and health check parameters
+LOCALSHIFT_ENTITY_CONFIG: dict[str, dict[str, Any]] = {
+    # Sensors - REQUIRED core
+    "sensor.localshift_price_cheap_effective": {
+        "category": EntityCategory.REQUIRED,
+        "expected_type": float,
+        "staleness_minutes": 15,
+    },
+    "sensor.localshift_price_cheap_charge_stop": {
+        "category": EntityCategory.REQUIRED,
+        "expected_type": float,
+        "staleness_minutes": 15,
+    },
+    "sensor.localshift_solar_weighted_avg_fit": {
+        "category": EntityCategory.REQUIRED,
+        "expected_type": float,
+        "staleness_minutes": 15,
+    },
+    "sensor.localshift_forecast_battery": {
+        "category": EntityCategory.REQUIRED,
+        "expected_type": float,
+        "staleness_minutes": 15,
+    },
+    "sensor.localshift_cost_electricity_net": {
+        "category": EntityCategory.REQUIRED,
+        "expected_type": float,
+        "staleness_minutes": 15,
+    },
+    "sensor.localshift_optimizer_plan": {
+        "category": EntityCategory.REQUIRED,
+        "expected_type": int,
+        "staleness_minutes": 15,
+    },
+    "sensor.localshift_forecast_prices": {
+        "category": EntityCategory.REQUIRED,
+        "expected_type": float,
+        "staleness_minutes": 15,
+    },
+    "sensor.localshift_optimizer_plan_grid": {
+        "category": EntityCategory.REQUIRED,
+        "expected_type": float,
+        "staleness_minutes": 15,
+    },
+    "sensor.localshift_forecast_diagnostics": {
+        "category": EntityCategory.REQUIRED,
+        "expected_type": str,
+        "staleness_minutes": 15,
+    },
+    "sensor.localshift_target_soc_minimum": {
+        "category": EntityCategory.REQUIRED,
+        "expected_type": float,
+        "staleness_minutes": None,
+    },
+    "sensor.localshift_excess_solar_kwh": {
+        "category": EntityCategory.REQUIRED,
+        "expected_type": float,
+        "staleness_minutes": 15,
+    },
+    "sensor.localshift_load_shift_signal": {
+        "category": EntityCategory.REQUIRED,
+        "expected_type": str,
+        "staleness_minutes": 15,
+    },
+    "sensor.localshift_forecast_status": {
+        "category": EntityCategory.REQUIRED,
+        "expected_type": str,
+        "staleness_minutes": 15,
+    },
+    "sensor.localshift_automation_ready": {
+        "category": EntityCategory.REQUIRED,
+        "expected_type": str,
+        "staleness_minutes": 15,
+    },
+    "sensor.localshift_optimizer_plan_detailed": {
+        "category": EntityCategory.REQUIRED,
+        "expected_type": str,
+        "staleness_minutes": 15,
+    },
+    "sensor.localshift_optimizer_summary": {
+        "category": EntityCategory.REQUIRED,
+        "expected_type": str,
+        "staleness_minutes": 15,
+    },
+    # Binary sensors - all REQUIRED
+    "binary_sensor.localshift_price_spike_coming": {
+        "category": EntityCategory.REQUIRED,
+        "expected_type": bool,
+        "staleness_minutes": 15,
+    },
+    "binary_sensor.localshift_discharge_forced": {
+        "category": EntityCategory.REQUIRED,
+        "expected_type": bool,
+        "staleness_minutes": 15,
+    },
+    "binary_sensor.localshift_charge_forced": {
+        "category": EntityCategory.REQUIRED,
+        "expected_type": bool,
+        "staleness_minutes": 15,
+    },
+    "binary_sensor.localshift_charge_boost": {
+        "category": EntityCategory.REQUIRED,
+        "expected_type": bool,
+        "staleness_minutes": 15,
+    },
+    "binary_sensor.localshift_price_expensive_coming": {
+        "category": EntityCategory.REQUIRED,
+        "expected_type": bool,
+        "staleness_minutes": 15,
+    },
+    "binary_sensor.localshift_solar_can_reach_target": {
+        "category": EntityCategory.REQUIRED,
+        "expected_type": bool,
+        "staleness_minutes": 15,
+    },
+    "binary_sensor.localshift_charge_boost_needed": {
+        "category": EntityCategory.REQUIRED,
+        "expected_type": bool,
+        "staleness_minutes": 15,
+    },
+    "binary_sensor.localshift_demand_window": {
+        "category": EntityCategory.REQUIRED,
+        "expected_type": bool,
+        "staleness_minutes": 15,
+    },
+    "binary_sensor.localshift_excess_solar_available": {
+        "category": EntityCategory.REQUIRED,
+        "expected_type": bool,
+        "staleness_minutes": 15,
+    },
+    "binary_sensor.localshift_tesla_override_active": {
+        "category": EntityCategory.REQUIRED,
+        "expected_type": bool,
+        "staleness_minutes": 15,
+    },
+    # Switches - all REQUIRED (static)
+    "switch.localshift_automation_enabled": {
+        "category": EntityCategory.REQUIRED,
+        "expected_type": bool,
+        "staleness_minutes": None,
+    },
+    "switch.localshift_spike_discharge_enabled": {
+        "category": EntityCategory.REQUIRED,
+        "expected_type": bool,
+        "staleness_minutes": None,
+    },
+    "switch.localshift_spike_discharge_conservative": {
+        "category": EntityCategory.REQUIRED,
+        "expected_type": bool,
+        "staleness_minutes": None,
+    },
+    "switch.localshift_dry_run": {
+        "category": EntityCategory.REQUIRED,
+        "expected_type": bool,
+        "staleness_minutes": None,
+    },
+    "switch.localshift_demand_window_block": {
+        "category": EntityCategory.REQUIRED,
+        "expected_type": bool,
+        "staleness_minutes": None,
+    },
+    "switch.localshift_allow_dw_entry_under_target": {
+        "category": EntityCategory.REQUIRED,
+        "expected_type": bool,
+        "staleness_minutes": None,
+    },
+    "switch.localshift_notifications_enabled": {
+        "category": EntityCategory.REQUIRED,
+        "expected_type": bool,
+        "staleness_minutes": None,
+    },
+    "switch.localshift_enable_learning": {
+        "category": EntityCategory.REQUIRED,
+        "expected_type": bool,
+        "staleness_minutes": None,
+    },
+    # Selects - REQUIRED (static)
+    "select.localshift_battery_mode": {
+        "category": EntityCategory.REQUIRED,
+        "expected_type": str,
+        "staleness_minutes": None,
+    },
+    "select.localshift_optimization_mode": {
+        "category": EntityCategory.REQUIRED,
+        "expected_type": str,
+        "staleness_minutes": None,
+    },
+    # Numbers - REQUIRED (static)
+    "number.localshift_cheap_price_percentile": {
+        "category": EntityCategory.REQUIRED,
+        "expected_type": float,
+        "staleness_minutes": None,
+    },
+    "number.localshift_max_pre_charge_price": {
+        "category": EntityCategory.REQUIRED,
+        "expected_type": float,
+        "staleness_minutes": None,
+    },
+    "number.localshift_battery_target": {
+        "category": EntityCategory.REQUIRED,
+        "expected_type": float,
+        "staleness_minutes": None,
+    },
+    "number.localshift_minimum_target_soc": {
+        "category": EntityCategory.REQUIRED,
+        "expected_type": float,
+        "staleness_minutes": None,
+    },
+    # Optional diagnostic sensors
+    "sensor.localshift_forecast_accuracy": {
+        "category": EntityCategory.OPTIONAL,
+        "expected_type": float,
+        "staleness_minutes": 60,
+    },
+    "sensor.localshift_extended_forecast_accuracy": {
+        "category": EntityCategory.OPTIONAL,
+        "expected_type": float,
+        "staleness_minutes": 1440,
+    },
+    "sensor.localshift_solar_forecast_accuracy": {
+        "category": EntityCategory.OPTIONAL,
+        "expected_type": float,
+        "staleness_minutes": 1440,
+    },
+    "sensor.localshift_decision_lag": {
+        "category": EntityCategory.OPTIONAL,
+        "expected_type": float,
+        "staleness_minutes": 15,
+    },
+    "sensor.localshift_cost_reconciliation": {
+        "category": EntityCategory.OPTIONAL,
+        "expected_type": str,
+        "staleness_minutes": 1440,
+    },
+    "sensor.localshift_learning_status": {
+        "category": EntityCategory.OPTIONAL,
+        "expected_type": str,
+        "staleness_minutes": 60,
+    },
+    "sensor.localshift_decision_quality": {
+        "category": EntityCategory.OPTIONAL,
+        "expected_type": float,
+        "staleness_minutes": 60,
+    },
+    "sensor.localshift_learning_decision_history": {
+        "category": EntityCategory.OPTIONAL,
+        "expected_type": int,
+        "staleness_minutes": 60,
+    },
+    "sensor.localshift_decision_log": {
+        "category": EntityCategory.OPTIONAL,
+        "expected_type": str,
+        "staleness_minutes": 60,
+    },
+    "sensor.localshift_forecast_history": {
+        "category": EntityCategory.OPTIONAL,
+        "expected_type": int,
+        "staleness_minutes": 1440,
+    },
+    "sensor.localshift_integration_status": {
+        "category": EntityCategory.OPTIONAL,
+        "expected_type": str,
+        "staleness_minutes": 15,
+    },
+    "sensor.localshift_entity_health": {
+        "category": EntityCategory.OPTIONAL,
+        "expected_type": str,
+        "staleness_minutes": 15,
+    },
+}
+
 
 class EntityValidator:
     """Centralized entity validation and health tracking.
@@ -236,6 +507,7 @@ class EntityValidator:
         self.hass = hass
         self._get_entity_id = get_entity_id_func
         self._entity_health: dict[str, EntityHealth] = {}
+        self._localshift_entity_health: dict[str, EntityHealth] = {}
         self._last_full_check: datetime | None = None
         self._cached_status: IntegrationStatus = IntegrationStatus.OK
         self._cached_errors: list[str] = []
@@ -536,6 +808,166 @@ class EntityValidator:
         self._update_cached_status()
 
         return self._entity_health
+
+    def _validate_type_value(
+        self, value_str: str, expected_type: Any, entity_id: str
+    ) -> tuple[bool, Any, str]:
+        """Validate a state value against an expected type.
+
+        Args:
+            value_str: The state value as string
+            expected_type: Type to validate against (bool, int, float, str, or tuple of types)
+            entity_id: Entity ID for error messages
+
+        Returns:
+            Tuple of (is_valid, parsed_value, error_message)
+        """
+        if expected_type is None:
+            return True, value_str, ""
+
+        # Handle boolean
+        if expected_type == bool:
+            bool_value = value_str.lower() in ("on", "true", "yes", "1")
+            return True, bool_value, ""
+
+        # Handle numeric (int or float)
+        if expected_type in ((int, float), int, float):
+            try:
+                num_value = float(value_str)
+            except (ValueError, TypeError):
+                return False, 0.0, f"value '{value_str}' is not a number"
+            return True, num_value, ""
+
+        # Handle string
+        if expected_type == str:
+            return True, value_str, ""
+
+        # Default: accept as is
+        return True, value_str, ""
+
+    def check_all_localshift_entities(self) -> dict[str, dict[str, Any]]:
+        """Check health of all LocalShift internal entities.
+
+        Returns:
+            Dictionary mapping entity_id to serialized health info dict
+        """
+        now = dt_util.now()
+        results: dict[str, EntityHealth] = {}
+
+        for entity_id, config in LOCALSHIFT_ENTITY_CONFIG.items():
+            # Get or create health object
+            health = self._localshift_entity_health.get(entity_id)
+            if health is None:
+                health = EntityHealth(
+                    entity_id=entity_id,
+                    config_key=entity_id,
+                    category=config["category"],
+                    status=EntityStatus.OK,
+                    last_check=now,
+                )
+                self._localshift_entity_health[entity_id] = health
+            else:
+                health.entity_id = entity_id
+                health.last_check = now
+
+            # Check existence
+            state = self.hass.states.get(entity_id)
+            if state is None:
+                health.status = EntityStatus.MISSING
+                health.error_message = f"Entity '{entity_id}' does not exist"
+                health.consecutive_failures += 1
+                self._check_failure_thresholds(health, entity_id)
+                results[entity_id] = health
+                continue
+
+            # Check unavailable/unknown
+            if state.state == "unavailable":
+                health.status = EntityStatus.UNAVAILABLE
+                health.error_message = f"Entity '{entity_id}' is unavailable"
+                health.consecutive_failures += 1
+                self._check_failure_thresholds(health, entity_id)
+                results[entity_id] = health
+                continue
+            if state.state == "unknown":
+                health.status = EntityStatus.UNKNOWN
+                health.error_message = f"Entity '{entity_id}' has unknown state"
+                health.consecutive_failures += 1
+                self._check_failure_thresholds(health, entity_id)
+                results[entity_id] = health
+                continue
+
+            # Type validation
+            expected_type = config.get("expected_type")
+            if expected_type is not None:
+                is_valid, parsed_value, error_msg = self._validate_type_value(
+                    state.state, expected_type, entity_id
+                )
+                if not is_valid:
+                    health.status = EntityStatus.INVALID_VALUE
+                    health.error_message = error_msg
+                    health.consecutive_failures += 1
+                    self._check_failure_thresholds(health, entity_id)
+                    results[entity_id] = health
+                    continue
+            else:
+                parsed_value = state.state
+
+            # Staleness check
+            staleness_minutes = config.get("staleness_minutes")
+            if staleness_minutes is not None:
+                threshold = timedelta(minutes=staleness_minutes)
+                freshness_ts = self._get_freshness_timestamp(state)
+                if freshness_ts is not None:
+                    try:
+                        age = now - freshness_ts
+                    except TypeError:
+                        _LOGGER.debug(
+                            "Skipping staleness for %s due to timestamp mismatch",
+                            entity_id,
+                        )
+                    else:
+                        if age > threshold:
+                            health.status = EntityStatus.STALE
+                            health.error_message = (
+                                f"Entity '{entity_id}' data is stale "
+                                f"({age.total_seconds():.0f}s old)"
+                            )
+                            results[entity_id] = health
+                            continue
+
+            # Entity is healthy
+            if health.is_broken:
+                _LOGGER.info(
+                    "Entity '%s' recovered from BROKEN status - now healthy",
+                    entity_id,
+                )
+                health.is_broken = False
+            health.status = EntityStatus.OK
+            health.error_message = ""
+            health.last_valid_value = parsed_value
+            health.last_valid_time = now
+            health.consecutive_failures = 0
+            results[entity_id] = health
+
+        # Serialize to plain dicts for coordinator data
+        summary: dict[str, dict[str, Any]] = {}
+        for entity_id, health in results.items():
+            summary[entity_id] = {
+                "entity_id": health.entity_id,
+                "status": health.status.value,
+                "category": health.category.value,
+                "last_valid_time": (
+                    health.last_valid_time.isoformat()
+                    if health.last_valid_time
+                    else None
+                ),
+                "consecutive_failures": health.consecutive_failures,
+                "is_broken": health.is_broken,
+                "error_message": health.error_message if health.error_message else None,
+            }
+
+        self._localshift_entity_health = results
+        return summary
 
     def _update_cached_status(self) -> None:
         """Update cached integration status and error messages."""

--- a/custom_components/localshift/sensor.py
+++ b/custom_components/localshift/sensor.py
@@ -747,18 +747,52 @@ class EntityHealthSensor(LocalShiftSensorBase):
 
     def _update_from_coordinator(self) -> None:
         """Update with count of healthy entities."""
-        health = self.coordinator.data.entity_health
-        healthy_count = sum(1 for e in health.values() if e.get("status") == "ok")
-        total_count = len(health)
+        dep_health = self.coordinator.data.entity_health
+        ls_health = self.coordinator.data.localshift_entity_health
+        all_entities = {**dep_health, **ls_health}
+        healthy_count = sum(1 for e in all_entities.values() if e.get("status") == "ok")
+        total_count = len(all_entities)
         self._attr_native_value = f"{healthy_count}/{total_count}"
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return detailed entity health."""
+        dep_health = self.coordinator.data.entity_health
+        ls_health = self.coordinator.data.localshift_entity_health
         return {
-            "entities": self.coordinator.data.entity_health,
+            "entities": dep_health,  # legacy key for backward compatibility
+            "dependencies": dep_health,
+            "localshift_entities": ls_health,
             "errors": self.coordinator.data.entity_errors,
             "warnings": self.coordinator.data.entity_warnings,
+            "summary": {
+                "dependencies": {
+                    "total": len(dep_health),
+                    "healthy": sum(
+                        1 for e in dep_health.values() if e.get("status") == "ok"
+                    ),
+                },
+                "localshift": {
+                    "total": len(ls_health),
+                    "healthy": sum(
+                        1 for e in ls_health.values() if e.get("status") == "ok"
+                    ),
+                    "by_category": {
+                        "required": sum(
+                            1
+                            for e in ls_health.values()
+                            if e.get("category") == "required"
+                            and e.get("status") == "ok"
+                        ),
+                        "optional": sum(
+                            1
+                            for e in ls_health.values()
+                            if e.get("category") == "optional"
+                            and e.get("status") == "ok"
+                        ),
+                    },
+                },
+            },
         }
 
 


### PR DESCRIPTION
Added comprehensive health tracking for 51 internal entities (sensors, binary sensors, switches, selects, numbers). The EntityHealthSensor now displays aggregate status for both external dependencies and internal components.

Changes:
- Added LOCALSHIFT_ENTITY_CONFIG with health parameters for all internal entities
- Implemented check_all_localshift_entities() in EntityValidator
- Extended CoordinatorData with localshift_entity_health field
- Updated EntityHealthSensor to show combined health metrics
- Maintained backward compatibility with existing attributes

Categories:
- 40 REQUIRED entities (critical for operation)
- 11 OPTIONAL diagnostic sensors

Staleness thresholds: 15min for dynamic sensors, None for static controls.

Closes #XXX
