### PR TITLE
Protect both main and test branches from direct commits

### DIFF
--- a/.agents/rules/worktrees.md
+++ b/.agents/rules/worktrees.md
@@ -106,6 +106,44 @@ gh pr create --base test --title "..."
 
 ---
 
+## PR Body Formatting Guidelines
+
+**ALWAYS use heredoc for PR bodies to preserve markdown formatting:**
+
+```bash
+# CORRECT - preserves backticks, pipes, newlines
+gh pr create --base test --title "Fix thing" --body "$(cat <<'EOF'
+This PR does `thing` with | table | support |
+- Item 1
+- Item 2
+EOF
+)"
+
+# WRONG - causes escaped characters like \` and broken tables
+gh pr create --base test --title "Fix thing" --body "This has \`backticks\` and broken|tables"
+```
+
+**Why this matters:** Shell escaping converts `\`` to `\\`` and breaks table formatting.
+
+**Template for standard PRs:**
+```bash
+gh pr create --base test --title "TITLE" --body "$(cat <<'EOF'
+## Summary
+Brief description
+
+## Changes
+- Change 1
+- Change 2
+
+## Testing
+- [ ] Tested in worktree
+- [ ] CI passes
+EOF
+)"
+```
+
+---
+
 ## Why This Matters
 
 - **Git hooks block main commits** - No exceptions (unless emergency bypass)

--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -1,52 +1,60 @@
 # Git Hooks - Branch Protection System
 
-This directory contains version-controlled git hooks that enforce the worktree-only workflow and protect the main branch.
+This directory contains version-controlled git hooks that enforce the worktree-only workflow and protect the `main` and `test` branches.
+
+## Protected Branches
+
+- **`main`** - Production branch
+- **`test`** - Continuous deployment branch for testing
+
+Both branches require changes to go through pull requests from feature worktrees.
 
 ## Hooks Overview
 
 ### `pre-commit` (HARD BLOCK)
-**Purpose:** Prevents ALL commits directly on the main branch.
+**Purpose:** Prevents ALL commits directly on protected branches (`main`, `test`).
 
 **Behavior:**
-- Exits with code 1 if current branch is `main`
+- Exits with code 1 if current branch is `main` or `test`
 - Logs blocked attempts to `.git-bypass.log`
 - No bypass method documented in error message
 
-**Recovery:** If you accidentally commit on main, run `.githooks/scripts/recover-main.sh`
+**Recovery:** If you accidentally commit on a protected branch, run `.githooks/scripts/recover-main.sh`
 
 ---
 
 ### `pre-push` (HARD BLOCK)
-**Purpose:** Prevents pushing from main branch (defense-in-depth if pre-commit is bypassed).
+**Purpose:** Prevents pushing from protected branches (defense-in-depth if pre-commit is bypassed).
 
 **Behavior:**
-- Exits with code 1 if pushing from `main` branch
+- Exits with code 1 if pushing from `main` or `test` branch
 - Logs blocked attempts to `.git-bypass.log`
 - Emergency override available (see below)
 
 **Emergency Override:**
 ```bash
 GIT_EMERGENCY_PUSH=1 git push origin main
+GIT_EMERGENCY_PUSH=1 git push origin test
 ```
 This bypass is logged to `.git-bypass.log` and should only be used in true emergencies.
 
 ---
 
 ### `post-checkout` (WARNING)
-**Purpose:** Inform users when they land on the main branch.
+**Purpose:** Inform users when they land on a protected branch.
 
 **Behavior:**
-- Displays warning message with recent main activity
+- Displays warning message with recent branch activity
 - Shows recommended worktree command
 - Does NOT block - informational only
 
 ---
 
 ### `prepare-commit-msg` (WARNING)
-**Purpose:** Add reviewer awareness for commits that mention main branch.
+**Purpose:** Add reviewer awareness for commits that mention protected branches.
 
 **Behavior:**
-- Prepends warning comment to commit messages mentioning "main"
+- Prepends warning comment to commit messages mentioning "main" or "test"
 - Does NOT block - comment for reviewer awareness only
 
 ---
@@ -95,9 +103,9 @@ Audit script to verify git protection is configured correctly.
 **Checks:**
 - `core.hooksPath` is set to `.githooks`
 - All hooks exist and are executable
-- No worktrees are on main branch
-- Current branch is not main
-- Main branch sync status with origin
+- No worktrees are on protected branches (`main`, `test`)
+- Current branch is not protected (`main`, `test`)
+- Protected branches sync status with origin
 
 **Usage:**
 ```bash
