### PR TITLE
feat: add test branch auto-deployment daemon

### DIFF
--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -17,10 +17,10 @@ if [ "$CHECKOUT_TYPE" != "1" ]; then
     exit 0
 fi
 
-if [ "$NEW_BRANCH" = "main" ]; then
+if [ "$NEW_BRANCH" = "main" ] || [ "$NEW_BRANCH" = "test" ]; then
     echo ""
     echo -e "${RED}==========================================${NC}"
-    echo -e "${RED}WARNING: You are now on the main branch${NC}"
+    echo -e "${RED}WARNING: You are now on the $NEW_BRANCH branch${NC}"
     echo -e "${RED}==========================================${NC}"
     echo ""
     
@@ -28,7 +28,7 @@ if [ "$NEW_BRANCH" = "main" ]; then
     if ! git diff-index --quiet HEAD -- 2>/dev/null; then
         echo -e "${RED}ERROR: Uncommitted changes detected!${NC}"
         echo ""
-        echo "You have uncommitted changes that would be stranded on main."
+        echo "You have uncommitted changes that would be stranded on $NEW_BRANCH."
         echo ""
         echo "Recommended action:"
         echo "  1. Stash changes: git stash push -m 'work in progress'"
@@ -40,7 +40,7 @@ if [ "$NEW_BRANCH" = "main" ]; then
         echo -e "${RED}==========================================${NC}"
         
         # Attempt to go back to previous branch
-        if [ -n "$PREV_BRANCH" ] && [ "$PREV_BRANCH" != "main" ]; then
+        if [ -n "$PREV_BRANCH" ] && [ "$PREV_BRANCH" != "main" ] && [ "$PREV_BRANCH" != "test" ]; then
             echo ""
             echo "Returning to previous branch: $PREV_BRANCH"
             git checkout "$PREV_BRANCH" 2>/dev/null
@@ -48,12 +48,12 @@ if [ "$NEW_BRANCH" = "main" ]; then
         exit 1
     fi
     
-    echo -e "${YELLOW}Direct commits to main are blocked. All changes require a pull request.${NC}"
+    echo -e "${YELLOW}Direct commits to $NEW_BRANCH are blocked. All changes require a pull request.${NC}"
     echo ""
     echo "Recommended workflow:"
     echo "  git worktree add worktrees/issue-{NNN} -b issue/{NNN}"
     echo ""
-    echo "Recent main branch activity:"
+    echo "Recent $NEW_BRANCH branch activity:"
     git log --oneline -3 --decorate 2>/dev/null | sed 's/^/  /'
     echo ""
     echo -e "${GREEN}Tip: Create a worktree to continue working${NC}"

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -4,12 +4,12 @@
 
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
-if [ "$BRANCH" = "main" ]; then
+if [ "$BRANCH" = "main" ] || [ "$BRANCH" = "test" ]; then
     echo "=========================================="
-    echo "ERROR: Direct commits to 'main' are blocked!"
+    echo "ERROR: Direct commits to '$BRANCH' are blocked!"
     echo "=========================================="
     echo ""
-    echo "The main branch is protected. All changes must go through pull requests."
+    echo "The $BRANCH branch is protected. All changes must go through pull requests."
     echo ""
     echo "Correct workflow:"
     echo "  1. Create worktree: git worktree add worktrees/issue-{NNN} -b issue/{NNN}"
@@ -17,13 +17,18 @@ if [ "$BRANCH" = "main" ]; then
     echo "  3. Commit and push from issue branch"
     echo "  4. Create pull request for review"
     echo ""
-    echo "If you accidentally committed on main:"
-    echo "  Run: .githooks/scripts/recover-main.sh"
+    if [ "$BRANCH" = "main" ]; then
+        echo "If you accidentally committed on main:"
+        echo "  Run: .githooks/scripts/recover-main.sh"
+    else
+        echo "If you accidentally committed on test:"
+        echo "  Create a new worktree from main and cherry-pick your changes"
+    fi
     echo ""
     echo "=========================================="
     
     # Log the attempt
