### PR TITLE
feat: improve TDD pre-commit hook with per-file coverage messages

### DIFF
--- a/.agents/rules/tdd-workflow.md
+++ b/.agents/rules/tdd-workflow.md
@@ -287,19 +287,58 @@ If test passes before implementation:
 
 ### Coverage Below 95%
 
-If coverage is below threshold:
-1. Run: `uv run pytest --cov-report=html`
-2. Open: `htmlcov/index.html`
-3. Find uncovered lines
-4. Write tests for uncovered code
-5. Re-run coverage check
+**Coverage is checked PER MODIFIED FILE, not project-wide.**
+
+When coverage fails, the pre-commit hook shows:
+- **Specific file** with low coverage
+- **Exact coverage percentage** vs 95% requirement  
+- **Uncovered line ranges** (e.g., L45-52, L78-85)
+- **Test file location** for that source file
+- **One-liner command** to re-run with details
+
+Example failure output:
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│ ❌ COVERAGE FAILURES - 1 file(s) below 95% threshold                 │
+├──────────────────────────────────────────────────────────────────────┤
+│ File: custom_components/localshift/optimizer.py                      │
+│ Coverage: 78.3% (need 95%)                                           │
+│ Uncovered: L45-52, L78-85                                            │
+│ Test file: tests/test_optimizer.py                                   │
+├──────────────────────────────────────────────────────────────────────┤
+│ Run this to see detailed coverage:                                   │
+│   uv run pytest tests/test_optimizer.py                              │
+│     --cov=custom_components.localshift.optimizer \                   │
+│     --cov-report=term-missing -v                                     │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+**Remediation steps:**
+1. Open the test file shown
+2. Write tests targeting the uncovered line ranges
+3. Re-run the command shown at the bottom
+4. Re-attempt commit when coverage ≥ 95%
+
+**For detailed HTML coverage report:**
+```bash
+uv run pytest --cov-report=html
+open htmlcov/index.html
+```
 
 ### Pre-Commit Hook Blocks Commit
 
-If commit is blocked:
-1. Read the error message
-2. Identify missing test file
-3. Create test file
-4. Write failing test (RED)
-5. Run test to confirm failure
+If commit is blocked by coverage:
+1. Read the structured error message
+2. Note the specific file and uncovered lines
+3. Open the test file shown
+4. Write tests for the uncovered lines
+5. Re-run the suggested command
+6. Re-attempt commit when coverage passes
+
+If commit is blocked by missing test file:
+1. Read the error message for expected test file location
+2. Create test file: `touch tests/test_module.py`
+3. Write failing test (RED phase)
+4. Run test to confirm failure
+5. Implement (GREEN phase)
 6. Re-attempt commit

--- a/.githooks/scripts/check-tdd.sh
+++ b/.githooks/scripts/check-tdd.sh
@@ -1,48 +1,20 @@
 #!/bin/bash
 # TDD enforcement pre-commit hook
-# Verifies test files exist for modified code and coverage meets threshold
+# Verifies test files exist for modified code and coverage meets 95% threshold per file
 
 set -e
 
 echo "🔍 Checking TDD compliance..."
 
-# Function to find test file for a given source file
-# Returns the path to the test file if found, or empty string if not found
-find_test_file() {
-    local SOURCE_FILE="$1"
-    local MODULE_NAME=$(basename "$SOURCE_FILE" .py)
-    
-    # Pattern 1: Flat test structure (most common)
-    # custom_components/localshift/module.py -> tests/test_module.py
-    local TEST_FLAT="tests/test_${MODULE_NAME}.py"
-    if [ -f "$TEST_FLAT" ]; then
-        echo "$TEST_FLAT"
-        return 0
-    fi
-    
-    # Pattern 2: Subdirectory-preserving test structure
-    # custom_components/localshift/subdir/module.py -> tests/subdir/test_module.py
-    local REL_PATH=$(echo "$SOURCE_FILE" | sed 's|custom_components/localshift/||')
-    if [[ "$REL_PATH" == *"/"* ]]; then
-        local SUBDIR=$(dirname "$REL_PATH")
-        local TEST_SUBDIR="tests/${SUBDIR}/test_${MODULE_NAME}.py"
-        if [ -f "$TEST_SUBDIR" ]; then
-            echo "$TEST_SUBDIR"
-            return 0
-        fi
-    fi
-    
-    # No test file found
-    return 1
-}
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+COVERAGE_CHECKER="$PROJECT_ROOT/scripts/coverage_checker.py"
 
