### PR TITLE
refactor(engine): reduce C901 complexity in outcomes.py and parameters.py

### DIFF
--- a/custom_components/localshift/engine/optimization_controller.py
+++ b/custom_components/localshift/engine/optimization_controller.py
@@ -30,6 +30,16 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
+_DAY_NAMES = [
+    "monday",
+    "tuesday",
+    "wednesday",
+    "thursday",
+    "friday",
+    "saturday",
+    "sunday",
+]
+
 
 @dataclass
 class ObjectiveWeights:
@@ -339,97 +349,85 @@ class OptimizationController:
     def _apply_active_bias_corrections(
         self, params: AdaptiveParameters, data: CoordinatorData
     ) -> AdaptiveParameters:
-        """Apply relevant bias corrections for current context.
-
-        Matches current conditions (day_of_week, weather, etc.) against
-        active BiasCorrection entries and applies matching adjustments.
-
-        Args:
-            params: Current parameters to adjust
-            data: Current coordinator data
-
-        Returns:
-            Adjusted parameters
-
-        """
+        """Apply relevant bias corrections for current context."""
         if not data.active_bias_corrections:
             return params
 
         now = dt_util.now()
-        current_day = now.weekday()  # 0=Monday, 6=Sunday
+        current_day = now.weekday()
         current_weather = data.weather_condition.lower()
 
         for correction in data.active_bias_corrections:
-            # Check if correction applies to current context
-            applies = False
-
-            dimension = correction.get("dimension", "")
-            group_key = correction.get("group_key", "")
-
-            if dimension == "day_of_week":
-                # Check if current day matches
-                day_names = [
-                    "monday",
-                    "tuesday",
-                    "wednesday",
-                    "thursday",
-                    "friday",
-                    "saturday",
-                    "sunday",
-                ]
-                if group_key.lower() == day_names[current_day]:
-                    applies = True
-
-            elif dimension == "weather":
-                # Check if current weather matches (partial match)
-                if (
-                    group_key.lower() in current_weather
-                    or current_weather in group_key.lower()
-                ):
-                    applies = True
-
-            elif dimension == "hour_of_day":
-                # Check if current hour matches
-                try:
-                    hour = int(group_key)
-                    if hour == now.hour:
-                        applies = True
-                except (ValueError, TypeError):
-                    pass
-
-            elif dimension == "season":
-                # Season matching (approximate by month)
-                month = now.month
-                season = self._get_season(month)
-                if group_key.lower() == season:
-                    applies = True
-
-            if applies:
-                param_name = correction.get("param_name", "")
-                adjustment = correction.get("adjustment", 0.0)
-                confidence = correction.get("confidence", 0.0)
-
-                # Only apply high-confidence corrections directly
-                if confidence >= 0.5 and param_name:
-                    current = params.get(param_name, 0.0)
-                    params.values[param_name] = current + adjustment
-                    self._active_contextual_adjustments.append(
-                        ContextualAdjustment(
-                            param_name=param_name,
-                            adjustment=adjustment,
-                            reason=f"Bias correction ({dimension}={group_key})",
-                        )
-                    )
-                    _LOGGER.debug(
-                        "Applied bias correction: %s +%.2f (%s=%s, confidence=%.2f)",
-                        param_name,
-                        adjustment,
-                        dimension,
-                        group_key,
-                        confidence,
-                    )
+            if self._correction_applies_to_context(
+                correction, current_day, current_weather, now
+            ):
+                self._apply_single_correction(params, correction)
 
         return params
+
+    def _correction_applies_to_context(
+        self,
+        correction: dict[str, Any],
+        current_day: int,
+        current_weather: str,
+        now: datetime,
+    ) -> bool:
+        """Check if a correction matches the current context."""
+        dimension = correction.get("dimension", "")
+        group_key = correction.get("group_key", "").lower()
+
+        if dimension == "day_of_week":
+            return group_key == _DAY_NAMES[current_day]
+
+        if dimension == "weather":
+            return group_key in current_weather or current_weather in group_key
+
+        if dimension == "hour_of_day":
+            return self._hour_matches(group_key, now)
+
+        if dimension == "season":
+            return group_key == self._get_season(now.month)
+
+        return False
+
+    def _hour_matches(self, group_key: str, now: datetime) -> bool:
+        """Check if hour matches group_key."""
+        try:
+            hour = int(group_key)
+            return hour == now.hour
+        except (ValueError, TypeError):
+            return False
+
+    def _apply_single_correction(
+        self, params: AdaptiveParameters, correction: dict[str, Any]
+    ) -> None:
+        """Apply a single bias correction if high confidence."""
+        param_name = correction.get("param_name", "")
+        adjustment = correction.get("adjustment", 0.0)
+        confidence = correction.get("confidence", 0.0)
+        dimension = correction.get("dimension", "")
+        group_key = correction.get("group_key", "")
+
+        if confidence < 0.5 or not param_name:
+            return
+
+        current = params.get(param_name, 0.0)
+        params.values[param_name] = current + adjustment
+        self._active_contextual_adjustments.append(
+            ContextualAdjustment(
+                param_name=param_name,
+                adjustment=adjustment,
+                reason=f"Bias correction ({dimension}={group_key})",
+            )
+        )
+        _LOGGER.debug(
+            "Applied bias correction: %s +%.2f (%s=%s, confidence=%.2f)",
+            param_name,
+            adjustment,
+            dimension,
+            group_key,
+            confidence,
+        )
 
     def _clamp_parameters(self, params: AdaptiveParameters) -> AdaptiveParameters:
         """Clamp all parameters to their defined bounds.

--- a/custom_components/localshift/engine/outcomes.py
+++ b/custom_components/localshift/engine/outcomes.py
@@ -458,7 +458,93 @@ class DecisionOutcomeTracker:
             pending.outcome_score,
         )
 
-    def compute_outcome_score(self, record: DecisionRecord) -> float:  # noqa: C901
+    def _compute_cost_score(self, record: DecisionRecord) -> float | None:
+        """Compute cost score component (0.0-1.0).
+
+        Returns None if cost data is unavailable.
+        """
+        if record.actual_cost_during_period is None:
+            return None
+
+        if record.mode_chosen in (
+            PlannerAction.CHARGE_GRID_NORMAL,
+            PlannerAction.CHARGE_GRID_BOOST,
+        ):
+            if record.actual_export_kwh and record.actual_export_kwh > 0.5:
+                return 0.2
+            return 0.7
+
+        if record.mode_chosen == PlannerAction.EXPORT_PROACTIVE:
+            if (
+                record.actual_cost_during_period
+                and record.actual_cost_during_period < 0
+            ):
+                return 0.9
+            return 0.4
+
+        return 0.6
+
+    def _compute_export_penalty(self, record: DecisionRecord) -> float:
+        """Compute export penalty (negative) or bonus (positive).
+
+        Returns a value to add to score (-0.15 to +0.05).
+        """
+        if not record.actual_export_kwh or record.actual_export_kwh <= 0.1:
+            return 0.0
+
+        grid_imported = (
+            record.actual_import_kwh is not None and record.actual_import_kwh > 0.1
+        )
+
+        if record.mode_chosen in (
+            PlannerAction.CHARGE_GRID_NORMAL,
+            PlannerAction.CHARGE_GRID_BOOST,
+        ):
+            if grid_imported:
+                return -0.15
+            return 0.0
+
+        if record.mode_chosen == PlannerAction.EXPORT_PROACTIVE:
+            return 0.05
+
+        return 0.0
+
+    def _compute_target_score(self, record: DecisionRecord) -> float:
+        """Compute target score component.
+
+        Returns a value to add to score (-0.10 to +0.15).
+        """
+        if record.battery_target_soc <= 0:
+            return 0.0
+
+        soc_at_end = record.soc_at_decision + (record.actual_soc_change or 0.0)
+        target_diff = abs(soc_at_end - record.battery_target_soc)
+
+        is_low_solar_weather = record.weather_condition in ("rainy", "cloudy")
+        far_threshold = 40 if is_low_solar_weather else 20
+
+        can_increase_soc = record.mode_chosen in (
+            PlannerAction.CHARGE_GRID_NORMAL,
+            PlannerAction.CHARGE_GRID_BOOST,
+        )
+        can_decrease_soc = record.mode_chosen == PlannerAction.EXPORT_PROACTIVE
+
+        if target_diff <= 5:
+            return 0.15
+        if target_diff <= 10:
+            return 0.05
+        if target_diff > far_threshold:
+            below_target = soc_at_end < record.battery_target_soc
+            above_target = soc_at_end > record.battery_target_soc
+
+            if below_target and can_increase_soc:
+                return -0.10
+            if above_target and can_decrease_soc:
+                return -0.10
+
+        return 0.0
+
+    def compute_outcome_score(self, record: DecisionRecord) -> float:
         """Score a decision outcome from 0.0 (worst) to 1.0 (best).
 
         Components:
@@ -474,100 +560,20 @@ class DecisionOutcomeTracker:
             Score from 0.0 to 1.0
 
         """
-        score = 0.5  # Start at neutral
+        score = 0.5
 
-        # 1. Cost Score (weight: 40%)
-        # Lower cost = better score
-        if record.actual_cost_during_period is not None:
-            if record.mode_chosen in (
-                PlannerAction.CHARGE_GRID_NORMAL,
-                PlannerAction.CHARGE_GRID_BOOST,
-            ):
-                # Grid charging: positive cost is expected
-                # Penalize if we charged and then exported (waste)
-                if record.actual_export_kwh and record.actual_export_kwh > 0.5:
-                    cost_score = 0.2  # Penalize grid-charge-then-export
-                else:
-                    cost_score = 0.7  # Normal grid charge
-            elif record.mode_chosen == PlannerAction.EXPORT_PROACTIVE:
-                # Proactive export: should make money
-                if (
-                    record.actual_cost_during_period
-                    and record.actual_cost_during_period < 0
-                ):
-                    cost_score = 0.9  # Made money
-                else:
-                    cost_score = 0.4
-            else:
-                cost_score = 0.6
+        cost_score = self._compute_cost_score(record)
+        if cost_score is not None:
             score = score * 0.6 + cost_score * 0.4
-        else:
-            if record.mode_chosen == PlannerAction.HOLD:
-                score = score * 0.6 + 0.5 * 0.4
+        elif record.mode_chosen == PlannerAction.HOLD:
+            score = score * 0.6 + 0.5 * 0.4
 
-        # 2. Export Penalty (weight: 20%)
-        # Penalize exporting grid-purchased energy (Issue #280)
-        # Only penalize if we actually imported grid energy AND exported
-        # Solar-driven export during charging modes is acceptable
-        if record.actual_export_kwh and record.actual_export_kwh > 0.1:
-            grid_imported = (
-                record.actual_import_kwh is not None and record.actual_import_kwh > 0.1
-            )
-            if record.mode_chosen in (
-                PlannerAction.CHARGE_GRID_NORMAL,
-                PlannerAction.CHARGE_GRID_BOOST,
-            ):
-                if grid_imported:
-                    # Bad: imported from grid then exported
-                    score -= 0.15
-                # else: solar-driven export is acceptable, no penalty
-            elif record.mode_chosen == PlannerAction.EXPORT_PROACTIVE:
-                # Good: this mode is supposed to export
-                score += 0.05
+        score += self._compute_export_penalty(record)
+        score += self._compute_target_score(record)
 
-        # 3. Target Score (weight: 25%)
-        # Did the decision help reach/maintain SOC target?
-        # Issue #281: Use weather-aware target gap thresholds
-        # Issue #651: Only penalize when mode could plausibly affect target progress
-        if record.battery_target_soc > 0:
-            soc_at_end = record.soc_at_decision + (record.actual_soc_change or 0.0)
-            target_diff = abs(soc_at_end - record.battery_target_soc)
-
-            # Adjust thresholds based on weather (Issue #281)
-            # On rainy/cloudy days, being far from target is more acceptable
-            is_low_solar_weather = record.weather_condition in ("rainy", "cloudy")
-            far_threshold = 40 if is_low_solar_weather else 20
-
-            # Issue #651: Only apply target penalty when mode could affect progress
-            can_increase_soc = record.mode_chosen in (
-                PlannerAction.CHARGE_GRID_NORMAL,
-                PlannerAction.CHARGE_GRID_BOOST,
-            )
-            can_decrease_soc = record.mode_chosen == PlannerAction.EXPORT_PROACTIVE
-
-            if target_diff <= 5:
-                score += 0.15  # Close to target
-            elif target_diff <= 10:
-                score += 0.05  # Acceptable
-            elif target_diff > far_threshold:
-                # Only penalize if mode could plausibly help reach target
-                below_target = soc_at_end < record.battery_target_soc
-                above_target = soc_at_end > record.battery_target_soc
-
-                if below_target and can_increase_soc:
-                    score -= 0.10  # Far below target, but could have charged
-                elif above_target and can_decrease_soc:
-                    score -= 0.10  # Far above target, but could have exported
-                # HOLD mode: no penalty, can't control SOC
-
-        # 4. Cycling Penalty (weight: 15%)
-        # Penalize rapid mode changes (< 3 min = actual cycling)
-        # Note: Control loop runs every 5 min (PERIODIC_INTERVAL_MEDIUM), so
-        # durations 3-5 min are normal re-planning, not cycling
         if record.duration_minutes is not None and record.duration_minutes < 3:
             score -= 0.10
 
-        # Clamp to valid range
         return max(0.0, min(1.0, score))
 
     def get_recent_decisions(self, hours: int = 24) -> list[DecisionRecord]:
@@ -586,6 +592,39 @@ class DecisionOutcomeTracker:
         return [
             record for record in self._completed_decisions if record.timestamp >= cutoff
         ]
+
+    def _compute_cost_trend(self, week_scores: list[float]) -> str:
+        """Determine cost trend from 7-day score data."""
+        if len(week_scores) < 7:
+            return "stable"
+
+        recent_avg = sum(week_scores[-3:]) / 3
+        older_avg = sum(week_scores[:4]) / 4
+
+        if recent_avg > older_avg + 0.05:
+            return "improving"
+        if recent_avg < older_avg - 0.05:
+            return "degrading"
+        return "stable"
+
+    def _aggregate_mode_metrics(
+        self, decisions: list[DecisionRecord]
+    ) -> tuple[dict[str, float], dict[str, float]]:
+        """Aggregate per-mode durations and costs from decisions."""
+        mode_durations: dict[str, float] = {}
+        mode_costs: dict[str, float] = {}
+
+        for record in decisions:
+            mode_key = record.mode_chosen.value
+            mode_durations[mode_key] = mode_durations.get(mode_key, 0.0) + (
+                record.duration_minutes or 0.0
+            )
+            if record.actual_cost_during_period:
+                mode_costs[mode_key] = (
+                    mode_costs.get(mode_key, 0.0) + record.actual_cost_during_period
+                )
+
+        return mode_durations, mode_costs
 
     def get_daily_summary(self) -> PerformanceMetrics:
         """Aggregate today's decision outcomes into summary metrics.
@@ -610,21 +649,8 @@ class DecisionOutcomeTracker:
             r.outcome_score for r in week_decisions if r.outcome_score is not None
         ]
         avg_score_7d = sum(week_scores) / len(week_scores) if week_scores else 0.0
+        cost_trend = self._compute_cost_trend(week_scores)
 
-        # Determine cost trend from 7-day data
-        if len(week_scores) >= 7:
-            recent_avg = sum(week_scores[-3:]) / 3
-            older_avg = sum(week_scores[:4]) / 4
-            if recent_avg > older_avg + 0.05:
-                cost_trend = "improving"
-            elif recent_avg < older_avg - 0.05:
-                cost_trend = "degrading"
-            else:
-                cost_trend = "stable"
-        else:
-            cost_trend = "stable"
-
-        # If no decisions today, return with 7-day metrics populated
         if not today_decisions:
             return PerformanceMetrics(
                 total_decisions_today=0,
@@ -640,20 +666,7 @@ class DecisionOutcomeTracker:
             r.outcome_score for r in today_decisions if r.outcome_score is not None
         ]
         avg_score = sum(scores) / len(scores) if scores else 0.0
