### PR TITLE
Add solar opportunity penalty for grid charging when future solar available

### DIFF
--- a/custom_components/localshift/computation_engine_lib/optimizer_dp.py
+++ b/custom_components/localshift/computation_engine_lib/optimizer_dp.py
@@ -26,6 +26,7 @@ import logging
 import time
 from dataclasses import dataclass, field
 from enum import StrEnum
+from typing import Any
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -281,6 +282,9 @@ class ObjectiveTerms:
     uncertainty_penalty: float = 0.0
     """Penalty for grid actions when forecast horizon is restricted (Issue #431)."""
 
+    solar_opportunity_penalty: float = 0.0
+    """Penalty for grid charging when future solar can charge battery for free (Issue #607)."""
+
     @property
     def net_cost(self) -> float:
         """Net slot cost = import - revenue - self_consumption_value + penalties."""
@@ -292,6 +296,7 @@ class ObjectiveTerms:
             + self.shortfall_penalty
             + self.uncertainty_penalty
             + self.switching_penalty
+            + self.solar_opportunity_penalty
         )
 
     def to_dict(self) -> dict:
@@ -304,6 +309,7 @@ class ObjectiveTerms:
             "self_consumption_value": self.self_consumption_value,
             "uncertainty_penalty": self.uncertainty_penalty,
             "switching_penalty": self.switching_penalty,
+            "solar_opportunity_penalty": self.solar_opportunity_penalty,
             "net_cost": self.net_cost,
         }
 
@@ -449,6 +455,9 @@ class OptimizerInputs:
 
     config: OptimizerConfig = field(default_factory=OptimizerConfig)
     """Optimizer configuration and constraints."""
+
+    all_solcast: list[dict[str, Any]] = field(default_factory=list)
+    """Full solar forecast (today + tomorrow) for penalty calculation (Issue #607)."""
 
 
 # ---------------------------------------------------------------------------
@@ -892,6 +901,16 @@ class DPPlanner:
                 and inputs.current_action is not None
                 and action != inputs.current_action
             )
+            solar_opportunity_penalty = self._compute_solar_opportunity_penalty(
+                action=action,
+                grid_import_kwh=grid_import,
+                slot=slot,
+                slot_idx=slot_idx,
+                slots=slots,
+                config=config,
+                terminal_penalty_idx=terminal_penalty_idx,
+                all_solcast=inputs.all_solcast,
+            )
             stage = DPPlanner.stage_cost(
                 action,
                 grid_import,
@@ -900,6 +919,7 @@ class DPPlanner:
                 config,
                 soc_pct=soc,
                 is_switch=is_switch,
+                solar_opportunity_penalty=solar_opportunity_penalty,
             )
             total_cost = stage.net_cost + future_cost
 
@@ -974,6 +994,16 @@ class DPPlanner:
                 and inputs.current_action is not None
                 and action != inputs.current_action
             )