-# Check if pytest-xdist is available for parallel execution
 check_xdist_available() {
     uv run python -c "import xdist" 2>/dev/null
     return $?
 }
 
-# Get list of staged Python files in custom_components/localshift/
 STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep '^custom_components/localshift/.*\.py$' || true)
 
 if [ -z "$STAGED_FILES" ]; then
@@ -50,49 +22,55 @@ if [ -z "$STAGED_FILES" ]; then
     exit 0
 fi
 
-# Check if any are exception files (docs, config, etc.)
 CHANGES_REQUIRE_TESTS=false
-
-# Array to collect test file paths
 declare -a TEST_FILE_PATHS
+declare -a SOURCE_FILE_PATHS
 
 for FILE in $STAGED_FILES; do
-    # Skip __init__.py, manifest.json, etc.
     if [[ "$FILE" == *"__init__.py" ]] || [[ "$FILE" == *"manifest.json" ]]; then
         continue
     fi
     
-    # This file requires tests
     CHANGES_REQUIRE_TESTS=true
+    SOURCE_FILE_PATHS+=("$FILE")
     
-    # Find the test file using our function
-    TEST_FILE=$(find_test_file "$FILE")
+    MODULE_NAME=$(basename "$FILE" .py)
+    TEST_FLAT="tests/test_${MODULE_NAME}.py"
     
-    if [ -z "$TEST_FILE" ]; then
-        echo "❌ ERROR: No test file found for $FILE"
-        echo ""
-        echo "Searched locations:"
-        echo "  - tests/test_$(basename "$FILE" .py).py"
-        
-        # Check if file is in subdirectory
-        REL_PATH=$(echo "$FILE" | sed 's|custom_components/localshift/||')
-        if [[ "$REL_PATH" == *"/"* ]]; then
-            SUBDIR=$(dirname "$REL_PATH")
-            echo "  - tests/${SUBDIR}/test_$(basename "$FILE" .py).py"
-        fi
-        
-        echo ""
-        echo "TDD Workflow:"
-        echo "  1. Create a test file at one of the above locations"
-        echo "  2. Write failing test (RED phase)"
-        echo "  3. Then commit"
-        echo ""
-        echo "See: .agents/rules/tdd-workflow.md"
-        exit 1
+    if [ -f "$TEST_FLAT" ]; then
+        TEST_FILE_PATHS+=("$TEST_FLAT")
+        echo "✅ Test file exists: $TEST_FLAT"
+        continue
     fi
     
-    echo "✅ Test file exists: $TEST_FILE"
-    TEST_FILE_PATHS+=("$TEST_FILE")
+    REL_PATH=$(echo "$FILE" | sed 's|custom_components/localshift/||')
+    if [[ "$REL_PATH" == *"/"* ]]; then
+        SUBDIR=$(dirname "$REL_PATH")
+        TEST_SUBDIR="tests/${SUBDIR}/test_${MODULE_NAME}.py"
+        if [ -f "$TEST_SUBDIR" ]; then
+            TEST_FILE_PATHS+=("$TEST_SUBDIR")
+            echo "✅ Test file exists: $TEST_SUBDIR"
+            continue
+        fi
+    fi
+    
+    echo "❌ ERROR: No test file found for $FILE"
+    echo ""
+    echo "Searched locations:"
+    echo "  - tests/test_${MODULE_NAME}.py"
+    REL_PATH=$(echo "$FILE" | sed 's|custom_components/localshift/||')
+    if [[ "$REL_PATH" == *"/"* ]]; then
+        SUBDIR=$(dirname "$REL_PATH")
+        echo "  - tests/${SUBDIR}/test_${MODULE_NAME}.py"
+    fi
+    echo ""
+    echo "TDD Workflow:"
+    echo "  1. Create a test file at one of the above locations"
+    echo "  2. Write failing test (RED phase)"
+    echo "  3. Then commit"
+    echo ""
+    echo "See: .agents/rules/tdd-workflow.md"
+    exit 1
 done
 
 if [ "$CHANGES_REQUIRE_TESTS" = false ]; then