-
-        # Compute per-mode durations and costs
-        mode_durations: dict[str, float] = {}
-        mode_costs: dict[str, float] = {}
-
-        for record in today_decisions:
-            mode_key = record.mode_chosen.value
-            mode_durations[mode_key] = mode_durations.get(mode_key, 0.0) + (
-                record.duration_minutes or 0.0
-            )
-            if record.actual_cost_during_period:
-                mode_costs[mode_key] = (
-                    mode_costs.get(mode_key, 0.0) + record.actual_cost_during_period
-                )
+        mode_durations, mode_costs = self._aggregate_mode_metrics(today_decisions)
 
         return PerformanceMetrics(
             total_decisions_today=len(today_decisions),

--- a/custom_components/localshift/engine/parameters.py
+++ b/custom_components/localshift/engine/parameters.py
@@ -189,6 +189,111 @@ class ParameterOptimizer:
 
         return self._current_params
 
+    def _apply_high_confidence_correction(
+        self,
+        param_name: str,
+        param_def: Any,
+        current_value: float,
+        corrections: list[Any],
+        values: dict[str, float],
+        confidence: dict[str, float],
+    ) -> bool:
+        """Apply high-confidence corrections directly as offsets.
+
+        Returns True if a correction was applied.
+        """
+        total_weight = sum(c.confidence for c in corrections)
+        weighted_adjustment = (
+            sum(c.adjustment * c.confidence for c in corrections) / total_weight
+        )
+
+        new_value = current_value + weighted_adjustment
+        new_value = max(param_def.min_val, min(param_def.max_val, new_value))
+
+        if new_value == current_value:
+            return False
+
+        values[param_name] = new_value
+        avg_confidence = total_weight / len(corrections)
+        confidence[param_name] = min(1.0, avg_confidence + 0.1)
+
+        _LOGGER.info(
+            "Applied bias correction to %s: %.3f -> %.3f (from %d high-confidence patterns)",
+            param_name,
+            current_value,
+            new_value,
+            len(corrections),
+        )
+        return True
+
+    def _apply_medium_confidence_correction(
+        self,
+        param_name: str,
+        param_def: Any,
+        current_value: float,
+        corrections: list[Any],
+        values: dict[str, float],
+    ) -> bool:
+        """Apply medium-confidence corrections as smaller adjustments.
+
+        Returns True if a correction was applied.
+        """
+        avg_adjustment = sum(c.adjustment for c in corrections) / len(corrections)
+        avg_conf = sum(c.confidence for c in corrections) / len(corrections)
+        scaled_adjustment = avg_adjustment * avg_conf
+
+        new_value = current_value + scaled_adjustment * 0.5
+        new_value = max(param_def.min_val, min(param_def.max_val, new_value))
+
+        if abs(new_value - current_value) <= 0.01:
+            return False
+
+        values[param_name] = new_value
+
+        _LOGGER.info(
+            "Applied medium-confidence bias correction to %s: %.3f -> %.3f (from %d patterns)",
+            param_name,
+            current_value,
+            new_value,
+            len(corrections),
+        )
+        return True
+
+    def _process_param_corrections(
+        self,
+        param_name: str,
+        corrections: list[Any],
+        values: dict[str, float],
+        confidence: dict[str, float],
+    ) -> int:
+        """Process corrections for a single parameter.
+
+        Returns the number of corrections applied (0 or 1).
+        """
+        if param_name not in OPTIMIZABLE_PARAMS:
+            _LOGGER.debug(
+                "Ignoring bias correction for unknown parameter: %s",
+                param_name,
+            )
+            return 0
+
+        param_def = OPTIMIZABLE_PARAMS[param_name]
+        current_value = values.get(param_name, param_def.default)
+
+        high_confidence = [c for c in corrections if c.confidence > 0.8]
+        if high_confidence and self._apply_high_confidence_correction(
+            param_name, param_def, current_value, high_confidence, values, confidence
+        ):
+            return 1
+
+        medium_confidence = [c for c in corrections if 0.5 <= c.confidence <= 0.8]
+        if medium_confidence and self._apply_medium_confidence_correction(
+            param_name, param_def, current_value, medium_confidence, values
+        ):
+            return 1
+
+        return 0
+
     def _apply_bias_corrections(
         self,
         values: dict[str, float],
@@ -210,89 +315,16 @@ class ParameterOptimizer:
             Tuple of (updated_values, updated_confidence)
 
         """
-        # Group corrections by parameter
         param_corrections: dict[str, list[BiasCorrection]] = {}
         for correction in bias_corrections:
             if correction.param_name not in param_corrections:
                 param_corrections[correction.param_name] = []
             param_corrections[correction.param_name].append(correction)
 
-        applied_count = 0
-
-        for param_name, corrections in param_corrections.items():
-            if param_name not in OPTIMIZABLE_PARAMS:
-                _LOGGER.debug(
-                    "Ignoring bias correction for unknown parameter: %s",
-                    param_name,
-                )
-                continue
-
-            param_def = OPTIMIZABLE_PARAMS[param_name]
-            current_value = values.get(param_name, param_def.default)
-
-            # Separate by confidence level
-            high_confidence = [c for c in corrections if c.confidence > 0.8]
-            medium_confidence = [c for c in corrections if 0.5 <= c.confidence <= 0.8]
-
-            # Apply high-confidence corrections directly
-            if high_confidence:
-                # Use weighted average based on confidence
-                total_weight = sum(c.confidence for c in high_confidence)
-                weighted_adjustment = (
-                    sum(c.adjustment * c.confidence for c in high_confidence)
-                    / total_weight
-                )
-
-                new_value = current_value + weighted_adjustment
-
-                # Clamp to bounds
-                new_value = max(param_def.min_val, min(param_def.max_val, new_value))
-
-                if new_value != current_value:
-                    values[param_name] = new_value
-                    # Boost confidence when multiple high-confidence corrections agree
-                    avg_confidence = total_weight / len(high_confidence)
-                    confidence[param_name] = min(1.0, avg_confidence + 0.1)
-
-                    _LOGGER.info(
-                        "Applied bias correction to %s: %.3f -> %.3f (from %d high-confidence patterns)",
-                        param_name,
-                        current_value,
-                        new_value,
-                        len(high_confidence),
-                    )
-                    applied_count += 1
-
-            # Apply medium-confidence corrections as smaller adjustments
-            elif medium_confidence:
-                # Use smaller weight for medium confidence
-                avg_adjustment = sum(c.adjustment for c in medium_confidence) / len(
-                    medium_confidence
-                )
-                # Scale down the adjustment based on confidence
-                avg_conf = sum(c.confidence for c in medium_confidence) / len(
-                    medium_confidence
-                )
-                scaled_adjustment = avg_adjustment * avg_conf
-
-                new_value = (
-                    current_value + scaled_adjustment * 0.5
-                )  # Scale down further
-
-                # Clamp to bounds
-                new_value = max(param_def.min_val, min(param_def.max_val, new_value))
-
-                if abs(new_value - current_value) > 0.01:  # Only log meaningful changes
-                    values[param_name] = new_value
-
-                    _LOGGER.info(
-                        "Applied medium-confidence bias correction to %s: %.3f -> %.3f (from %d patterns)",
-                        param_name,
-                        current_value,
-                        new_value,
-                        len(medium_confidence),
-                    )
-                    applied_count += 1
+        applied_count = sum(
+            self._process_param_corrections(param_name, corrections, values, confidence)
+            for param_name, corrections in param_corrections.items()
+        )
 
         if applied_count > 0:
             _LOGGER.info(
@@ -302,10 +334,58 @@ class ParameterOptimizer:
 
         return values, confidence
 
-    def _optimize_single_param(  # noqa: C901
+    def _select_best_bin(
+        self, bins: dict[int, list[float]], num_bins: int
+    ) -> int | None:
+        """Select best bin using Thompson sampling.
+
+        Returns the best bin index, or None if no valid bins.
+        """
+        best_bin = None
+        best_sample = -float("inf")
+
+        for bin_idx in range(num_bins):
+            scores = bins[bin_idx]
+            if not scores:
+                continue
+
+            mean_score = sum(scores) / len(scores)
+            n = len(scores)
+            alpha = mean_score * n + 1
+            beta = (1 - mean_score) * n + 1
+
+            sample = self._sample_beta(alpha, beta)
+
+            if sample > best_sample:
+                best_sample = sample
+                best_bin = bin_idx
+
+        return best_bin
+
+    def _compute_bin_confidence(self, bin_scores: list[float]) -> float:
+        """Calculate confidence based on sample count and variance."""
+        if not bin_scores:
+            return 0.0
+
+        mean_score = sum(bin_scores) / len(bin_scores)
+        variance = sum((s - mean_score) ** 2 for s in bin_scores) / len(bin_scores)
+        return min(1.0, len(bin_scores) / 50.0) * (1 - min(variance, 0.25) * 4)
+
+    def _apply_step_limit(
+        self, bin_center: float, current_val: float, step_size: float
+    ) -> float:
+        """Apply step limit to bin center value."""
+        if abs(bin_center - current_val) <= step_size:
+            return bin_center
+
+        if bin_center > current_val:
+            return current_val + step_size
+        return current_val - step_size
+
+    def _optimize_single_param(
         self,
         param_name: str,
-        param_def: Any,  # OptimizableParam
+        param_def: Any,
         decisions: list[DecisionRecord],
     ) -> tuple[float | None, float]:
         """Optimize a single parameter using Thompson sampling.
@@ -319,83 +399,36 @@ class ParameterOptimizer:
             Tuple of (optimal_value, confidence) or (None, 0.0) if no data
 
         """
-        # Group decisions by parameter value ranges
         num_bins = 5
         bin_width = (param_def.max_val - param_def.min_val) / num_bins
         bins: dict[int, list[float]] = defaultdict(list)
 
         current_value = self._current_params.values.get(param_name, param_def.default)
 
-        # Assign decisions to bins based on what parameter value would have been optimal
         for decision in decisions:
             if decision.outcome_score is None:
                 continue
 
-            # Calculate which bin the current value falls into
             bin_idx = int((current_value - param_def.min_val) / bin_width)
             bin_idx = max(0, min(num_bins - 1, bin_idx))
             bins[bin_idx].append(decision.outcome_score)
 
-        # If we don't have enough data, don't adjust
         total_samples = sum(len(scores) for scores in bins.values())
         if total_samples < 10:
             return None, 0.0
 
-        # Thompson sampling: sample from Beta distribution for each bin
-        best_bin = None
-        best_sample = -float("inf")
-
-        for bin_idx in range(num_bins):
-            scores = bins[bin_idx]
-            if not scores:
-                continue
-
-            # Convert scores to success/failure counts
-            # Score is 0-1, so we can use it directly as success rate
-            mean_score = sum(scores) / len(scores)
-            n = len(scores)
-
-            # Beta distribution parameters (add 1 for prior)
-            alpha = mean_score * n + 1
-            beta = (1 - mean_score) * n + 1
-
-            # Sample from Beta distribution
-            sample = self._sample_beta(alpha, beta)
-
-            if sample > best_sample:
-                best_sample = sample
-                best_bin = bin_idx
-
+        best_bin = self._select_best_bin(bins, num_bins)
         if best_bin is None:
             return None, 0.0
 
-        # Calculate the center value of the winning bin
         bin_center = param_def.min_val + (best_bin + 0.5) * bin_width
 
-        # Apply step limit: can only move one step from current value
-        current_val = self._current_params.values.get(param_name, param_def.default)
-        step_size = param_def.step
-        if abs(bin_center - current_val) > step_size:
-            # Move one step in the direction of the bin center
-            if bin_center > current_val:
-                bin_center = current_val + step_size
-            else:
-                bin_center = current_val - step_size
+        current_val = self._current_params.values.get(param_name) or param_def.default
+        bin_center = self._apply_step_limit(bin_center, current_val, param_def.step)
 
-        # Clamp to bounds
         bin_center = max(param_def.min_val, min(param_def.max_val, bin_center))
 
-        # Calculate confidence based on sample count and variance
-        bin_scores = bins.get(best_bin, [])
-        if bin_scores:
-            mean_score = sum(bin_scores) / len(bin_scores)
-            variance = sum((s - mean_score) ** 2 for s in bin_scores) / len(bin_scores)
-            # Higher sample count and lower variance = higher confidence
-            confidence = min(1.0, len(bin_scores) / 50.0) * (
-                1 - min(variance, 0.25) * 4
-            )
-        else:
-            confidence = 0.0
+        confidence = self._compute_bin_confidence(bins.get(best_bin, []))
 
         return bin_center, confidence
 

--- a/custom_components/localshift/engine/price_calculator.py
+++ b/custom_components/localshift/engine/price_calculator.py
@@ -21,6 +21,39 @@ from ..coordinator.data import CoordinatorData
 from .utils import parse_forecast_dt
 
 
+def _parse_price_entry(
+    entry: Any, slot_start: datetime, slot_end: datetime
+) -> dict[str, Any] | None:
+    """Parse a price forecast entry, returning None if invalid.
+
+    Returns dict with: start_local, end_local, price, duration_minutes, is_overlap.
+    """
+    if not isinstance(entry, dict):
+        return None
+
+    start_raw = entry.get("start_time")
+    if start_raw is None:
+        return None
+
+    start_dt = parse_forecast_dt(start_raw)
+    if start_dt is None:
+        return None
+
+    start_local = dt_util.as_local(start_dt)
+    duration_minutes = int(entry.get("duration", 5))
+    end_local = start_local + timedelta(minutes=duration_minutes)
+    price = float(entry.get("per_kwh", 0.0))
+
+    return {
+        "start_local": start_local,
+        "end_local": end_local,
+        "price": price,
+        "duration_minutes": duration_minutes,
+        "is_overlap": start_local < slot_end and end_local > slot_start,
+        "is_fallback_candidate": start_local <= slot_start,
+    }
+
+
 def _compute_price_slot_data(
     price_forecasts: list[dict[str, Any]],
     slot_start: datetime,
@@ -32,19 +65,7 @@ def _compute_price_slot_data(
 
     Amber mixes 5-min dispatch intervals (near-term) with 30-min extended
     forecast periods. The overlap scan handles both correctly.
-
-    Args:
-        price_forecasts: List of price forecast entries from Amber.
-        slot_start: Start time of the slot to check.
-
-    Returns:
-        Tuple of (prices_in_slot, fallback_price, fallback_start):
-        - prices_in_slot: List of prices that overlap with the slot.
-        - fallback_price: Price from the most recent entry at or before slot_start.
-        - fallback_start: Start time of the fallback entry (None if no fallback).
-
     """
-    # Ensure slot boundaries are timezone-aware local datetimes
     if slot_start.tzinfo is None:
         slot_start = dt_util.as_local(dt_util.as_utc(slot_start))
     else:
@@ -57,33 +78,17 @@ def _compute_price_slot_data(
     fallback_start: datetime | None = None
 
     for entry in price_forecasts:
-        if not isinstance(entry, dict):
+        parsed = _parse_price_entry(entry, slot_start, slot_end)
+        if parsed is None:
             continue
 
-        start_raw = entry.get("start_time")
-        if start_raw is None:
-            continue
+        if parsed["is_overlap"]:
+            prices_in_slot.append(parsed["price"])
 
-        start_dt = parse_forecast_dt(start_raw)
-        if start_dt is None:
-            continue
-
-        start_local = dt_util.as_local(start_dt)
-
-        # Overlap check: use per-entry duration from the data when available,
-        # otherwise assume 5 minutes (standard Amber dispatch interval).
-        duration_minutes: int = int(entry.get("duration", 5))
-        end_local = start_local + timedelta(minutes=duration_minutes)
-
-        if start_local < slot_end and end_local > slot_start:
-            price = float(entry.get("per_kwh", 0.0))
-            prices_in_slot.append(price)
-
-        # Track most-recent entry at or before slot_start for fallback
-        if start_local <= slot_start:
-            if fallback_start is None or start_local > fallback_start:
-                fallback_start = start_local
-                fallback_price = float(entry.get("per_kwh", 0.0))
+        if parsed["is_fallback_candidate"]:
+            if fallback_start is None or parsed["start_local"] > fallback_start:
+                fallback_start = parsed["start_local"]
+                fallback_price = parsed["price"]
 
     return prices_in_slot, fallback_price, fallback_start
 
@@ -118,34 +123,12 @@ def get_price_for_slot(
     return fallback_price
 
 
-def get_price_for_slot_with_source(
+def _collect_prices_by_source(
     price_forecasts: list[dict[str, Any]],
     slot_start: datetime,
-    interval_minutes: int = 15,
-) -> tuple[float, str]:
-    """Get price for a slot along with price source metadata.
-
-    Issue #327: Returns the price source ("5min" or "30min") to support
-    hybrid timescale forecasting.
-
-    Issue #329: Supports variable slot durations (5, 15, or 30 minutes).
-
-    Args:
-        price_forecasts: List of price forecast entries from Amber.
-        slot_start: Start time of the slot to check.
-        interval_minutes: Slot duration in minutes (default 15).
-
-    Returns:
-        Tuple of (price, price_source):
-        - price: Price in $/kWh for the slot.
-        - price_source: "5min" if from 5-min data, "30min" if from 30-min data,
-                       "unknown" if no data found.
-
-    """
-    if not price_forecasts:
-        return 0.0, "unknown"
-
-    # Ensure slot boundaries are timezone-aware local datetimes
+    interval_minutes: int,
+) -> dict[str, Any]:
+    """Collect prices grouped by source (5min/30min) with fallback info."""
     if slot_start.tzinfo is None:
         slot_start = dt_util.as_local(dt_util.as_utc(slot_start))
     else:
@@ -153,7 +136,6 @@ def get_price_for_slot_with_source(
 
     slot_end = slot_start + timedelta(minutes=interval_minutes)
 
-    # Track prices and their sources
     prices_5min: list[float] = []
     prices_30min: list[float] = []
     fallback_price: float = 0.0
@@ -161,49 +143,50 @@ def get_price_for_slot_with_source(
     fallback_start: datetime | None = None
 
     for entry in price_forecasts:
-        if not isinstance(entry, dict):
+        parsed = _parse_price_entry(entry, slot_start, slot_end)
+        if parsed is None:
             continue
 
-        start_raw = entry.get("start_time")
-        if start_raw is None:
-            continue
+        source = "5min" if parsed["duration_minutes"] <= 5 else "30min"
 
-        start_dt = parse_forecast_dt(start_raw)
-        if start_dt is None:
-            continue
-
-        start_local = dt_util.as_local(start_dt)
-        duration_minutes: int = int(entry.get("duration", 5))
-        end_local = start_local + timedelta(minutes=duration_minutes)
-        price = float(entry.get("per_kwh", 0.0))
-
-        # Determine source based on duration
-        source = "5min" if duration_minutes <= 5 else "30min"
-
-        if start_local < slot_end and end_local > slot_start:
-            # Price overlaps with slot
+        if parsed["is_overlap"]:
             if source == "5min":
-                prices_5min.append(price)
+                prices_5min.append(parsed["price"])
             else:
-                prices_30min.append(price)
+                prices_30min.append(parsed["price"])
 
-        # Track most-recent entry for fallback
-        if start_local <= slot_start:
-            if fallback_start is None or start_local > fallback_start:
-                fallback_start = start_local
-                fallback_price = price
+        if parsed["is_fallback_candidate"]:
+            if fallback_start is None or parsed["start_local"] > fallback_start:
+                fallback_start = parsed["start_local"]
+                fallback_price = parsed["price"]
                 fallback_source = source
 
-    # Prefer 5-min data if available (more precise for near-term)
-    if prices_5min:
-        return sum(prices_5min) / len(prices_5min), "5min"
+    return {
+        "prices_5min": prices_5min,
+        "prices_30min": prices_30min,
+        "fallback_price": fallback_price,
+        "fallback_source": fallback_source,
+    }
 
-    # Fall back to 30-min data
-    if prices_30min:
-        return sum(prices_30min) / len(prices_30min), "30min"
 
-    # No overlapping data - use fallback
-    return fallback_price, fallback_source
+def get_price_for_slot_with_source(
+    price_forecasts: list[dict[str, Any]],
+    slot_start: datetime,
+    interval_minutes: int = 15,
+) -> tuple[float, str]:
+    """Get price for a slot along with price source metadata."""
+    if not price_forecasts:
+        return 0.0, "unknown"
+
+    data = _collect_prices_by_source(price_forecasts, slot_start, interval_minutes)
+
+    if data["prices_5min"]:
+        return sum(data["prices_5min"]) / len(data["prices_5min"]), "5min"
+
+    if data["prices_30min"]:
+        return sum(data["prices_30min"]) / len(data["prices_30min"]), "30min"
+
+    return data["fallback_price"], data["fallback_source"]
 
 
 def get_price_for_slot_or_none(
@@ -494,6 +477,52 @@ class PriceCalculator:
         # Apply hysteresis and smoothing (Issue #282)
         data.effective_cheap_price = self._apply_threshold_hysteresis(raw_threshold)
 
+    def _get_fit_price_for_period(
+        self, feed_in_forecast: list[dict[str, Any]], mid_local: datetime
+    ) -> float:
+        """Get FIT price for a specific time from forecast."""
+        for forecast in feed_in_forecast:
+            forecast_start = self._parse_forecast_dt(forecast.get("start_time"))
+            forecast_end = self._parse_forecast_dt(forecast.get("end_time"))
+            if forecast_start is None or forecast_end is None:
+                continue
+            forecast_start_local = dt_util.as_local(forecast_start)
+            forecast_end_local = dt_util.as_local(forecast_end)
+            if forecast_start_local <= mid_local < forecast_end_local:
+                return float(forecast.get("per_kwh", 0))
+        return 0.0
+
+    def _compute_weighted_fit(
+        self,
+        all_solcast: list[dict[str, Any]],
+        feed_in_forecast: list[dict[str, Any]],
+        now_dt: datetime,
+        target_dt: datetime,
+    ) -> tuple[float, float]:
+        """Compute solar-weighted average FIT. Returns (weighted_avg, total_solar)."""
+        weighted_sum = 0.0
+        total_solar = 0.0
+
+        for period in all_solcast:
+            period_start = self._parse_forecast_dt(period.get("period_start"))
+            if period_start is None:
+                continue
+            period_start_local = dt_util.as_local(period_start)
+            if not (period_start_local >= now_dt and period_start_local < target_dt):
+                continue
+
+            solar_kwh_val = float(period.get("pv_estimate", 0))
+            if solar_kwh_val <= 0:
+                continue
+
+            mid_local = period_start_local + timedelta(minutes=15)
+            fit_price = self._get_fit_price_for_period(feed_in_forecast, mid_local)
+
+            weighted_sum += solar_kwh_val * fit_price
+            total_solar += solar_kwh_val
+
+        return weighted_sum, total_solar
+
     def compute_solar_weighted_avg_fit(
         self,
         data: CoordinatorData,
@@ -507,40 +536,12 @@ class PriceCalculator:
             data.solar_remaining_kwh = 0.0
             return
 
-        weighted_sum = 0.0
-        total_solar = 0.0
-
-        # Include tomorrow's forecast when target is tomorrow morning
         all_solcast = [*data.solcast_today, *data.solcast_tomorrow]
-
-        # Compute target datetime (demand window start)
         target_dt = now_dt.replace(hour=target_hour, minute=0, second=0, microsecond=0)
 
-        for period in all_solcast:
-            period_start = self._parse_forecast_dt(period.get("period_start"))
-            if period_start is None:
-                continue
-            period_start_local = dt_util.as_local(period_start)
-            if period_start_local >= now_dt and period_start_local < target_dt:
-                solar_kwh_val = float(period.get("pv_estimate", 0))
-                if solar_kwh_val <= 0:
-                    continue
-
-                mid_local = period_start_local + timedelta(minutes=15)
-                fit_price = 0.0
-                for forecast in data.feed_in_forecast:
-                    forecast_start = self._parse_forecast_dt(forecast.get("start_time"))
-                    forecast_end = self._parse_forecast_dt(forecast.get("end_time"))
-                    if forecast_start is None or forecast_end is None:
-                        continue
-                    forecast_start_local = dt_util.as_local(forecast_start)
-                    forecast_end_local = dt_util.as_local(forecast_end)
-                    if forecast_start_local <= mid_local < forecast_end_local:
-                        fit_price = float(forecast.get("per_kwh", 0))
-                        break
-
-                weighted_sum += solar_kwh_val * fit_price
-                total_solar += solar_kwh_val
+        weighted_sum, total_solar = self._compute_weighted_fit(
+            all_solcast, data.feed_in_forecast, now_dt, target_dt
+        )
 
         if total_solar > 0:
             data.solar_weighted_avg_fit = round(weighted_sum / total_solar, 4)

--- a/custom_components/localshift/engine/slots.py
+++ b/custom_components/localshift/engine/slots.py
@@ -131,28 +131,13 @@ class SlotBuilder:
         self._config_options = config_options
         self._ha_timezone = ha_timezone
 
-    def build_slots(  # noqa: C901
+    def build_slots(
         self,
-        data: Any,  # CoordinatorData — avoid circular import
+        data: Any,
         adaptive_params: AdaptiveParameters | None,
         now_dt: datetime | None = None,
     ) -> tuple[list[SlotContext], SlotBuildMetadata]:
-        """Build SlotContext list from raw coordinator data.
-
-        Args:
-            data: CoordinatorData instance with raw forecast fields.
-            adaptive_params: AdaptiveParameters from learning system, or None.
-            now_dt: Reference "now" datetime. When provided (e.g. in tests that
-                mock time), slots are filtered relative to this time rather than
-                the real wall-clock. Defaults to datetime.now().astimezone().
-
-        Returns:
-            (contexts, metadata) tuple where:
-            - contexts: list of SlotContext objects for DP optimizer
-            - metadata: SlotBuildMetadata with diagnostic counts
-
-        """
-        # Step 1: Get hybrid slot schedule from general_forecast
+        """Build SlotContext list from raw coordinator data."""
         now_local = (
             now_dt.astimezone() if now_dt is not None else datetime.now().astimezone()
         )
@@ -162,140 +147,34 @@ class SlotBuilder:
             ha_timezone=self._ha_timezone,
         )
 
-        # Step 2: Parse demand window times from config
         dw_start_time = self._parse_time_option("demand_window_start")
         dw_end_time = self._parse_time_option("demand_window_end")
 
-        # Step 3: Read adaptive parameters
-        solar_confidence_factor = 1.0
-        if adaptive_params is not None:
-            solar_confidence_factor = adaptive_params.get(
-                "solar_confidence_factor", 1.0
-            )
-        # Clamp to safe range [0.0, 2.0] to guard against corrupted learning values
-        solar_confidence_factor = max(0.0, min(2.0, solar_confidence_factor))
-
-        # Step 4: Combine solcast forecasts
+        solar_confidence_factor = self._get_solar_confidence_factor(adaptive_params)
         all_solcast = [*data.solcast_today, *data.solcast_tomorrow]
+        base_slot = self._compute_base_slot(now_local)
+        local_tz = self._get_local_timezone()
 
-        # Step 5: Compute base slot for load_forecast_slots indexing
-        current_5min = (now_local.minute // 5) * 5
-        base_slot = now_local.replace(minute=current_5min, second=0, microsecond=0)
+        contexts, counts = self._process_all_slots(
+            hybrid_slots=hybrid_slots,
+            data=data,
+            all_solcast=all_solcast,
+            solar_confidence_factor=solar_confidence_factor,
+            base_slot=base_slot,
+            local_tz=local_tz,
+            dw_start_time=dw_start_time,
+            dw_end_time=dw_end_time,
+        )
 
-        # Resolve local timezone object once for DW time comparisons.
-        # DW start/end times are always in the HA local timezone, so we must
-        # convert each slot_start to local time before comparing.
-        try:
-            local_tz = ZoneInfo(self._ha_timezone)
-        except Exception:
-            local_tz = None
-
-        # Step 6: Build SlotContext for each hybrid slot
-        contexts: list[SlotContext] = []
-        five_min_count = 0
-        thirty_min_count = 0
-        slots_with_defaulted_solar = 0
-        slots_with_defaulted_price = 0
-        slots_with_defaulted_consumption = 0
-
-        prev_in_demand_window = False
-
-        for i, slot in enumerate(hybrid_slots):
-            slot_start: datetime = slot["start"]
-            interval_minutes: int = slot["interval_minutes"]
-
-            # Convert to local timezone for DW comparison.
-            # slot_start may be in any tz (UTC when ha_timezone is not set in tests,
-            # or local otherwise). DW times are always in HA local tz.
-            if local_tz is not None and slot_start.tzinfo is not None:
-                slot_time = slot_start.astimezone(local_tz).time()
-            else:
-                slot_time = slot_start.time()
-
-            # Track slot duration counts
-            if interval_minutes == 5:
-                five_min_count += 1
-            elif interval_minutes == 30:
-                thirty_min_count += 1
-
-            # Buy price: from hybrid slot (already computed from general_forecast)
-            buy_price = float(slot.get("price", 0.0))
-
-            # Sell price: lookup in feed_in_forecast
-            sell_price_result = get_price_for_slot_or_none(
-                data.feed_in_forecast, slot_start
-            )
-            sell_price = sell_price_result if sell_price_result is not None else 0.0
-
-            # Solar: lookup in solcast and apply confidence factor
-            solar_kwh = get_solar_for_slot_by_interval(
-                all_solcast, slot_start, interval_minutes
-            )
-            solar_kwh = max(0.0, solar_kwh * solar_confidence_factor)
-            if solar_kwh < 0.001:  # Effectively zero
-                slots_with_defaulted_solar += 1
-
-            # Consumption: lookup in load_forecast_slots by 15-min index
-            # Phase 1 already applied consumption_forecast_bias here
-            consumption_kwh = 0.0
-            if data.load_forecast_slots:
-                elapsed_min = (slot_start - base_slot).total_seconds() / 60.0
-                fixed_idx = min(int(elapsed_min // 15), TOTAL_SLOTS - 1)
-                if 0 <= fixed_idx < len(data.load_forecast_slots):
-                    consumption_kw = data.load_forecast_slots[fixed_idx]
-                    consumption_kwh = consumption_kw * interval_minutes / 60.0
-                    if interval_minutes == 30 and 11 <= slot_start.hour <= 14:
-                        _LOGGER.info(
-                            "ISSUE_500 slot_builder: slot=%d time=%s interval=%d fixed_idx=%d "
-                            "slots_len=%d kw_idx_%d=%.3f kwh=%.3f",
-                            i,
-                            slot_start.strftime("%H:%M"),
-                            interval_minutes,
-                            fixed_idx,
-                            len(data.load_forecast_slots),
-                            fixed_idx,
-                            consumption_kw,
-                            consumption_kwh,
-                        )
-
-            if consumption_kwh < 0.001:
-                slots_with_defaulted_consumption += 1
-
-            # Track price defaults
-            if buy_price < 0.001 or sell_price < 0.001:
-                slots_with_defaulted_price += 1
-
-            # Demand window flags
-            in_demand_window = dw_start_time <= slot_time < dw_end_time
-            is_demand_window_entry = in_demand_window and not prev_in_demand_window
-
-            # Build SlotContext
-            ctx = SlotContext(
-                slot_index=i,
-                timestamp_iso=slot_start.isoformat(),
-                slot_interval_minutes=interval_minutes,
-                buy_price=buy_price,
-                sell_price=sell_price,
-                solar_kwh=solar_kwh,
-                consumption_kwh=consumption_kwh,
-                is_demand_window_entry=is_demand_window_entry,
-                is_demand_window_slot=in_demand_window,
-                price_source=slot.get("price_source", "unknown"),
-            )
-            contexts.append(ctx)
-
-            prev_in_demand_window = in_demand_window
-
-        # Step 7: Build metadata
         metadata = SlotBuildMetadata(
             total_slots=len(contexts),
-            five_min_slots=five_min_count,
-            thirty_min_slots=thirty_min_count,
+            five_min_slots=counts["five_min"],
+            thirty_min_slots=counts["thirty_min"],
             horizon_hours=hybrid_metadata.get("horizon_hours", 24.0),
             solar_confidence_factor=solar_confidence_factor,
-            slots_with_defaulted_solar=slots_with_defaulted_solar,
-            slots_with_defaulted_price=slots_with_defaulted_price,
-            slots_with_defaulted_consumption=slots_with_defaulted_consumption,
+            slots_with_defaulted_solar=counts["defaulted_solar"],
+            slots_with_defaulted_price=counts["defaulted_price"],
+            slots_with_defaulted_consumption=counts["defaulted_consumption"],
             all_solcast=all_solcast,
         )
 
@@ -303,15 +182,206 @@ class SlotBuilder:
             "SlotBuilder: built %d slots (%d x 5min, %d x 30min), "
             "solar_confidence=%.2f, defaulted: solar=%d price=%d consumption=%d",
             len(contexts),
-            five_min_count,
-            thirty_min_count,
+            counts["five_min"],
+            counts["thirty_min"],
             solar_confidence_factor,
-            slots_with_defaulted_solar,
-            slots_with_defaulted_price,
-            slots_with_defaulted_consumption,
+            counts["defaulted_solar"],
+            counts["defaulted_price"],
+            counts["defaulted_consumption"],
         )
 
         return contexts, metadata
+
+    def _get_solar_confidence_factor(
+        self, adaptive_params: AdaptiveParameters | None
+    ) -> float:
+        """Extract and clamp solar_confidence_factor from adaptive params."""
+        factor = 1.0
+        if adaptive_params is not None:
+            factor = adaptive_params.get("solar_confidence_factor", 1.0)
+        return max(0.0, min(2.0, factor))
+
+    def _compute_base_slot(self, now_local: datetime) -> datetime:
+        """Compute base slot time for load_forecast_slots indexing."""
+        current_5min = (now_local.minute // 5) * 5
+        return now_local.replace(minute=current_5min, second=0, microsecond=0)
+
+    def _get_local_timezone(self) -> ZoneInfo | None:
+        """Resolve local timezone object for DW time comparisons."""
+        try:
+            return ZoneInfo(self._ha_timezone)
+        except Exception:
+            return None
+
+    def _process_all_slots(
+        self,
+        hybrid_slots: list[dict[str, Any]],
+        data: Any,
+        all_solcast: list[dict[str, Any]],
+        solar_confidence_factor: float,
+        base_slot: datetime,
+        local_tz: ZoneInfo | None,
+        dw_start_time: time,
+        dw_end_time: time,
+    ) -> tuple[list[SlotContext], dict[str, int]]:
+        """Process all hybrid slots and return contexts with counts."""
+        contexts: list[SlotContext] = []
+        counts = {
+            "five_min": 0,
+            "thirty_min": 0,
+            "defaulted_solar": 0,
+            "defaulted_price": 0,
+            "defaulted_consumption": 0,
+        }
+        prev_in_demand_window = False
+
+        for i, slot in enumerate(hybrid_slots):
+            ctx, slot_counts, in_demand_window = self._process_single_slot(
+                i=i,
+                slot=slot,
+                data=data,
+                all_solcast=all_solcast,
+                solar_confidence_factor=solar_confidence_factor,
+                base_slot=base_slot,
+                local_tz=local_tz,
+                dw_start_time=dw_start_time,
+                dw_end_time=dw_end_time,
+                prev_in_demand_window=prev_in_demand_window,
+            )
+            contexts.append(ctx)
+            for key in counts:
+                counts[key] += slot_counts.get(key, 0)
+            prev_in_demand_window = in_demand_window
+
+        return contexts, counts
+
+    def _process_single_slot(
+        self,
+        i: int,
+        slot: dict[str, Any],
+        data: Any,
+        all_solcast: list[dict[str, Any]],
+        solar_confidence_factor: float,
+        base_slot: datetime,
+        local_tz: ZoneInfo | None,
+        dw_start_time: time,
+        dw_end_time: time,
+        prev_in_demand_window: bool,
+    ) -> tuple[SlotContext, dict[str, int], bool]:
+        """Process a single slot, returning (context, counts, in_demand_window)."""
+        slot_start: datetime = slot["start"]
+        interval_minutes: int = slot["interval_minutes"]
+
+        slot_time = self._get_slot_time_for_dw(slot_start, local_tz)
+
+        counts: dict[str, int] = {
+            "five_min": 1 if interval_minutes == 5 else 0,
+            "thirty_min": 1 if interval_minutes == 30 else 0,
+            "defaulted_solar": 0,
+            "defaulted_price": 0,
+            "defaulted_consumption": 0,
+        }
+
+        buy_price = float(slot.get("price", 0.0))
+        sell_price = self._get_sell_price(data.feed_in_forecast, slot_start)
+
+        solar_kwh = self._get_solar_kwh(
+            all_solcast, slot_start, interval_minutes, solar_confidence_factor
+        )
+        if solar_kwh < 0.001:
+            counts["defaulted_solar"] = 1
+
+        consumption_kwh = self._get_consumption_kwh(
+            data.load_forecast_slots, slot_start, base_slot, interval_minutes, i
+        )
+        if consumption_kwh < 0.001:
+            counts["defaulted_consumption"] = 1
+
+        if buy_price < 0.001 or sell_price < 0.001:
+            counts["defaulted_price"] = 1
+
+        in_demand_window = dw_start_time <= slot_time < dw_end_time
+        is_demand_window_entry = in_demand_window and not prev_in_demand_window
+
+        ctx = SlotContext(
+            slot_index=i,
+            timestamp_iso=slot_start.isoformat(),
+            slot_interval_minutes=interval_minutes,
+            buy_price=buy_price,
+            sell_price=sell_price,
+            solar_kwh=solar_kwh,
+            consumption_kwh=consumption_kwh,
+            is_demand_window_entry=is_demand_window_entry,
+            is_demand_window_slot=in_demand_window,
+            price_source=slot.get("price_source", "unknown"),
+        )
+
+        return ctx, counts, in_demand_window
+
+    def _get_slot_time_for_dw(
+        self, slot_start: datetime, local_tz: ZoneInfo | None
+    ) -> time:
+        """Get slot time in local timezone for demand window comparison."""
+        if local_tz is not None and slot_start.tzinfo is not None:
+            return slot_start.astimezone(local_tz).time()
+        return slot_start.time()
+
+    def _get_sell_price(
+        self, feed_in_forecast: list[dict[str, Any]], slot_start: datetime
+    ) -> float:
+        """Get sell price for a slot from feed_in_forecast."""
+        result = get_price_for_slot_or_none(feed_in_forecast, slot_start)
+        return result if result is not None else 0.0
+
+    def _get_solar_kwh(
+        self,
+        all_solcast: list[dict[str, Any]],
+        slot_start: datetime,
+        interval_minutes: int,
+        solar_confidence_factor: float,
+    ) -> float:
+        """Get solar kWh for a slot with confidence factor applied."""
+        solar_kwh = get_solar_for_slot_by_interval(
+            all_solcast, slot_start, interval_minutes
+        )
+        return max(0.0, solar_kwh * solar_confidence_factor)
+
+    def _get_consumption_kwh(
+        self,
+        load_forecast_slots: list[float],
+        slot_start: datetime,
+        base_slot: datetime,
+        interval_minutes: int,
+        slot_index: int,
+    ) -> float:
+        """Get consumption kWh for a slot from load_forecast_slots."""
+        if not load_forecast_slots:
+            return 0.0
+
+        elapsed_min = (slot_start - base_slot).total_seconds() / 60.0
+        fixed_idx = min(int(elapsed_min // 15), TOTAL_SLOTS - 1)
+
+        if not (0 <= fixed_idx < len(load_forecast_slots)):
+            return 0.0
+
+        consumption_kw = load_forecast_slots[fixed_idx]
+        consumption_kwh = consumption_kw * interval_minutes / 60.0
+
+        if interval_minutes == 30 and 11 <= slot_start.hour <= 14:
+            _LOGGER.info(
+                "ISSUE_500 slot_builder: slot=%d time=%s interval=%d fixed_idx=%d "
+                "slots_len=%d kw_idx_%d=%.3f kwh=%.3f",
+                slot_index,
+                slot_start.strftime("%H:%M"),
+                interval_minutes,
+                fixed_idx,
+                len(load_forecast_slots),
+                fixed_idx,
+                consumption_kw,
+                consumption_kwh,
+            )
+
+        return consumption_kwh
 
     def _parse_time_option(self, key: str) -> time:
         """Parse time option from config_options.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,9 +35,6 @@ select = [
 ]
 
 [tool.ruff.lint.per-file-ignores]
-"custom_components/localshift/engine/optimization_controller.py" = ["C901"]
-"custom_components/localshift/engine/price_calculator.py" = ["C901"]
-"custom_components/localshift/engine/slots.py" = ["C901"]
 "custom_components/localshift/forecast/history.py" = ["C901"]
 "custom_components/localshift/forecast/solar.py" = ["C901"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,11 +35,11 @@ select = [
 ]
 
 [tool.ruff.lint.per-file-ignores]
-"custom_components/localshift/engine/decision_outcome_tracker.py" = ["C901"]
+"custom_components/localshift/engine/outcomes.py" = ["C901"]
 "custom_components/localshift/engine/optimization_controller.py" = ["C901"]
-"custom_components/localshift/engine/parameter_optimizer.py" = ["C901"]
+"custom_components/localshift/engine/parameters.py" = ["C901"]
 "custom_components/localshift/engine/price_calculator.py" = ["C901"]
-"custom_components/localshift/engine/slot_builder.py" = ["C901"]
+"custom_components/localshift/engine/slots.py" = ["C901"]
 "custom_components/localshift/forecast/history.py" = ["C901"]
 "custom_components/localshift/forecast/solar.py" = ["C901"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,9 +35,7 @@ select = [
 ]
 
 [tool.ruff.lint.per-file-ignores]
-"custom_components/localshift/engine/outcomes.py" = ["C901"]
 "custom_components/localshift/engine/optimization_controller.py" = ["C901"]
-"custom_components/localshift/engine/parameters.py" = ["C901"]
 "custom_components/localshift/engine/price_calculator.py" = ["C901"]
 "custom_components/localshift/engine/slots.py" = ["C901"]
 "custom_components/localshift/forecast/history.py" = ["C901"]

--- a/tests/engine/test_price_calculator.py
+++ b/tests/engine/test_price_calculator.py
@@ -1,16 +1,24 @@
 """Tests for price_calculator.py helper functions."""
 
 from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from custom_components.localshift.engine.price_calculator import (
+    _collect_prices_by_source,
     _compute_price_slot_data,
     _parse_price_entry,
     get_price_for_slot,
     get_price_for_slot_or_none,
     get_price_for_slot_with_source,
 )
+from custom_components.localshift.engine.price_calculator import PriceCalculator
+
+
+def _make_utc_datetime(offset_minutes: int = 0) -> datetime:
+    """Create a timezone-aware UTC datetime."""
+    return datetime.now(timezone.utc) + timedelta(minutes=offset_minutes)
 
 
 class TestParsePriceEntry:
@@ -18,7 +26,7 @@ class TestParsePriceEntry:
 
     def test_parse_valid_entry(self):
         """Test parsing a valid price entry."""
-        now = datetime.now(timezone.utc)
+        now = _make_utc_datetime()
         entry = {
             "start_time": now.isoformat(),
             "per_kwh": 0.15,
@@ -28,21 +36,90 @@ class TestParsePriceEntry:
         assert result is not None
         assert result["price"] == 0.15
         assert result["duration_minutes"] == 5
+        assert result["is_overlap"] is True
+
+    def test_parse_entry_overlapping_slot(self):
+        """Test entry that overlaps with slot."""
+        now = _make_utc_datetime()
+        entry = {
+            "start_time": (now - timedelta(minutes=5)).isoformat(),
+            "per_kwh": 0.20,
+            "duration": 30,
+        }
+        result = _parse_price_entry(entry, now, now + timedelta(minutes=15))
+        assert result is not None
+        assert result["is_overlap"] is True
+
+    def test_parse_entry_not_overlapping_slot(self):
+        """Test entry that does not overlap with slot."""
+        now = _make_utc_datetime()
+        entry = {
+            "start_time": (now + timedelta(minutes=30)).isoformat(),
+            "per_kwh": 0.25,
+            "duration": 5,
+        }
+        result = _parse_price_entry(entry, now, now + timedelta(minutes=15))
+        assert result is not None
+        assert result["is_overlap"] is False
+
+    def test_parse_entry_is_fallback_candidate(self):
+        """Test entry that is a fallback candidate."""
+        now = _make_utc_datetime()
+        entry = {
+            "start_time": (now - timedelta(minutes=10)).isoformat(),
+            "per_kwh": 0.18,
+            "duration": 30,
+        }
+        result = _parse_price_entry(entry, now, now + timedelta(minutes=15))
+        assert result is not None
+        assert result["is_fallback_candidate"] is True
+
+    def test_parse_entry_not_fallback_candidate(self):
+        """Test entry that starts after slot_start."""
+        now = _make_utc_datetime()
+        entry = {
+            "start_time": (now + timedelta(minutes=5)).isoformat(),
+            "per_kwh": 0.22,
+            "duration": 5,
+        }
+        result = _parse_price_entry(entry, now, now + timedelta(minutes=15))
+        assert result is not None
+        assert result["is_fallback_candidate"] is False
 
     def test_parse_invalid_entry_not_dict(self):
         """Test that non-dict entries return None."""
         result = _parse_price_entry(
-            "not a dict", datetime.now(timezone.utc), datetime.now(timezone.utc)
+            "not a dict", _make_utc_datetime(), _make_utc_datetime()
         )
         assert result is None
 
     def test_parse_entry_missing_start_time(self):
         """Test that entries without start_time return None."""
         entry = {"per_kwh": 0.15}
-        result = _parse_price_entry(
-            entry, datetime.now(timezone.utc), datetime.now(timezone.utc)
-        )
+        result = _parse_price_entry(entry, _make_utc_datetime(), _make_utc_datetime())
         assert result is None
+
+    def test_parse_entry_default_duration(self):
+        """Test default duration of 5 minutes."""
+        now = _make_utc_datetime()
+        entry = {
+            "start_time": now.isoformat(),
+            "per_kwh": 0.10,
+        }
+        result = _parse_price_entry(entry, now, now + timedelta(minutes=15))
+        assert result is not None
+        assert result["duration_minutes"] == 5
+
+    def test_parse_entry_default_price(self):
+        """Test default price of 0.0."""
+        now = _make_utc_datetime()
+        entry = {
+            "start_time": now.isoformat(),
+            "duration": 30,
+        }
+        result = _parse_price_entry(entry, now, now + timedelta(minutes=15))
+        assert result is not None
+        assert result["price"] == 0.0
 
 
 class TestComputePriceSlotData:
@@ -50,16 +127,14 @@ class TestComputePriceSlotData:
 
     def test_empty_forecast_returns_empty(self):
         """Test empty forecast returns empty lists."""
-        prices, fallback, start = _compute_price_slot_data(
-            [], datetime.now(timezone.utc)
-        )
+        prices, fallback, start = _compute_price_slot_data([], _make_utc_datetime())
         assert prices == []
         assert fallback == 0.0
         assert start is None
 
     def test_single_overlapping_price(self):
         """Test single price overlapping slot."""
-        now = datetime.now(timezone.utc)
+        now = _make_utc_datetime()
         forecast = [
             {
                 "start_time": now.isoformat(),
@@ -71,17 +146,159 @@ class TestComputePriceSlotData:
         assert prices == [0.20]
         assert fallback == 0.20
 
+    def test_multiple_overlapping_prices_averaged(self):
+        """Test multiple overlapping prices are collected."""
+        now = _make_utc_datetime()
+        forecast = [
+            {
+                "start_time": now.isoformat(),
+                "per_kwh": 0.10,
+                "duration": 5,
+            },
+            {
+                "start_time": (now + timedelta(minutes=5)).isoformat(),
+                "per_kwh": 0.15,
+                "duration": 5,
+            },
+        ]
+        prices, _, _ = _compute_price_slot_data(forecast, now)
+        assert 0.10 in prices
+        assert 0.15 in prices
+
+    def test_fallback_from_prior_entry(self):
+        """Test fallback from entry starting before slot."""
+        now = _make_utc_datetime()
+        forecast = [
+            {
+                "start_time": (now - timedelta(minutes=30)).isoformat(),
+                "per_kwh": 0.25,
+                "duration": 30,
+            },
+            {
+                "start_time": (now + timedelta(minutes=30)).isoformat(),
+                "per_kwh": 0.30,
+                "duration": 30,
+            },
+        ]
+        prices, fallback, _ = _compute_price_slot_data(forecast, now)
+        assert prices == []
+        assert fallback == 0.25
+
+    def test_naive_datetime_converted_to_local(self):
+        """Test naive datetime is converted to local timezone."""
+        naive_now = datetime.now()
+        forecast = [
+            {
+                "start_time": naive_now.isoformat(),
+                "per_kwh": 0.12,
+                "duration": 30,
+            }
+        ]
+        prices, fallback, _ = _compute_price_slot_data(forecast, naive_now)
+        assert prices == [0.12]
+
+
+class TestCollectPricesBySource:
+    """Tests for _collect_prices_by_source helper."""
+
+    def test_empty_forecast(self):
+        """Test empty forecast returns empty data."""
+        result = _collect_prices_by_source([], _make_utc_datetime(), 15)
+        assert result["prices_5min"] == []
+        assert result["prices_30min"] == []
+        assert result["fallback_price"] == 0.0
+        assert result["fallback_source"] == "unknown"
+
+    def test_5min_prices_collected(self):
+        """Test 5-minute prices are collected separately."""
+        now = _make_utc_datetime()
+        forecast = [
+            {
+                "start_time": now.isoformat(),
+                "per_kwh": 0.10,
+                "duration": 5,
+            },
+            {
+                "start_time": (now + timedelta(minutes=5)).isoformat(),
+                "per_kwh": 0.12,
+                "duration": 5,
+            },
+        ]
+        result = _collect_prices_by_source(forecast, now, 15)
+        assert result["prices_5min"] == [0.10, 0.12]
+        assert result["prices_30min"] == []
+
+    def test_30min_prices_collected(self):
+        """Test 30-minute prices are collected separately."""
+        now = _make_utc_datetime()
+        forecast = [
+            {
+                "start_time": now.isoformat(),
+                "per_kwh": 0.15,
+                "duration": 30,
+            }
+        ]
+        result = _collect_prices_by_source(forecast, now, 15)
+        assert result["prices_30min"] == [0.15]
+        assert result["prices_5min"] == []
+
+    def test_mixed_sources(self):
+        """Test mixed 5min and 30min data."""
+        now = _make_utc_datetime()
+        forecast = [
+            {
+                "start_time": now.isoformat(),
+                "per_kwh": 0.10,
+                "duration": 5,
+            },
+            {
+                "start_time": (now + timedelta(minutes=5)).isoformat(),
+                "per_kwh": 0.20,
+                "duration": 30,
+            },
+        ]
+        result = _collect_prices_by_source(forecast, now, 15)
+        assert result["prices_5min"] == [0.10]
+        assert result["prices_30min"] == [0.20]
+
+    def test_fallback_tracking(self):
+        """Test fallback price and source tracking."""
+        now = _make_utc_datetime()
+        forecast = [
+            {
+                "start_time": (now - timedelta(minutes=10)).isoformat(),
+                "per_kwh": 0.18,
+                "duration": 30,
+            }
+        ]
+        result = _collect_prices_by_source(forecast, now, 15)
+        assert result["fallback_price"] == 0.18
+        assert result["fallback_source"] == "30min"
+
+    def test_custom_interval_minutes(self):
+        """Test custom interval minutes for slot end."""
+        now = _make_utc_datetime()
+        forecast = [
+            {
+                "start_time": now.isoformat(),
+                "per_kwh": 0.25,
+                "duration": 30,
+            }
+        ]
+        result = _collect_prices_by_source(forecast, now, 30)
+        assert result["prices_30min"] == [0.25]
+
 
 class TestGetPriceForSlot:
     """Tests for get_price_for_slot function."""
 
     def test_empty_forecast_returns_zero(self):
         """Test empty forecast returns 0.0."""
-        assert get_price_for_slot([], datetime.now(timezone.utc)) == 0.0
+        assert get_price_for_slot([], _make_utc_datetime()) == 0.0
 
     def test_single_price_forecast(self):
         """Test single price forecast."""
-        now = datetime.now(timezone.utc)
+        now = _make_utc_datetime()
         forecast = [
             {
                 "start_time": now.isoformat(),
@@ -91,19 +308,48 @@ class TestGetPriceForSlot:
         ]
         assert get_price_for_slot(forecast, now) == 0.25
 
+    def test_multiple_prices_averaged(self):
+        """Test multiple prices are averaged."""
+        now = _make_utc_datetime()
+        forecast = [
+            {
+                "start_time": now.isoformat(),
+                "per_kwh": 0.20,
+                "duration": 5,
+            },
+            {
+                "start_time": (now + timedelta(minutes=5)).isoformat(),
+                "per_kwh": 0.30,
+                "duration": 5,
+            },
+        ]
+        assert get_price_for_slot(forecast, now) == 0.25
+
+    def test_fallback_when_no_overlap(self):
+        """Test fallback when no prices overlap."""
+        now = _make_utc_datetime()
+        forecast = [
+            {
+                "start_time": (now - timedelta(minutes=30)).isoformat(),
+                "per_kwh": 0.15,
+                "duration": 30,
+            }
+        ]
+        assert get_price_for_slot(forecast, now) == 0.15
+
 
 class TestGetPriceForSlotWithSource:
     """Tests for get_price_for_slot_with_source function."""
 
     def test_empty_forecast_returns_unknown(self):
         """Test empty forecast returns 0.0, unknown."""
-        price, source = get_price_for_slot_with_source([], datetime.now(timezone.utc))
+        price, source = get_price_for_slot_with_source([], _make_utc_datetime())
         assert price == 0.0
         assert source == "unknown"
 
     def test_5min_data_preferred(self):
         """Test 5-min data is preferred over 30-min."""
-        now = datetime.now(timezone.utc)
+        now = _make_utc_datetime()
         forecast = [
             {
                 "start_time": now.isoformat(),
@@ -117,7 +363,7 @@ class TestGetPriceForSlotWithSource:
 
     def test_30min_data_fallback(self):
         """Test 30-min data is used when no 5-min available."""
-        now = datetime.now(timezone.utc)
+        now = _make_utc_datetime()
         forecast = [
             {
                 "start_time": now.isoformat(),
@@ -129,17 +375,64 @@ class TestGetPriceForSlotWithSource:
         assert price == 0.15
         assert source == "30min"
 
+    def test_5min_priority_over_30min(self):
+        """Test 5-min data takes priority when both available."""
+        now = _make_utc_datetime()
+        forecast = [
+            {
+                "start_time": now.isoformat(),
+                "per_kwh": 0.10,
+                "duration": 5,
+            },
+            {
+                "start_time": now.isoformat(),
+                "per_kwh": 0.20,
+                "duration": 30,
+            },
+        ]
+        price, source = get_price_for_slot_with_source(forecast, now)
+        assert price == 0.10
+        assert source == "5min"
+
+    def test_custom_interval(self):
+        """Test custom interval minutes."""
+        now = _make_utc_datetime()
+        forecast = [
+            {
+                "start_time": now.isoformat(),
+                "per_kwh": 0.22,
+                "duration": 30,
+            }
+        ]
+        price, source = get_price_for_slot_with_source(forecast, now, 30)
+        assert price == 0.22
+        assert source == "30min"
+
+    def test_fallback_source(self):
+        """Test fallback when no overlapping data."""
+        now = _make_utc_datetime()
+        forecast = [
+            {
+                "start_time": (now - timedelta(minutes=10)).isoformat(),
+                "per_kwh": 0.18,
+                "duration": 5,
+            }
+        ]
+        price, source = get_price_for_slot_with_source(forecast, now)
+        assert price == 0.18
+        assert source == "5min"
+
 
 class TestGetPriceForSlotOrNull:
     """Tests for get_price_for_slot_or_none function."""
 
     def test_empty_forecast_returns_none(self):
         """Test empty forecast returns None."""
-        assert get_price_for_slot_or_none([], datetime.now(timezone.utc)) is None
+        assert get_price_for_slot_or_none([], _make_utc_datetime()) is None
 
     def test_overlapping_price_returns_value(self):
         """Test overlapping price returns value."""
-        now = datetime.now(timezone.utc)
+        now = _make_utc_datetime()
         forecast = [
             {
                 "start_time": now.isoformat(),
@@ -148,3 +441,842 @@ class TestGetPriceForSlotOrNull:
             }
         ]
         assert get_price_for_slot_or_none(forecast, now) == 0.30
+
+    def test_no_overlap_no_fallback_returns_none(self):
+        """Test None when no overlap and no fallback candidate."""
+        now = _make_utc_datetime()
+        forecast = [
+            {
+                "start_time": (now + timedelta(minutes=30)).isoformat(),
+                "per_kwh": 0.25,
+                "duration": 30,
+            }
+        ]
+        assert get_price_for_slot_or_none(forecast, now) is None
+
+    def test_fallback_returns_value(self):
+        """Test fallback price when no overlap but fallback exists."""
+        now = _make_utc_datetime()
+        forecast = [
+            {
+                "start_time": (now - timedelta(minutes=10)).isoformat(),
+                "per_kwh": 0.20,
+                "duration": 30,
+            }
+        ]
+        assert get_price_for_slot_or_none(forecast, now) == 0.20
+
+
+class TestPriceCalculatorInit:
+    """Tests for PriceCalculator initialization."""
+
+    def test_init_stores_dependencies(self):
+        """Test __init__ stores all dependencies."""
+        entry = MagicMock()
+        entry.options = {}
+        calc = PriceCalculator(
+            entry=entry,
+            parse_forecast_dt=lambda x: None,
+            percentile_func=lambda x, y: 0.0,
+            sum_solar_before_target=lambda x, y, z: 0.0,
+            get_expected_load_kw=lambda x, y: 0.0,
+        )
+        assert calc.entry is entry
+        assert calc._smoothed_effective_cheap_price is None
+
+
+class TestPriceCalculatorHysteresis:
+    """Tests for _apply_threshold_hysteresis method."""
+
+    @pytest.fixture
+    def calculator(self):
+        """Create a PriceCalculator instance."""
+        entry = MagicMock()
+        entry.options = {}
+        return PriceCalculator(
+            entry=entry,
+            parse_forecast_dt=lambda x: None,
+            percentile_func=lambda x, y: 0.0,
+            sum_solar_before_target=lambda x, y, z: 0.0,
+            get_expected_load_kw=lambda x, y: 0.0,
+        )
+
+    def test_first_call_initializes(self, calculator):
+        """Test first call initializes smoothed value."""
+        result = calculator._apply_threshold_hysteresis(0.15)
+        assert result == 0.15
+        assert calculator._smoothed_effective_cheap_price == 0.15
+
+    def test_small_change_ignored(self, calculator):
+        """Test changes below hysteresis threshold are ignored."""
+        calculator._apply_threshold_hysteresis(0.15)
+        result = calculator._apply_threshold_hysteresis(0.16)
+        assert result == 0.15
+
+    def test_large_change_applied(self, calculator):
+        """Test changes above hysteresis threshold are applied."""
+        calculator._apply_threshold_hysteresis(0.15)
+        result = calculator._apply_threshold_hysteresis(0.20)
+        assert result != 0.15
+        assert 0.15 < result < 0.20
+
+    def test_smoothing_applied(self, calculator):
+        """Test EMA smoothing is applied."""
+        calculator._apply_threshold_hysteresis(0.10)
+        result = calculator._apply_threshold_hysteresis(0.20)
+        expected = 0.3 * 0.20 + 0.7 * 0.10
+        assert abs(result - round(expected, 2)) < 0.01
+
+
+class TestPriceCalculatorFitPrice:
+    """Tests for _get_fit_price_for_period method."""
+
+    @pytest.fixture
+    def calculator(self):
+        """Create a PriceCalculator instance with parse_forecast_dt."""
+        from homeassistant.util import dt as dt_util
+
+        def parse_dt(val):
+            if val is None:
+                return None
+            try:
+                from datetime import datetime
+
+                return datetime.fromisoformat(val.replace("Z", "+00:00"))
+            except Exception:
+                return None
+
+        entry = MagicMock()
+        entry.options = {}
+        return PriceCalculator(
+            entry=entry,
+            parse_forecast_dt=parse_dt,
+            percentile_func=lambda x, y: 0.0,
+            sum_solar_before_target=lambda x, y, z: 0.0,
+            get_expected_load_kw=lambda x, y: 0.0,
+        )
+
+    def test_matching_period(self, calculator):
+        """Test FIT price returned for matching period."""
+        now = _make_utc_datetime()
+        forecast = [
+            {
+                "start_time": now.isoformat(),
+                "end_time": (now + timedelta(minutes=30)).isoformat(),
+                "per_kwh": 0.08,
+            }
+        ]
+        mid = now + timedelta(minutes=15)
+        result = calculator._get_fit_price_for_period(forecast, mid)
+        assert result == 0.08
+
+    def test_no_matching_period(self, calculator):
+        """Test 0.0 returned when no period matches."""
+        now = _make_utc_datetime()
+        forecast = [
+            {
+                "start_time": (now + timedelta(hours=1)).isoformat(),
+                "end_time": (now + timedelta(hours=2)).isoformat(),
+                "per_kwh": 0.10,
+            }
+        ]
+        mid = now + timedelta(minutes=15)
+        result = calculator._get_fit_price_for_period(forecast, mid)
+        assert result == 0.0
+
+    def test_multiple_periods(self, calculator):
+        """Test first matching period is used."""
+        now = _make_utc_datetime()
+        forecast = [
+            {
+                "start_time": (now - timedelta(hours=1)).isoformat(),
+                "end_time": now.isoformat(),
+                "per_kwh": 0.05,
+            },
+            {
+                "start_time": now.isoformat(),
+                "end_time": (now + timedelta(minutes=30)).isoformat(),
+                "per_kwh": 0.07,
+            },
+        ]
+        mid = now + timedelta(minutes=10)
+        result = calculator._get_fit_price_for_period(forecast, mid)
+        assert result == 0.07
+
+
+class TestPriceCalculatorWeightedFit:
+    """Tests for _compute_weighted_fit method."""
+
+    @pytest.fixture
+    def calculator(self):
+        """Create a PriceCalculator instance."""
+        from homeassistant.util import dt as dt_util
+
+        def parse_dt(val):
+            if val is None:
+                return None
+            try:
+                from datetime import datetime
+
+                return datetime.fromisoformat(val.replace("Z", "+00:00"))
+            except Exception:
+                return None
+
+        entry = MagicMock()
+        entry.options = {}
+        return PriceCalculator(
+            entry=entry,
+            parse_forecast_dt=parse_dt,
+            percentile_func=lambda x, y: 0.0,
+            sum_solar_before_target=lambda x, y, z: 0.0,
+            get_expected_load_kw=lambda x, y: 0.0,
+        )
+
+    def test_single_period(self, calculator):
+        """Test weighted fit for single solar period."""
+        now = _make_utc_datetime()
+        target = now + timedelta(hours=4)
+
+        solcast = [
+            {
+                "period_start": now.isoformat(),
+                "pv_estimate": 2.0,
+            }
+        ]
+        fit_forecast = [
+            {
+                "start_time": now.isoformat(),
+                "end_time": (now + timedelta(minutes=30)).isoformat(),
+                "per_kwh": 0.10,
+            }
+        ]
+
+        weighted_sum, total_solar = calculator._compute_weighted_fit(
+            solcast, fit_forecast, now, target
+        )
+        assert total_solar == 2.0
+        assert weighted_sum == 0.20
+
+    def test_multiple_periods(self, calculator):
+        """Test weighted fit for multiple solar periods."""
+        now = _make_utc_datetime()
+        target = now + timedelta(hours=4)
+
+        solcast = [
+            {
+                "period_start": now.isoformat(),
+                "pv_estimate": 1.0,
+            },
+            {
+                "period_start": (now + timedelta(minutes=30)).isoformat(),
+                "pv_estimate": 2.0,
+            },
+        ]
+        fit_forecast = [
+            {
+                "start_time": now.isoformat(),
+                "end_time": (now + timedelta(hours=2)).isoformat(),
+                "per_kwh": 0.08,
+            }
+        ]
+
+        weighted_sum, total_solar = calculator._compute_weighted_fit(
+            solcast, fit_forecast, now, target
+        )
+        assert total_solar == 3.0
+        assert weighted_sum == 0.24
+
+    def test_no_solar_in_range(self, calculator):
+        """Test zero solar when no periods in range."""
+        now = _make_utc_datetime()
+        target = now + timedelta(hours=2)
+
+        solcast = [
+            {
+                "period_start": (now + timedelta(hours=4)).isoformat(),
+                "pv_estimate": 2.0,
+            }
+        ]
+        fit_forecast = []
+
+        weighted_sum, total_solar = calculator._compute_weighted_fit(
+            solcast, fit_forecast, now, target
+        )
+        assert total_solar == 0.0
+        assert weighted_sum == 0.0
+
+    def test_zero_solar_skipped(self, calculator):
+        """Test periods with zero solar are skipped."""
+        now = _make_utc_datetime()
+        target = now + timedelta(hours=4)
+
+        solcast = [
+            {
+                "period_start": now.isoformat(),
+                "pv_estimate": 0.0,
+            }
+        ]
+        fit_forecast = []
+
+        weighted_sum, total_solar = calculator._compute_weighted_fit(
+            solcast, fit_forecast, now, target
+        )
+        assert total_solar == 0.0
+
+
+class TestPriceCalculatorSolarWeightedAvgFit:
+    """Tests for compute_solar_weighted_avg_fit method."""
+
+    @pytest.fixture
+    def calculator(self):
+        """Create a PriceCalculator instance."""
+        from homeassistant.util import dt as dt_util
+
+        def parse_dt(val):
+            if val is None:
+                return None
+            try:
+                from datetime import datetime
+
+                return datetime.fromisoformat(val.replace("Z", "+00:00"))
+            except Exception:
+                return None
+
+        entry = MagicMock()
+        entry.options = {}
+        return PriceCalculator(
+            entry=entry,
+            parse_forecast_dt=parse_dt,
+            percentile_func=lambda x, y: 0.0,
+            sum_solar_before_target=lambda x, y, z: 0.0,
+            get_expected_load_kw=lambda x, y: 0.0,
+        )
+
+    def test_after_dw_returns_zero(self, calculator):
+        """Test zero values when after demand window."""
+        data = MagicMock()
+        data.solcast_today = []
+        data.solcast_tomorrow = []
+        data.feed_in_forecast = []
+
+        calculator.compute_solar_weighted_avg_fit(
+            data, _make_utc_datetime(), 18, after_dw=True
+        )
+        assert data.solar_weighted_avg_fit == 0.0
+        assert data.solar_remaining_kwh == 0.0
+
+    def test_computes_weighted_average(self, calculator):
+        """Test weighted average is computed correctly."""
+        now = _make_utc_datetime()
+        data = MagicMock()
+        data.solcast_today = [
+            {
+                "period_start": now.isoformat(),
+                "pv_estimate": 2.0,
+            }
+        ]
+        data.solcast_tomorrow = []
+        data.feed_in_forecast = [
+            {
+                "start_time": now.isoformat(),
+                "end_time": (now + timedelta(minutes=30)).isoformat(),
+                "per_kwh": 0.10,
+            }
+        ]
+
+        calculator.compute_solar_weighted_avg_fit(data, now, 18, after_dw=False)
+        assert data.solar_weighted_avg_fit == 0.10
+        assert data.solar_remaining_kwh == 2.0
+
+    def test_no_solar_defaults_to_zero(self, calculator):
+        """Test zero values when no solar forecast."""
+        now = _make_utc_datetime()
+        data = MagicMock()
+        data.solcast_today = []
+        data.solcast_tomorrow = []
+        data.feed_in_forecast = []
+
+        calculator.compute_solar_weighted_avg_fit(data, now, 18, after_dw=False)
+        assert data.solar_weighted_avg_fit == 0.0
+        assert data.solar_remaining_kwh == 0.0
+
+
+class TestPriceCalculatorCollectForecastPrices:
+    """Tests for _collect_forecast_prices_and_base method."""
+
+    @pytest.fixture
+    def calculator(self):
+        """Create a PriceCalculator instance."""
+        from homeassistant.util import dt as dt_util
+
+        def parse_dt(val):
+            if val is None:
+                return None
+            try:
+                from datetime import datetime
+
+                return datetime.fromisoformat(val.replace("Z", "+00:00"))
+            except Exception:
+                return None
+
+        entry = MagicMock()
+        entry.options = {
+            "cheap_price_percentile": 0.2,
+            "max_pre_charge_price": 0.30,
+        }
+        return PriceCalculator(
+            entry=entry,
+            parse_forecast_dt=parse_dt,
+            percentile_func=lambda prices, pct: (
+                sorted(prices)[int(len(prices) * pct)] if prices else 0.0
+            ),
+            sum_solar_before_target=lambda x, y, z: 0.0,
+            get_expected_load_kw=lambda x, y: 0.0,
+        )
+
+    def test_collects_prices_in_horizon(self, calculator):
+        """Test prices within horizon are collected."""
+        now = _make_utc_datetime()
+        forecast = [
+            {
+                "start_time": now.isoformat(),
+                "per_kwh": 0.10,
+            },
+            {
+                "start_time": (now + timedelta(hours=1)).isoformat(),
+                "per_kwh": 0.15,
+            },
+            {
+                "start_time": (now + timedelta(hours=30)).isoformat(),
+                "per_kwh": 0.20,
+            },
+        ]
+
+        prices, base, max_price = calculator._collect_forecast_prices_and_base(
+            forecast, now, 24.0
+        )
+        assert len(prices) == 2
+        assert 0.10 in prices
+        assert 0.15 in prices
+
+    def test_empty_forecast_uses_max_precharge(self, calculator):
+        """Test empty forecast uses max precharge price."""
+        now = _make_utc_datetime()
+        prices, base, max_price = calculator._collect_forecast_prices_and_base(
+            [], now, 24.0
+        )
+        assert prices == []
+        assert base == 0.30
+        assert max_price == 0.30
+
+    def test_horizon_factor_applied(self, calculator):
+        """Test horizon factor scales percentile."""
+        now = _make_utc_datetime()
+        forecast = [
+            {
+                "start_time": now.isoformat(),
+                "per_kwh": 0.10,
+            },
+        ]
+
+        prices, base, max_price = calculator._collect_forecast_prices_and_base(
+            forecast, now, 12.0
+        )
+        assert len(prices) == 1
+
+
+class TestPriceCalculatorUrgencyAdjustedPrice:
+    """Tests for _calculate_urgency_adjusted_price method."""
+
+    @pytest.fixture
+    def calculator(self):
+        """Create a PriceCalculator instance."""
+        from homeassistant.util import dt as dt_util
+
+        def parse_dt(val):
+            if val is None:
+                return None
+            try:
+                from datetime import datetime
+
+                return datetime.fromisoformat(val.replace("Z", "+00:00"))
+            except Exception:
+                return None
+
+        entry = MagicMock()
+        entry.options = {"max_pre_charge_price": 0.50}
+        return PriceCalculator(
+            entry=entry,
+            parse_forecast_dt=parse_dt,
+            percentile_func=lambda x, y: 0.0,
+            sum_solar_before_target=lambda x, y, z: 0.0,
+            get_expected_load_kw=lambda x, y: 0.0,
+        )
+
+    def test_no_urgency_when_far_from_target(self, calculator):
+        """Test no urgency adjustment when far from target."""
+        now = _make_utc_datetime()
+        target_hour = (now + timedelta(hours=6)).hour
+        data = MagicMock()
+        data.general_forecast = [
+            {
+                "start_time": now.isoformat(),
+                "per_kwh": 0.10,
+            }
+        ]
+
+        result = calculator._calculate_urgency_adjusted_price(
+            data, now, target_hour, base=0.10, max_price=0.50
+        )
+        assert result == 0.10
+
+    def test_high_urgency_near_target(self, calculator):
+        """Test urgency increases price near target."""
+        now = _make_utc_datetime().replace(minute=0, second=0, microsecond=0)
+        target_hour = (now + timedelta(hours=1)).hour
+        data = MagicMock()
+        data.general_forecast = []
+
+        result = calculator._calculate_urgency_adjusted_price(
+            data, now, target_hour, base=0.10, max_price=0.50
+        )
+        assert result > 0.10
+
+    def test_respects_forecast_floor(self, calculator):
+        """Test price respects minimum forecast price."""
+        now = _make_utc_datetime().replace(minute=0, second=0, microsecond=0)
+        target_hour = (now + timedelta(hours=1)).hour
+        data = MagicMock()
+        data.general_forecast = [
+            {
+                "start_time": now.isoformat(),
+                "per_kwh": 0.25,
+            }
+        ]
+
+        result = calculator._calculate_urgency_adjusted_price(
+            data, now, target_hour, base=0.10, max_price=0.50
+        )
+        assert result >= 0.25
+
+    def test_capped_at_max_price(self, calculator):
+        """Test urgency price is capped at max_price."""
+        now = _make_utc_datetime().replace(minute=0, second=0, microsecond=0)
+        target_hour = (now + timedelta(minutes=30)).hour
+        data = MagicMock()
+        data.general_forecast = []
+
+        result = calculator._calculate_urgency_adjusted_price(
+            data, now, target_hour, base=0.40, max_price=0.50
+        )
+        assert result <= 0.50
+
+
+class TestComputeEffectiveCheapPricePreliminary:
+    """Tests for compute_effective_cheap_price_preliminary method."""
+
+    @pytest.fixture
+    def calculator(self):
+        """Create a PriceCalculator instance."""
+        from datetime import datetime
+
+        def parse_dt(val):
+            if val is None:
+                return None
+            try:
+                return datetime.fromisoformat(val.replace("Z", "+00:00"))
+            except Exception:
+                return None
+
+        entry = MagicMock()
+        entry.options = {"max_pre_charge_price": 0.50}
+        return PriceCalculator(
+            entry=entry,
+            parse_forecast_dt=parse_dt,
+            percentile_func=lambda x, y: 0.10,
+            sum_solar_before_target=lambda x, y, z: 10.0,
+            get_expected_load_kw=lambda x, y: 1.0,
+        )
+
+    def test_no_urgency_when_solar_can_reach(self, calculator):
+        """Test base price when solar can reach target."""
+        now = _make_utc_datetime()
+        data = MagicMock()
+        data.general_forecast = [{"start_time": now.isoformat(), "per_kwh": 0.15}]
+        data.forecast_horizon_hours = 12.0
+        data.soc = 80.0
+        data.target_reached_today = False
+        data.solcast_today = []
+        data.solcast_tomorrow = []
+
+        calculator.compute_effective_cheap_price_preliminary(
+            data, now, before_dw=True, target_hour=18, target_pct=70.0
+        )
+        assert data.effective_cheap_price == 0.10
+
+    def test_urgency_when_solar_gap_and_before_dw(self, calculator):
+        """Test urgency price when solar gap and before demand window."""
+        now = _make_utc_datetime()
+        data = MagicMock()
+        data.general_forecast = [{"start_time": now.isoformat(), "per_kwh": 0.10}]
+        data.forecast_horizon_hours = 12.0
+        data.soc = 30.0
+        data.target_reached_today = False
+        data.solcast_today = []
+        data.solcast_tomorrow = []
+
+        calculator.compute_effective_cheap_price_preliminary(
+            data, now, before_dw=True, target_hour=18, target_pct=80.0
+        )
+        assert data.effective_cheap_price is not None
+
+    def test_base_price_when_target_reached(self, calculator):
+        """Test base price when target already reached today."""
+        now = _make_utc_datetime()
+        data = MagicMock()
+        data.general_forecast = [{"start_time": now.isoformat(), "per_kwh": 0.15}]
+        data.forecast_horizon_hours = 12.0
+        data.soc = 30.0
+        data.target_reached_today = True
+        data.solcast_today = []
+        data.solcast_tomorrow = []
+
+        calculator.compute_effective_cheap_price_preliminary(
+            data, now, before_dw=True, target_hour=18, target_pct=80.0
+        )
+        assert data.effective_cheap_price == 0.10
+
+    def test_base_price_when_not_before_dw(self, calculator):
+        """Test base price when not before demand window."""
+        now = _make_utc_datetime()
+        data = MagicMock()
+        data.general_forecast = [{"start_time": now.isoformat(), "per_kwh": 0.15}]
+        data.forecast_horizon_hours = 12.0
+        data.soc = 30.0
+        data.target_reached_today = False
+        data.solcast_today = []
+        data.solcast_tomorrow = []
+
+        calculator.compute_effective_cheap_price_preliminary(
+            data, now, before_dw=False, target_hour=18, target_pct=80.0
+        )
+        assert data.effective_cheap_price == 0.10
+
+
+class TestComputeEffectiveCheapPrice:
+    """Tests for compute_effective_cheap_price method."""
+
+    @pytest.fixture
+    def calculator(self):
+        """Create a PriceCalculator instance."""
+        from datetime import datetime
+
+        def parse_dt(val):
+            if val is None:
+                return None
+            try:
+                return datetime.fromisoformat(val.replace("Z", "+00:00"))
+            except Exception:
+                return None
+
+        entry = MagicMock()
+        entry.options = {"max_pre_charge_price": 0.50}
+        return PriceCalculator(
+            entry=entry,
+            parse_forecast_dt=parse_dt,
+            percentile_func=lambda x, y: 0.10,
+            sum_solar_before_target=lambda x, y, z: 10.0,
+            get_expected_load_kw=lambda x, y: 1.0,
+        )
+
+    def test_base_price_when_no_solar_gap(self, calculator):
+        """Test base price when solar can reach target."""
+        now = _make_utc_datetime()
+        data = MagicMock()
+        data.general_forecast = [{"start_time": now.isoformat(), "per_kwh": 0.15}]
+        data.forecast_horizon_hours = 12.0
+        data.solar_can_reach_target = True
+        data.target_reached_today = False
+
+        calculator.compute_effective_cheap_price(
+            data, now, target_hour=18, before_dw=True
+        )
+        assert data.effective_cheap_price == 0.10
+
+    def test_urgency_when_solar_gap(self, calculator):
+        """Test urgency price when solar cannot reach target."""
+        now = _make_utc_datetime()
+        data = MagicMock()
+        data.general_forecast = [{"start_time": now.isoformat(), "per_kwh": 0.10}]
+        data.forecast_horizon_hours = 12.0
+        data.solar_can_reach_target = False
+        data.target_reached_today = False
+
+        calculator.compute_effective_cheap_price(
+            data, now, target_hour=18, before_dw=True
+        )
+        assert data.effective_cheap_price is not None
+
+    def test_base_price_when_not_before_dw(self, calculator):
+        """Test base price when not before demand window."""
+        now = _make_utc_datetime()
+        data = MagicMock()
+        data.general_forecast = [{"start_time": now.isoformat(), "per_kwh": 0.15}]
+        data.forecast_horizon_hours = 12.0
+        data.solar_can_reach_target = False
+        data.target_reached_today = False
+
+        calculator.compute_effective_cheap_price(
+            data, now, target_hour=18, before_dw=False
+        )
+        assert data.effective_cheap_price == 0.10
+
+
+class TestGetFitPriceForPeriod:
+    """Tests for _get_fit_price_for_period method."""
+
+    @pytest.fixture
+    def calculator(self):
+        """Create a PriceCalculator instance."""
+        from datetime import datetime
+
+        def parse_dt(val):
+            if val is None:
+                return None
+            try:
+                return datetime.fromisoformat(val.replace("Z", "+00:00"))
+            except Exception:
+                return None
+
+        entry = MagicMock()
+        entry.options = {}
+        return PriceCalculator(
+            entry=entry,
+            parse_forecast_dt=parse_dt,
+            percentile_func=lambda x, y: 0.0,
+            sum_solar_before_target=lambda x, y, z: 0.0,
+            get_expected_load_kw=lambda x, y: 0.0,
+        )
+
+    def test_returns_price_when_in_period(self, calculator):
+        """Test returns FIT price when time is within forecast period."""
+        now = _make_utc_datetime()
+        feed_in_forecast = [
+            {
+                "start_time": now.isoformat(),
+                "end_time": (now + timedelta(minutes=30)).isoformat(),
+                "per_kwh": 0.12,
+            }
+        ]
+        mid_local = now + timedelta(minutes=10)
+
+        result = calculator._get_fit_price_for_period(feed_in_forecast, mid_local)
+        assert result == 0.12
+
+    def test_returns_zero_when_no_match(self, calculator):
+        """Test returns zero when no forecast period matches."""
+        now = _make_utc_datetime()
+        feed_in_forecast = [
+            {
+                "start_time": (now + timedelta(hours=1)).isoformat(),
+                "end_time": (now + timedelta(hours=2)).isoformat(),
+                "per_kwh": 0.12,
+            }
+        ]
+        mid_local = now + timedelta(minutes=10)
+
+        result = calculator._get_fit_price_for_period(feed_in_forecast, mid_local)
+        assert result == 0.0
+
+    def test_skips_invalid_entries(self, calculator):
+        """Test skips entries with invalid start/end times."""
+        now = _make_utc_datetime()
+        feed_in_forecast = [
+            {"start_time": None, "end_time": None, "per_kwh": 0.12},
+        ]
+        mid_local = now + timedelta(minutes=10)
+
+        result = calculator._get_fit_price_for_period(feed_in_forecast, mid_local)
+        assert result == 0.0
+
+
+class TestComputeWeightedFit:
+    """Tests for _compute_weighted_fit method."""
+
+    @pytest.fixture
+    def calculator(self):
+        """Create a PriceCalculator instance."""
+        from datetime import datetime
+
+        def parse_dt(val):
+            if val is None:
+                return None
+            try:
+                return datetime.fromisoformat(val.replace("Z", "+00:00"))
+            except Exception:
+                return None
+
+        entry = MagicMock()
+        entry.options = {}
+        return PriceCalculator(
+            entry=entry,
+            parse_forecast_dt=parse_dt,
+            percentile_func=lambda x, y: 0.0,
+            sum_solar_before_target=lambda x, y, z: 0.0,
+            get_expected_load_kw=lambda x, y: 0.0,
+        )
+
+    def test_computes_weighted_sum(self, calculator):
+        """Test computes weighted sum correctly."""
+        now = _make_utc_datetime()
+        all_solcast = [
+            {
+                "period_start": now.isoformat(),
+                "pv_estimate": 2.0,
+            }
+        ]
+        feed_in_forecast = [
+            {
+                "start_time": now.isoformat(),
+                "end_time": (now + timedelta(minutes=30)).isoformat(),
+                "per_kwh": 0.10,
+            }
+        ]
+        target_dt = now + timedelta(hours=6)
+
+        weighted_sum, total_solar = calculator._compute_weighted_fit(
+            all_solcast, feed_in_forecast, now, target_dt
+        )
+        assert total_solar == 2.0
+        assert weighted_sum == 0.2
+
+    def test_skips_zero_solar(self, calculator):
+        """Test skips periods with zero solar."""
+        now = _make_utc_datetime()
+        all_solcast = [
+            {
+                "period_start": now.isoformat(),
+                "pv_estimate": 0.0,
+            }
+        ]
+        feed_in_forecast = []
+        target_dt = now + timedelta(hours=6)
+
+        weighted_sum, total_solar = calculator._compute_weighted_fit(
+            all_solcast, feed_in_forecast, now, target_dt
+        )
+        assert total_solar == 0.0
+
+    def test_skips_invalid_period_start(self, calculator):
+        """Test skips periods with invalid period_start."""
+        now = _make_utc_datetime()
+        all_solcast = [
+            {"period_start": None, "pv_estimate": 2.0},
+        ]
+        feed_in_forecast = []
+        target_dt = now + timedelta(hours=6)
+
+        weighted_sum, total_solar = calculator._compute_weighted_fit(
+            all_solcast, feed_in_forecast, now, target_dt
+        )
+        assert total_solar == 0.0

--- a/tests/engine/test_price_calculator.py
+++ b/tests/engine/test_price_calculator.py
@@ -1,0 +1,150 @@
+"""Tests for price_calculator.py helper functions."""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from custom_components.localshift.engine.price_calculator import (
+    _compute_price_slot_data,
+    _parse_price_entry,
+    get_price_for_slot,
+    get_price_for_slot_or_none,
+    get_price_for_slot_with_source,
+)
+
+
+class TestParsePriceEntry:
+    """Tests for _parse_price_entry helper."""
+
+    def test_parse_valid_entry(self):
+        """Test parsing a valid price entry."""
+        now = datetime.now(timezone.utc)
+        entry = {
+            "start_time": now.isoformat(),
+            "per_kwh": 0.15,
+            "duration": 5,
+        }
+        result = _parse_price_entry(entry, now, now + timedelta(minutes=15))
+        assert result is not None
+        assert result["price"] == 0.15
+        assert result["duration_minutes"] == 5
+
+    def test_parse_invalid_entry_not_dict(self):
+        """Test that non-dict entries return None."""
+        result = _parse_price_entry(
+            "not a dict", datetime.now(timezone.utc), datetime.now(timezone.utc)
+        )
+        assert result is None
+
+    def test_parse_entry_missing_start_time(self):
+        """Test that entries without start_time return None."""
+        entry = {"per_kwh": 0.15}
+        result = _parse_price_entry(
+            entry, datetime.now(timezone.utc), datetime.now(timezone.utc)
+        )
+        assert result is None
+
+
+class TestComputePriceSlotData:
+    """Tests for _compute_price_slot_data helper."""
+
+    def test_empty_forecast_returns_empty(self):
+        """Test empty forecast returns empty lists."""
+        prices, fallback, start = _compute_price_slot_data(
+            [], datetime.now(timezone.utc)
+        )
+        assert prices == []
+        assert fallback == 0.0
+        assert start is None
+
+    def test_single_overlapping_price(self):
+        """Test single price overlapping slot."""
+        now = datetime.now(timezone.utc)
+        forecast = [
+            {
+                "start_time": now.isoformat(),
+                "per_kwh": 0.20,
+                "duration": 30,
+            }
+        ]
+        prices, fallback, _ = _compute_price_slot_data(forecast, now)
+        assert prices == [0.20]
+        assert fallback == 0.20
+
+
+class TestGetPriceForSlot:
+    """Tests for get_price_for_slot function."""
+
+    def test_empty_forecast_returns_zero(self):
+        """Test empty forecast returns 0.0."""
+        assert get_price_for_slot([], datetime.now(timezone.utc)) == 0.0
+
+    def test_single_price_forecast(self):
+        """Test single price forecast."""
+        now = datetime.now(timezone.utc)
+        forecast = [
+            {
+                "start_time": now.isoformat(),
+                "per_kwh": 0.25,
+                "duration": 30,
+            }
+        ]
+        assert get_price_for_slot(forecast, now) == 0.25
+
+
+class TestGetPriceForSlotWithSource:
+    """Tests for get_price_for_slot_with_source function."""
+
+    def test_empty_forecast_returns_unknown(self):
+        """Test empty forecast returns 0.0, unknown."""
+        price, source = get_price_for_slot_with_source([], datetime.now(timezone.utc))
+        assert price == 0.0
+        assert source == "unknown"
+
+    def test_5min_data_preferred(self):
+        """Test 5-min data is preferred over 30-min."""
+        now = datetime.now(timezone.utc)
+        forecast = [
+            {
+                "start_time": now.isoformat(),
+                "per_kwh": 0.10,
+                "duration": 5,
+            }
+        ]
+        price, source = get_price_for_slot_with_source(forecast, now)
+        assert price == 0.10
+        assert source == "5min"
+
+    def test_30min_data_fallback(self):
+        """Test 30-min data is used when no 5-min available."""
+        now = datetime.now(timezone.utc)
+        forecast = [
+            {
+                "start_time": now.isoformat(),
+                "per_kwh": 0.15,
+                "duration": 30,
+            }
+        ]
+        price, source = get_price_for_slot_with_source(forecast, now)
+        assert price == 0.15
+        assert source == "30min"
+
+
+class TestGetPriceForSlotOrNull:
+    """Tests for get_price_for_slot_or_none function."""
+
+    def test_empty_forecast_returns_none(self):
+        """Test empty forecast returns None."""
+        assert get_price_for_slot_or_none([], datetime.now(timezone.utc)) is None
+
+    def test_overlapping_price_returns_value(self):
+        """Test overlapping price returns value."""
+        now = datetime.now(timezone.utc)
+        forecast = [
+            {
+                "start_time": now.isoformat(),
+                "per_kwh": 0.30,
+                "duration": 30,
+            }
+        ]
+        assert get_price_for_slot_or_none(forecast, now) == 0.30

--- a/tests/test_optimization_controller.py
+++ b/tests/test_optimization_controller.py
@@ -387,3 +387,819 @@ class TestOptimizationControllerEdgeCases:
         params = minimal_controller.evaluate(data)
 
         assert isinstance(params, AdaptiveParameters)
+
+
+class TestCorrectionAppliesToContext:
+    """Tests for _correction_applies_to_context method."""
+
+    @pytest.fixture
+    def mock_hass(self):
+        """Create a mock HomeAssistant instance."""
+        hass = MagicMock()
+        hass.loop = MagicMock()
+        hass.loop.run_in_executor = AsyncMock(return_value=None)
+        hass.async_add_executor_job = AsyncMock(return_value=None)
+        return hass
+
+    @pytest.fixture
+    def controller(self, mock_hass):
+        """Create a minimal controller for testing."""
+        tracker = MagicMock(spec=DecisionOutcomeTracker)
+        tracker.get_recent_decisions = MagicMock(return_value=[])
+
+        optimizer = MagicMock(spec=ParameterOptimizer)
+        optimizer._params = AdaptiveParameters()
+
+        analyzer = MagicMock(spec=PatternAnalyzer)
+
+        return OptimizationController(mock_hass, "test", tracker, optimizer, analyzer)
+
+    def test_day_of_week_match(self, controller):
+        """Test day_of_week dimension matches correctly."""
+        from datetime import datetime
+
+        now = datetime.now()
+        current_day = now.weekday()
+        day_names = [
+            "monday",
+            "tuesday",
+            "wednesday",
+            "thursday",
+            "friday",
+            "saturday",
+            "sunday",
+        ]
+
+        correction = {
+            "dimension": "day_of_week",
+            "group_key": day_names[current_day],
+        }
+        result = controller._correction_applies_to_context(
+            correction, current_day, "sunny", now
+        )
+        assert result is True
+
+    def test_day_of_week_no_match(self, controller):
+        """Test day_of_week dimension rejects non-matching days."""
+        from datetime import datetime
+
+        now = datetime.now()
+        current_day = now.weekday()
+        day_names = [
+            "monday",
+            "tuesday",
+            "wednesday",
+            "thursday",
+            "friday",
+            "saturday",
+            "sunday",
+        ]
+        wrong_day = (current_day + 1) % 7
+
+        correction = {
+            "dimension": "day_of_week",
+            "group_key": day_names[wrong_day],
+        }
+        result = controller._correction_applies_to_context(
+            correction, current_day, "sunny", now
+        )
+        assert result is False
+
+    def test_weather_partial_match(self, controller):
+        """Test weather dimension with partial match."""
+        from datetime import datetime
+
+        now = datetime.now()
+        correction = {
+            "dimension": "weather",
+            "group_key": "sun",
+        }
+        result = controller._correction_applies_to_context(correction, 0, "sunny", now)
+        assert result is True
+
+    def test_weather_reverse_partial_match(self, controller):
+        """Test weather dimension with reverse partial match."""
+        from datetime import datetime
+
+        now = datetime.now()
+        correction = {
+            "dimension": "weather",
+            "group_key": "cloudy",
+        }
+        result = controller._correction_applies_to_context(
+            correction, 0, "partly_cloudy", now
+        )
+        assert result is True
+
+    def test_weather_no_match(self, controller):
+        """Test weather dimension rejects non-matching conditions."""
+        from datetime import datetime
+
+        now = datetime.now()
+        correction = {
+            "dimension": "weather",
+            "group_key": "rain",
+        }
+        result = controller._correction_applies_to_context(correction, 0, "sunny", now)
+        assert result is False
+
+    def test_hour_of_day_match(self, controller):
+        """Test hour_of_day dimension matches correctly."""
+        from datetime import datetime
+
+        now = datetime.now()
+        current_hour = now.hour
+
+        correction = {
+            "dimension": "hour_of_day",
+            "group_key": str(current_hour),
+        }
+        result = controller._correction_applies_to_context(correction, 0, "sunny", now)
+        assert result is True
+
+    def test_hour_of_day_no_match(self, controller):
+        """Test hour_of_day dimension rejects non-matching hours."""
+        from datetime import datetime
+
+        now = datetime.now()
+        wrong_hour = (now.hour + 1) % 24
+
+        correction = {
+            "dimension": "hour_of_day",
+            "group_key": str(wrong_hour),
+        }
+        result = controller._correction_applies_to_context(correction, 0, "sunny", now)
+        assert result is False
+
+    def test_season_match(self, controller):
+        """Test season dimension matches correctly."""
+        from datetime import datetime
+
+        now = datetime.now()
+        expected_season = controller._get_season(now.month)
+
+        correction = {
+            "dimension": "season",
+            "group_key": expected_season,
+        }
+        result = controller._correction_applies_to_context(correction, 0, "sunny", now)
+        assert result is True
+
+    def test_season_no_match(self, controller):
+        """Test season dimension rejects non-matching seasons."""
+        from datetime import datetime
+
+        now = datetime.now()
+        wrong_seasons = ["spring", "summer", "autumn", "winter"]
+        actual_season = controller._get_season(now.month)
+        wrong_season = next(s for s in wrong_seasons if s != actual_season)
+
+        correction = {
+            "dimension": "season",
+            "group_key": wrong_season,
+        }
+        result = controller._correction_applies_to_context(correction, 0, "sunny", now)
+        assert result is False
+
+    def test_unknown_dimension(self, controller):
+        """Test unknown dimension returns False."""
+        from datetime import datetime
+
+        now = datetime.now()
+        correction = {
+            "dimension": "unknown_dimension",
+            "group_key": "value",
+        }
+        result = controller._correction_applies_to_context(correction, 0, "sunny", now)
+        assert result is False
+
+
+class TestHourMatches:
+    """Tests for _hour_matches method."""
+
+    @pytest.fixture
+    def mock_hass(self):
+        """Create a mock HomeAssistant instance."""
+        hass = MagicMock()
+        hass.loop = MagicMock()
+        hass.loop.run_in_executor = AsyncMock(return_value=None)
+        hass.async_add_executor_job = AsyncMock(return_value=None)
+        return hass
+
+    @pytest.fixture
+    def controller(self, mock_hass):
+        """Create a minimal controller for testing."""
+        tracker = MagicMock(spec=DecisionOutcomeTracker)
+        optimizer = MagicMock(spec=ParameterOptimizer)
+        optimizer._params = AdaptiveParameters()
+        analyzer = MagicMock(spec=PatternAnalyzer)
+        return OptimizationController(mock_hass, "test", tracker, optimizer, analyzer)
+
+    def test_valid_hour_string(self, controller):
+        """Test matching valid hour string."""
+        from datetime import datetime
+
+        now = datetime.now().replace(hour=14)
+        result = controller._hour_matches("14", now)
+        assert result is True
+
+    def test_invalid_hour_string(self, controller):
+        """Test non-matching hour string."""
+        from datetime import datetime
+
+        now = datetime.now().replace(hour=10)
+        result = controller._hour_matches("not_a_number", now)
+        assert result is False
+
+    def test_hour_out_of_range(self, controller):
+        """Test hour value outside normal range."""
+        from datetime import datetime
+
+        now = datetime.now().replace(hour=5)
+        result = controller._hour_matches("25", now)
+        assert result is False
+
+    def test_empty_string(self, controller):
+        """Test empty string returns False."""
+        from datetime import datetime
+
+        now = datetime.now()
+        result = controller._hour_matches("", now)
+        assert result is False
+
+
+class TestApplySingleCorrection:
+    """Tests for _apply_single_correction method."""
+
+    @pytest.fixture
+    def mock_hass(self):
+        """Create a mock HomeAssistant instance."""
+        hass = MagicMock()
+        hass.loop = MagicMock()
+        hass.loop.run_in_executor = AsyncMock(return_value=None)
+        hass.async_add_executor_job = AsyncMock(return_value=None)
+        return hass
+
+    @pytest.fixture
+    def controller(self, mock_hass):
+        """Create a minimal controller for testing."""
+        tracker = MagicMock(spec=DecisionOutcomeTracker)
+        optimizer = MagicMock(spec=ParameterOptimizer)
+        optimizer._params = AdaptiveParameters()
+        analyzer = MagicMock(spec=PatternAnalyzer)
+        return OptimizationController(mock_hass, "test", tracker, optimizer, analyzer)
+
+    def test_high_confidence_applied(self, controller):
+        """Test high confidence correction is applied."""
+        params = AdaptiveParameters(values={"cheap_price_bias": 0.0})
+        correction = {
+            "param_name": "cheap_price_bias",
+            "adjustment": 0.5,
+            "confidence": 0.8,
+            "dimension": "day_of_week",
+            "group_key": "monday",
+        }
+
+        controller._apply_single_correction(params, correction)
+
+        assert params.values["cheap_price_bias"] == 0.5
+        assert len(controller._active_contextual_adjustments) == 1
+
+    def test_low_confidence_skipped(self, controller):
+        """Test low confidence correction is skipped."""
+        params = AdaptiveParameters(values={"cheap_price_bias": 0.0})
+        correction = {
+            "param_name": "cheap_price_bias",
+            "adjustment": 0.5,
+            "confidence": 0.4,
+            "dimension": "day_of_week",
+            "group_key": "monday",
+        }
+
+        controller._apply_single_correction(params, correction)
+
+        assert params.values.get("cheap_price_bias", 0.0) == 0.0
+        assert len(controller._active_contextual_adjustments) == 0
+
+    def test_confidence_boundary_0_49(self, controller):
+        """Test confidence just below threshold is skipped."""
+        params = AdaptiveParameters(values={"test_param": 0.0})
+        correction = {
+            "param_name": "test_param",
+            "adjustment": 0.3,
+            "confidence": 0.49,
+            "dimension": "weather",
+            "group_key": "sunny",
+        }
+
+        controller._apply_single_correction(params, correction)
+
+        assert params.values.get("test_param", 0.0) == 0.0
+
+    def test_confidence_boundary_0_50(self, controller):
+        """Test confidence at threshold is applied."""
+        params = AdaptiveParameters(values={"test_param": 0.0})
+        correction = {
+            "param_name": "test_param",
+            "adjustment": 0.3,
+            "confidence": 0.50,
+            "dimension": "weather",
+            "group_key": "sunny",
+        }
+
+        controller._apply_single_correction(params, correction)
+
+        assert params.values["test_param"] == 0.3
+
+    def test_empty_param_name_skipped(self, controller):
+        """Test empty param_name is skipped."""
+        params = AdaptiveParameters(values={})
+        correction = {
+            "param_name": "",
+            "adjustment": 0.5,
+            "confidence": 0.9,
+            "dimension": "day_of_week",
+            "group_key": "monday",
+        }
+
+        controller._apply_single_correction(params, correction)
+
+        assert len(controller._active_contextual_adjustments) == 0
+
+    def test_accumulates_adjustments(self, controller):
+        """Test multiple corrections accumulate."""
+        params = AdaptiveParameters(values={"cheap_price_bias": 0.0})
+
+        correction1 = {
+            "param_name": "cheap_price_bias",
+            "adjustment": 0.3,
+            "confidence": 0.8,
+            "dimension": "day_of_week",
+            "group_key": "monday",
+        }
+        correction2 = {
+            "param_name": "cheap_price_bias",
+            "adjustment": 0.2,
+            "confidence": 0.9,
+            "dimension": "weather",
+            "group_key": "sunny",
+        }
+
+        controller._apply_single_correction(params, correction1)
+        controller._apply_single_correction(params, correction2)
+
+        assert params.values["cheap_price_bias"] == 0.5
+        assert len(controller._active_contextual_adjustments) == 2
+
+
+class TestGetSeason:
+    """Tests for _get_season method."""
+
+    @pytest.fixture
+    def mock_hass(self):
+        """Create a mock HomeAssistant instance."""
+        hass = MagicMock()
+        hass.loop = MagicMock()
+        hass.loop.run_in_executor = AsyncMock(return_value=None)
+        hass.async_add_executor_job = AsyncMock(return_value=None)
+        return hass
+
+    @pytest.fixture
+    def controller(self, mock_hass):
+        """Create a minimal controller for testing."""
+        tracker = MagicMock(spec=DecisionOutcomeTracker)
+        optimizer = MagicMock(spec=ParameterOptimizer)
+        optimizer._params = AdaptiveParameters()
+        analyzer = MagicMock(spec=PatternAnalyzer)
+        return OptimizationController(mock_hass, "test", tracker, optimizer, analyzer)
+
+    def test_winter_months(self, controller):
+        """Test winter months return 'winter' (southern hemisphere: Jun-Aug)."""
+        for month in [6, 7, 8]:
+            assert controller._get_season(month) == "winter"
+
+    def test_spring_months(self, controller):
+        """Test spring months return 'spring' (southern hemisphere: Sep-Nov)."""
+        for month in [9, 10, 11]:
+            assert controller._get_season(month) == "spring"
+
+    def test_summer_months(self, controller):
+        """Test summer months return 'summer' (southern hemisphere: Dec-Feb)."""
+        for month in [12, 1, 2]:
+            assert controller._get_season(month) == "summer"
+
+    def test_autumn_months(self, controller):
+        """Test autumn months return 'autumn' (southern hemisphere: Mar-May)."""
+        for month in [3, 4, 5]:
+            assert controller._get_season(month) == "autumn"
+
+
+class TestObjectiveWeightsNormalize:
+    """Tests for ObjectiveWeights.normalize edge cases."""
+
+    def test_normalize_zero_weights_returns_default(self):
+        """Test that normalize with all zeros returns default weights."""
+        weights = ObjectiveWeights(
+            cost_minimization=0.0,
+            export_avoidance=0.0,
+            target_achievement=0.0,
+            cycle_reduction=0.0,
+        )
+
+        normalized = weights.normalize()
+
+        assert normalized.cost_minimization == 0.50
+        assert normalized.export_avoidance == 0.20
+        assert normalized.target_achievement == 0.20
+        assert normalized.cycle_reduction == 0.10
+
+
+class TestRealTimeAdjustments:
+    """Tests for _apply_contextual_adjustments method."""
+
+    @pytest.fixture
+    def mock_hass(self):
+        """Create a mock HomeAssistant instance."""
+        hass = MagicMock()
+        hass.loop = MagicMock()
+        hass.loop.run_in_executor = AsyncMock(return_value=None)
+        hass.async_add_executor_job = AsyncMock(return_value=None)
+        return hass
+
+    @pytest.fixture
+    def controller(self, mock_hass):
+        """Create a minimal controller for testing."""
+        tracker = MagicMock(spec=DecisionOutcomeTracker)
+        optimizer = MagicMock(spec=ParameterOptimizer)
+        optimizer._params = AdaptiveParameters()
+        analyzer = MagicMock(spec=PatternAnalyzer)
+        return OptimizationController(mock_hass, "test", tracker, optimizer, analyzer)
+
+    def test_export_leak_detection_applied(self, controller):
+        """Test that high export loss ratio triggers adjustment."""
+        data = CoordinatorData()
+        data.performance_metrics.export_loss_ratio = 0.4
+        data.soc = 50.0
+        params = AdaptiveParameters()
+
+        result = controller._apply_contextual_adjustments(params, data)
+
+        assert "export_threshold_adjustment" in result.values
+        assert result.values["export_threshold_adjustment"] == 1.0
+
+    def test_export_leak_not_applied_below_threshold(self, controller):
+        """Test that low export loss ratio does not trigger adjustment."""
+        data = CoordinatorData()
+        data.performance_metrics.export_loss_ratio = 0.2
+        data.soc = 50.0
+        params = AdaptiveParameters()
+
+        result = controller._apply_contextual_adjustments(params, data)
+
+        assert "export_threshold_adjustment" not in result.values
+
+    def test_low_forecast_accuracy_adjusts_solar_confidence(self, controller):
+        """Test that low forecast accuracy reduces solar confidence."""
+        data = CoordinatorData()
+        data.forecast_accuracy_soc_1h = 40.0
+        data.forecast_accuracy_soc_4h = 45.0
+        data.soc = 50.0
+        params = AdaptiveParameters(values={"solar_confidence_factor": 1.0})
+
+        result = controller._apply_contextual_adjustments(params, data)
+
+        assert result.values.get("solar_confidence_factor") == 0.8
+
+    def test_low_forecast_accuracy_increases_safety_margin(self, controller):
+        """Test that low forecast accuracy increases overnight drain margin."""
+        data = CoordinatorData()
+        data.forecast_accuracy_soc_1h = 40.0
+        data.forecast_accuracy_soc_4h = 45.0
+        data.soc = 50.0
+        params = AdaptiveParameters(values={"overnight_drain_safety_margin": 0.0})
+
+        result = controller._apply_contextual_adjustments(params, data)
+
+        assert result.values.get("overnight_drain_safety_margin") == 3.0
+
+    def test_forecast_accuracy_none_uses_default(self, controller):
+        """Test that None accuracy values use 100% default."""
+        data = CoordinatorData()
+        data.forecast_accuracy_soc_1h = None
+        data.forecast_accuracy_soc_4h = None
+        data.soc = 50.0
+        params = AdaptiveParameters()
+
+        result = controller._apply_contextual_adjustments(params, data)
+
+        assert "solar_confidence_factor" not in result.values
+
+    def test_approaching_demand_window_with_soc_gap(self, controller):
+        """Test approaching demand window with SOC gap triggers adjustment."""
+        data = CoordinatorData()
+        data.soc = 50.0
+        data.battery_target_soc = 80.0
+        params = AdaptiveParameters(values={"cheap_price_bias": 0.0})
+
+        controller._is_approaching_demand_window = MagicMock(return_value=True)
+        result = controller._apply_contextual_adjustments(params, data)
+
+        assert "cheap_price_bias" in result.values
+        assert result.values["cheap_price_bias"] > 0
+
+    def test_approaching_demand_window_no_soc_gap(self, controller):
+        """Test approaching demand window without SOC gap does not adjust."""
+        data = CoordinatorData()
+        data.soc = 80.0
+        data.battery_target_soc = 80.0
+        params = AdaptiveParameters()
+
+        controller._is_approaching_demand_window = MagicMock(return_value=True)
+        result = controller._apply_contextual_adjustments(params, data)
+
+        assert "cheap_price_bias" not in result.values
+
+
+class TestAsyncSaveLoad:
+    """Tests for async_save and async_load methods."""
+
+    @pytest.fixture
+    def mock_hass(self):
+        """Create a mock HomeAssistant instance with storage."""
+        hass = MagicMock()
+        hass.loop = MagicMock()
+        hass.loop.run_in_executor = AsyncMock(return_value=None)
+        hass.async_add_executor_job = AsyncMock(return_value=None)
+        return hass
+
+    @pytest.fixture
+    def controller(self, mock_hass):
+        """Create a minimal controller for testing."""
+        tracker = MagicMock(spec=DecisionOutcomeTracker)
+        optimizer = MagicMock(spec=ParameterOptimizer)
+        optimizer._params = AdaptiveParameters()
+        analyzer = MagicMock(spec=PatternAnalyzer)
+        return OptimizationController(mock_hass, "test", tracker, optimizer, analyzer)
+
+    @pytest.mark.asyncio
+    async def test_async_save_stores_weights(self, controller):
+        """Test that async_save stores weights."""
+        controller._weights = ObjectiveWeights(cost_minimization=0.6)
+        controller._learning_enabled = True
+
+        mock_save = AsyncMock()
+        controller._store.async_save = mock_save
+
+        await controller.async_save()
+
+        mock_save.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_async_load_restores_state(self, controller):
+        """Test that async_load restores saved state."""
+        saved_data = {
+            "weights": {
+                "cost_minimization": 0.6,
+                "export_avoidance": 0.2,
+                "target_achievement": 0.1,
+                "cycle_reduction": 0.1,
+            },
+            "learning_enabled": True,
+            "weight_history": [],
+            "last_weight_update": datetime.now().isoformat(),
+        }
+        controller._store.async_load = AsyncMock(return_value=saved_data)
+
+        await controller.async_load()
+
+        assert controller._learning_enabled == True
+        assert controller._weights.cost_minimization == 0.6
+
+    @pytest.mark.asyncio
+    async def test_async_load_none_data(self, controller):
+        """Test that async_load handles None data gracefully."""
+        controller._store.async_load = AsyncMock(return_value=None)
+
+        await controller.async_load()
+
+        assert controller._learning_enabled == False
+
+    @pytest.mark.asyncio
+    async def test_async_load_weight_history(self, controller):
+        """Test that async_load restores weight history."""
+        saved_data = {
+            "weights": {},
+            "learning_enabled": False,
+            "weight_history": [
+                {
+                    "timestamp": datetime.now().isoformat(),
+                    "weights": {
+                        "cost_minimization": 0.5,
+                        "export_avoidance": 0.2,
+                        "target_achievement": 0.2,
+                        "cycle_reduction": 0.1,
+                    },
+                }
+            ],
+            "last_weight_update": None,
+        }
+        controller._store.async_load = AsyncMock(return_value=saved_data)
+
+        await controller.async_load()
+
+        assert len(controller._weight_history) == 1
+
+
+class TestApplyActiveBiasCorrectionsIntegration:
+    """Tests for _apply_active_bias_corrections with actual loop execution."""
+
+    @pytest.fixture
+    def mock_hass(self):
+        """Create a mock HomeAssistant instance."""
+        hass = MagicMock()
+        hass.loop = MagicMock()
+        hass.loop.run_in_executor = AsyncMock(return_value=None)
+        hass.async_add_executor_job = AsyncMock(return_value=None)
+        return hass
+
+    @pytest.fixture
+    def controller(self, mock_hass):
+        """Create a minimal controller for testing."""
+        tracker = MagicMock(spec=DecisionOutcomeTracker)
+        optimizer = MagicMock(spec=ParameterOptimizer)
+        optimizer._params = AdaptiveParameters()
+        analyzer = MagicMock(spec=PatternAnalyzer)
+        return OptimizationController(mock_hass, "test", tracker, optimizer, analyzer)
+
+    def test_applies_multiple_corrections(self, controller):
+        """Test that multiple matching corrections are applied in loop."""
+        current_hour = datetime.now().hour
+        data = CoordinatorData()
+        data.weather_condition = "sunny"
+        data.active_bias_corrections = [
+            {
+                "dimension": "weather",
+                "group_key": "sunny",
+                "param_name": "cheap_price_bias",
+                "adjustment": 0.2,
+                "confidence": 0.8,
+            },
+            {
+                "dimension": "weather",
+                "group_key": "clear",
+                "param_name": "cheap_price_bias",
+                "adjustment": 0.1,
+                "confidence": 0.7,
+            },
+        ]
+        params = AdaptiveParameters(values={"cheap_price_bias": 0.0})
+
+        result = controller._apply_active_bias_corrections(params, data)
+
+        assert result.values.get("cheap_price_bias") == 0.2
+
+    def test_empty_corrections_returns_unchanged(self, controller):
+        """Test empty corrections list returns unchanged params."""
+        data = CoordinatorData()
+        data.active_bias_corrections = []
+        params = AdaptiveParameters(values={"test": 1.0})
+
+        result = controller._apply_active_bias_corrections(params, data)
+
+        assert result.values.get("test") == 1.0
+
+
+class TestClampParameters:
+    """Tests for _clamp_parameters method."""
+
+    @pytest.fixture
+    def mock_hass(self):
+        """Create a mock HomeAssistant instance."""
+        hass = MagicMock()
+        hass.loop = MagicMock()
+        hass.loop.run_in_executor = AsyncMock(return_value=None)
+        hass.async_add_executor_job = AsyncMock(return_value=None)
+        return hass
+
+    @pytest.fixture
+    def controller(self, mock_hass):
+        """Create a minimal controller for testing."""
+        tracker = MagicMock(spec=DecisionOutcomeTracker)
+        optimizer = MagicMock(spec=ParameterOptimizer)
+        optimizer._params = AdaptiveParameters()
+        analyzer = MagicMock(spec=PatternAnalyzer)
+        return OptimizationController(mock_hass, "test", tracker, optimizer, analyzer)
+
+    def test_clamps_value_above_max(self, controller):
+        """Test that values above max are clamped."""
+        params = AdaptiveParameters(values={"cheap_price_bias": 10.0})
+
+        result = controller._clamp_parameters(params)
+
+        assert result.values.get("cheap_price_bias") <= 5.0
+
+    def test_clamps_value_below_min(self, controller):
+        """Test that values below min are clamped."""
+        params = AdaptiveParameters(values={"solar_confidence_factor": -1.0})
+
+        result = controller._clamp_parameters(params)
+
+        assert result.values.get("solar_confidence_factor") >= 0.0
+
+
+class TestIsApproachingDemandWindow:
+    """Tests for _is_approaching_demand_window method."""
+
+    @pytest.fixture
+    def mock_hass(self):
+        """Create a mock HomeAssistant instance."""
+        hass = MagicMock()
+        hass.loop = MagicMock()
+        hass.loop.run_in_executor = AsyncMock(return_value=None)
+        hass.async_add_executor_job = AsyncMock(return_value=None)
+        return hass
+
+    @pytest.fixture
+    def controller(self, mock_hass):
+        """Create a minimal controller for testing."""
+        tracker = MagicMock(spec=DecisionOutcomeTracker)
+        optimizer = MagicMock(spec=ParameterOptimizer)
+        optimizer._params = AdaptiveParameters()
+        analyzer = MagicMock(spec=PatternAnalyzer)
+        return OptimizationController(mock_hass, "test", tracker, optimizer, analyzer)
+
+    def test_within_two_hours_returns_true(self, controller):
+        """Test that being within 2 hours returns True."""
+        from datetime import datetime
+
+        now = datetime.now().replace(hour=13, minute=0)
+        data = CoordinatorData()
+
+        result = controller._is_approaching_demand_window(now, data)
+
+        assert isinstance(result, bool)
+
+    def test_far_from_window_returns_false(self, controller):
+        """Test that being far from window returns False."""
+        from datetime import datetime
+
+        now = datetime.now().replace(hour=6, minute=0)
+        data = CoordinatorData()
+
+        result = controller._is_approaching_demand_window(now, data)
+
+        assert result == False
+
+
+class TestAsyncLoadErrorHandling:
+    """Tests for async_load error handling."""
+
+    @pytest.fixture
+    def mock_hass(self):
+        """Create a mock HomeAssistant instance."""
+        hass = MagicMock()
+        hass.loop = MagicMock()
+        hass.loop.run_in_executor = AsyncMock(return_value=None)
+        hass.async_add_executor_job = AsyncMock(return_value=None)
+        return hass
+
+    @pytest.fixture
+    def controller(self, mock_hass):
+        """Create a minimal controller for testing."""
+        tracker = MagicMock(spec=DecisionOutcomeTracker)
+        optimizer = MagicMock(spec=ParameterOptimizer)
+        optimizer._params = AdaptiveParameters()
+        analyzer = MagicMock(spec=PatternAnalyzer)
+        return OptimizationController(mock_hass, "test", tracker, optimizer, analyzer)
+
+    @pytest.mark.asyncio
+    async def test_async_load_malformed_weight_history_entry(self, controller):
+        """Test that malformed weight history entries are skipped."""
+        saved_data = {
+            "weights": {},
+            "learning_enabled": False,
+            "weight_history": [
+                {"timestamp": "invalid", "weights": {}},
+            ],
+            "last_weight_update": None,
+        }
+        controller._store.async_load = AsyncMock(return_value=saved_data)
+
+        await controller.async_load()
+
+        assert len(controller._weight_history) == 0
+
+    @pytest.mark.asyncio
+    async def test_async_load_malformed_last_weight_update(self, controller):
+        """Test that malformed last_weight_update is handled."""
+        saved_data = {
+            "weights": {},
+            "learning_enabled": False,
+            "weight_history": [],
+            "last_weight_update": "invalid-timestamp",
+        }
+        controller._store.async_load = AsyncMock(return_value=saved_data)
+
+        await controller.async_load()
+
+        assert controller._last_weight_update is None

--- a/tests/test_slots.py
+++ b/tests/test_slots.py
@@ -18,6 +18,7 @@ import pytest
 from custom_components.localshift.engine.slots import (
     SlotBuilder,
     SlotBuildMetadata,
+    SlotContext,
 )
 from custom_components.localshift.coordinator import AdaptiveParameters
 
@@ -450,3 +451,540 @@ class TestIntegration:
         # Verify builder has required methods
         assert hasattr(builder, "build_slots")
         assert callable(builder.build_slots)
+
+
+class TestGetSolarConfidenceFactor:
+    """Tests for _get_solar_confidence_factor method."""
+
+    @pytest.fixture
+    def builder(self):
+        """Create a SlotBuilder instance."""
+        config = {"demand_window_start": "18:00:00", "demand_window_end": "22:00:00"}
+        return SlotBuilder(config_options=config, ha_timezone="Australia/Sydney")
+
+    def test_none_params_returns_default(self, builder):
+        """Test None adaptive params returns 1.0."""
+        result = builder._get_solar_confidence_factor(None)
+        assert result == 1.0
+
+    def test_params_with_value(self, builder):
+        """Test adaptive params with solar_confidence_factor."""
+        params = AdaptiveParameters(values={"solar_confidence_factor": 0.8})
+        result = builder._get_solar_confidence_factor(params)
+        assert result == 0.8
+
+    def test_params_without_value_uses_default(self, builder):
+        """Test adaptive params without solar_confidence_factor uses default."""
+        params = AdaptiveParameters(values={})
+        result = builder._get_solar_confidence_factor(params)
+        assert result == 1.0
+
+    def test_clamp_at_zero(self, builder):
+        """Test negative values clamped to 0.0."""
+        params = AdaptiveParameters(values={"solar_confidence_factor": -0.5})
+        result = builder._get_solar_confidence_factor(params)
+        assert result == 0.0
+
+    def test_clamp_at_two(self, builder):
+        """Test values > 2.0 clamped to 2.0."""
+        params = AdaptiveParameters(values={"solar_confidence_factor": 3.0})
+        result = builder._get_solar_confidence_factor(params)
+        assert result == 2.0
+
+    def test_exact_boundary_values(self, builder):
+        """Test exact boundary values 0.0 and 2.0."""
+        params = AdaptiveParameters(values={"solar_confidence_factor": 0.0})
+        assert builder._get_solar_confidence_factor(params) == 0.0
+
+        params = AdaptiveParameters(values={"solar_confidence_factor": 2.0})
+        assert builder._get_solar_confidence_factor(params) == 2.0
+
+
+class TestComputeBaseSlot:
+    """Tests for _compute_base_slot method."""
+
+    @pytest.fixture
+    def builder(self):
+        """Create a SlotBuilder instance."""
+        config = {"demand_window_start": "18:00:00", "demand_window_end": "22:00:00"}
+        return SlotBuilder(config_options=config, ha_timezone="Australia/Sydney")
+
+    def test_rounds_to_5min_interval(self, builder):
+        """Test that time is rounded to 5-minute interval."""
+        now = datetime(2024, 1, 15, 14, 23, 37)
+        result = builder._compute_base_slot(now)
+        assert result.minute % 5 == 0
+        assert result.second == 0
+        assert result.microsecond == 0
+
+    def test_preserves_hour(self, builder):
+        """Test that hour is preserved."""
+        now = datetime(2024, 1, 15, 14, 23, 37)
+        result = builder._compute_base_slot(now)
+        assert result.hour == 14
+
+
+class TestGetLocalTimezone:
+    """Tests for _get_local_timezone method."""
+
+    def test_valid_timezone(self):
+        """Test valid timezone returns ZoneInfo."""
+        config = {"demand_window_start": "18:00:00", "demand_window_end": "22:00:00"}
+        builder = SlotBuilder(config_options=config, ha_timezone="Australia/Sydney")
+        result = builder._get_local_timezone()
+        assert result is not None
+
+    def test_invalid_timezone_returns_none(self):
+        """Test invalid timezone returns None."""
+        config = {"demand_window_start": "18:00:00", "demand_window_end": "22:00:00"}
+        builder = SlotBuilder(config_options=config, ha_timezone="Invalid/Timezone")
+        result = builder._get_local_timezone()
+        assert result is None
+
+
+class TestGetSlotTimeForDW:
+    """Tests for _get_slot_time_for_dw method."""
+
+    @pytest.fixture
+    def builder(self):
+        """Create a SlotBuilder instance."""
+        config = {"demand_window_start": "18:00:00", "demand_window_end": "22:00:00"}
+        return SlotBuilder(config_options=config, ha_timezone="Australia/Sydney")
+
+    def test_no_timezone_returns_original_time(self, builder):
+        """Test None timezone returns original slot time."""
+        from datetime import timezone
+
+        now = datetime(2024, 1, 15, 14, 30, tzinfo=timezone.utc)
+        result = builder._get_slot_time_for_dw(now, None)
+        assert result == now.time()
+
+    def test_with_timezone_converts(self, builder):
+        """Test with timezone converts to local time."""
+        from datetime import timezone
+        from zoneinfo import ZoneInfo
+
+        local_tz = ZoneInfo("Australia/Sydney")
+        slot_start = datetime(2024, 1, 15, 4, 30, tzinfo=timezone.utc)
+        result = builder._get_slot_time_for_dw(slot_start, local_tz)
+        assert result is not None
+
+
+class TestGetSellPrice:
+    """Tests for _get_sell_price method."""
+
+    @pytest.fixture
+    def builder(self):
+        """Create a SlotBuilder instance."""
+        config = {"demand_window_start": "18:00:00", "demand_window_end": "22:00:00"}
+        return SlotBuilder(config_options=config, ha_timezone="Australia/Sydney")
+
+    def test_empty_forecast_returns_zero(self, builder):
+        """Test empty feed_in_forecast returns 0.0."""
+        from datetime import timezone
+
+        now = datetime.now(timezone.utc)
+        result = builder._get_sell_price([], now)
+        assert result == 0.0
+
+    def test_matching_forecast_returns_price(self, builder):
+        """Test matching forecast entry returns price."""
+        from datetime import timezone
+
+        now = datetime.now(timezone.utc)
+        forecast = [
+            {
+                "start_time": now.isoformat(),
+                "per_kwh": 0.08,
+                "duration": 30,
+            }
+        ]
+        result = builder._get_sell_price(forecast, now)
+        assert result == 0.08
+
+
+class TestGetSolarKwh:
+    """Tests for _get_solar_kwh method."""
+
+    @pytest.fixture
+    def builder(self):
+        """Create a SlotBuilder instance."""
+        config = {"demand_window_start": "18:00:00", "demand_window_end": "22:00:00"}
+        return SlotBuilder(config_options=config, ha_timezone="Australia/Sydney")
+
+    def test_empty_solcast_returns_zero(self, builder):
+        """Test empty solcast returns 0.0."""
+        from datetime import timezone
+
+        now = datetime.now(timezone.utc)
+        result = builder._get_solar_kwh([], now, 30, 1.0)
+        assert result == 0.0
+
+    def test_applies_confidence_factor(self, builder):
+        """Test confidence factor is applied."""
+        from datetime import timezone
+
+        now = datetime.now(timezone.utc)
+        solcast = [
+            {
+                "period_start": now.isoformat(),
+                "pv_estimate": 2.0,
+            }
+        ]
+        result = builder._get_solar_kwh(solcast, now, 30, 0.5)
+        assert result == 0.5
+
+    def test_clamp_negative_to_zero(self, builder):
+        """Test negative solar values are clamped to 0.0."""
+        from datetime import timezone
+
+        now = datetime.now(timezone.utc)
+        result = builder._get_solar_kwh([], now, 30, -1.0)
+        assert result >= 0.0
+
+
+class TestGetConsumptionKwh:
+    """Tests for _get_consumption_kwh method."""
+
+    @pytest.fixture
+    def builder(self):
+        """Create a SlotBuilder instance."""
+        config = {"demand_window_start": "18:00:00", "demand_window_end": "22:00:00"}
+        return SlotBuilder(config_options=config, ha_timezone="Australia/Sydney")
+
+    def test_empty_forecast_returns_zero(self, builder):
+        """Test empty load_forecast_slots returns 0.0."""
+        from datetime import timezone
+
+        now = datetime.now(timezone.utc)
+        result = builder._get_consumption_kwh([], now, now, 30, 0)
+        assert result == 0.0
+
+    def test_computes_from_kw(self, builder):
+        """Test consumption computed from kW values."""
+        from datetime import timezone
+
+        now = datetime.now(timezone.utc)
+        base_slot = now.replace(minute=0, second=0, microsecond=0)
+        load_slots = [1.0] * 96
+
+        result = builder._get_consumption_kwh(load_slots, base_slot, base_slot, 30, 0)
+        assert result == 0.5
+
+    def test_out_of_range_index_returns_zero(self, builder):
+        """Test out of range index returns 0.0."""
+        from datetime import timezone
+
+        now = datetime.now(timezone.utc)
+        base_slot = now - timedelta(hours=48)
+        load_slots = [1.0] * 96
+
+        result = builder._get_consumption_kwh(load_slots, now, base_slot, 30, 0)
+        assert result >= 0.0
+
+
+class TestParseTimeOption:
+    """Tests for _parse_time_option method."""
+
+    @pytest.fixture
+    def builder(self):
+        """Create a SlotBuilder instance."""
+        config = {"demand_window_start": "18:30:00", "demand_window_end": "22:00:00"}
+        return SlotBuilder(config_options=config, ha_timezone="Australia/Sydney")
+
+    def test_parse_with_seconds(self, builder):
+        """Test parsing time with seconds."""
+        result = builder._parse_time_option("demand_window_start")
+        assert result.hour == 18
+        assert result.minute == 30
+
+    def test_parse_without_seconds(self, builder):
+        """Test parsing time without seconds."""
+        result = builder._parse_time_option("demand_window_end")
+        assert result.hour == 22
+        assert result.minute == 0
+
+    def test_missing_key_uses_default(self, builder):
+        """Test missing key uses default."""
+        result = builder._parse_time_option("unknown_key")
+        assert result.hour == 18
+        assert result.minute == 0
+
+    def test_time_object_passed_through(self):
+        """Test time object is passed through."""
+        config = {"test_time": time(15, 45)}
+        builder = SlotBuilder(config_options=config, ha_timezone="Australia/Sydney")
+        result = builder._parse_time_option("test_time")
+        assert result.hour == 15
+
+
+class TestBuildSlotsIntegration:
+    """Integration tests for build_slots method."""
+
+    @pytest.fixture
+    def builder(self):
+        """Create a SlotBuilder instance."""
+        return SlotBuilder(
+            config_options={
+                "demand_window_start": "18:00:00",
+                "demand_window_end": "22:00:00",
+            },
+            ha_timezone="UTC",
+        )
+
+    @pytest.fixture
+    def mock_coordinator_data(self):
+        """Create mock CoordinatorData with timezone-aware data."""
+        from datetime import timezone
+
+        data = MagicMock()
+        now = datetime.now(timezone.utc)
+
+        data.general_forecast = [
+            {
+                "start_time": (now + timedelta(minutes=30 * i)).isoformat(),
+                "per_kwh": 0.10 + i * 0.01,
+                "duration": 30,
+            }
+            for i in range(48)
+        ]
+        data.feed_in_forecast = [
+            {
+                "start_time": (now + timedelta(minutes=30 * i)).isoformat(),
+                "per_kwh": 0.05,
+                "duration": 30,
+            }
+            for i in range(48)
+        ]
+        data.solcast_today = [
+            {
+                "period_end": (now + timedelta(minutes=30 * i)).isoformat(),
+                "pv_estimate": 2.0
+                if 6 <= (now + timedelta(minutes=30 * i)).hour <= 18
+                else 0.0,
+            }
+            for i in range(48)
+        ]
+        data.solcast_tomorrow = []
+        data.load_forecast_slots = [0.5 + (i % 24) * 0.1 for i in range(96)]
+        data.adaptive_params = AdaptiveParameters(
+            values={"solar_confidence_factor": 1.0}
+        )
+
+        return data
+
+    def test_build_slots_returns_slots_and_metadata(
+        self, builder, mock_coordinator_data
+    ):
+        """Test build_slots returns list of SlotContext and metadata."""
+        slots, metadata = builder.build_slots(
+            mock_coordinator_data, mock_coordinator_data.adaptive_params
+        )
+
+        assert isinstance(slots, list)
+        assert len(slots) > 0
+        assert all(isinstance(s, SlotContext) for s in slots)
+        assert isinstance(metadata, SlotBuildMetadata)
+
+    def test_build_slots_metadata_counts(self, builder, mock_coordinator_data):
+        """Test build_slots metadata has correct counts."""
+        slots, metadata = builder.build_slots(
+            mock_coordinator_data, mock_coordinator_data.adaptive_params
+        )
+
+        assert metadata.total_slots == len(slots)
+        assert (
+            metadata.five_min_slots + metadata.thirty_min_slots == metadata.total_slots
+        )
+        assert metadata.solar_confidence_factor == 1.0
+
+    def test_build_slots_with_none_adaptive_params(
+        self, builder, mock_coordinator_data
+    ):
+        """Test build_slots handles None adaptive params."""
+        slots, metadata = builder.build_slots(mock_coordinator_data, None)
+
+        assert metadata.solar_confidence_factor == 1.0
+        assert len(slots) > 0
+
+    def test_build_slots_with_custom_now_dt(self, builder, mock_coordinator_data):
+        """Test build_slots respects custom now_dt parameter."""
+        from datetime import timezone
+
+        custom_now = datetime.now(timezone.utc)
+        slots, metadata = builder.build_slots(
+            mock_coordinator_data, None, now_dt=custom_now
+        )
+
+        assert len(slots) >= 0
+
+
+class TestProcessAllSlots:
+    """Tests for _process_all_slots method."""
+
+    @pytest.fixture
+    def builder(self):
+        """Create a SlotBuilder instance."""
+        return SlotBuilder(
+            config_options={
+                "demand_window_start": "18:00:00",
+                "demand_window_end": "22:00:00",
+            },
+            ha_timezone="UTC",
+        )
+
+    def test_process_all_slots_returns_contexts_and_counts(self, builder):
+        """Test _process_all_slots returns correct structure."""
+        from datetime import timezone
+        from zoneinfo import ZoneInfo
+
+        now = datetime.now(timezone.utc)
+        hybrid_slots = [
+            {
+                "start": now,
+                "interval_minutes": 30,
+                "price": 0.10,
+                "price_source": "30min",
+            }
+        ]
+
+        data = MagicMock()
+        data.feed_in_forecast = []
+        data.load_forecast_slots = [0.5] * 96
+
+        contexts, counts = builder._process_all_slots(
+            hybrid_slots=hybrid_slots,
+            data=data,
+            all_solcast=[],
+            solar_confidence_factor=1.0,
+            base_slot=now,
+            local_tz=ZoneInfo("UTC"),
+            dw_start_time=time(18, 0),
+            dw_end_time=time(22, 0),
+        )
+
+        assert len(contexts) == 1
+        assert "five_min" in counts
+        assert "thirty_min" in counts
+
+    def test_process_all_slots_counts_slots_correctly(self, builder):
+        """Test _process_all_slots counts 5min and 30min slots."""
+        from datetime import timezone
+        from zoneinfo import ZoneInfo
+
+        now = datetime.now(timezone.utc)
+        hybrid_slots = [
+            {
+                "start": now,
+                "interval_minutes": 5,
+                "price": 0.10,
+                "price_source": "5min",
+            },
+            {
+                "start": now + timedelta(minutes=5),
+                "interval_minutes": 30,
+                "price": 0.12,
+                "price_source": "30min",
+            },
+        ]
+
+        data = MagicMock()
+        data.feed_in_forecast = []
+        data.load_forecast_slots = [0.5] * 96
+
+        contexts, counts = builder._process_all_slots(
+            hybrid_slots=hybrid_slots,
+            data=data,
+            all_solcast=[],
+            solar_confidence_factor=1.0,
+            base_slot=now,
+            local_tz=ZoneInfo("UTC"),
+            dw_start_time=time(18, 0),
+            dw_end_time=time(22, 0),
+        )
+
+        assert counts["five_min"] == 1
+        assert counts["thirty_min"] == 1
+
+
+class TestProcessSingleSlot:
+    """Tests for _process_single_slot method."""
+
+    @pytest.fixture
+    def builder(self):
+        """Create a SlotBuilder instance."""
+        return SlotBuilder(
+            config_options={
+                "demand_window_start": "18:00:00",
+                "demand_window_end": "22:00:00",
+            },
+            ha_timezone="UTC",
+        )
+
+    def test_process_single_slot_returns_context(self, builder):
+        """Test _process_single_slot returns SlotContext."""
+        from datetime import timezone
+        from zoneinfo import ZoneInfo
+
+        now = datetime.now(timezone.utc)
+        slot = {
+            "start": now,
+            "interval_minutes": 30,
+            "price": 0.10,
+            "price_source": "30min",
+        }
+
+        data = MagicMock()
+        data.feed_in_forecast = []
+        data.load_forecast_slots = [0.5] * 96
+
+        ctx, counts, in_dw = builder._process_single_slot(
+            i=0,
+            slot=slot,
+            data=data,
+            all_solcast=[],
+            solar_confidence_factor=1.0,
+            base_slot=now,
+            local_tz=ZoneInfo("UTC"),
+            dw_start_time=time(18, 0),
+            dw_end_time=time(22, 0),
+            prev_in_demand_window=False,
+        )
+
+        assert isinstance(ctx, SlotContext)
+        assert ctx.slot_index == 0
+        assert ctx.buy_price == 0.10
+        assert counts["thirty_min"] == 1
+
+    def test_process_single_slot_demand_window_entry(self, builder):
+        """Test _process_single_slot detects demand window entry."""
+        from datetime import timezone
+        from zoneinfo import ZoneInfo
+
+        now = datetime.now(timezone.utc).replace(hour=18, minute=0)
+        slot = {
+            "start": now,
+            "interval_minutes": 30,
+            "price": 0.10,
+            "price_source": "30min",
+        }
+
+        data = MagicMock()
+        data.feed_in_forecast = []
+        data.load_forecast_slots = [0.5] * 96
+
+        ctx, counts, in_dw = builder._process_single_slot(
+            i=0,
+            slot=slot,
+            data=data,
+            all_solcast=[],
+            solar_confidence_factor=1.0,
+            base_slot=now,
+            local_tz=ZoneInfo("UTC"),
+            dw_start_time=time(18, 0),
+            dw_end_time=time(22, 0),
+            prev_in_demand_window=False,
+        )
+
+        assert ctx.is_demand_window_entry is True
+        assert ctx.is_demand_window_slot is True


### PR DESCRIPTION
## Summary
- Fix stale C901 ignore paths in pyproject.toml (files renamed in #640)
- Reduce complexity in `outcomes.py`: `compute_outcome_score` 26→5, `get_daily_summary` 14→8
- Reduce complexity in `parameters.py`: `_apply_bias_corrections` 18→5, `_optimize_single_param` 13→7

## Remaining Work
5 functions across 3 files still have complexity >10:
- `slots.py: build_slots()` (17)
- `optimization_controller.py: _apply_active_bias_corrections()` (16)
- `price_calculator.py` (15, 12, 11)

These will be addressed in follow-up commits to this PR.

## Test Plan
- [ ] All 720 tests pass
- [ ] Deploy to HA and verify integration still functions
- [ ] Check logs for any unexpected behavior

Fixes #639