### PR TITLE
fix: differentiate HOLD mapping based on hold_soc flag (Issue #559 regression)

### DIFF
--- a/custom_components/localshift/computation_engine_lib/optimizer_runner.py
+++ b/custom_components/localshift/computation_engine_lib/optimizer_runner.py
@@ -792,11 +792,21 @@ def _derive_runtime_apply_plan(
 
     # Map PlannerAction string to BatteryMode
     if action_str == "hold":
+        # Issue: HOLD overloading - distinguish between strict SOC preservation
+        # (during demand window) vs default self-consumption behavior
+        battery_mode = (
+            BatteryMode.HOLD.value
+            if config.hold_soc
+            else BatteryMode.SELF_CONSUMPTION.value
+        )
+        reason = (
+            "optimizer_hold_strict" if config.hold_soc else "optimizer_self_consumption"
+        )
         return {
             "action": action_str,
-            "battery_mode": BatteryMode.HOLD.value,
+            "battery_mode": battery_mode,
             "target_soc": None,
-            "reason": "optimizer_hold",
+            "reason": reason,
         }
 
     if action_str == "charge_grid_normal":

--- a/tests/test_optimizer_active_mode.py
+++ b/tests/test_optimizer_active_mode.py
@@ -163,7 +163,11 @@ class TestApplyPathMapping:
     """Tests for _derive_runtime_apply_plan mapping."""
 
     def test_hold_maps_to_hold_mode(self):
-        """HOLD action should map to HOLD mode (Issue #522)."""
+        """HOLD action should map to SELF_CONSUMPTION when hold_soc is False.
+
+        The HOLD action is now differentiated based on hold_soc flag.
+        See issue #559 / #591.
+        """
         config = OptimizerConfig(demand_window_target_soc_pct=80.0)
         decisions = [
             {
@@ -176,7 +180,7 @@ class TestApplyPathMapping:
 
         result = _derive_runtime_apply_plan(decisions, 0, config)
 
-        assert result["battery_mode"] == "hold"
+        assert result["battery_mode"] == "self_consumption"
         assert "fallback_to_legacy" not in result
 
     def test_charge_grid_normal_maps_to_grid_charging(self):

--- a/tests/test_optimizer_runner.py
+++ b/tests/test_optimizer_runner.py
@@ -1,0 +1,113 @@
+"""Tests for _derive_runtime_apply_plan mapping PlannerAction to BatteryMode.
+
+This tests the fix for the HOLD overloading issue where HOLD was always mapped
+to BatteryMode.HOLD, causing overnight grid imports instead of battery discharge.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from custom_components.localshift.computation_engine_lib.optimizer_dp import (
+    OptimizerConfig,
+)
+from custom_components.localshift.computation_engine_lib.optimizer_runner import (
+    _derive_runtime_apply_plan,
+)
+from custom_components.localshift.const import BatteryMode
+
+
+class TestDeriveRuntimeApplyPlan:
+    """Test cases for _derive_runtime_apply_plan action-to-mode mapping."""
+
+    def test_hold_maps_to_self_consumption_when_hold_soc_false(self):
+        """HOLD action should map to SELF_CONSUMPTION when hold_soc is False."""
+        config = OptimizerConfig(hold_soc=False)
+        decisions = [{"action": "hold"}]
+
+        result = _derive_runtime_apply_plan(decisions, 0, config)
+
+        assert result["action"] == "hold"
+        assert result["battery_mode"] == BatteryMode.SELF_CONSUMPTION.value
+        assert result["reason"] == "optimizer_self_consumption"
+
+    def test_hold_maps_to_hold_when_hold_soc_true(self):
+        """HOLD action should map to HOLD when hold_soc is True (strict preserve)."""
+        config = OptimizerConfig(hold_soc=True)
+        decisions = [{"action": "hold"}]
+
+        result = _derive_runtime_apply_plan(decisions, 0, config)
+
+        assert result["action"] == "hold"
+        assert result["battery_mode"] == BatteryMode.HOLD.value
+        assert result["reason"] == "optimizer_hold_strict"
+
+    def test_charge_grid_normal_maps_correctly(self):
+        """CHARGE_GRID_NORMAL should map to GRID_CHARGING with target_soc."""
+        config = OptimizerConfig(demand_window_target_soc_pct=80.0)
+        decisions = [{"action": "charge_grid_normal"}]
+
+        result = _derive_runtime_apply_plan(decisions, 0, config)
+
+        assert result["action"] == "charge_grid_normal"
+        assert result["battery_mode"] == BatteryMode.GRID_CHARGING.value
+        assert result["target_soc"] == 80.0
+        assert result["reason"] == "optimizer_charge_grid_normal"
+
+    def test_charge_grid_boost_maps_correctly(self):
+        """CHARGE_GRID_BOOST should map to BOOST_CHARGING with target_soc."""
+        config = OptimizerConfig(demand_window_target_soc_pct=95.0)
+        decisions = [{"action": "charge_grid_boost"}]
+
+        result = _derive_runtime_apply_plan(decisions, 0, config)
+
+        assert result["action"] == "charge_grid_boost"
+        assert result["battery_mode"] == BatteryMode.BOOST_CHARGING.value
+        assert result["target_soc"] == 95.0
+        assert result["reason"] == "optimizer_charge_grid_boost"
+
+    def test_export_proactive_maps_correctly(self):
+        """EXPORT_PROACTIVE should map to PROACTIVE_EXPORT."""
+        config = OptimizerConfig()
+        decisions = [{"action": "export_proactive"}]
+
+        result = _derive_runtime_apply_plan(decisions, 0, config)
+
+        assert result["action"] == "export_proactive"
+        assert result["battery_mode"] == BatteryMode.PROACTIVE_EXPORT.value
+        assert result["target_soc"] is None
+        assert result["reason"] == "optimizer_export_proactive"
+
+    def test_invalid_slot_index_returns_self_consumption(self):
+        """Invalid slot index should default to SELF_CONSUMPTION."""
+        config = OptimizerConfig(hold_soc=True)  # Even with hold_soc=True
+        decisions = [{"action": "hold"}]
+
+        result = _derive_runtime_apply_plan(decisions, -1, config)
+
+        assert result["action"] == "hold"
+        assert result["battery_mode"] == BatteryMode.SELF_CONSUMPTION.value
+        assert result["reason"] == "no_valid_decision_for_current_slot"
+
+    def test_empty_decisions_returns_self_consumption(self):
+        """Empty decisions list should default to SELF_CONSUMPTION."""
+        config = OptimizerConfig(hold_soc=True)
+        decisions = []
+
+        result = _derive_runtime_apply_plan(decisions, 0, config)
+
+        assert result["action"] == "hold"
+        assert result["battery_mode"] == BatteryMode.SELF_CONSUMPTION.value
+        assert result["reason"] == "no_valid_decision_for_current_slot"
+
+    def test_unknown_action_returns_self_consumption(self):
+        """Unknown action should default to SELF_CONSUMPTION."""
+        config = OptimizerConfig()
+        decisions = [{"action": "unknown_action"}]
+
+        result = _derive_runtime_apply_plan(decisions, 0, config)
+
+        assert result["action"] == "unknown_action"
+        assert result["battery_mode"] == BatteryMode.SELF_CONSUMPTION.value
+        assert result["target_soc"] is None
+        assert result["reason"] == "unknown_action_unknown_action"


### PR DESCRIPTION
## Summary

Fixes the HOLD action overloading regression introduced in #559 where battery remained in HOLD mode overnight, causing wasteful grid imports instead of discharging to meet household load.

## Root Cause

The DP planner only outputs  for all non-charging, non-exporting slots. A previous change mapped all HOLD actions to , which preserves SOC (backup reserve = 100%) rather than allowing discharge. This mapping should only apply when  (during demand window), but was applied globally.

## Changes

- **optimizer_runner.py**: Update  to map HOLD to:
  -  when  (default self-consumption behavior)
  -  when  (strict SOC preservation)
- Add unit tests in  covering both mappings
- Update  to reflect new behavior

## Expected Behavior

- During demand window (or when hold_soc=True): Battery SOC is preserved, grid powers household load.
- Outside demand window (or when hold_soc=False): Battery discharges to meet load (self-consumption), avoiding grid imports.

## Testing

- All 622 tests pass
- 8 new unit tests verify the mapping logic
- No lint or format issues

## Related Issues

- Regression from commit 4766144 (Issue #522: Add HOLD mode)
- Related to Issue #559 (Pointless overnight battery cycles)
- Does not affect Issue #591 (solar_remaining_kwh sensor display fix)

Closes #NNN