-    echo "$(date -Iseconds) - pre-commit blocked commit on main" >> .git-bypass.log
+    echo "$(date -Iseconds) - pre-commit blocked commit on $BRANCH" >> .git-bypass.log
     
     exit 1
 fi

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -11,20 +11,20 @@ URL="$2"
 
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
-if [ "$BRANCH" = "main" ]; then
+if [ "$BRANCH" = "main" ] || [ "$BRANCH" = "test" ]; then
     # Check for emergency override
     if [ "$GIT_EMERGENCY_PUSH" = "1" ]; then
-        echo "$(date -Iseconds) - pre-push EMERGENCY OVERRIDE: push from main to $REMOTE" >> .git-bypass.log
-        echo -e "${YELLOW}WARNING: Emergency push from main branch logged for audit${NC}"
+        echo "$(date -Iseconds) - pre-push EMERGENCY OVERRIDE: push from $BRANCH to $REMOTE" >> .git-bypass.log
+        echo -e "${YELLOW}WARNING: Emergency push from $BRANCH branch logged for audit${NC}"
         exit 0
     fi
     
     echo ""
     echo -e "${RED}==========================================${NC}"
-    echo -e "${RED}ERROR: Pushes from 'main' branch are blocked!${NC}"
+    echo -e "${RED}ERROR: Pushes from '$BRANCH' branch are blocked!${NC}"
     echo -e "${RED}==========================================${NC}"
     echo ""
-    echo "The main branch is protected. Push from feature branches only."
+    echo "The $BRANCH branch is protected. Push from feature branches only."
     echo ""
     echo "Correct workflow:"
     echo "  1. Push your issue branch: git push origin issue/{NNN}"
@@ -32,12 +32,12 @@ if [ "$BRANCH" = "main" ]; then
     echo "  3. Merge via GitHub UI after review"
     echo ""
     echo "Emergency override (logged, audit required):"
-    echo "  GIT_EMERGENCY_PUSH=1 git push origin main"
+    echo "  GIT_EMERGENCY_PUSH=1 git push origin $BRANCH"
     echo ""
     echo -e "${RED}==========================================${NC}"
     
     # Log the attempt
-    echo "$(date -Iseconds) - pre-push blocked push from main to $REMOTE" >> .git-bypass.log
+    echo "$(date -Iseconds) - pre-push blocked push from $BRANCH to $REMOTE" >> .git-bypass.log
     
     exit 1
 fi

--- a/.githooks/prepare-commit-msg
+++ b/.githooks/prepare-commit-msg
@@ -13,10 +13,10 @@ fi
 # Read the commit message
 COMMIT_MSG=$(cat "$COMMIT_MSG_FILE")
 
-# Check if message mentions main branch or merge
-if echo "$COMMIT_MSG" | grep -qiE "(main branch|merge.*main|main.*merge)"; then
+# Check if message mentions main or test branch or merge
+if echo "$COMMIT_MSG" | grep -qiE "(main branch|test branch|merge.*main|main.*merge|merge.*test|test.*merge)"; then
     # Prepend warning comment
-    echo "# WARNING: This commit references main branch - ensure this is via approved PR" > "$COMMIT_MSG_FILE.tmp"
+    echo "# WARNING: This commit references main/test branch - ensure this is via approved PR" > "$COMMIT_MSG_FILE.tmp"
     echo "$COMMIT_MSG" >> "$COMMIT_MSG_FILE.tmp"
     mv "$COMMIT_MSG_FILE.tmp" "$COMMIT_MSG_FILE"
 fi

--- a/.github/workflows/duplicate-check.yml
+++ b/.github/workflows/duplicate-check.yml
@@ -2,7 +2,7 @@ name: Duplicate Code Check
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, test]
 
 jobs:
   check:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,7 +2,7 @@ name: Lint
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, test]
 
 jobs:
   lint:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Test
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, test]
 
 jobs:
   test:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,16 +4,16 @@
 
 # ⚠️ STOP: MANDATORY FIRST ACTION
 
-**You MUST verify you're NOT on the `main` branch before ANY file edit.**
+**You MUST verify you're NOT on the `main` or `test` branches before ANY file edit.**
 
 ## Verification Steps
 
 1. Run: `git branch --show-current`