@@ -115,6 +123,7 @@ All bypass attempts and recovery actions are logged to `.git-bypass.log` in the 
 **Log format:**
 ```
 2026-03-03T09:15:23+11:00 - pre-commit blocked commit on main
+2026-03-03T09:16:45+11:00 - pre-commit blocked commit on test
 2026-03-03T09:20:45+11:00 - pre-push blocked push from main to origin
 2026-03-03T09:25:12+11:00 - RECOVERY: Created backup branch backup-main-20260303-092512
 2026-03-03T09:26:30+11:00 - RECOVERY: Reset main to origin/main (was ahead by 3 commits)
@@ -128,30 +137,31 @@ All bypass attempts and recovery actions are logged to `.git-bypass.log` in the 
 1. Create worktree for each task: `git worktree add worktrees/issue-{NNN} -b issue/{NNN}`
 2. Work in the worktree directory
 3. Commit and push from the issue branch
-4. Create pull request for review
+4. Create pull request targeting `test` (for testing) or `main` (for production)
 5. Merge via GitHub UI after approval
 
 ### ❌ DON'T:
-1. Commit directly on main branch (blocked)
-2. Push from main branch (blocked)
-3. Create worktrees on main branch
+1. Commit directly on `main` or `test` branches (blocked)
+2. Push from `main` or `test` branches (blocked)
+3. Create worktrees on protected branches
 4. Use `git commit --no-verify` to bypass hooks
 
 ---
 
 ## Emergency Procedures
 
-### If you accidentally commit on main:
+### If you accidentally commit on a protected branch:
 
 1. **Don't panic** - the commit didn't push
 2. Run: `.githooks/scripts/recover-main.sh`
-3. Choose option A to reset main to origin/main
+3. Choose option A to reset the branch to origin
 4. Your work is preserved in the backup branch
 
-### If you need to emergency-push from main:
+### If you need to emergency-push from a protected branch:
 
 ```bash
 GIT_EMERGENCY_PUSH=1 git push origin main