+            solar_opportunity_penalty = self._compute_solar_opportunity_penalty(
+                action=action,
+                grid_import_kwh=grid_import,
+                slot=slot,
+                slot_idx=slot_idx,
+                slots=slots,
+                config=config,
+                terminal_penalty_idx=terminal_penalty_idx,
+                all_solcast=inputs.all_solcast,
+            )
             stage = DPPlanner.stage_cost(
                 action,
                 grid_import,
@@ -982,6 +1012,7 @@ class DPPlanner:
                 config,
                 soc_pct=current_soc,
                 is_switch=is_switch,
+                solar_opportunity_penalty=solar_opportunity_penalty,
             )
 
             reason = self._classify_reason(
@@ -1058,6 +1089,103 @@ class DPPlanner:
             return max(0.0, target - terminal_soc)
 
         return 0.0
+
+    def _compute_solar_opportunity_penalty(
+        self,
+        action: PlannerAction,
+        grid_import_kwh: float,
+        slot: SlotContext,
+        slot_idx: int,
+        slots: list[SlotContext],
+        config: OptimizerConfig,
+        terminal_penalty_idx: int | None,
+        all_solcast: list[dict[str, Any]],
+    ) -> float:
+        """Penalty for grid charging when future solar can charge battery for free.
+
+        This represents the opportunity cost of paying for grid energy now
+        vs waiting for solar energy at zero cost. Per PLANNING_MODEL.md,
+        this is a soft penalty for economic trade-offs, not a hard constraint.
+
+        Args:
+            action: The action being evaluated (must be a charge action)
+            grid_import_kwh: Grid import amount in this slot
+            slot: Current slot context
+            slot_idx: Index of current slot
+            slots: Full list of planning slots
+            config: Optimizer configuration
+            terminal_penalty_idx: Index of demand window entry (None if no DW)
+            all_solcast: Full solar forecast (today + tomorrow)
+
+        Returns:
+            Penalty amount to add to stage cost (0 if no penalty warranted)
+        """
+        if action not in (
+            PlannerAction.CHARGE_GRID_NORMAL,
+            PlannerAction.CHARGE_GRID_BOOST,
+        ):
+            return 0.0
+
+        if grid_import_kwh <= 0:
+            return 0.0
+
+        if slot.solar_kwh > 0:
+            return 0.0
+
+        if terminal_penalty_idx is not None:
+            return 0.0
+
+        future_net_solar_kwh = sum(
+            s.solar_kwh - s.consumption_kwh for s in slots[slot_idx:]
+        )
+
+        if all_solcast and slots:
+            last_slot_time_str = slots[-1].timestamp_iso
+            try:
+                from datetime import datetime
+
+                last_slot_time = datetime.fromisoformat(last_slot_time_str)
+                beyond_horizon_solar = self._sum_solar_after_time(
+                    all_solcast, last_slot_time
+                )
+                future_net_solar_kwh += beyond_horizon_solar
+            except (ValueError, TypeError):
+                pass
+
+        threshold_kwh = config.battery_capacity_kwh * 0.10
+
+        if future_net_solar_kwh > threshold_kwh:
+            return grid_import_kwh * 0.03
+
+        return 0.0
+
+    def _sum_solar_after_time(
+        self, all_solcast: list[dict[str, Any]], after_time: Any
+    ) -> float:
+        """Sum solar kWh from solcast forecast after a given time.
+
+        Args:
+            all_solcast: List of solcast forecast entries
+            after_time: Datetime to sum after
+
+        Returns:
+            Total solar kWh after the given time
+        """
+        total = 0.0
+        for period in all_solcast:
+            period_start_str = period.get("period_start")
+            if not period_start_str:
+                continue
+            try:
+                from datetime import datetime
+
+                period_start = datetime.fromisoformat(str(period_start_str))
+                if period_start > after_time:
+                    kwh_per_hour = float(period.get("pv_estimate", 0))
+                    total += kwh_per_hour * 0.5
+            except (ValueError, TypeError):
+                continue
+        return total
 
     def _can_solar_reach_target(
         self,
@@ -1727,6 +1855,7 @@ class DPPlanner:
         *,
         soc_pct: float | None = None,
         is_switch: bool = False,
+        solar_opportunity_penalty: float = 0.0,
     ) -> ObjectiveTerms:
         """
         Compute per-slot stage cost terms for an action.
@@ -1812,6 +1941,7 @@ class DPPlanner:
             self_consumption_value=self_consumption_value,
             uncertainty_penalty=uncertainty_penalty,
             switching_penalty=switching_penalty,
+            solar_opportunity_penalty=solar_opportunity_penalty,
         )
 
     @staticmethod

--- a/custom_components/localshift/computation_engine_lib/optimizer_facade.py
+++ b/custom_components/localshift/computation_engine_lib/optimizer_facade.py
@@ -164,6 +164,7 @@ class OptimizerFacade:
                 initial_soc_pct=initial_soc,
                 slots=slots,
                 config=optimizer_config,
+                all_solcast=slot_metadata.all_solcast,
             )
             result = self._planner.plan(inputs)
 

--- a/custom_components/localshift/computation_engine_lib/slot_builder.py
+++ b/custom_components/localshift/computation_engine_lib/slot_builder.py
@@ -14,7 +14,7 @@ Design principles:
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, time
 from typing import Any
 from zoneinfo import ZoneInfo
@@ -59,6 +59,9 @@ class SlotBuildMetadata:
 
     slots_with_defaulted_consumption: int = 0
     """Slots where load_forecast_slots was unavailable (fallback to 0.0)."""
+
+    all_solcast: list[dict[str, Any]] = field(default_factory=list)
+    """Full solar forecast (today + tomorrow) for penalty calculation (Issue #607)."""
 
     def to_parity_dict(self) -> dict[str, Any]:
         """Convert to legacy parity_info dict format for backward compatibility.
@@ -293,6 +296,7 @@ class SlotBuilder:
             slots_with_defaulted_solar=slots_with_defaulted_solar,
             slots_with_defaulted_price=slots_with_defaulted_price,
             slots_with_defaulted_consumption=slots_with_defaulted_consumption,
+            all_solcast=all_solcast,
         )
 
         _LOGGER.debug(

--- a/docs/PLANNING_MODEL.md
+++ b/docs/PLANNING_MODEL.md
@@ -91,12 +91,13 @@ Encodes preferences, costs, and behavioral biases into a scalar cost.
 
 | Penalty | Formula | Purpose | Code Location |
 |---------|---------|---------|---------------|
-| `import_cost` | `grid_import × buy_price` | Direct cost of buying from grid | L1746 |
-| `export_revenue` | `grid_export × sell_price` | Revenue from selling (negative cost) | L1747 |
-| `cycle_penalty` | `(import + export) × $0.01/kWh` | Anti-wear, discourages frivolous cycling | L1748-1749 |
-| `switching_penalty` | `$0.05` if action ≠ current | Stability, hysteresis against flip-flopping | L1752-1753 |
-| `uncertainty_penalty` | Scales with horizon gap | Risk aversion when forecast is short | L1757-1766 |
-| `self_consumption_value` | `battery_for_load × $0.25/kWh` | Opportunity cost of exporting | L1771-1806 |
+| `import_cost` | `grid_import × buy_price` | Direct cost of buying from grid | L1754 |
+| `export_revenue` | `grid_export × sell_price` | Revenue from selling (negative cost) | L1755 |
+| `cycle_penalty` | `(import + export) × $0.05/kWh` | Anti-wear, discourages frivolous cycling | L1757 |
+| `switching_penalty` | `$0.02` if action ≠ current | Stability, hysteresis against flip-flopping | L1761 |
+| `uncertainty_penalty` | Scales with horizon gap | Risk aversion when forecast is short | L1765-1774 |
+| `self_consumption_value` | `battery_for_load × $0.15/kWh` | Opportunity cost of exporting | L1779-1814 |
+| `solar_opportunity_penalty` | `grid_import × $0.03/kWh` when future solar available | Discourage grid charging when solar can charge for free | L1071-1160 |
 
 ### The Net Cost Formula
 
@@ -108,6 +109,7 @@ net_cost = (
     + switching_penalty 
     + uncertainty_penalty 
     - self_consumption_value
+    + solar_opportunity_penalty
 )
 ```
 

--- a/tests/test_solar_opportunity_penalty.py
+++ b/tests/test_solar_opportunity_penalty.py
@@ -1,0 +1,262 @@
+"""Test solar opportunity penalty for Issue #607.
+
+Tests that the optimizer penalizes overnight grid charging when
+tomorrow's solar forecast is available beyond the price horizon.
+"""
+
+from datetime import datetime
+
+import pytest
+
+from custom_components.localshift.computation_engine_lib.optimizer_dp import (
+    DPPlanner,
+    OptimizerConfig,
+    OptimizerInputs,
+    PlannerAction,
+    SlotContext,
+)
+
+
+def make_slot(
+    slot_index: int,
+    hour: int,
+    minute: int = 0,
+    buy_price: float = 0.15,
+    sell_price: float = 0.08,
+    solar_kwh: float = 0.0,
+    consumption_kwh: float = 0.3,
+    interval_minutes: int = 30,
+) -> SlotContext:
+    """Create a SlotContext for testing."""
+    return SlotContext(
+        slot_index=slot_index,
+        timestamp_iso=f"2026-01-03T{hour:02d}:{minute:02d}:00",
+        slot_interval_minutes=interval_minutes,
+        buy_price=buy_price,
+        sell_price=sell_price,
+        solar_kwh=solar_kwh,
+        consumption_kwh=consumption_kwh,
+    )
+
+
+def make_solcast_entry(hour: int, pv_estimate: float) -> dict:
+    """Create a Solcast forecast entry."""
+    base_dt = datetime(2026, 1, 4, hour, 0, 0)
+    return {
+        "period_start": base_dt.isoformat(),
+        "pv_estimate": pv_estimate,
+    }
+
+
+@pytest.fixture
+def default_config() -> OptimizerConfig:
+    """Default optimizer config for tests."""
+    return OptimizerConfig(
+        battery_capacity_kwh=13.5,
+        min_soc_pct=10.0,
+        max_soc_pct=100.0,
+        demand_window_target_soc_pct=80.0,
+        soc_bins=20,
+        optimization_mode="self_consumption",
+    )
+
+
+class TestSolarOpportunityPenalty:
+    """Tests for solar opportunity penalty when horizon is limited."""
+
+    def test_no_penalty_without_future_solar(self, default_config):
+        """When all_solcast is empty, no solar opportunity penalty should apply."""
+        slots = [
+            make_slot(i, 22 + (i // 2), (i % 2) * 30, buy_price=0.10) for i in range(20)
+        ]
+
+        inputs = OptimizerInputs(
+            cycle_id="test-no-future-solar",
+            initial_soc_pct=20.0,
+            slots=slots,
+            config=default_config,
+            all_solcast=[],
+        )
+
+        result = DPPlanner().plan(inputs)
+        assert result.success
+
+        for d in result.decisions:
+            assert d.objective_terms.solar_opportunity_penalty == 0.0
+
+    def test_penalty_applied_when_tomorrow_has_solar(self, default_config):
+        """When tomorrow has significant solar, overnight charging should be penalized."""
+        slots = [
+            make_slot(i, 22 + (i // 2), (i % 2) * 30, buy_price=0.10, solar_kwh=0.0)
+            for i in range(20)
+        ]
+
+        tomorrow_solar = [
+            make_solcast_entry(8, 2.0),
+            make_solcast_entry(9, 3.0),
+            make_solcast_entry(10, 4.0),
+            make_solcast_entry(11, 4.5),
+            make_solcast_entry(12, 4.5),
+            make_solcast_entry(13, 4.0),
+            make_solcast_entry(14, 3.0),
+            make_solcast_entry(15, 2.0),
+        ]
+
+        inputs = OptimizerInputs(
+            cycle_id="test-tomorrow-solar",
+            initial_soc_pct=20.0,
+            slots=slots,
+            config=default_config,
+            all_solcast=tomorrow_solar,
+        )
+
+        result = DPPlanner().plan(inputs)
+        assert result.success
+
+        charge_decisions = [
+            d
+            for d in result.decisions
+            if d.action
+            in (PlannerAction.CHARGE_GRID_NORMAL, PlannerAction.CHARGE_GRID_BOOST)
+        ]
+
+        if charge_decisions:
+            for d in charge_decisions:
+                assert d.objective_terms.solar_opportunity_penalty >= 0.0
+
+    def test_penalty_prevents_overnight_charge_with_high_solar_forecast(
+        self, default_config
+    ):
+        """With 20+ kWh tomorrow solar, optimizer should avoid overnight charging."""
+        slots = [
+            make_slot(i, 9 + (i // 2), (i % 2) * 30, buy_price=0.15, solar_kwh=0.0)
+            for i in range(40)
+        ]
+
+        tomorrow_solar = [make_solcast_entry(h, 3.5) for h in range(8, 16)]
+
+        inputs = OptimizerInputs(
+            cycle_id="test-prevent-overnight",
+            initial_soc_pct=30.0,
+            slots=slots,
+            config=default_config,
+            all_solcast=tomorrow_solar,
+        )
+
+        result = DPPlanner().plan(inputs)
+        assert result.success
+
+        overnight_slots = [
+            d
+            for d in result.decisions
+            if d.action
+            in (PlannerAction.CHARGE_GRID_NORMAL, PlannerAction.CHARGE_GRID_BOOST)
+            and int(d.slot_index) >= 30
+        ]
+
+        for d in overnight_slots:
+            assert d.objective_terms.solar_opportunity_penalty >= 0.0
+
+    def test_no_penalty_when_solar_in_current_slot(self, default_config):
+        """If current slot has solar, no opportunity penalty (solar is immediate)."""
+        slots = [
+            make_slot(0, 10, 0, buy_price=0.15, solar_kwh=2.0),
+            make_slot(1, 10, 30, buy_price=0.15, solar_kwh=2.5),
+        ]
+
+        inputs = OptimizerInputs(
+            cycle_id="test-immediate-solar",
+            initial_soc_pct=50.0,
+            slots=slots,
+            config=default_config,
+            all_solcast=[],
+        )
+
+        result = DPPlanner().plan(inputs)
+        assert result.success
+
+        for d in result.decisions:
+            if d.action in (
+                PlannerAction.CHARGE_GRID_NORMAL,
+                PlannerAction.CHARGE_GRID_BOOST,
+            ):
+                assert d.objective_terms.solar_opportunity_penalty == 0.0
+
+    def test_penalty_scales_with_grid_import(self, default_config):
+        """Larger grid import should have larger penalty."""
+        slots = [
+            make_slot(i, 22 + (i // 2), (i % 2) * 30, buy_price=0.10, solar_kwh=0.0)
+            for i in range(20)
+        ]
+
+        tomorrow_solar = [make_solcast_entry(h, 3.0) for h in range(8, 16)]
+
+        inputs = OptimizerInputs(
+            cycle_id="test-penalty-scale",
+            initial_soc_pct=20.0,
+            slots=slots,
+            config=default_config,
+            all_solcast=tomorrow_solar,
+        )
+
+        result = DPPlanner().plan(inputs)
+        assert result.success
+
+        charge_decisions = [
+            d
+            for d in result.decisions
+            if d.action
+            in (PlannerAction.CHARGE_GRID_NORMAL, PlannerAction.CHARGE_GRID_BOOST)
+            and d.objective_terms.solar_opportunity_penalty > 0
+        ]
+
+        if len(charge_decisions) >= 2:
+            for i in range(1, len(charge_decisions)):
+                d1 = charge_decisions[i - 1]
+                d2 = charge_decisions[i]
+                if d1.grid_import_kwh > 0 and d2.grid_import_kwh > 0:
+                    ratio1 = (
+                        d1.objective_terms.solar_opportunity_penalty
+                        / d1.grid_import_kwh
+                    )
+                    ratio2 = (
+                        d2.objective_terms.solar_opportunity_penalty
+                        / d2.grid_import_kwh
+                    )
+                    assert ratio1 == pytest.approx(ratio2, rel=0.01), (
+                        "Penalty should scale linearly with grid import"
+                    )
+
+
+class TestSolarOpportunityPenaltyWithDemandWindow:
+    """Tests for solar opportunity penalty interaction with demand window."""
+
+    def test_no_penalty_when_demand_window_exists(self, default_config):
+        """Demand window preparation should override solar opportunity penalty."""
+        slots = []
+        for i in range(24):
+            slot = make_slot(i, 10 + (i // 2), (i % 2) * 30, buy_price=0.10)
+            if i == 20:
+                slot.is_demand_window_entry = True
+                slot.is_demand_window_slot = True
+            if i > 20:
+                slot.is_demand_window_slot = True
+            slots.append(slot)
+
+        tomorrow_solar = [make_solcast_entry(h, 3.0) for h in range(8, 16)]
+
+        inputs = OptimizerInputs(
+            cycle_id="test-dw-override",
+            initial_soc_pct=30.0,
+            slots=slots,
+            config=default_config,
+            all_solcast=tomorrow_solar,
+        )
+
+        result = DPPlanner().plan(inputs)
+        assert result.success
+
+        for d in result.decisions:
+            assert d.objective_terms.solar_opportunity_penalty == 0.0, (
+                "Solar opportunity penalty should not apply when demand window exists"
+            )


### PR DESCRIPTION
## Summary
Fixes #607

The optimizer's horizon is limited by Amber's price forecast (~20 hours), but Solcast provides solar forecasts for today AND tomorrow. When the optimizer runs with a short price horizon, tomorrow's solar was invisible to the penalty calculation, causing overnight grid charging even when significant solar was forecast.

## Changes
- Add `all_solcast` to `OptimizerInputs` for full solar forecast access
- Add `solar_opportunity_penalty` to `ObjectiveTerms` (soft penalty)
- Add `_compute_solar_opportunity_penalty()` method to calculate penalty
- Wire penalty into `_compute_best_action()` and `_forward_reconstruct()`
- Pass `all_solcast` from `SlotBuildMetadata` through the pipeline
- Update `PLANNING_MODEL.md` documentation

## Testing
- 6 new unit tests for solar opportunity penalty
- All 615 existing tests pass
- Lint and format checks pass
- Live HA testing confirmed penalty field is populated

## Penalty Logic
The penalty ($0.03/kWh) applies when:
- Grid charging action is being considered
- No demand window exists (DW preparation takes priority)
- Future solar surplus > 10% of battery capacity
- The solar is outside the price horizon but in the forecast