-2. If output is `"main"`: **STOP HERE**
-   - Create worktree: `git worktree add worktrees/issue-{NNN} -b issue/{NNN}`
+2. If output is `"main"` or `"test"`: **STOP HERE**
+   - Create worktree: `git worktree add worktrees/issue-{NNN} -b issue/{NNN} test`
    - Change directory: `cd worktrees/issue-{NNN}`
    - Then proceed with edits
-3. If output is NOT `"main"`: Proceed with the task
+3. If output is NOT `"main"` and NOT `"test"`: Proceed with the task
 
 ## Why This Matters
 
@@ -42,12 +42,12 @@ LocalShift is a Home Assistant integration for automated Tesla Powerwall battery
 ### Before Starting ANY Task
 
 1. Run `git worktree list` - verify you're in a worktree
-2. Run `git branch --show-current` - must NOT be `main`
-3. If on main, create worktree: `git worktree add worktrees/issue-{NNN} -b issue/{NNN}`
+2. Run `git branch --show-current` - must NOT be `main` or `test`
+3. If on main or test, create worktree: `git worktree add worktrees/issue-{NNN} -b issue/{NNN} test`
 
 ### Emergency Bypass
 
-**Only in emergencies (logged, audit required):** `GIT_EMERGENCY_PUSH=1 git push origin main`
+**Only in emergencies (logged, audit required):** `GIT_EMERGENCY_PUSH=1 git push origin main` or `GIT_EMERGENCY_PUSH=1 git push origin test`
 
 See `.opencode/rules` and `.githooks/README.md` for full workflow.
 
@@ -105,6 +105,37 @@ See `.opencode/rules` and `.githooks/README.md` for full workflow.
 - Async tests: `async def test_*` (pytest-asyncio auto-detects)
 
 ---
+
+## Test Branch Workflow
+
+The development workflow uses two long-lived branches:
+
+- `test`: Integration branch where all changes must be PR'd first. Auto-deploys to a test Home Assistant instance after merges.
+- `main`: Production branch for stable releases. Manual deployment.
+
+### Feature Development
+
+1. Create a feature branch from `test`:
+   ```bash
+   git worktree add worktrees/issue-{NNN} -b issue/{NNN} test
+   cd worktrees/issue-{NNN}
+   ```
+2. Make changes, lint, test, and deploy from the worktree using `./deploy.sh` (ask user). The same HA instance is used for test deployments.
+3. Push your feature branch and open a PR targeting `test`.
+4. After PR merges to `test`, the **test deployment daemon** automatically deploys to HA (within ~30 seconds). Monitor logs to verify.
+5. Once validated in HA, create a PR from `test` → `main`.
+6. After merge to `main`, deploy to production manually with `./deploy.sh --reserve && ./deploy.sh`.
+
+### Test Deployment Daemon
+
+The daemon runs in `worktrees/test-deploy` and synchronizes `origin/test` to the HA instance automatically.
+
+- Start: `./scripts/start-test-deploy.sh`
+- Stop: `./scripts/stop-test-deploy.sh`
+- Status: `./scripts/status-test-deploy.sh`
+- Logs: `tail -f logs/test-deploy.log`
+
+The daemon checks `origin/test` every 30 seconds. On changes, it merges and runs `deploy.sh --force`. Merge conflicts stop the daemon and require manual resolution.
 
 ## Notes
 

--- a/README.md
+++ b/README.md
@@ -282,6 +282,82 @@ If button entities show as "missing or not currently available":
    - Sometimes Home Assistant needs a full restart to register new entities
    - Restart Home Assistant and check again
 
