### PR TITLE
fix: handle timezone-aware datetimes in forecast extension (Issue #632)

### DIFF
--- a/custom_components/localshift/state_reader.py
+++ b/custom_components/localshift/state_reader.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.util import dt as dt_util
 
 from .const import (
     CONF_PRICING_FEED_IN_FORECAST,
@@ -178,6 +179,12 @@ class StateReader:
             last_time = datetime.fromisoformat(last_time_str)
         except (ValueError, TypeError):
             return forecast
+
+        # Normalize timezone for comparison (Issue #632)
+        # datetime.fromisoformat() may return timezone-aware datetime
+        # while the 'now' parameter may be timezone-aware from dt_util.now()
+        if last_time.tzinfo is None and now.tzinfo is not None:
+            last_time = last_time.replace(tzinfo=now.tzinfo)
 
         target_time = now + timedelta(hours=24)
         last_duration = last_entry.get("duration", 30)
@@ -370,7 +377,7 @@ class StateReader:
         # Issue #632: Extend forecasts to 24 hours if needed
         # This ensures the optimizer can see tomorrow's solar opportunities
         # even when price forecast (e.g., Amber free tier) provides only ~16 hours
-        now_dt = datetime.now()
+        now_dt = dt_util.now()
         if data.general_forecast:
             avg_buy_price = self._calculate_current_day_average_price(
                 data.general_forecast, now_dt

--- a/tests/test_state_reader.py
+++ b/tests/test_state_reader.py
@@ -2,6 +2,7 @@
 
 from datetime import datetime, timedelta
 from unittest.mock import MagicMock, patch
+from zoneinfo import ZoneInfo
 
 import pytest
 
@@ -1142,7 +1143,8 @@ class TestForecastExtensionIntegration:
         self, state_reader, mock_hass, coordinator_data
     ):
         """Test that short forecast is extended to 24 hours."""
-        now = datetime(2026, 3, 10, 14, 0)
+        tz = ZoneInfo("Australia/Sydney")
+        now = datetime(2026, 3, 10, 14, 0, tzinfo=tz)
 
         def mock_get_state(entity_id):
             state = MagicMock()
@@ -1176,9 +1178,8 @@ class TestForecastExtensionIntegration:
             return state
 
         mock_hass.states.get = mock_get_state
-        with patch("custom_components.localshift.state_reader.datetime") as mock_dt:
-            mock_dt.now.return_value = now
-            mock_dt.fromisoformat.side_effect = datetime.fromisoformat
+        with patch("custom_components.localshift.state_reader.dt_util") as mock_dt_util:
+            mock_dt_util.now.return_value = now
             state_reader.read_all_external_state(coordinator_data)
 
         last_general = coordinator_data.general_forecast[-1]
@@ -1189,7 +1190,8 @@ class TestForecastExtensionIntegration:
         self, state_reader, mock_hass, coordinator_data
     ):
         """Test that forecast is not extended when already 24+ hours."""
-        now = datetime(2026, 3, 10, 14, 0)
+        tz = ZoneInfo("Australia/Sydney")
+        now = datetime(2026, 3, 10, 14, 0, tzinfo=tz)
         forecast_24h = []
         for i in range(48):
             forecast_24h.append({
@@ -1214,9 +1216,8 @@ class TestForecastExtensionIntegration:
             return state
 
         mock_hass.states.get = mock_get_state
-        with patch("custom_components.localshift.state_reader.datetime") as mock_dt:
-            mock_dt.now.return_value = now
-            mock_dt.fromisoformat.side_effect = datetime.fromisoformat
+        with patch("custom_components.localshift.state_reader.dt_util") as mock_dt_util:
+            mock_dt_util.now.return_value = now
             state_reader.read_all_external_state(coordinator_data)
 
         assert len(coordinator_data.general_forecast) == 48


### PR DESCRIPTION
## Summary
- Use `dt_util.now()` instead of `datetime.now()` for timezone-aware current time
- Add timezone normalization for `last_time` when comparing with aware datetime
- Update integration tests to use `ZoneInfo` and mock `dt_util.now()`

## Problem
The original PR #634 merged without the actual code changes. The timezone fix was never committed, causing the error to reappear after merging to `test`:

```
TypeError: can't compare offset-naive and offset-aware datetimes
```

at `state_reader.py:185` in `_extend_forecast_with_assumed_prices()`.

## Root Cause
- `datetime.now()` returns a naive datetime (no timezone info)
- `datetime.fromisoformat()` can return timezone-aware datetime if the string contains timezone info
- Comparison `last_entry_end >= target_time` fails when mixing naive/aware

## Fix
1. Import `dt_util` from `homeassistant.util`
2. Use `dt_util.now()` which returns timezone-aware datetime
3. Add normalization: if `last_time` is naive but `now` is aware, apply timezone to `last_time`

## Test Plan
- [x] All 700 tests pass
- [x] Lint/format checks pass
- [ ] Deploy to test HA and verify integration loads
- [ ] Check HA logs for no timezone errors

Fixes #632