### PR TITLE
docs: update PR targeting rules - default to test branch

### DIFF
--- a/.agents/rules/worktrees.md
+++ b/.agents/rules/worktrees.md
@@ -33,6 +33,29 @@ git worktree list
 
 ---
 
+## ⚠️ PR Creation from Worktrees
+
+**All feature PRs from worktrees MUST target `test`, not `main`.**
+
+When your work is complete and you're asked to create a PR:
+
+```bash
+# From your worktree, create PR targeting test branch
+gh pr create --base test --title "..."
+```
+
+**Why test by default:**
+- Changes are validated in live Home Assistant before production
+- Enables watch mode for rapid iteration
+- Catches integration issues early
+
+**Only target `main` if:**
+- User explicitly requests direct-to-main
+- Hotfix requiring immediate production deployment
+- Documentation-only with no code changes
+
+---
+
 ## ⚠️ HARD STOP SIGNALS
 
 **When user issues any of these commands, IMMEDIATELY stop all work and respond:**

--- a/.opencode/rules
+++ b/.opencode/rules
@@ -75,25 +75,26 @@ Bypass attempts are logged to `.git-bypass.log` for audit.
 
 ## PR Target Branches
 
-**Default: target `main`** for production-ready changes.
+**⚠️ DEFAULT for feature worktrees: target `test`**
 
-**Target `test` when:**
-- Changes need live testing in Home Assistant
-- You want to use watch mode for rapid iteration
-- Behavior depends on real HA entity states
-- Need to validate with actual Powerwall/solar data
+When working in a feature worktree (issue/*, feature/*, docs/*, etc.), always create PRs targeting the `test` branch:
 
-**How to target test:**
 ```bash
-# Create worktree from test
-git worktree add worktrees/deploy-test -b test
-cd worktrees/deploy-test
-
-# After changes, create PR targeting test
 gh pr create --base test --title "..."
 ```
 
-**Workflow:** PR to test → merge → watch mode deploys → validate → PR test→main for production
+**Why target test by default:**
+- All changes should be validated in live Home Assistant before production
+- Enables rapid iteration with watch mode auto-deploy
+- Catches integration issues early with real Powerwall/solar data
+- Production releases are deliberate, not accidental
+
+**Only target `main` when:**
+- Hotfixes that need immediate production deployment
+- Documentation-only changes with no code impact
+- User explicitly requests direct-to-main release
+
+**Workflow:** Feature worktree → PR to `test` → merge → validate → PR `test`→`main` for production
 
 ## If You See Changes on Main
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,31 +111,26 @@ The `test` branch is a persistent branch for continuous testing/deployment. Chan
 
 ### PR Target Branches
 
-**When to target `main`:**
-- Production-ready changes that should be released
-- Bug fixes, features, refactoring that don't need live testing
-- Default target for most PRs
+**⚠️ DEFAULT for feature worktrees: target `test`**
 
-**When to target `test`:**
-- Changes that need live testing in Home Assistant before production release
-- Changes where you want to use watch mode for rapid iteration
-- Changes where behavior depends on real HA entity states
-- Changes that need to be validated with actual Powerwall/solar data
+When working in a feature worktree (issue/*, feature/*, docs/*, etc.), always create PRs targeting the `test` branch:
 
-**How to target test:**
 ```bash
-# Create worktree from test branch
-git worktree add worktrees/deploy-test -b test
-cd worktrees/deploy-test
-
-# Make changes, commit, then create PR with base = test
 gh pr create --base test --title "..."
 ```
 
-**After PR to test is merged:**
-- Run watch mode to see changes deploy automatically
-- Validate in live HA
-- If successful, create follow-up PR from test to main for production release
+**Why target test by default:**
+- All changes should be validated in live Home Assistant before production
+- Enables rapid iteration with watch mode auto-deploy
+- Catches integration issues early with real Powerwall/solar data
+- Production releases are deliberate, not accidental
+
+**Only target `main` when:**
+- Hotfixes that need immediate production deployment
+- Documentation-only changes with no code impact
+- User explicitly requests direct-to-main release
+
+**Workflow:** Feature worktree → PR to `test` → merge → validate → PR `test`→`main` for production
 
 ### PR Creation & CI Monitoring
 


### PR DESCRIPTION
## Summary
- Feature worktrees now default to targeting `test` branch
- Added explicit `gh pr create --base test` guidance in all rule files
- `main` is now only for hotfixes or explicit user request
- Updated `.opencode/rules`, `.agents/rules/worktrees.md`, `AGENTS.md`

## Changes
| File | Change |
|------|--------|
| `.opencode/rules` | "PR Target Branches" - `test` is now default |
| `.agents/rules/worktrees.md` | Added "PR Creation from Worktrees" section |
| `AGENTS.md` | Flipped "PR Target Branches" - `test` first |

## New Workflow
```
Feature worktree → PR to test → merge → validate → PR test→main for production
```

Agents will now automatically use `--base test` when creating PRs from feature worktrees.