+## Development Workflow with Test Branch
+
+This project uses a two-branch workflow with automated testing and deployment:
+
+- `test` branch: Integration environment - all changes must be PR'd here first. Auto-deploys to a test Home Assistant instance.
+- `main` branch: Production - only merged, stable code. Manual deployment.
+
+### Getting Started
+
+1. **Create a feature branch from `test`**:
+   ```bash
+   git worktree add worktrees/issue-{NNN} -b issue/{NNN} test
+   cd worktrees/issue-{NNN}
+   ```
+   Replace `{NNN}` with your issue number.
+
+2. **Make your changes**, then lint and test:
+   ```bash
+   uv run ruff check custom_components/localshift
+   uv run ruff format --check custom_components/localshift
+   uv run pytest
+   ```
+
+3. **Deploy to test HA** (requires HA_LONG_LIVED_TOKEN):
+   ```bash
+   ./deploy.sh --reserve
+   ./deploy.sh
+   # Check logs: tail -f /homeassistant/home-assistant.log | grep -i localshift
+   ./deploy.sh --release
+   ```
+
+4. **Push and open a PR** with your feature branch as the base and `test` as the target (compare across forks if needed). The CI will automatically run lint, tests, and duplicate checks.
+
+5. **After PR merges to `test`**, the automated test deployment daemon will deploy to the test HA instance within ~30 seconds. Monitor the logs to verify.
+
+6. **Validate** the changes in the test HA instance. If everything works, create a PR from `test` → `main`.
+
+7. **After merge to `main`**, deploy to production manually:
+   ```bash
+   ./deploy.sh --reserve
+   ./deploy.sh
+   # Optionally restart: ./deploy.sh --restart
+   ./deploy.sh --release
+   ```
+
+### Test Deployment Daemon
+
+The daemon automatically pulls from `origin/test` and deploys to the test HA instance. It's managed via these scripts:
+
+- **Start**: `./scripts/start-test-deploy.sh`
+- **Stop**: `./scripts/stop-test-deploy.sh`
+- **Status**: `./scripts/status-test-deploy.sh`
+- **Logs**: `tail -f logs/test-deploy.log`
+
+**How it works**:
+
+- The daemon runs in a dedicated worktree at `worktrees/test-deploy`.
+- Every 30 seconds it fetches `origin/test`. If there are new commits, it merges them and runs `deploy.sh --force` to deploy.
+- The `--force` flag bypasses the reservation system since the daemon is the sole test deployer.
+- If a merge conflict occurs, the daemon stops and alerts you to resolve it manually.
+- The daemon uses the `HA_LONG_LIVED_TOKEN`, `HA_URL`, and `HA_CONFIG` environment variables (same as `deploy.sh`).
+
+### Branch Protection
+
+Both `main` and `test` branches are protected:
+- Direct commits are blocked by git hooks.
+- Direct pushes are blocked.
+- All changes must go through pull requests.
+- PRs require CI checks to pass before merging.
+
+### Notes
+
+- You can run `./scripts/status-test-deploy.sh` to see if the daemon is running and view recent logs.
+- If you need to manually trigger a deploy from the test worktree (e.g., after resolving a conflict), run `./deploy.sh --force`.
+- The daemon will automatically resume after a reboot once you run `start-test-deploy.sh`.
+
 ## License
 
 MIT