+GIT_EMERGENCY_PUSH=1 git push origin test
 ```
 
 This is logged and should only be used when:

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,15 +1,16 @@
 #!/bin/bash
-# Pre-commit hook: Block all commits on main branch
+# Pre-commit hook: Block all commits on protected branches
 # No bypass documented - use worktree workflow instead
 
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
+PROTECTED_BRANCHES="main test"
 
-if [ "$BRANCH" = "main" ]; then
+if [[ "$PROTECTED_BRANCHES" =~ "$BRANCH" ]]; then
     echo "=========================================="
-    echo "ERROR: Direct commits to 'main' are blocked!"
+    echo "ERROR: Direct commits to '$BRANCH' are blocked!"
     echo "=========================================="
     echo ""
-    echo "The main branch is protected. All changes must go through pull requests."
+    echo "The '$BRANCH' branch is protected. All changes must go through pull requests."
     echo ""
     echo "Correct workflow:"
     echo "  1. Create worktree: git worktree add worktrees/issue-{NNN} -b issue/{NNN}"
@@ -17,14 +18,14 @@ if [ "$BRANCH" = "main" ]; then
     echo "  3. Commit and push from issue branch"
     echo "  4. Create pull request for review"
     echo ""
-    echo "If you accidentally committed on main:"
+    echo "If you accidentally committed on $BRANCH:"
     echo "  Run: .githooks/scripts/recover-main.sh"
     echo ""
     echo "=========================================="
-    
+
     # Log the attempt
-    echo "$(date -Iseconds) - pre-commit blocked commit on main" >> .git-bypass.log
-    
+    echo "$(date -Iseconds) - pre-commit blocked commit on $BRANCH" >> .git-bypass.log
+
     exit 1
 fi
 

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Pre-push hook: Block all pushes from main branch
+# Pre-push hook: Block all pushes from protected branches
 # Emergency override: GIT_EMERGENCY_PUSH=1 (logged)
 
 RED='\033[0;31m'
@@ -10,21 +10,22 @@ REMOTE="$1"
 URL="$2"
 
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
+PROTECTED_BRANCHES="main test"
 
-if [ "$BRANCH" = "main" ]; then
+if [[ "$PROTECTED_BRANCHES" =~ "$BRANCH" ]]; then
     # Check for emergency override
     if [ "$GIT_EMERGENCY_PUSH" = "1" ]; then
-        echo "$(date -Iseconds) - pre-push EMERGENCY OVERRIDE: push from main to $REMOTE" >> .git-bypass.log
-        echo -e "${YELLOW}WARNING: Emergency push from main branch logged for audit${NC}"
+        echo "$(date -Iseconds) - pre-push EMERGENCY OVERRIDE: push from $BRANCH to $REMOTE" >> .git-bypass.log
+        echo -e "${YELLOW}WARNING: Emergency push from $BRANCH branch logged for audit${NC}"
         exit 0
     fi
-    
+
     echo ""
     echo -e "${RED}==========================================${NC}"
-    echo -e "${RED}ERROR: Pushes from 'main' branch are blocked!${NC}"
+    echo -e "${RED}ERROR: Pushes from '$BRANCH' branch are blocked!${NC}"
     echo -e "${RED}==========================================${NC}"
     echo ""
-    echo "The main branch is protected. Push from feature branches only."
+    echo "The '$BRANCH' branch is protected. Push from feature branches only."
     echo ""
     echo "Correct workflow:"
     echo "  1. Push your issue branch: git push origin issue/{NNN}"
@@ -32,13 +33,13 @@ if [ "$BRANCH" = "main" ]; then
     echo "  3. Merge via GitHub UI after review"
     echo ""
     echo "Emergency override (logged, audit required):"
-    echo "  GIT_EMERGENCY_PUSH=1 git push origin main"
+    echo "  GIT_EMERGENCY_PUSH=1 git push origin $BRANCH"
     echo ""
     echo -e "${RED}==========================================${NC}"
-    
+
     # Log the attempt
-    echo "$(date -Iseconds) - pre-push blocked push from main to $REMOTE" >> .git-bypass.log
-    
+    echo "$(date -Iseconds) - pre-push blocked push from $BRANCH to $REMOTE" >> .git-bypass.log
+
     exit 1
 fi
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,22 +4,22 @@
 
 # ⚠️ STOP: MANDATORY FIRST ACTION
 
-**You MUST verify you're NOT on the `main` branch before ANY file edit.**
+**You MUST verify you're NOT on a protected branch (`main` or `test`) before ANY file edit.**
 
 ## Verification Steps
 
 1. Run: `git branch --show-current`
-2. If output is `"main"`: **STOP HERE**
+2. If output is `"main"` or `"test"`: **STOP HERE**
    - Create worktree: `git worktree add worktrees/issue-{NNN} -b issue/{NNN}`
    - Change directory: `cd worktrees/issue-{NNN}`
    - Then proceed with edits
-3. If output is NOT `"main"`: Proceed with the task
+3. If output is NOT `"main"` or `"test"`: Proceed with the task
 
 ## Why This Matters
 
-- **Git hooks block all commits on main** - No exceptions
-- **Editing on main wastes time** - You'll be forced to move changes anyway
-- **Main is read-only** - All changes go through PR
+- **Git hooks block all commits on `main` and `test`** - No exceptions
+- **Editing on protected branches wastes time** - You'll be forced to move changes anyway
+- **`main` and `test` are read-only** - All changes go through PR
 
 **The enforcement is real. Start in a worktree.**
 
@@ -52,13 +52,13 @@ LocalShift is a Home Assistant integration for automated Tesla Powerwall battery
 
 ## ⚠️ ENFORCED: Worktree-Only Workflow
 
-**Git hooks in `.githooks/` block all main branch commits and pushes.**
+**Git hooks in `.githooks/` block all commits and pushes on `main` and `test` branches.**
 
 ### Before Starting ANY Task
 
 1. Run `git worktree list` - verify you're in a worktree
-2. Run `git branch --show-current` - must NOT be `main`
-3. If on main, create worktree: `git worktree add worktrees/issue-{NNN} -b issue/{NNN}`
+2. Run `git branch --show-current` - must NOT be `main` or `test`
+3. If on `main` or `test`, create worktree: `git worktree add worktrees/issue-{NNN} -b issue/{NNN}`
 
 ### Emergency Bypass
 


### PR DESCRIPTION
This PR extends branch protection to include the `test` branch in addition to `main`.

## Changes

- `.githooks/pre-commit`: Now blocks commits on both `main` and `test` branches
- `.githooks/pre-push`: Now blocks pushes from both `main` and `test` branches
- `.githooks/README.md`: Updated documentation to reflect both protected branches
- `AGENTS.md`: Updated agent guidelines to warn about both `main` and `test`

## Why

The `test` branch is used for continuous deployment and should be treated with the same protection as `main`. This prevents agents from accidentally making direct commits to `test`, which can cause conflicts when multiple agents work simultaneously.

## Protected Branches

| Branch | Commits | Pushes | Emergency Bypass |
|--------|---------|--------|------------------|
| `main` | Blocked | Blocked | `GIT_EMERGENCY_PUSH=1` |
| `test` | Blocked | Blocked | `GIT_EMERGENCY_PUSH=1` |
| `issue/*` | Allowed | Allowed | N/A |