@@ -100,45 +78,62 @@ if [ "$CHANGES_REQUIRE_TESTS" = false ]; then
     exit 0
 fi
 
-# Build --cov flags only for staged files (not entire codebase)
 COV_FLAGS=""
-for FILE in $STAGED_FILES; do
-    if [[ "$FILE" == *"__init__.py" ]]; then
-        continue
-    fi
+for FILE in "${SOURCE_FILE_PATHS[@]}"; do
     MODULE=$(echo "$FILE" | sed 's|\.py$||' | tr '/' '.')
     COV_FLAGS="$COV_FLAGS --cov=$MODULE"
 done
 
-# Check for xdist availability and set parallel flag
 PARALLEL_FLAG=""
 if check_xdist_available; then
     PARALLEL_FLAG="-n logical"
     echo "🚀 Using parallel execution (pytest-xdist)"
 fi
 
-# Convert array to space-separated string
 TEST_FILES="${TEST_FILE_PATHS[*]}"
+COVERAGE_JSON="$PROJECT_ROOT/.coverage-tdd.json"
 
-# Run tests with coverage in single invocation
 echo ""
 echo "🔍 Running tests with coverage for modified files..."
 
 if [ -n "$COV_FLAGS" ]; then
     if ! uv run pytest $TEST_FILES $COV_FLAGS \
         $PARALLEL_FLAG \
+        --cov-report=json:"$COVERAGE_JSON" \
         --cov-report=term-missing \
-        --cov-fail-under=95 \
         -v --tb=short 2>&1; then
         echo ""
-        echo "❌ ERROR: Tests failed or coverage below 95%"
+        echo "❌ ERROR: Tests failed"
         echo ""
-        echo "All tests must pass and modified files must have 95% coverage"
+        echo "All tests must pass before commit (TDD GREEN phase)"
         echo "See: .agents/rules/tdd-workflow.md"
+        rm -f "$COVERAGE_JSON"
         exit 1
     fi
+    
     echo ""
-    echo "✅ All tests pass with 95%+ coverage"
+    echo "📊 Checking per-file coverage (95% threshold)..."
+    
+    if [ -f "$COVERAGE_CHECKER" ]; then
+        if ! uv run python "$COVERAGE_CHECKER" "$COVERAGE_JSON" "${SOURCE_FILE_PATHS[@]}"; then
+            rm -f "$COVERAGE_JSON"
+            exit 1
+        fi
+    else
+        echo "⚠️  coverage_checker.py not found, falling back to --cov-fail-under"
+        if ! uv run pytest $TEST_FILES $COV_FLAGS \
+            --cov-fail-under=95 \
+            -q 2>&1; then
+            echo ""
+            echo "❌ ERROR: Coverage below 95%"
+            rm -f "$COVERAGE_JSON"
+            exit 1
+        fi
+    fi
+    
+    rm -f "$COVERAGE_JSON"
+    echo ""
+    echo "✅ All tests pass with 95%+ coverage per file"
 else
     if ! uv run pytest $TEST_FILES $PARALLEL_FLAG -v --tb=short 2>&1; then
         echo ""

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -252,7 +252,12 @@ Before adding any optimizer feature:
 
 ### Coverage Requirement
 