--- a/docs/TEST_DEPLOYMENT.md
+++ b/docs/TEST_DEPLOYMENT.md
@@ -1,0 +1,161 @@
+# Test Deployment Daemon
+
+This document describes the automated test deployment system for LocalShift.
+
+## Overview
+
+The test deployment daemon monitors the `test` branch for updates and automatically deploys them to the Home Assistant test instance. This allows rapid validation of changes before promoting to production.
+
+## Requirements
+
+- The HA instance must be accessible at `/homeassistant` (or set `HA_CONFIG`).
+- Environment variables `HA_LONG_LIVED_TOKEN`, `HA_URL` (optional, defaults to http://homeassistant:8123) must be set when starting the daemon.
+- The `test` branch must exist and be tracked on `origin`.
+
+## Directory Structure
+
+- `worktrees/test-deploy/` - Dedicated worktree for the daemon (tracking `test` branch)
+- `logs/test-deploy.log` - Daemon output log
+- `run/test-deploy.pid` - PID file for the running daemon
+
+## Starting the Daemon
+
+```bash
+./scripts/start-test-deploy.sh
+```
+
+This script will:
+- Create the `worktrees/test-deploy` worktree if it doesn't exist (from `test` branch)
+- Pull the latest from `origin/test`
+- Start the `run-test-deploy-daemon.sh` process in the background
+- Write its PID to `run/test-deploy.pid`
+
+You can start the daemon from any directory within the repository.
+
+## Stopping the Daemon
+
+```bash
+./scripts/stop-test-deploy.sh
+```
+
+This will:
+- Send SIGTERM to the daemon process (followed by SIGKILL if needed)
+- Remove the PID file
+- Release any HA reservation (just in case)
+
+## Checking Status
+
+```bash
+./scripts/status-test-deploy.sh
+```
+
+Shows:
+- Whether the daemon is running (PID)
+- Worktree location and current branch
+- Latest commit on `test` and `origin/test`
+- Tail of the log file
+
+## How It Works
+
+The daemon (`scripts/run-test-deploy-daemon.sh`) runs an infinite loop:
+
+1. `git fetch origin test` to get updates.
+2. Compare local HEAD with `origin/test`.
+3. If different, attempt `git merge origin/test --no-edit`.
+   - On success, runs `./deploy.sh --no-reload --force` to copy files to HA and reload integration. The `--force` flag bypasses reservation checks.
+   - On failure (merge conflict), logs an error and exits. The daemon stops; you must resolve the conflict manually and restart.
+4. Sleep 30 seconds, repeat.
+
+The daemon runs with `set -euo pipefail` and traps signals for clean exit.
+
+## Environment Variables
+
+The daemon inherits environment from the shell that started it. The `deploy.sh` script uses:
+
+- `HA_CONFIG` - Path to Home Assistant config directory (default: `/homeassistant`)
+- `HA_URL` - Home Assistant API URL (default: `http://homeassistant:8123`)
+- `HA_LONG_LIVED_TOKEN` - Long-lived access token for API calls (required for auto-reload)
+
+Set these before running `start-test-deploy.sh`, e.g.:
+
+```bash
+export HA_LONG_LIVED_TOKEN="your_token_here"
+export HA_URL="http://homeassistant:8123"
+./scripts/start-test-deploy.sh
+```
+
+If the token is not set, `deploy.sh` will skip API reload (you may need to manually restart HA).
+
+## Logs
+
+The daemon writes to `logs/test-deploy.log`. Use `tail -f` to monitor live:
+
+```bash
+tail -f logs/test-deploy.log
+```
+
+Log entries include timestamps and messages about fetch, merge, deployment, errors.
+
+## Manual Deployment from Test Worktree
+
+If you need to manually force a deployment (e.g., after resolving a conflict), you can run directly from the worktree:
+
+```bash
+cd worktrees/test-deploy
+./deploy.sh --force
+```
+
+This bypasses the reservation system and immediately copies the current worktree state to HA.
+
+## Handling Merge Conflicts
+
+If the daemon exits due to a merge conflict, you'll see an error in the logs. To resolve:
+
+1. Stop the daemon if still running: `./scripts/stop-test-deploy.sh`
+2. Enter the worktree: `cd worktrees/test-deploy`
+3. Check status: `git status` - you'll see conflicting files.
+4. Resolve conflicts manually (edit files, `git add`, `git commit`).
+5. Ensure you're on the `test` branch and it's up to date with `origin/test`.
+6. Restart the daemon: `./scripts/start-test-deploy.sh`
+
+The daemon will resume normal operation.
+
+## Troubleshooting
+
+**Daemon not starting?**
+- Check if a stale PID file exists in `run/test-deploy.pid`; delete it.
+- Ensure `git worktree add` works (you have permission, etc.)
+
+**No deployments happening?**
+- Verify the daemon is running: `ps -p $(cat run/test-deploy.pid)`
+- Check that the worktree is on `test` branch: `git -C worktrees/test-deploy branch --show-current`
+- Ensure `origin/test` is set and reachable: `git -C worktrees/test-deploy fetch origin test`
+- Check the log for errors.
+
+**HA not updating?**
+- Confirm `HA_LONG_LIVED_TOKEN` is set and valid.
+- Check HA logs: `tail -f /homeassistant/home-assistant.log | grep -i localshift`
+- Verify the `deploy.sh` script runs without errors manually.
+
+**Daemon died unexpectedly?**
+- Look at `logs/test-deploy.log` for the last messages.
+- Common causes: git fetch failure, merge conflict, deploy error.
+- After fixing, restart with `./scripts/start-test-deploy.sh`.
+
+## Resetting the Daemon
+
+If you need to start fresh:
+
+```bash
+./scripts/stop-test-deploy.sh
+rm -rf worktrees/test-deploy
+./scripts/start-test-deploy.sh
+```
+
+**Caution**: This discards any uncommitted changes in the test-deploy worktree (should be none, but just in case).
+
+## Interaction with CI/CD
+
+- PRs to `test` trigger CI (lint, test, duplicate check).
+- The daemon only deploys after PR merges to `test` (i.e., when `origin/test` advances).
+- There may be a delay of up to 30 seconds from merge to deployment.

--- a/scripts/run-test-deploy-daemon.sh
+++ b/scripts/run-test-deploy-daemon.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+set -euo pipefail
+
+# Run Test Deploy Daemon
+# This script runs in a loop, checking for updates on origin/test and deploying them.
+# Intended to be run in the background by start-test-deploy.sh.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKTREE_DIR="$SCRIPT_DIR/../worktrees/test-deploy"
+cd "$WORKTREE_DIR"
+
+# Ensure we're on test branch
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [ "$CURRENT_BRANCH" != "test" ]; then
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] ERROR: Daemon worktree is on branch '$CURRENT_BRANCH', not 'test'" >&2
+    exit 1
+fi
+
+# Log function
+log() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*"
+}
+
+log "Test deploy daemon started (branch: test)"
+log "Monitoring origin/test for changes"
+log "Worktree: $WORKTREE_DIR"
+
+# Main loop
+while true; do
+    # Fetch updates from origin
+    if git fetch origin test >/dev/null 2>&1; then
+        LOCAL=$(git rev-parse @)
+        REMOTE=$(git rev-parse origin/test 2>/dev/null || echo "")
+        
+        if [ -n "$REMOTE" ] && [ "$LOCAL" != "$REMOTE" ]; then
+            log "Changes detected on origin/test"
+            log "Local:  $LOCAL"
+            log "Remote: $REMOTE"
+            log "Merging..."
+            
+            if git merge origin/test --no-edit; then
+                log "Merge successful, deploying..."
+                ./deploy.sh --no-reload --force
+                log "Deployment complete"
+            else
+                log "MERGE FAILED! Manual intervention required."
+                log "Resolve conflicts in $WORKTREE_DIR, then restart daemon."
+                exit 1
+            fi
+        fi
+    else
+        log "WARNING: git fetch failed"
+    fi
+    
+    sleep 30
+done

