### PR TITLE
fix: disable SOC-based mode exit to respect optimizer control

### DIFF
--- a/custom_components/localshift/state_machine.py
+++ b/custom_components/localshift/state_machine.py
@@ -399,23 +399,16 @@ class StateMachine:
         ):
             return False
 
+        # SOC target reached, but we respect optimizer control.
+        # Hardware will naturally stop charging when backup reserve is reached.
+        # Do not transition; let the optimizer decide when to change modes.
         _LOGGER.info(
-            "SOC %.1f%% reached battery target %.0f%% — stopping %s, transitioning to SELF_CONSUMPTION",
+            "SOC %.1f%% reached battery target %.0f%% but remaining in %s (optimizer control)",
             data.soc,
             battery_target,
             self._commanded_mode.value,
         )
-        transition_success = await self._execute_mode_transition(
-            data, BatteryMode.SELF_CONSUMPTION
-        )
-        if transition_success:
-            old_mode = self._commanded_mode
-            self._commanded_mode = BatteryMode.SELF_CONSUMPTION
-            self._mode_desired_since.clear()
-            await self._notification_service.send_transition_notification(
-                old_mode, BatteryMode.SELF_CONSUMPTION, data
-            )
-        return True
+        return False
 
     def _should_defer_for_minimum_duration(
         self, desired: BatteryMode, now: datetime


### PR DESCRIPTION
**Problem**: The state machine was autonomously transitioning from GRID_CHARGING/BOOST_CHARGING to SELF_CONSUMPTION when the battery reached its target SOC, causing rapid cycling independent of the optimizer's price-based decisions.

**Root Cause**: SOC monitoring in  triggered transitions even when the optimizer still wanted the battery in charging mode. The minimum duration guard (5 min) did not apply to SOC-triggered transitions.

**Solution**: Replace SOC-triggered transition with informational log only. The battery now remains in the commanded mode until the optimizer changes its decision based on amber price data. Hardware naturally stops charging when backup reserve is reached, so no safety is lost.

**Changes**:
- Modified  to return  instead of executing transition
- Updated log message to reflect optimizer control philosophy

**Testing**: All 58 state machine tests pass. Lint passes.

Ready for review.