### PR TITLE
Fix TDD hook to support tests in subdirectories

### DIFF
--- a/.githooks/scripts/check-tdd.sh
+++ b/.githooks/scripts/check-tdd.sh
@@ -6,6 +6,36 @@ set -e
 
 echo "🔍 Checking TDD compliance..."
 
+# Function to find test file for a given source file
+# Returns the path to the test file if found, or empty string if not found
+find_test_file() {
+    local SOURCE_FILE="$1"
+    local MODULE_NAME=$(basename "$SOURCE_FILE" .py)
+    
+    # Pattern 1: Flat test structure (most common)
+    # custom_components/localshift/module.py -> tests/test_module.py
+    local TEST_FLAT="tests/test_${MODULE_NAME}.py"
+    if [ -f "$TEST_FLAT" ]; then
+        echo "$TEST_FLAT"
+        return 0
+    fi
+    
+    # Pattern 2: Subdirectory-preserving test structure
+    # custom_components/localshift/subdir/module.py -> tests/subdir/test_module.py
+    local REL_PATH=$(echo "$SOURCE_FILE" | sed 's|custom_components/localshift/||')
+    if [[ "$REL_PATH" == *"/"* ]]; then
+        local SUBDIR=$(dirname "$REL_PATH")
+        local TEST_SUBDIR="tests/${SUBDIR}/test_${MODULE_NAME}.py"
+        if [ -f "$TEST_SUBDIR" ]; then
+            echo "$TEST_SUBDIR"
+            return 0
+        fi
+    fi
+    
+    # No test file found
+    return 1
+}
+
 # Get list of staged Python files in custom_components/localshift/
 STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep '^custom_components/localshift/.*\.py$' || true)
 
@@ -17,6 +47,9 @@ fi
 # Check if any are exception files (docs, config, etc.)
 CHANGES_REQUIRE_TESTS=false
 
+# Array to collect test file paths
+declare -a TEST_FILE_PATHS
+
 for FILE in $STAGED_FILES; do
     # Skip __init__.py, manifest.json, etc.
     if [[ "$FILE" == *"__init__.py" ]] || [[ "$FILE" == *"manifest.json" ]]; then
@@ -26,19 +59,25 @@ for FILE in $STAGED_FILES; do
     # This file requires tests
     CHANGES_REQUIRE_TESTS=true
     
-    # Extract module name
-    MODULE_NAME=$(basename "$FILE" .py)
+    # Find the test file using our function
+    TEST_FILE=$(find_test_file "$FILE")
     
-    # Check if corresponding test file exists
-    TEST_FILE="tests/test_${MODULE_NAME}.py"
-    
-    if [ ! -f "$TEST_FILE" ]; then
+    if [ -z "$TEST_FILE" ]; then
         echo "❌ ERROR: No test file found for $FILE"
         echo ""
-        echo "Expected test file: $TEST_FILE"
+        echo "Searched locations:"
+        echo "  - tests/test_$(basename "$FILE" .py).py"
+        
+        # Check if file is in subdirectory
+        REL_PATH=$(echo "$FILE" | sed 's|custom_components/localshift/||')
+        if [[ "$REL_PATH" == *"/"* ]]; then
+            SUBDIR=$(dirname "$REL_PATH")
+            echo "  - tests/${SUBDIR}/test_$(basename "$FILE" .py).py"
+        fi
+        
         echo ""
         echo "TDD Workflow:"
-        echo "  1. Create: $TEST_FILE"
+        echo "  1. Create a test file at one of the above locations"
         echo "  2. Write failing test (RED phase)"
         echo "  3. Then commit"
         echo ""
@@ -47,6 +86,7 @@ for FILE in $STAGED_FILES; do
     fi
     
     echo "✅ Test file exists: $TEST_FILE"
+    TEST_FILE_PATHS+=("$TEST_FILE")
 done
 
 if [ "$CHANGES_REQUIRE_TESTS" = false ]; then
@@ -58,16 +98,8 @@ fi
 echo ""
 echo "🔍 Running tests for modified files..."
 
-# Extract test file paths
-TEST_FILES=$(echo "$STAGED_FILES" | sed 's|custom_components/localshift/\(.*\)\.py|tests/test_\1.py|' | xargs)
-
-# Check if test files exist before running
-for TEST_FILE in $TEST_FILES; do
-    if [ ! -f "$TEST_FILE" ]; then
-        # Already checked above, but double-check
-        continue
-    fi
-done
+# Convert array to space-separated string
+TEST_FILES="${TEST_FILE_PATHS[*]}"
 
 # Run the tests
 if ! uv run pytest $TEST_FILES -v --tb=short 2>&1; then


### PR DESCRIPTION
## Summary
Fixes the TDD pre-commit hook to correctly identify test files for source code in subdirectories.

## Problem
The TDD hook was using a sed pattern that incorrectly derived test file paths for subdirectory modules:
- Source: `custom_components/localshift/computation_engine_lib/optimizer_runner.py`
- Expected: `tests/computation_engine_lib/test_optimizer_runner.py`
- Actual: `tests/test_computation_engine_lib/optimizer_runner.py` (wrong!)

This forced use of `--no-verify` workaround and violated TDD enforcement.

## Solution
- Added `find_test_file()` function that checks both patterns:
  1. Flat: `tests/test_<module>.py` (most common)
  2. Subdirectory: `tests/<subdir>/test_<module>.py`
- Improved error messages to show both searched locations
- Fixed the sed pattern bug

## Testing
✅ Tested with:
- Root level files (e.g., `state_machine.py`)
- Subdirectory files with flat tests (e.g., `parameter_optimizer.py`)
- Subdirectory files with subdirectory tests (e.g., `optimizer_runner.py`)
- Files without tests (correctly rejected)

## Related
Fixes #597