--- a/scripts/start-test-deploy.sh
+++ b/scripts/start-test-deploy.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+set -euo pipefail
+
+# Start Test Deploy Daemon
+# Creates worktree if needed and starts the background daemon that auto-deploys from test branch.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$SCRIPT_DIR"
+WORKTREE_DIR="$REPO_ROOT/worktrees/test-deploy"
+PID_FILE="$REPO_ROOT/run/test-deploy.pid"
+LOG_FILE="$REPO_ROOT/logs/test-deploy.log"
+
+# Ensure run and logs directories exist
+mkdir -p "$REPO_ROOT/run" "$REPO_ROOT/logs"
+
+# Check if already running
+if [ -f "$PID_FILE" ]; then
+    OLD_PID=$(cat "$PID_FILE")
+    if ps -p "$OLD_PID" > /dev/null 2>&1; then
+        echo "Daemon already running (PID $OLD_PID)"
+        exit 0
+    else
+        echo "Stale PID file found, removing"
+        rm -f "$PID_FILE"
+    fi
+fi
+
+# Ensure worktree exists
+if [ ! -d "$WORKTREE_DIR" ]; then
+    echo "Creating worktree at $WORKTREE_DIR"
+    git worktree add "$WORKTREE_DIR" test
+fi
+
+# Enter worktree and ensure on test branch, then pull latest
+cd "$WORKTREE_DIR"
+git checkout test >/dev/null 2>&1
+git fetch origin test >/dev/null 2>&1
+git pull origin test >/dev/null 2>&1
+
+# Start daemon
+echo "Starting test deploy daemon..."
+cd "$WORKTREE_DIR"
+nohup ./scripts/run-test-deploy-daemon.sh >> "$LOG_FILE" 2>&1 &
+DAEMON_PID=$!
+echo $DAEMON_PID > "$PID_FILE"
+echo "Daemon started (PID $DAEMON_PID)"
+echo "Log file: $LOG_FILE"
+echo ""
+echo "To monitor: tail -f $LOG_FILE"
+echo "To stop:   $REPO_ROOT/scripts/stop-test-deploy.sh"

