### PR TITLE
Fix: solar_remaining_kwh excludes tomorrow's forecast

### DIFF
--- a/custom_components/localshift/computation_engine_lib/price_calculator.py
+++ b/custom_components/localshift/computation_engine_lib/price_calculator.py
@@ -508,12 +508,14 @@ class PriceCalculator:
         # Include tomorrow's forecast when target is tomorrow morning
         all_solcast = [*data.solcast_today, *data.solcast_tomorrow]
 
+        # Compute target datetime (demand window start)
+        target_dt = now_dt.replace(hour=target_hour, minute=0, second=0, microsecond=0)
         for period in all_solcast:
             period_start = self._parse_forecast_dt(period.get("period_start"))
             if period_start is None:
                 continue
             period_start_local = dt_util.as_local(period_start)
-            if period_start_local >= now_dt and period_start_local.hour <= target_hour:
+            if period_start_local >= now_dt and period_start_local < target_dt:
                 solar_kwh_val = float(period.get("pv_estimate", 0))
                 if solar_kwh_val <= 0:
                     continue


### PR DESCRIPTION
## Problem

The  reports an incorrect  attribute that is significantly higher than the actual remaining solar production from the Solcast forecast.

## Evidence

- LocalShift reports: 
- Solcast entity reports: 
- Discrepancy: LocalShift value is **3.7x higher** than Solcast's own remaining forecast

## Root Cause

In , the  function (line 516) uses an incorrect filter:



This compares **only the hour component**, not the full datetime. The function combines today's and tomorrow's forecasts (line 509) and then filters by hour. This erroneously includes tomorrow's early-morning periods (00:00-15:00) when  is the typical demand window start (15:00).

The correct approach, used consistently elsewhere in the codebase (e.g., ), is to compare full datetimes:



## Impact

- Inflated  distorts the weighted average FIT calculation
- May cause suboptimal battery dispatch decisions (system thinks there's more solar remaining than actually exists)
- Could lead to unnecessary grid charging or missed export opportunities

## Fix

Changed the filter condition in  to compute  and use full datetime comparison:



This matches the pattern used in  (lines 318-355).

## Scope

The bug only affects . Other functions that use combined solcast lists (e.g., in , , ) correctly delegate to  and are not affected.

Fixes #563