-**Minimum 95% test coverage enforced:**
+**Minimum 95% coverage required PER MODIFIED FILE.**
+
+The pre-commit hook checks each staged file individually:
+- Each modified `.py` file must have ≥ 95% coverage
+- Uncovered lines are shown in the error message
+- Run the suggested command to see detailed coverage
 
 ```bash
 # Check coverage before commit
@@ -263,7 +268,7 @@ uv run pytest --cov=custom_components/localshift --cov-report=term-missing
 
 **Automatically checks before commit:**
 - Test file exists for modified code
-- Coverage >= 95%
+- **Per-file coverage >= 95%** (not project-wide average)
 - Tests pass
 
 ### Integration with Workflow

--- a/scripts/coverage_checker.py
+++ b/scripts/coverage_checker.py
@@ -1,0 +1,232 @@
+"""Coverage checker for TDD pre-commit hook.
+
+Parses pytest-cov JSON output and generates detailed failure messages
+when coverage is below the 95% threshold for modified files.
+"""
+
+import json
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass
+class CoverageFailure:
+    file_path: str
+    coverage_pct: float
+    uncovered_lines: list[int]
+    test_file: str | None = None
+
+    def to_dict(self) -> dict:
+        return {
+            "file_path": self.file_path,
+            "coverage_pct": self.coverage_pct,
+            "uncovered_lines": self.uncovered_lines,
+            "test_file": self.test_file,
+        }
+
+
+@dataclass
+class CoverageCheckResult:
+    passed: bool
+    failures: list[CoverageFailure] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return {
+            "passed": self.passed,
+            "failures": [f.to_dict() for f in self.failures],
+        }
+
+
+def find_test_file(source_file: str) -> str | None:
+    module_name = Path(source_file).stem
+
+    test_flat = f"tests/test_{module_name}.py"
+    if Path(test_flat).exists():
+        return test_flat
+
+    rel_path = source_file.replace("custom_components/localshift/", "")
+    if "/" in rel_path:
+        subdir = Path(rel_path).parent
+        test_subdir = f"tests/{subdir}/test_{module_name}.py"
+        if Path(test_subdir).exists():
+            return test_subdir
+
+    return None
+
+
+def parse_coverage_json(
+    json_path: str, staged_files: list[str], threshold: float = 95.0
+) -> CoverageCheckResult:
+    with open(json_path) as f:
+        data = json.load(f)
+
+    failures = []
+
+    for file_path in staged_files:
+        if file_path.endswith("__init__.py"):
+            continue
+
+        if file_path not in data.get("files", {}):
+            continue
+
+        file_data = data["files"][file_path]
+        summary = file_data.get("summary", {})
+        pct = summary.get("percent_covered", 0.0)
+
+        if pct < threshold:
+            executed = set(file_data.get("executed_lines", []))
+            all_lines = (
+                set(
+                    range(
+                        min(
+                            file_data.get("executed_lines", [1])
+                            + file_data.get("missing_lines", [1])
+                        ),
+                        max(
+                            file_data.get("executed_lines", [1])
+                            + file_data.get("missing_lines", [1])
+                        )
+                        + 1,
+                    )
+                )
+                if file_data.get("executed_lines") or file_data.get("missing_lines")
+                else set()
+            )
+
+            uncovered = sorted(all_lines - executed)
+
+            test_file = find_test_file(file_path)
+
+            failures.append(
+                CoverageFailure(
+                    file_path=file_path,
+                    coverage_pct=pct,
+                    uncovered_lines=uncovered,
+                    test_file=test_file,
+                )
+            )
+
+    return CoverageCheckResult(
+        passed=len(failures) == 0,
+        failures=failures,
+    )
+
+
+def format_failure_report(result: CoverageCheckResult) -> str:
+    if result.passed:
+        return "✅ All modified files have 95%+ coverage"
+
+    lines = [
+        "┌" + "─" * 70 + "┐",
+        f"│ ❌ COVERAGE FAILURES - {len(result.failures)} file(s) below 95% threshold"
+        + " " * (70 - 44 - len(str(len(result.failures))) - 25)
+        + "│",
+        "├" + "─" * 70 + "┤",
+    ]
+
+    for failure in result.failures:
+        file_display = failure.file_path
+        if len(file_display) > 60:
+            file_display = "..." + file_display[-57:]
+
+        lines.append(
+            f"│ File: {file_display}" + " " * (70 - 8 - len(file_display) - 1) + "│"
+        )
+        lines.append(
+            f"│ Coverage: {failure.coverage_pct:.1f}% (need 95%)"
+            + " " * (70 - 13 - len(f"{failure.coverage_pct:.1f}") - 15)
+            + "│"
+        )
+
+        if failure.uncovered_lines:
+            ranges = _format_line_ranges(failure.uncovered_lines)
+            for i, r in enumerate(ranges[:3]):
+                prefix = "Uncovered: " if i == 0 else "            "
+                lines.append(
+                    f"│ {prefix}{r}" + " " * (70 - 2 - len(prefix) - len(r) - 1) + "│"
+                )
+            if len(ranges) > 3:
+                lines.append(
+                    f"│            ... and {len(ranges) - 3} more ranges"
+                    + " " * 30
+                    + "│"
+                )
+
+        if failure.test_file:
+            lines.append(
+                f"│ Test file: {failure.test_file}"
+                + " " * (70 - 13 - len(failure.test_file) - 1)
+                + "│"
+            )
+
+        lines.append("├" + "─" * 70 + "┤")
+
+    test_files = [f.test_file for f in result.failures if f.test_file]
+    cov_modules = [
+        f.file_path.replace(".py", "").replace("/", ".") for f in result.failures
+    ]
+
+    lines.append("│ Run this to see detailed coverage:" + " " * 34 + "│")
+    cmd = f"uv run pytest {' '.join(test_files[:2])}"
+    if len(test_files) > 2:
+        cmd += " ..."
+    lines.append(f"│   {cmd}" + " " * (70 - 5 - len(cmd) - 1) + "│")
+    lines.append(
+        "│     --cov=" + " --cov=".join(cov_modules[:2]) + " \\" + " " * 30 + "│"
+    )
+    lines.append("│     --cov-report=term-missing -v" + " " * 35 + "│")
+    lines.append("└" + "─" * 70 + "┘")
+    lines.append("")
+    lines.append("TDD Workflow: .agents/rules/tdd-workflow.md")
+
+    return "\n".join(lines)
+
+
+def _format_line_ranges(lines: list[int]) -> list[str]:
+    if not lines:
+        return []
+
+    ranges = []
+    start = lines[0]
+    end = lines[0]
+
+    for i in range(1, len(lines)):
+        if lines[i] == end + 1:
+            end = lines[i]
+        else:
+            if start == end:
+                ranges.append(f"L{start}")
+            else:
+                ranges.append(f"L{start}-{end}")
+            start = lines[i]
+            end = lines[i]
+
+    if start == end:
+        ranges.append(f"L{start}")
+    else:
+        ranges.append(f"L{start}-{end}")
+
+    return ranges
+
+
+def main():
+    if len(sys.argv) < 3:
+        print(
+            "Usage: coverage_checker.py <coverage.json> <file1> [file2 ...]",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    json_path = sys.argv[1]
+    staged_files = sys.argv[2:]
+
+    result = parse_coverage_json(json_path, staged_files)
+
+    print(format_failure_report(result))
+
+    sys.exit(0 if result.passed else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_coverage_checker.py
+++ b/tests/test_coverage_checker.py
@@ -1,0 +1,322 @@
+"""Unit tests for coverage_checker module.
+
+Tests the Python coverage checking logic used by the TDD pre-commit hook.
+"""
+
+import json
+from pathlib import Path
+
+from scripts.coverage_checker import (
+    CoverageCheckResult,
+    CoverageFailure,
+    _format_line_ranges,
+    find_test_file,
+    format_failure_report,
+    parse_coverage_json,
+)
+
+
+class TestFormatLineRanges:
+    """Test line range formatting for uncovered lines."""
+
+    def test_single_line(self):
+        assert _format_line_ranges([42]) == ["L42"]
+
+    def test_consecutive_lines(self):
+        assert _format_line_ranges([1, 2, 3, 4, 5]) == ["L1-5"]
+
+    def test_multiple_ranges(self):
+        assert _format_line_ranges([1, 2, 3, 10, 11, 20]) == ["L1-3", "L10-11", "L20"]
+
+    def test_empty_list(self):
+        assert _format_line_ranges([]) == []
+
+    def test_single_gap(self):
+        assert _format_line_ranges([1, 2, 3, 5, 6, 7]) == ["L1-3", "L5-7"]
+
+
+class TestFindTestFile:
+    """Test test file discovery for source files."""
+
+    def test_finds_flat_test_file(self, tmp_path: Path, monkeypatch):
+        source = "custom_components/localshift/optimizer.py"
+        test_file = tmp_path / "tests" / "test_optimizer.py"
+        test_file.parent.mkdir(parents=True)
+        test_file.touch()
+
+        monkeypatch.chdir(tmp_path)
+        result = find_test_file(source)
+        assert result == "tests/test_optimizer.py"
+
+    def test_finds_subdir_test_file(self, tmp_path: Path, monkeypatch):
+        source = "custom_components/localshift/engine/optimizer.py"
+        test_file = tmp_path / "tests" / "engine" / "test_optimizer.py"
+        test_file.parent.mkdir(parents=True)
+        test_file.touch()
+
+        monkeypatch.chdir(tmp_path)
+        result = find_test_file(source)
+        assert result == "tests/engine/test_optimizer.py"
+
+    def test_returns_none_when_not_found(self, tmp_path: Path, monkeypatch):
+        source = "custom_components/localshift/nonexistent.py"
+        monkeypatch.chdir(tmp_path)
+        result = find_test_file(source)
+        assert result is None
+
+    def test_skips_init_file(self):
+        result = find_test_file("custom_components/localshift/__init__.py")
+        assert result is None or "test_" in (result or "")
+
+
+class TestParseCoverageJson:
+    """Test coverage JSON parsing and threshold checking."""
+
+    def test_passes_when_above_threshold(self, tmp_path: Path):
+        coverage_json = tmp_path / "coverage.json"
+        coverage_json.write_text(
+            json.dumps({
+                "meta": {"version": "1.0"},
+                "files": {
+                    "custom_components/localshift/optimizer.py": {
+                        "executed_lines": [1, 2, 3, 4, 5],
+                        "missing_lines": [],
+                        "summary": {
+                            "num_statements": 5,
+                            "covered_lines": 5,
+                            "percent_covered": 100.0,
+                        },
+                    }
+                },
+            })
+        )
+
+        staged_files = ["custom_components/localshift/optimizer.py"]
+        result = parse_coverage_json(str(coverage_json), staged_files)
+
+        assert result.passed is True
+        assert len(result.failures) == 0
+
+    def test_fails_when_below_threshold(self, tmp_path: Path):
+        coverage_json = tmp_path / "coverage.json"
+        coverage_json.write_text(
+            json.dumps({
+                "meta": {"version": "1.0"},
+                "files": {
+                    "custom_components/localshift/optimizer.py": {
+                        "executed_lines": [1, 2, 3],
+                        "missing_lines": [4, 5, 6, 7],
+                        "summary": {
+                            "num_statements": 10,
+                            "covered_lines": 3,
+                            "percent_covered": 78.0,
+                        },
+                    }
+                },
+            })
+        )
+
+        staged_files = ["custom_components/localshift/optimizer.py"]
+        result = parse_coverage_json(str(coverage_json), staged_files)
+
+        assert result.passed is False
+        assert len(result.failures) == 1
+        assert result.failures[0].coverage_pct == 78.0
+
+    def test_shows_uncovered_lines(self, tmp_path: Path):
+        coverage_json = tmp_path / "coverage.json"
+        coverage_json.write_text(
+            json.dumps({
+                "meta": {"version": "1.0"},
+                "files": {
+                    "custom_components/localshift/optimizer.py": {
+                        "executed_lines": [1, 2, 5, 8, 9, 10],
+                        "missing_lines": [3, 4, 6, 7],
+                        "summary": {
+                            "num_statements": 10,
+                            "covered_lines": 6,
+                            "percent_covered": 60.0,
+                        },
+                    }
+                },
+            })
+        )
+
+        staged_files = ["custom_components/localshift/optimizer.py"]
+        result = parse_coverage_json(str(coverage_json), staged_files)
+
+        assert result.passed is False
+        uncovered = result.failures[0].uncovered_lines
+        assert 3 in uncovered
+        assert 4 in uncovered
+        assert 6 in uncovered
+        assert 7 in uncovered
+
+    def test_checks_per_file_not_project_wide(self, tmp_path: Path):
+        coverage_json = tmp_path / "coverage.json"
+        coverage_json.write_text(
+            json.dumps({
+                "meta": {"version": "1.0"},
+                "files": {
+                    "custom_components/localshift/good.py": {
+                        "executed_lines": [1, 2, 3, 4, 5],
+                        "missing_lines": [],
+                        "summary": {
+                            "num_statements": 5,
+                            "covered_lines": 5,
+                            "percent_covered": 100.0,
+                        },
+                    },
+                    "custom_components/localshift/bad.py": {
+                        "executed_lines": [1],
+                        "missing_lines": [2, 3, 4, 5],
+                        "summary": {
+                            "num_statements": 10,
+                            "covered_lines": 1,
+                            "percent_covered": 78.0,
+                        },
+                    },
+                },
+            })
+        )
+
+        staged_files = [
+            "custom_components/localshift/good.py",
+            "custom_components/localshift/bad.py",
+        ]
+        result = parse_coverage_json(str(coverage_json), staged_files)
+
+        assert result.passed is False
+        assert len(result.failures) == 1
+        assert result.failures[0].file_path == "custom_components/localshift/bad.py"
+
+    def test_skips_init_files(self, tmp_path: Path):
+        coverage_json = tmp_path / "coverage.json"
+        coverage_json.write_text(
+            json.dumps({
+                "meta": {"version": "1.0"},
+                "files": {
+                    "custom_components/localshift/__init__.py": {
+                        "executed_lines": [1],
+                        "missing_lines": [2, 3, 4, 5],
+                        "summary": {
+                            "num_statements": 5,
+                            "covered_lines": 1,
+                            "percent_covered": 20.0,
+                        },
+                    }
+                },
+            })
+        )
+
+        staged_files = ["custom_components/localshift/__init__.py"]
+        result = parse_coverage_json(str(coverage_json), staged_files)
+
+        assert result.passed is True
+
+
+class TestFormatFailureReport:
+    """Test failure report formatting."""
+
+    def test_shows_specific_file_coverage(self):
+        result = CoverageCheckResult(
+            passed=False,
+            failures=[
+                CoverageFailure(
+                    file_path="custom_components/localshift/optimizer.py",
+                    coverage_pct=78.3,
+                    uncovered_lines=[45, 46, 47, 48, 49, 50],
+                )
+            ],
+        )
+
+        report = format_failure_report(result)
+
+        assert "optimizer.py" in report
+        assert "78.3%" in report
+        assert "95%" in report
+
+    def test_shows_uncovered_lines(self):
+        result = CoverageCheckResult(
+            passed=False,
+            failures=[
+                CoverageFailure(
+                    file_path="custom_components/localshift/foo.py",
+                    coverage_pct=80.0,
+                    uncovered_lines=[10, 11, 12, 20, 21],
+                )
+            ],
+        )
+
+        report = format_failure_report(result)
+
+        assert "L10-12" in report
+        assert "L20-21" in report
+
+    def test_shows_test_file_location(self):
+        result = CoverageCheckResult(
+            passed=False,
+            failures=[
+                CoverageFailure(
+                    file_path="custom_components/localshift/optimizer.py",
+                    coverage_pct=80.0,
+                    uncovered_lines=[1],
+                    test_file="tests/test_optimizer.py",
+                )
+            ],
+        )
+
+        report = format_failure_report(result)
+
+        assert "tests/test_optimizer.py" in report
+        assert "Test file:" in report
+
+    def test_shows_remediation_command(self):
+        result = CoverageCheckResult(
+            passed=False,
+            failures=[
+                CoverageFailure(
+                    file_path="custom_components/localshift/optimizer.py",
+                    coverage_pct=80.0,
+                    uncovered_lines=[1],
+                    test_file="tests/test_optimizer.py",
+                )
+            ],
+        )
+
+        report = format_failure_report(result)
+
+        assert "uv run pytest" in report
+        assert "--cov-report=term-missing" in report
+
+    def test_shows_multiple_failures(self):
+        result = CoverageCheckResult(
+            passed=False,
+            failures=[
+                CoverageFailure(
+                    file_path="custom_components/localshift/foo.py",
+                    coverage_pct=78.0,
+                    uncovered_lines=[1],
+                    test_file="tests/test_foo.py",
+                ),
+                CoverageFailure(
+                    file_path="custom_components/localshift/bar.py",
+                    coverage_pct=85.0,
+                    uncovered_lines=[5, 6],
+                    test_file="tests/test_bar.py",
+                ),
+            ],
+        )
+
+        report = format_failure_report(result)
+
+        assert "2 file" in report
+        assert "foo.py" in report
+        assert "bar.py" in report
+
+    def test_success_message_when_passed(self):
+        result = CoverageCheckResult(passed=True, failures=[])
+        report = format_failure_report(result)
+
+        assert "✅" in report
+        assert "95%+" in report


### PR DESCRIPTION
## Summary

- Add Python `coverage_checker` module for detailed per-file coverage failure reports
- Show specific file, coverage %, uncovered line ranges, and test file location
- Check per-file 95% threshold instead of project-wide average
- Update documentation with new error format examples
- Add 20 unit tests for coverage_checker

## Problem

Pre-commit hooks were blocking commits with vague "coverage below 95%" messages. Agents had to manually diagnose which files had low coverage and find uncovered lines.

## Solution

Structured error output that shows:
- Specific file with low coverage
- Exact coverage percentage vs 95% requirement
- Uncovered line ranges (e.g., L45-52, L78-85)
- Test file location for remediation
- One-liner command to re-run with details

## Example Output

```
┌──────────────────────────────────────────────────────────────────────┐
│ ❌ COVERAGE FAILURES - 1 file(s) below 95% threshold                 │
├──────────────────────────────────────────────────────────────────────┤
│ File: custom_components/localshift/optimizer.py                      │
│ Coverage: 78.3% (need 95%)                                           │
│ Uncovered: L45-52, L78-85                                            │
│ Test file: tests/test_optimizer.py                                   │
├──────────────────────────────────────────────────────────────────────┤
│ Run this to see detailed coverage:                                   │
│   uv run pytest tests/test_optimizer.py --cov=...                    │
└──────────────────────────────────────────────────────────────────────┘
```

## Test Plan

- [x] 20 new unit tests for coverage_checker module
- [x] All 967 existing tests pass
- [x] Lint/format clean