--- a/scripts/status-test-deploy.sh
+++ b/scripts/status-test-deploy.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -euo pipefail
+
+# Status of Test Deploy Daemon
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$SCRIPT_DIR"
+PID_FILE="$REPO_ROOT/run/test-deploy.pid"
+LOG_FILE="$REPO_ROOT/logs/test-deploy.log"
+WORKTREE_DIR="$REPO_ROOT/worktrees/test-deploy"
+
+echo "=== Test Deploy Daemon Status ==="
+echo ""
+
+if [ -f "$PID_FILE" ]; then
+    PID=$(cat "$PID_FILE")
+    if ps -p "$PID" > /dev/null 2>&1; then
+        echo "Status: RUNNING (PID $PID)"
+    else
+        echo "Status: STOPPED (stale PID file)"
+    fi
+else
+    echo "Status: STOPPED"
+fi
+
+echo ""
+if [ -d "$WORKTREE_DIR" ]; then
+    echo "Worktree: $WORKTREE_DIR"
+    cd "$WORKTREE_DIR"
+    BRANCH=$(git rev-parse --abbrev-ref HEAD)
+    COMMIT=$(git log -1 --oneline)
+    echo "Branch: $BRANCH"
+    echo "Latest: $COMMIT"
+    echo "Origin/test:"
+    git log -1 --oneline origin/test 2>/dev/null || echo "  (unavailable)"
+else
+    echo "Worktree: NOT FOUND"
+fi
+
+echo ""
+echo "Log file: $LOG_FILE"
+if [ -f "$LOG_FILE" ]; then
+    echo "--- Last 10 lines ---"
+    tail -n 10 "$LOG_FILE"
+else
+    echo "Log file not created yet"
+fi

--- a/scripts/stop-test-deploy.sh
+++ b/scripts/stop-test-deploy.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -euo pipefail
+
+# Stop Test Deploy Daemon
+# Kills the background daemon and releases any HA reservation.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$SCRIPT_DIR"
+PID_FILE="$REPO_ROOT/run/test-deploy.pid"
+WORKTREE_DIR="$REPO_ROOT/worktrees/test-deploy"
+
+if [ -f "$PID_FILE" ]; then
+    PID=$(cat "$PID_FILE")
+    echo "Stopping daemon (PID $PID)..."
+    kill "$PID" 2>/dev/null || true
+    # Wait a bit
+    sleep 2
+    if ps -p "$PID" > /dev/null 2>&1; then
+        echo "Daemon still running, forcing kill..."
+        kill -9 "$PID" 2>/dev/null || true
+    fi
+    rm -f "$PID_FILE"
+    echo "Daemon stopped"
+else
+    echo "No PID file - daemon may not be running"
+fi
+
+# Release reservation if any (just in case)
+if [ -d "$WORKTREE_DIR" ]; then
+    echo "Releasing any HA reservation..."
+    (cd "$WORKTREE_DIR" && ./deploy.sh --release > /dev/null 2>&1 || true)
+    echo "Reservation released (if any)"
+fi


### PR DESCRIPTION
This implements a persistent 'test' branch with auto-deployment.

Key changes:
- Git hooks protect both main and test branches
- CI runs on PRs to main or test
- Daemon scripts (start/stop/status) for auto-deployment
- Documentation updates (README, AGENTS, TEST_DEPLOYMENT.md)

After merge to test, the daemon will auto-deploy to HA.

Closes #<issue_number>