### PR TITLE
test: Add comprehensive tests for forecast/solar_accuracy.py (fixes #666)

### DIFF
--- a/tests/forecast/test_solar_accuracy.py
+++ b/tests/forecast/test_solar_accuracy.py
@@ -1,0 +1,591 @@
+"""Tests for forecast/solar_accuracy.py - Solar forecast accuracy tracking."""
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.localshift.forecast.solar_accuracy import (
+    MAX_PERIOD_RECORDS,
+    SolarAccuracyTracker,
+    SolarBiasMetrics,
+    SolarPeriodRecord,
+)
+
+
+class TestSolarPeriodRecord:
+    """Tests for SolarPeriodRecord dataclass."""
+
+    def test_initialization_with_forecast(self):
+        """Test record initialization with forecast value."""
+        record = SolarPeriodRecord(
+            period_start=datetime(2026, 1, 15, 10, 0, tzinfo=UTC),
+            forecast_kwh=2.5,
+            actual_kwh=2.0,
+            weather_condition="sunny",
+            time_of_day="morning",
+            season="summer",
+        )
+        assert record.forecast_kwh == 2.5
+        assert record.actual_kwh == 2.0
+        # Bias = (forecast - actual) / forecast = (2.5 - 2.0) / 2.5 = 0.2
+        assert record.bias == pytest.approx(0.2)
+
+    def test_initialization_with_zero_forecast(self):
+        """Test record initialization with zero forecast - bias should be 0."""
+        record = SolarPeriodRecord(
+            period_start=datetime(2026, 1, 15, 10, 0, tzinfo=UTC),
+            forecast_kwh=0.0,
+            actual_kwh=0.0,
+            weather_condition="cloudy",
+            time_of_day="morning",
+            season="summer",
+        )
+        assert record.bias == 0.0
+
+    def test_initialization_with_small_forecast(self):
+        """Test record initialization with very small forecast - bias should be 0."""
+        record = SolarPeriodRecord(
+            period_start=datetime(2026, 1, 15, 10, 0, tzinfo=UTC),
+            forecast_kwh=0.001,
+            actual_kwh=0.0,
+            weather_condition="cloudy",
+            time_of_day="morning",
+            season="summer",
+        )
+        assert record.bias == 0.0
+
+    def test_to_dict(self):
+        """Test serialization to dictionary."""
+        record = SolarPeriodRecord(
+            period_start=datetime(2026, 1, 15, 10, 0, tzinfo=UTC),
+            forecast_kwh=2.5,
+            actual_kwh=2.0,
+            weather_condition="sunny",
+            time_of_day="morning",
+            season="summer",
+        )
+        data = record.to_dict()
+        assert data["forecast_kwh"] == 2.5
+        assert data["actual_kwh"] == 2.0
+        assert data["weather_condition"] == "sunny"
+        assert data["time_of_day"] == "morning"
+        assert data["season"] == "summer"
+        assert "period_start" in data
+
+    def test_from_dict(self):
+        """Test deserialization from dictionary."""
+        data = {
+            "period_start": "2026-01-15T10:00:00+00:00",
+            "forecast_kwh": 2.5,
+            "actual_kwh": 2.0,
+            "weather_condition": "sunny",
+            "time_of_day": "morning",
+            "season": "summer",
+            "bias": 0.2,
+        }
+        record = SolarPeriodRecord.from_dict(data)
+        assert record.forecast_kwh == 2.5
+        assert record.actual_kwh == 2.0
+        assert record.weather_condition == "sunny"
+        assert record.time_of_day == "morning"
+        assert record.season == "summer"
+
+    def test_from_dict_with_defaults(self):
+        """Test deserialization with missing fields uses defaults."""
+        data = {"period_start": "2026-01-15T10:00:00+00:00"}
+        record = SolarPeriodRecord.from_dict(data)
+        assert record.forecast_kwh == 0.0
+        assert record.actual_kwh == 0.0
+        assert record.weather_condition == "unknown"
+        assert record.time_of_day == "unknown"
+        assert record.season == "unknown"
+
+
+class TestSolarBiasMetrics:
+    """Tests for SolarBiasMetrics dataclass."""
+
+    def test_defaults(self):
+        """Test default values."""
+        metrics = SolarBiasMetrics()
+        assert metrics.overall_bias == 0.0
+        assert metrics.bias_by_time == {}
+        assert metrics.bias_by_weather == {}
+        assert metrics.bias_by_season == {}
+        assert metrics.sample_count == 0
+        assert metrics.mape == 0.0
+        assert metrics.accuracy == 100.0
+
+    def test_to_dict(self):
+        """Test serialization to dictionary."""
+        metrics = SolarBiasMetrics(
+            overall_bias=0.1,
+            bias_by_time={"morning": 0.05},
+            bias_by_weather={"sunny": 0.1},
+            sample_count=10,
+            mape=15.0,
+            accuracy=85.0,
+        )
+        data = metrics.to_dict()
+        assert data["overall_bias"] == 0.1
+        assert data["bias_by_time"] == {"morning": 0.05}
+        assert data["sample_count"] == 10
+
+    def test_from_dict(self):
+        """Test deserialization from dictionary."""
+        data = {
+            "overall_bias": 0.1,
+            "bias_by_time": {"morning": 0.05},
+            "bias_by_weather": {"sunny": 0.1},
+            "bias_by_season": {"summer": 0.15},
+            "sample_count": 10,
+            "mape": 15.0,
+            "accuracy": 85.0,
+        }
+        metrics = SolarBiasMetrics.from_dict(data)
+        assert metrics.overall_bias == 0.1
+        assert metrics.bias_by_time == {"morning": 0.05}
+        assert metrics.sample_count == 10
+
+    def test_from_dict_with_defaults(self):
+        """Test deserialization with missing fields uses defaults."""
+        data = {}
+        metrics = SolarBiasMetrics.from_dict(data)
+        assert metrics.overall_bias == 0.0
+        assert metrics.accuracy == 100.0
+
+
+class TestSolarAccuracyTracker:
+    """Tests for SolarAccuracyTracker class."""
+
+    @pytest.fixture
+    def mock_hass(self):
+        """Create mock HomeAssistant instance."""
+        hass = MagicMock()
+        hass.data = {}
+        return hass
+
+    @pytest.fixture
+    def tracker(self, mock_hass):
+        """Create SolarAccuracyTracker instance."""
+        return SolarAccuracyTracker(mock_hass, "test_entry")
+
+    def test_initialization(self, tracker):
+        """Test tracker initialization."""
+        assert tracker._hass is not None
+        assert tracker._pending_forecasts == {}
+        assert tracker._period_records.maxlen == MAX_PERIOD_RECORDS
+        assert tracker.metrics is not None
+        assert tracker._save_pending is False
+
+    def test_record_forecast(self, tracker):
+        """Test recording a forecast."""
+        period_start = datetime(2026, 1, 15, 10, 0, tzinfo=UTC)
+        tracker.record_forecast(period_start, 2.5, "sunny")
+
+        key = period_start.isoformat()
+        assert key in tracker._pending_forecasts
+        record = tracker._pending_forecasts[key]
+        assert record.forecast_kwh == 2.5
+        assert record.weather_condition == "sunny"
+        assert record.time_of_day == "morning"
+        assert record.season == "summer"
+
+    def test_record_forecast_normalizes_weather(self, tracker):
+        """Test weather normalization when recording forecast."""
+        period_start = datetime(2026, 1, 15, 10, 0, tzinfo=UTC)
+        tracker.record_forecast(period_start, 2.5, "partly cloudy")
+
+        record = tracker._pending_forecasts[period_start.isoformat()]
+        assert record.weather_condition == "cloudy"
+
+    def test_record_forecast_weather_clear(self, tracker):
+        """Test weather normalization for clear conditions."""
+        period_start = datetime(2026, 1, 15, 10, 0, tzinfo=UTC)
+        tracker.record_forecast(period_start, 2.5, "clear skies")
+
+        record = tracker._pending_forecasts[period_start.isoformat()]
+        assert record.weather_condition == "sunny"
+
+    def test_record_forecast_weather_rain(self, tracker):
+        """Test weather normalization for rainy conditions."""
+        period_start = datetime(2026, 1, 15, 10, 0, tzinfo=UTC)
+        tracker.record_forecast(period_start, 2.5, "light rain shower")
+
+        record = tracker._pending_forecasts[period_start.isoformat()]
+        assert record.weather_condition == "rainy"
+
+    def test_record_forecast_weather_snow(self, tracker):
+        """Test weather normalization for snowy conditions."""
+        period_start = datetime(2026, 1, 15, 10, 0, tzinfo=UTC)
+        tracker.record_forecast(period_start, 2.5, "snow flurries")
+
+        record = tracker._pending_forecasts[period_start.isoformat()]
+        assert record.weather_condition == "snow"
+
+    def test_record_forecast_weather_fog(self, tracker):
+        """Test weather normalization for foggy conditions."""
+        period_start = datetime(2026, 1, 15, 10, 0, tzinfo=UTC)
+        tracker.record_forecast(period_start, 2.5, "foggy morning")
+
+        record = tracker._pending_forecasts[period_start.isoformat()]
+        assert record.weather_condition == "foggy"
+
+    def test_record_forecast_weather_unknown(self, tracker):
+        """Test weather normalization for unknown conditions."""
+        period_start = datetime(2026, 1, 15, 10, 0, tzinfo=UTC)
+        tracker.record_forecast(period_start, 2.5, "")
+
+        record = tracker._pending_forecasts[period_start.isoformat()]
+        assert record.weather_condition == "unknown"
+
+    def test_record_forecast_weather_none(self, tracker):
+        """Test weather normalization for None conditions."""
+        period_start = datetime(2026, 1, 15, 10, 0, tzinfo=UTC)
+        tracker.record_forecast(period_start, 2.5, None)
+
+        record = tracker._pending_forecasts[period_start.isoformat()]
+        assert record.weather_condition == "unknown"
+
+    def test_backfill_actual(self, tracker):
+        """Test backfilling actual solar value."""
+        period_start = datetime(2026, 1, 15, 10, 0, tzinfo=UTC)
+        tracker.record_forecast(period_start, 2.5, "sunny")
+
+        tracker.backfill_actual(period_start, 2.0)
+
+        # Should no longer be pending
+        assert period_start.isoformat() not in tracker._pending_forecasts
+
+        # Should be in period records
+        assert len(tracker._period_records) == 1
+
+        # Metrics should be recomputed
+        assert tracker._metrics.sample_count == 1
+        assert tracker._save_pending is True
+
+    def test_backfill_actual_missing_forecast(self, tracker):
+        """Test backfill with no matching forecast - should be no-op."""
+        period_start = datetime(2026, 1, 15, 10, 0, tzinfo=UTC)
+        # Don't record forecast first
+        tracker.backfill_actual(period_start, 2.0)
+
+        # Should be no records
+        assert len(tracker._period_records) == 0
+
+    def test_backfill_multiple_records(self, tracker):
+        """Test multiple backfills."""
+        # Record multiple forecasts
+        for hour in [8, 9, 10, 11]:
+            period_start = datetime(2026, 1, 15, hour, 0, tzinfo=UTC)
+            tracker.record_forecast(period_start, 2.5, "sunny")
+
+        # Backfill some
+        tracker.backfill_actual(datetime(2026, 1, 15, 8, 0, tzinfo=UTC), 2.0)
+        tracker.backfill_actual(datetime(2026, 1, 15, 9, 0, tzinfo=UTC), 2.5)
+
+        assert len(tracker._period_records) == 2
+        assert tracker._metrics.sample_count == 2
+
+    def test_metrics_computation(self, tracker):
+        """Test that metrics are computed correctly."""
+        # Add multiple records
+        for hour in [8, 9, 10]:
+            period_start = datetime(2026, 1, 15, hour, 0, tzinfo=UTC)
+            tracker.record_forecast(period_start, 2.0, "sunny")
+
+        # Backfill with different actuals
+        tracker.backfill_actual(
+            datetime(2026, 1, 15, 8, 0, tzinfo=UTC), 2.0
+        )  # bias = 0
+        tracker.backfill_actual(
+            datetime(2026, 1, 15, 9, 0, tzinfo=UTC), 1.0
+        )  # bias = 0.5
+        tracker.backfill_actual(
+            datetime(2026, 1, 15, 10, 0, tzinfo=UTC), 3.0
+        )  # bias = -0.5
+
+        # Overall bias should be (0 + 0.5 - 0.5) / 3 = 0
+        assert tracker._metrics.sample_count == 3
+        assert tracker._metrics.overall_bias == pytest.approx(0.0, abs=0.01)
+
+    def test_metrics_accuracy_calculation(self, tracker):
+        """Test accuracy calculation."""
+        # Record and backfill
+        period_start = datetime(2026, 1, 15, 10, 0, tzinfo=UTC)
+        tracker.record_forecast(period_start, 2.0, "sunny")
+        tracker.backfill_actual(period_start, 2.0)  # Perfect forecast
+
+        # With perfect forecasts, accuracy should be high
+        assert tracker._metrics.accuracy > 90
+
+    def test_get_bias_correction_no_data(self, tracker):
+        """Test get_bias_correction with no historical data returns 1.0."""
+        correction = tracker.get_bias_correction("morning", "sunny", "summer")
+        assert correction == 1.0
+
+    def test_get_bias_correction_with_data(self, tracker):
+        """Test get_bias_correction with historical data."""
+        # Add historical data with known bias
+        period_start = datetime(2026, 1, 15, 10, 0, tzinfo=UTC)
+        tracker.record_forecast(period_start, 2.0, "sunny")
+        tracker.backfill_actual(period_start, 1.0)  # 50% overestimate
+
+        correction = tracker.get_bias_correction("morning", "sunny", "summer")
+        # Correction = 1.0 - bias = 1.0 - 0.5 = 0.5
+        assert correction == pytest.approx(0.5, rel=0.1)
+
+    def test_get_bias_correction_under_estimate(self, tracker):
+        """Test get_bias_correction when forecasts underestimate."""
+        # Add historical data showing underestimate
+        period_start = datetime(2026, 1, 15, 10, 0, tzinfo=UTC)
+        tracker.record_forecast(period_start, 1.0, "sunny")
+        tracker.backfill_actual(period_start, 2.0)  # -100% bias (underestimate)
+
+        correction = tracker.get_bias_correction("morning", "sunny", "summer")
+        # Correction = 1.0 - (-1.0) = 2.0
+        assert correction == pytest.approx(2.0, rel=0.1)
+
+    @pytest.mark.asyncio
+    async def test_async_load_no_data(self, tracker, mock_hass):
+        """Test async_load with no stored data."""
+        mock_store = MagicMock()
+        mock_store.async_load = AsyncMock(return_value=None)
+        tracker._store = mock_store
+
+        await tracker.async_load()
+
+        assert len(tracker._period_records) == 0
+
+    @pytest.mark.asyncio
+    async def test_async_load_with_data(self, tracker, mock_hass):
+        """Test async_load with stored data."""
+        mock_store = MagicMock()
+        mock_store.async_load = AsyncMock(
+            return_value={
+                "period_records": [
+                    {
+                        "period_start": "2026-01-15T10:00:00+00:00",
+                        "forecast_kwh": 2.0,
+                        "actual_kwh": 1.5,
+                        "weather_condition": "sunny",
+                        "time_of_day": "morning",
+                        "season": "summer",
+                        "bias": 0.25,
+                    }
+                ],
+                "metrics": {
+                    "overall_bias": 0.25,
+                    "bias_by_time": {"morning": 0.25},
+                    "bias_by_weather": {"sunny": 0.25},
+                    "bias_by_season": {"summer": 0.25},
+                    "sample_count": 1,
+                    "mape": 25.0,
+                    "accuracy": 75.0,
+                },
+            }
+        )
+        tracker._store = mock_store
+
+        await tracker.async_load()
+
+        assert len(tracker._period_records) == 1
+        assert tracker._metrics.sample_count == 1
+        assert tracker._metrics.overall_bias == 0.25
+
+    @pytest.mark.asyncio
+    async def test_async_load_with_bad_record(self, tracker, mock_hass, caplog):
+        """Test async_load handles corrupted records gracefully."""
+        import logging
+
+        mock_store = MagicMock()
+        mock_store.async_load = AsyncMock(
+            return_value={
+                "period_records": [
+                    {"invalid": "data"},  # This will cause an error
+                ],
+                "metrics": {},
+            }
+        )
+        tracker._store = mock_store
+
+        with caplog.at_level(logging.WARNING):
+            await tracker.async_load()
+
+        # Should not crash, just skip bad record
+        assert len(tracker._period_records) == 0
+
+    @pytest.mark.asyncio
+    async def test_async_save_no_pending(self, tracker, mock_hass):
+        """Test async_save with no pending changes."""
+        tracker._save_pending = False
+
+        mock_store = MagicMock()
+        mock_store.async_save = AsyncMock()
+        tracker._store = mock_store
+
+        await tracker.async_save()
+
+        # Should not save if nothing pending
+        mock_store.async_save.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_async_save_with_pending(self, tracker, mock_hass):
+        """Test async_save with pending changes."""
+        tracker._save_pending = True
+        # Add a record
+        period_start = datetime(2026, 1, 15, 10, 0, tzinfo=UTC)
+        tracker.record_forecast(period_start, 2.0, "sunny")
+        tracker.backfill_actual(period_start, 1.5)
+
+        mock_store = MagicMock()
+        mock_store.async_save = AsyncMock()
+        tracker._store = mock_store
+
+        await tracker.async_save()
+
+        mock_store.async_save.assert_called_once()
+        # save_pending should be reset
+        assert tracker._save_pending is False
+
+
+class TestGetTimeOfDay:
+    """Tests for _get_time_of_day static method."""
+
+    def test_morning_hours(self):
+        """Test morning hours (6-12)."""
+        for hour in [6, 7, 8, 9, 10, 11]:
+            dt = datetime(2026, 1, 15, hour, 0, tzinfo=UTC)
+            assert SolarAccuracyTracker._get_time_of_day(dt) == "morning"
+
+    def test_afternoon_hours(self):
+        """Test afternoon hours (12-18)."""
+        for hour in [12, 13, 14, 15, 16, 17]:
+            dt = datetime(2026, 1, 15, hour, 0, tzinfo=UTC)
+            assert SolarAccuracyTracker._get_time_of_day(dt) == "afternoon"
+
+    def test_evening_hours(self):
+        """Test evening hours (18-21)."""
+        for hour in [18, 19, 20]:
+            dt = datetime(2026, 1, 15, hour, 0, tzinfo=UTC)
+            assert SolarAccuracyTracker._get_time_of_day(dt) == "evening"
+
+    def test_night_hours(self):
+        """Test night hours (21-6)."""
+        for hour in [21, 22, 23, 0, 1, 2, 3, 4, 5]:
+            dt = datetime(2026, 1, 15, hour, 0, tzinfo=UTC)
+            assert SolarAccuracyTracker._get_time_of_day(dt) == "night"
+
+
+class TestGetSeason:
+    """Tests for _get_season static method - Southern hemisphere."""
+
+    def test_summer_months(self):
+        """Test summer months (Dec, Jan, Feb)."""
+        for month in [12, 1, 2]:
+            dt = datetime(2026, month, 15, 12, 0, tzinfo=UTC)
+            assert SolarAccuracyTracker._get_season(dt) == "summer"
+
+    def test_autumn_months(self):
+        """Test autumn months (Mar, Apr, May)."""
+        for month in [3, 4, 5]:
+            dt = datetime(2026, month, 15, 12, 0, tzinfo=UTC)
+            assert SolarAccuracyTracker._get_season(dt) == "autumn"
+
+    def test_winter_months(self):
+        """Test winter months (Jun, Jul, Aug)."""
+        for month in [6, 7, 8]:
+            dt = datetime(2026, month, 15, 12, 0, tzinfo=UTC)
+            assert SolarAccuracyTracker._get_season(dt) == "winter"
+
+    def test_spring_months(self):
+        """Test spring months (Sep, Oct, Nov)."""
+        for month in [9, 10, 11]:
+            dt = datetime(2026, month, 15, 12, 0, tzinfo=UTC)
+            assert SolarAccuracyTracker._get_season(dt) == "spring"
+
+
+class TestNormalizeWeather:
+    """Tests for _normalize_weather static method."""
+
+    def test_sunny_variations(self):
+        """Test sunny variations."""
+        assert SolarAccuracyTracker._normalize_weather("sunny") == "sunny"
+        assert SolarAccuracyTracker._normalize_weather("Sunny") == "sunny"
+        assert SolarAccuracyTracker._normalize_weather("clear") == "sunny"
+        assert SolarAccuracyTracker._normalize_weather("Clear Skies") == "sunny"
+
+    def test_cloudy_variations(self):
+        """Test cloudy variations."""
+        assert SolarAccuracyTracker._normalize_weather("cloudy") == "cloudy"
+        assert SolarAccuracyTracker._normalize_weather("overcast") == "cloudy"
+        assert SolarAccuracyTracker._normalize_weather("Partly Cloudy") == "cloudy"
+
+    def test_rainy_variations(self):
+        """Test rainy variations."""
+        assert SolarAccuracyTracker._normalize_weather("rain") == "rainy"
+        assert SolarAccuracyTracker._normalize_weather("rainy") == "rainy"
+        assert SolarAccuracyTracker._normalize_weather("showers") == "rainy"
+        assert SolarAccuracyTracker._normalize_weather("Light Rain") == "rainy"
+
+    def test_snow_variations(self):
+        """Test snow variations."""
+        assert SolarAccuracyTracker._normalize_weather("snow") == "snow"
+        assert SolarAccuracyTracker._normalize_weather("hail") == "snow"
+        assert SolarAccuracyTracker._normalize_weather("Snow flurries") == "snow"
+
+    def test_fog_variations(self):
+        """Test fog variations."""
+        assert SolarAccuracyTracker._normalize_weather("fog") == "foggy"
+        assert SolarAccuracyTracker._normalize_weather("mist") == "foggy"
+        assert SolarAccuracyTracker._normalize_weather("Foggy") == "foggy"
+
+    def test_unknown_conditions(self):
+        """Test unknown conditions."""
+        assert SolarAccuracyTracker._normalize_weather("unknown") == "unknown"
+        assert SolarAccuracyTracker._normalize_weather("") == "unknown"
+        assert SolarAccuracyTracker._normalize_weather(None) == "unknown"
+        assert SolarAccuracyTracker._normalize_weather("blustery") == "unknown"
+
+
+class TestComputeContextBias:
+    """Tests for _compute_context_bias method."""
+
+    @pytest.fixture
+    def tracker_with_data(self, mock_hass):
+        """Create tracker with historical data."""
+        tracker = SolarAccuracyTracker(mock_hass, "test_entry")
+
+        # Add data for different contexts
+        # Morning, sunny, summer
+        for _ in range(3):
+            dt = datetime(2026, 1, 15, 10, 0, tzinfo=UTC)
+            tracker.record_forecast(dt, 2.0, "sunny")
+            tracker.backfill_actual(dt, 1.5)  # 25% overestimate
+
+        # Morning, cloudy, summer
+        dt = datetime(2026, 1, 15, 9, 0, tzinfo=UTC)
+        tracker.record_forecast(dt, 1.0, "cloudy")
+        tracker.backfill_actual(dt, 1.0)  # Perfect
+
+        return tracker
+
+    def test_finds_matching_context(self, tracker_with_data):
+        """Test finding bias for matching context."""
+        result = tracker_with_data._compute_context_bias("morning", "sunny", "summer")
+        assert result is not None
+        weighted_bias, count = result
+        assert count == 3
+        assert weighted_bias == pytest.approx(0.25, rel=0.1)
+
+    def test_no_matching_context(self, tracker_with_data):
+        """Test when no matching context exists."""
+        result = tracker_with_data._compute_context_bias("evening", "sunny", "summer")
+        assert result is None
+
+    def test_no_season_filter(self, tracker_with_data):
+        """Test without season filter."""
+        result = tracker_with_data._compute_context_bias("morning", "sunny", None)
+        assert result is not None
+        _, count = result
+        assert count == 3


### PR DESCRIPTION
## Summary
Added 49 comprehensive tests for `forecast/solar_accuracy.py` module, improving test coverage from 34% to 97%.

## Changes
- Added `tests/forecast/test_solar_accuracy.py` with 49 tests covering:
  - `SolarPeriodRecord` dataclass: initialization, bias calculation, serialization
  - `SolarBiasMetrics` dataclass: defaults, serialization
  - `SolarAccuracyTracker` class:
    - `record_forecast()` and weather normalization
    - `backfill_actual()` for actual values
    - `_recompute_metrics()` for aggregated metrics
    - `get_bias_correction()` for context-aware bias
    - `async_load()` and `async_save()` persistence
    - Static methods: `_get_time_of_day()`, `_get_season()`, `_normalize_weather()`

## Testing
- [x] 49 tests pass
- [x] 97% test coverage (exceeds 95% requirement)
- [x] Lint and format checks pass