### PR TITLE
feat: add additive solar bias correction alongside multiplicative

### DIFF
--- a/custom_components/localshift/engine/optimizer_facade.py
+++ b/custom_components/localshift/engine/optimizer_facade.py
@@ -65,14 +65,16 @@ class OptimizerFacade:
 
         recorded = 0
         for slot in slots:
-            if slot.solar_kwh > 0.01:
-                period_start = datetime.fromisoformat(slot.timestamp_iso)
-                self._solar_accuracy_tracker.record_forecast(
-                    period_start=period_start,
-                    forecast_kwh=slot.solar_kwh,
-                    weather_condition=weather_condition,
-                )
-                recorded += 1
+            period_start = datetime.fromisoformat(slot.timestamp_iso)
+            if not self._is_backfillable_period_start(period_start):
+                continue
+
+            self._solar_accuracy_tracker.record_forecast(
+                period_start=period_start,
+                forecast_kwh=slot.solar_kwh,
+                weather_condition=weather_condition,
+            )
+            recorded += 1
 
         if recorded > 0:
             _LOGGER.debug("Recorded %d solar forecasts for accuracy tracking", recorded)
@@ -90,39 +92,51 @@ class OptimizerFacade:
         if self._solar_accuracy_tracker is None:
             return
 
-        time_of_day = "day" if 6 <= dt_util.now().hour < 18 else "night"
-        now = dt_util.now()
-        month = now.month
-        if month in (12, 1, 2):
-            season = "summer"
-        elif month in (3, 4, 5):
-            season = "autumn"
-        elif month in (6, 7, 8):
-            season = "winter"
-        else:
-            season = "spring"
+        corrected = 0
+        for slot in slots:
+            slot_dt = datetime.fromisoformat(slot.timestamp_iso)
+            time_of_day = self._get_time_of_day(slot_dt)
+            season = self._get_season(slot_dt)
+            original = slot.solar_kwh
+            slot.solar_kwh = self._solar_accuracy_tracker.apply_bias_correction(
+                slot.solar_kwh,
+                time_of_day,
+                weather_condition,
+                season,
+            )
+            if abs(slot.solar_kwh - original) > 0.001:
+                corrected += 1
 
-        bias_multiplier = self._solar_accuracy_tracker.get_bias_correction(
-            time_of_day, weather_condition, season
-        )
+        if corrected > 0:
+            _LOGGER.info(
+                "Applied solar bias correction for weather=%s to %d slots",
+                weather_condition,
+                corrected,
+            )
 
-        if bias_multiplier != 1.0:
-            corrected = 0
-            for slot in slots:
-                if slot.solar_kwh > 0.01:
-                    original = slot.solar_kwh
-                    slot.solar_kwh = max(0.0, slot.solar_kwh * bias_multiplier)
-                    if abs(slot.solar_kwh - original) > 0.001:
-                        corrected += 1
-            if corrected > 0:
-                _LOGGER.info(
-                    "Applied bias correction: multiplier=%.2f (%s/%s/%s), corrected %d slots",
-                    bias_multiplier,
-                    time_of_day,
-                    weather_condition,
-                    season,
-                    corrected,
-                )
+    @staticmethod
+    def _is_backfillable_period_start(period_start: datetime) -> bool:
+        return period_start.minute in (0, 30)
+
+    @staticmethod
+    def _get_time_of_day(dt: datetime) -> str:
+        if 6 <= dt.hour < 12:
+            return "morning"
+        if 12 <= dt.hour < 18:
+            return "afternoon"
+        if 18 <= dt.hour < 21:
+            return "evening"
+        return "night"
+
+    @staticmethod
+    def _get_season(dt: datetime) -> str:
+        if dt.month in (12, 1, 2):
+            return "summer"
+        if dt.month in (3, 4, 5):
+            return "autumn"
+        if dt.month in (6, 7, 8):
+            return "winter"
+        return "spring"
 
     def run_inline(
         self, data: CoordinatorData, now_dt: Any, config_options: dict[str, Any]

--- a/custom_components/localshift/forecast/solar_accuracy.py
+++ b/custom_components/localshift/forecast/solar_accuracy.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import logging
 import math
 from collections import defaultdict, deque
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
@@ -24,6 +25,7 @@ _LOGGER = logging.getLogger(__name__)
 
 MAX_PERIOD_RECORDS = 1440
 BIAS_HALF_LIFE_DAYS = 7.0
+MAX_ADDITIVE_OFFSET_KWH = 2.0
 
 
 @dataclass
@@ -48,9 +50,11 @@ class SolarPeriodRecord:
     time_of_day: str
     season: str
     bias: float = 0.0
+    additive_bias: float = 0.0
 
     def __post_init__(self) -> None:
         """Calculate bias after initialization."""
+        self.additive_bias = self.forecast_kwh - self.actual_kwh
         if self.forecast_kwh > 0.01:
             self.bias = (self.forecast_kwh - self.actual_kwh) / self.forecast_kwh
         else:
@@ -71,6 +75,7 @@ class SolarPeriodRecord:
             "time_of_day": self.time_of_day,
             "season": self.season,
             "bias": self.bias,
+            "additive_bias": self.additive_bias,
         }
 
     @classmethod
@@ -93,6 +98,7 @@ class SolarPeriodRecord:
             time_of_day=data.get("time_of_day", "unknown"),
             season=data.get("season", "unknown"),
             bias=data.get("bias", 0.0),
+            additive_bias=data.get("additive_bias", 0.0),
         )
 
 
@@ -112,9 +118,13 @@ class SolarBiasMetrics:
     """
 
     overall_bias: float = 0.0
+    overall_additive_bias: float = 0.0
     bias_by_time: dict[str, float] = field(default_factory=dict)
     bias_by_weather: dict[str, float] = field(default_factory=dict)
     bias_by_season: dict[str, float] = field(default_factory=dict)
+    additive_bias_by_time: dict[str, float] = field(default_factory=dict)
+    additive_bias_by_weather: dict[str, float] = field(default_factory=dict)
+    additive_bias_by_season: dict[str, float] = field(default_factory=dict)
     sample_count: int = 0
     mape: float = 0.0
     accuracy: float = 100.0
@@ -128,9 +138,13 @@ class SolarBiasMetrics:
         """
         return {
             "overall_bias": self.overall_bias,
+            "overall_additive_bias": self.overall_additive_bias,
             "bias_by_time": self.bias_by_time,
             "bias_by_weather": self.bias_by_weather,
             "bias_by_season": self.bias_by_season,
+            "additive_bias_by_time": self.additive_bias_by_time,
+            "additive_bias_by_weather": self.additive_bias_by_weather,
+            "additive_bias_by_season": self.additive_bias_by_season,
             "sample_count": self.sample_count,
             "mape": self.mape,
             "accuracy": self.accuracy,
@@ -149,9 +163,13 @@ class SolarBiasMetrics:
         """
         return cls(
             overall_bias=data.get("overall_bias", 0.0),
+            overall_additive_bias=data.get("overall_additive_bias", 0.0),
             bias_by_time=data.get("bias_by_time", {}),
             bias_by_weather=data.get("bias_by_weather", {}),
             bias_by_season=data.get("bias_by_season", {}),
+            additive_bias_by_time=data.get("additive_bias_by_time", {}),
+            additive_bias_by_weather=data.get("additive_bias_by_weather", {}),
+            additive_bias_by_season=data.get("additive_bias_by_season", {}),
             sample_count=data.get("sample_count", 0),
             mape=data.get("mape", 0.0),
             accuracy=data.get("accuracy", 100.0),
@@ -207,7 +225,9 @@ class SolarAccuracyTracker:
                 except Exception as err:
                     _LOGGER.warning("Failed to load solar period record: %s", err)
 
-            if "metrics" in data:
+            if self._period_records:
+                self._recompute_metrics()
+            elif "metrics" in data:
                 self._metrics = SolarBiasMetrics.from_dict(data["metrics"])
 
             _LOGGER.info(
@@ -313,6 +333,9 @@ class SolarAccuracyTracker:
 
         self._metrics.sample_count = len(records)
         self._metrics.overall_bias = sum(r.bias for r in records) / len(records)
+        self._metrics.overall_additive_bias = sum(
+            r.additive_bias for r in records
+        ) / len(records)
 
         mape_sum = 0.0
         mape_count = 0
@@ -326,12 +349,18 @@ class SolarAccuracyTracker:
         by_time: dict[str, list[float]] = defaultdict(list)
         by_weather: dict[str, list[float]] = defaultdict(list)
         by_season: dict[str, list[float]] = defaultdict(list)
+        additive_by_time: dict[str, list[float]] = defaultdict(list)
+        additive_by_weather: dict[str, list[float]] = defaultdict(list)
+        additive_by_season: dict[str, list[float]] = defaultdict(list)
         self._count_by_time: dict[str, int] = defaultdict(int)
 
         for r in records:
             by_time[r.time_of_day].append(r.bias)
             by_weather[r.weather_condition].append(r.bias)
             by_season[r.season].append(r.bias)
+            additive_by_time[r.time_of_day].append(r.additive_bias)
+            additive_by_weather[r.weather_condition].append(r.additive_bias)
+            additive_by_season[r.season].append(r.additive_bias)
             self._count_by_time[r.time_of_day] += 1
 
         self._metrics.bias_by_time = {k: sum(v) / len(v) for k, v in by_time.items()}
@@ -341,16 +370,25 @@ class SolarAccuracyTracker:
         self._metrics.bias_by_season = {
             k: sum(v) / len(v) for k, v in by_season.items()
         }
+        self._metrics.additive_bias_by_time = {
+            k: sum(v) / len(v) for k, v in additive_by_time.items()
+        }
+        self._metrics.additive_bias_by_weather = {
+            k: sum(v) / len(v) for k, v in additive_by_weather.items()
+        }
+        self._metrics.additive_bias_by_season = {
+            k: sum(v) / len(v) for k, v in additive_by_season.items()
+        }
 
-    def _compute_context_bias(
+    def _compute_context_metric(
         self,
         time_of_day: str,
         weather: str,
         season: str | None,
+        metric_getter: Callable[[SolarPeriodRecord], float],
     ) -> tuple[float, int] | None:
-        """Compute weighted average bias for specific context."""
         now = dt_util.now()
-        biases: list[tuple[float, float]] = []
+        values: list[tuple[float, float]] = []
 
         for record in self._period_records:
             if record.time_of_day != time_of_day:
@@ -361,15 +399,44 @@ class SolarAccuracyTracker:
                 continue
 
             age_days = (now - record.period_start).total_seconds() / 86400.0
-            weight = math.exp(-age_days / BIAS_HALF_LIFE_DAYS)
-            biases.append((record.bias, weight))
+            weight = math.exp(-(math.log(2) * age_days) / BIAS_HALF_LIFE_DAYS)
+            values.append((metric_getter(record), weight))
 
-        if not biases:
+        if not values:
             return None
 
-        total_weight = sum(w for _, w in biases)
-        weighted_bias = sum(b * w for b, w in biases) / total_weight
-        return (weighted_bias, len(biases))
+        total_weight = sum(weight for _, weight in values)
+        weighted_value = sum(value * weight for value, weight in values) / total_weight
+        return (weighted_value, len(values))
+
+    def _compute_context_bias(
+        self,
+        time_of_day: str,
+        weather: str,
+        season: str | None,
+    ) -> tuple[float, int] | None:
+        """Compute weighted average bias for specific context."""
+        normalized_weather = self._normalize_weather(weather)
+        return self._compute_context_metric(
+            time_of_day,
+            normalized_weather,
+            season,
+            lambda record: record.bias,
+        )
+
+    def _compute_context_additive_bias(
+        self,
+        time_of_day: str,
+        weather: str,
+        season: str | None,
+    ) -> tuple[float, int] | None:
+        normalized_weather = self._normalize_weather(weather)
+        return self._compute_context_metric(
+            time_of_day,
+            normalized_weather,
+            season,
+            lambda record: record.additive_bias,
+        )
 
     @staticmethod
     def _get_time_of_day(dt: datetime) -> str:
@@ -440,7 +507,8 @@ class SolarAccuracyTracker:
             Values < 1.0 reduce forecast (overestimate), > 1.0 increase (underestimate).
 
         """
-        result = self._compute_context_bias(time_of_day, weather, season)
+        normalized_weather = self._normalize_weather(weather)
+        result = self._compute_context_bias(time_of_day, normalized_weather, season)
         if result is None:
             return 1.0
 
@@ -448,9 +516,36 @@ class SolarAccuracyTracker:
         _LOGGER.debug(
             "Bias correction for %s/%s/%s: bias=%.2f%%, samples=%d",
             time_of_day,
-            weather,
+            normalized_weather,
             season or "any",
             weighted_bias * 100,
             sample_count,
         )
         return 1.0 - weighted_bias
+
+    def get_additive_correction(
+        self,
+        time_of_day: str,
+        weather: str,
+        season: str | None = None,
+    ) -> float:
+        result = self._compute_context_additive_bias(time_of_day, weather, season)
+        if result is None:
+            return 0.0
+
+        weighted_bias, _sample_count = result
+        return max(
+            -MAX_ADDITIVE_OFFSET_KWH,
+            min(MAX_ADDITIVE_OFFSET_KWH, weighted_bias),
+        )
+
+    def apply_bias_correction(
+        self,
+        forecast_kwh: float,
+        time_of_day: str,
+        weather: str,
+        season: str | None = None,
+    ) -> float:
+        multiplier = self.get_bias_correction(time_of_day, weather, season)
+        additive_offset = self.get_additive_correction(time_of_day, weather, season)
+        return max(0.0, forecast_kwh * multiplier - additive_offset)

--- a/tests/forecast/test_solar_accuracy.py
+++ b/tests/forecast/test_solar_accuracy.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from custom_components.localshift.forecast.solar_accuracy import (
+    BIAS_HALF_LIFE_DAYS,
     MAX_PERIOD_RECORDS,
     SolarAccuracyTracker,
     SolarBiasMetrics,
@@ -30,6 +31,7 @@ class TestSolarPeriodRecord:
         assert record.actual_kwh == 2.0
         # Bias = (forecast - actual) / forecast = (2.5 - 2.0) / 2.5 = 0.2
         assert record.bias == pytest.approx(0.2)
+        assert record.additive_bias == pytest.approx(0.5)
 
     def test_initialization_with_zero_forecast(self):
         """Test record initialization with zero forecast - bias should be 0."""
@@ -42,6 +44,7 @@ class TestSolarPeriodRecord:
             season="summer",
         )
         assert record.bias == 0.0
+        assert record.additive_bias == 0.0
 
     def test_initialization_with_small_forecast(self):
         """Test record initialization with very small forecast - bias should be 0."""
@@ -54,6 +57,7 @@ class TestSolarPeriodRecord:
             season="summer",
         )
         assert record.bias == 0.0
+        assert record.additive_bias == pytest.approx(0.001)
 
     def test_to_dict(self):
         """Test serialization to dictionary."""
@@ -71,6 +75,7 @@ class TestSolarPeriodRecord:
         assert data["weather_condition"] == "sunny"
         assert data["time_of_day"] == "morning"
         assert data["season"] == "summer"
+        assert data["additive_bias"] == pytest.approx(0.5)
         assert "period_start" in data
 
     def test_from_dict(self):
@@ -83,6 +88,7 @@ class TestSolarPeriodRecord:
             "time_of_day": "morning",
             "season": "summer",
             "bias": 0.2,
+            "additive_bias": 0.5,
         }
         record = SolarPeriodRecord.from_dict(data)
         assert record.forecast_kwh == 2.5
@@ -90,6 +96,7 @@ class TestSolarPeriodRecord:
         assert record.weather_condition == "sunny"
         assert record.time_of_day == "morning"
         assert record.season == "summer"
+        assert record.additive_bias == pytest.approx(0.5)
 
     def test_from_dict_with_defaults(self):
         """Test deserialization with missing fields uses defaults."""
@@ -100,6 +107,7 @@ class TestSolarPeriodRecord:
         assert record.weather_condition == "unknown"
         assert record.time_of_day == "unknown"
         assert record.season == "unknown"
+        assert record.additive_bias == 0.0
 
 
 class TestSolarBiasMetrics:
@@ -109,9 +117,13 @@ class TestSolarBiasMetrics:
         """Test default values."""
         metrics = SolarBiasMetrics()
         assert metrics.overall_bias == 0.0
+        assert metrics.overall_additive_bias == 0.0
         assert metrics.bias_by_time == {}
         assert metrics.bias_by_weather == {}
         assert metrics.bias_by_season == {}
+        assert metrics.additive_bias_by_time == {}
+        assert metrics.additive_bias_by_weather == {}
+        assert metrics.additive_bias_by_season == {}
         assert metrics.sample_count == 0
         assert metrics.mape == 0.0
         assert metrics.accuracy == 100.0
@@ -120,31 +132,42 @@ class TestSolarBiasMetrics:
         """Test serialization to dictionary."""
         metrics = SolarBiasMetrics(
             overall_bias=0.1,
+            overall_additive_bias=0.2,
             bias_by_time={"morning": 0.05},
             bias_by_weather={"sunny": 0.1},
+            additive_bias_by_time={"morning": 0.1},
+            additive_bias_by_weather={"sunny": 0.2},
             sample_count=10,
             mape=15.0,
             accuracy=85.0,
         )
         data = metrics.to_dict()
         assert data["overall_bias"] == 0.1
+        assert data["overall_additive_bias"] == 0.2
         assert data["bias_by_time"] == {"morning": 0.05}
+        assert data["additive_bias_by_time"] == {"morning": 0.1}
         assert data["sample_count"] == 10
 
     def test_from_dict(self):
         """Test deserialization from dictionary."""
         data = {
             "overall_bias": 0.1,
+            "overall_additive_bias": 0.2,
             "bias_by_time": {"morning": 0.05},
             "bias_by_weather": {"sunny": 0.1},
             "bias_by_season": {"summer": 0.15},
+            "additive_bias_by_time": {"morning": 0.1},
+            "additive_bias_by_weather": {"sunny": 0.2},
+            "additive_bias_by_season": {"summer": 0.25},
             "sample_count": 10,
             "mape": 15.0,
             "accuracy": 85.0,
         }
         metrics = SolarBiasMetrics.from_dict(data)
         assert metrics.overall_bias == 0.1
+        assert metrics.overall_additive_bias == 0.2
         assert metrics.bias_by_time == {"morning": 0.05}
+        assert metrics.additive_bias_by_weather == {"sunny": 0.2}
         assert metrics.sample_count == 10
 
     def test_from_dict_with_defaults(self):
@@ -346,6 +369,72 @@ class TestSolarAccuracyTracker:
         # Correction = 1.0 - (-1.0) = 2.0
         assert correction == pytest.approx(2.0, rel=0.1)
 
+    def test_get_additive_correction_no_data(self, tracker):
+        correction = tracker.get_additive_correction("morning", "sunny", "summer")
+        assert correction == 0.0
+
+    def test_get_additive_correction_with_data(self, tracker):
+        period_start = datetime(2026, 1, 15, 10, 0, tzinfo=UTC)
+        tracker.record_forecast(period_start, 2.0, "sunny")
+        tracker.backfill_actual(period_start, 1.5)
+
+        correction = tracker.get_additive_correction("morning", "sunny", "summer")
+        assert correction == pytest.approx(0.5, rel=0.1)
+
+    def test_get_additive_correction_clamps_to_bounds(self, tracker):
+        period_start = datetime(2026, 1, 15, 10, 0, tzinfo=UTC)
+        tracker.record_forecast(period_start, 3.0, "sunny")
+        tracker.backfill_actual(period_start, 0.0)
+
+        correction = tracker.get_additive_correction("morning", "sunny", "summer")
+        assert correction == pytest.approx(2.0)
+
+    def test_apply_bias_correction_combines_multiplicative_and_additive(self, tracker):
+        period_start = datetime(2026, 1, 15, 10, 0, tzinfo=UTC)
+        tracker.record_forecast(period_start, 4.0, "sunny")
+        tracker.backfill_actual(period_start, 3.0)
+
+        corrected = tracker.apply_bias_correction(2.0, "morning", "sunny", "summer")
+        assert corrected == pytest.approx(0.5, rel=0.1)
+
+    def test_apply_bias_correction_floors_at_zero(self, tracker):
+        period_start = datetime(2026, 1, 15, 10, 0, tzinfo=UTC)
+        tracker.record_forecast(period_start, 1.0, "sunny")
+        tracker.backfill_actual(period_start, 0.4)
+
+        corrected = tracker.apply_bias_correction(0.2, "morning", "sunny", "summer")
+        assert corrected == 0.0
+
+    def test_apply_bias_correction_can_raise_zero_forecast_from_additive_history(
+        self, tracker
+    ):
+        period_start = datetime(2026, 1, 15, 10, 0, tzinfo=UTC)
+        tracker.record_forecast(period_start, 0.0, "sunny")
+        tracker.backfill_actual(period_start, 0.5)
+
+        assert tracker.get_additive_correction("morning", "sunny", "summer") == (
+            pytest.approx(-0.5, rel=0.1)
+        )
+        corrected = tracker.apply_bias_correction(0.0, "morning", "sunny", "summer")
+        assert corrected == pytest.approx(0.5, rel=0.1)
+
+    def test_get_additive_correction_is_context_specific(self, tracker):
+        morning = datetime(2026, 1, 15, 10, 0, tzinfo=UTC)
+        afternoon = datetime(2026, 1, 15, 14, 0, tzinfo=UTC)
+
+        tracker.record_forecast(morning, 2.0, "sunny")
+        tracker.backfill_actual(morning, 1.5)
+        tracker.record_forecast(afternoon, 2.0, "cloudy")
+        tracker.backfill_actual(afternoon, 1.9)
+
+        sunny_correction = tracker.get_additive_correction("morning", "sunny", "summer")
+        cloudy_correction = tracker.get_additive_correction(
+            "afternoon", "cloudy", "summer"
+        )
+
+        assert sunny_correction == pytest.approx(0.5, rel=0.1)
+        assert cloudy_correction == pytest.approx(0.1, rel=0.1)
+
     @pytest.mark.asyncio
     async def test_async_load_no_data(self, tracker, mock_hass):
         """Test async_load with no stored data."""
@@ -392,6 +481,8 @@ class TestSolarAccuracyTracker:
         assert len(tracker._period_records) == 1
         assert tracker._metrics.sample_count == 1
         assert tracker._metrics.overall_bias == 0.25
+        assert tracker._metrics.overall_additive_bias == pytest.approx(0.5)
+        assert tracker._metrics.additive_bias_by_time == {"morning": pytest.approx(0.5)}
 
     @pytest.mark.asyncio
     async def test_async_load_with_bad_record(self, tracker, mock_hass, caplog):
@@ -589,3 +680,52 @@ class TestComputeContextBias:
         assert result is not None
         _, count = result
         assert count == 3
+
+    def test_compute_context_additive_bias(self, tracker_with_data):
+        result = tracker_with_data._compute_context_additive_bias(
+            "morning", "sunny", "summer"
+        )
+        assert result is not None
+        weighted_bias, count = result
+        assert count == 3
+        assert weighted_bias == pytest.approx(0.5, rel=0.1)
+
+    def test_compute_context_bias_uses_true_half_life_weighting(
+        self, tracker_with_data
+    ):
+        tracker_with_data._period_records.clear()
+        now = datetime(2026, 1, 15, 10, 0, tzinfo=UTC)
+        tracker_with_data._period_records.extend([
+            SolarPeriodRecord(
+                period_start=now,
+                forecast_kwh=1.0,
+                actual_kwh=1.0,
+                weather_condition="sunny",
+                time_of_day="morning",
+                season="summer",
+            ),
+            SolarPeriodRecord(
+                period_start=now.replace(day=8),
+                forecast_kwh=1.0,
+                actual_kwh=0.0,
+                weather_condition="sunny",
+                time_of_day="morning",
+                season="summer",
+            ),
+        ])
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(
+                "custom_components.localshift.forecast.solar_accuracy.dt_util.now",
+                lambda: now,
+            )
+            result = tracker_with_data._compute_context_bias(
+                "morning", "sunny", "summer"
+            )
+
+        assert result is not None
+        weighted_bias, count = result
+        expected = 0.5 / (1.0 + 0.5)
+        assert count == 2
+        assert BIAS_HALF_LIFE_DAYS == 7.0
+        assert weighted_bias == pytest.approx(expected, rel=0.01)

--- a/tests/test_optimizer_facade.py
+++ b/tests/test_optimizer_facade.py
@@ -1,12 +1,16 @@
 """Unit tests for OptimizerFacade."""
 
 from datetime import UTC, datetime
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import pytest
+
+from custom_components.localshift.const import BatteryMode
+from custom_components.localshift.coordinator import CoordinatorData
 from custom_components.localshift.engine.optimizer_facade import (
     OptimizerFacade,
 )
-from custom_components.localshift.coordinator import CoordinatorData
 
 
 class _StubSlotBuilder:
@@ -15,6 +19,24 @@ class _StubSlotBuilder:
 
     def build_slots(self, _data, _adaptive_params, now_dt=None):
         return [], None
+
+
+class _StubSlotBuilderWithOneSlot:
+    def __init__(self, **_kwargs) -> None:
+        pass
+
+    def build_slots(self, _data, _adaptive_params, now_dt=None):
+        return [
+            SimpleNamespace(solar_kwh=1.0, timestamp_iso="2026-01-15T10:00:00+00:00")
+        ], MagicMock()
+
+
+class _ExplodingSlotBuilder:
+    def __init__(self, **_kwargs) -> None:
+        pass
+
+    def build_slots(self, _data, _adaptive_params, now_dt=None):
+        raise RuntimeError("boom")
 
 
 def test_run_inline_no_slots_leaves_optimizer_fields():
@@ -81,3 +103,212 @@ def test_facade_wires_solar_can_reach_target_in_dw_correctly():
     assert data.solar_can_reach_target_in_dw is True, (
         "Facade must wire solar_can_reach_target_in_dw from result.can_solar_reach_target_in_dw"
     )
+
+
+def test_apply_bias_correction_to_slots_uses_tracker_combined_correction():
+    tracker = MagicMock()
+    tracker.apply_bias_correction.side_effect = [0.5, 0.0]
+
+    slots = [
+        SimpleNamespace(solar_kwh=2.0, timestamp_iso="2026-01-15T10:00:00+00:00"),
+        SimpleNamespace(solar_kwh=1.0, timestamp_iso="2026-01-15T10:15:00+00:00"),
+    ]
+
+    facade = OptimizerFacade(slot_builder_cls=_StubSlotBuilder)
+    facade.set_solar_accuracy_tracker(tracker)
+
+    with patch(
+        "custom_components.localshift.engine.optimizer_facade.dt_util.now",
+        return_value=datetime(2026, 1, 15, 10, 0, tzinfo=UTC),
+    ):
+        facade._apply_bias_correction_to_slots(slots, "sunny")
+
+    assert slots[0].solar_kwh == 0.5
+    assert slots[1].solar_kwh == 0.0
+    tracker.apply_bias_correction.assert_any_call(2.0, "morning", "sunny", "summer")
+    tracker.apply_bias_correction.assert_any_call(1.0, "morning", "sunny", "summer")
+
+
+def test_apply_bias_correction_to_slots_includes_zero_forecasts():
+    tracker = MagicMock()
+    tracker.apply_bias_correction.return_value = 0.4
+
+    slots = [
+        SimpleNamespace(solar_kwh=0.0, timestamp_iso="2026-01-15T10:00:00+00:00"),
+    ]
+
+    facade = OptimizerFacade(slot_builder_cls=_StubSlotBuilder)
+    facade.set_solar_accuracy_tracker(tracker)
+    facade._apply_bias_correction_to_slots(slots, "sunny")
+
+    assert slots[0].solar_kwh == 0.4
+    tracker.apply_bias_correction.assert_called_once_with(
+        0.0, "morning", "sunny", "summer"
+    )
+
+
+def test_record_forecasts_for_slots_records_only_backfillable_timestamps():
+    tracker = MagicMock()
+    slots = [
+        SimpleNamespace(solar_kwh=0.0, timestamp_iso="2026-01-15T10:00:00+00:00"),
+        SimpleNamespace(solar_kwh=1.0, timestamp_iso="2026-01-15T10:15:00+00:00"),
+        SimpleNamespace(solar_kwh=0.2, timestamp_iso="2026-01-15T10:30:00+00:00"),
+    ]
+
+    facade = OptimizerFacade(slot_builder_cls=_StubSlotBuilder)
+    facade.set_solar_accuracy_tracker(tracker)
+    facade._record_forecasts_for_slots(slots, "sunny")
+
+    assert tracker.record_forecast.call_count == 2
+    tracker.record_forecast.assert_any_call(
+        period_start=datetime(2026, 1, 15, 10, 0, tzinfo=UTC),
+        forecast_kwh=0.0,
+        weather_condition="sunny",
+    )
+    tracker.record_forecast.assert_any_call(
+        period_start=datetime(2026, 1, 15, 10, 30, tzinfo=UTC),
+        forecast_kwh=0.2,
+        weather_condition="sunny",
+    )
+
+
+@pytest.mark.parametrize(
+    ("hour", "expected"),
+    [
+        (13, "afternoon"),
+        (19, "evening"),
+        (3, "night"),
+    ],
+)
+def test_get_time_of_day_maps_remaining_buckets(hour: int, expected: str):
+    assert (
+        OptimizerFacade._get_time_of_day(datetime(2026, 1, 15, hour, 0, tzinfo=UTC))
+        == expected
+    )
+
+
+@pytest.mark.parametrize(
+    ("month", "expected"),
+    [
+        (4, "autumn"),
+        (7, "winter"),
+        (10, "spring"),
+    ],
+)
+def test_get_season_maps_remaining_buckets(month: int, expected: str):
+    assert (
+        OptimizerFacade._get_season(datetime(2026, month, 15, 10, 0, tzinfo=UTC))
+        == expected
+    )
+
+
+def test_run_inline_skips_invalid_soc_before_planner_call():
+    planner = MagicMock()
+    data = CoordinatorData()
+    data.soc = 50.0
+
+    facade = OptimizerFacade(
+        planner=planner, slot_builder_cls=_StubSlotBuilderWithOneSlot
+    )
+
+    with patch(
+        "custom_components.localshift.engine.optimizer_facade._normalize_initial_soc",
+        return_value=(None, {"error": "invalid_soc"}),
+    ):
+        facade.run_inline(
+            data=data,
+            now_dt=datetime(2026, 1, 15, 10, 0, tzinfo=UTC),
+            config_options={},
+        )
+
+    planner.plan.assert_not_called()
+
+
+def test_run_inline_logs_and_swallows_unexpected_exception(caplog):
+    facade = OptimizerFacade(slot_builder_cls=_ExplodingSlotBuilder)
+
+    with caplog.at_level("WARNING"):
+        facade.run_inline(
+            data=CoordinatorData(),
+            now_dt=datetime(2026, 1, 15, 10, 0, tzinfo=UTC),
+            config_options={},
+        )
+
+    assert "Inline DP optimizer failed (non-blocking): boom" in caplog.text
+
+
+def test_assign_active_mode_sets_mode_and_apply_status():
+    facade = OptimizerFacade(slot_builder_cls=_StubSlotBuilder)
+    data = CoordinatorData()
+    data.active_mode = BatteryMode.SELF_CONSUMPTION
+    data.optimizer_decisions = [{"action": "charge_grid_normal"}]
+    result = MagicMock()
+    optimizer_config = MagicMock()
+    decision_time = datetime(2026, 1, 15, 10, 0, tzinfo=UTC)
+
+    with (
+        patch(
+            "custom_components.localshift.engine.optimizer_facade.OptimizerSafetyGate"
+        ) as mock_gate,
+        patch(
+            "custom_components.localshift.engine.optimizer_facade._find_current_slot_index",
+            return_value=2,
+        ),
+        patch(
+            "custom_components.localshift.engine.optimizer_facade._derive_runtime_apply_plan",
+            return_value={
+                "battery_mode": BatteryMode.GRID_CHARGING.value,
+                "action": "charge_grid_normal",
+            },
+        ),
+        patch(
+            "custom_components.localshift.engine.optimizer_facade.dt_util.now",
+            return_value=decision_time,
+        ),
+    ):
+        mock_gate.return_value.check_admission.return_value = SimpleNamespace(
+            allowed=True,
+            block_reason=None,
+        )
+        facade._assign_active_mode(data, result, optimizer_config, {})
+
+    assert data.optimizer_apply_plan == {
+        "battery_mode": BatteryMode.GRID_CHARGING.value,
+        "action": "charge_grid_normal",
+    }
+    assert data.active_mode == BatteryMode.GRID_CHARGING
+    assert data.optimizer_last_apply_status == "ready_to_apply"
+    assert data.optimizer_safety_block_reason == ""
+    assert data.decision_timestamp == decision_time
+    assert data.decision_mode == BatteryMode.GRID_CHARGING
+
+
+def test_assign_active_mode_falls_back_on_invalid_battery_mode():
+    facade = OptimizerFacade(slot_builder_cls=_StubSlotBuilder)
+    data = CoordinatorData()
+    data.active_mode = BatteryMode.GRID_CHARGING
+    data.optimizer_decisions = [{"action": "hold"}]
+    result = MagicMock()
+    optimizer_config = MagicMock()
+
+    with (
+        patch(
+            "custom_components.localshift.engine.optimizer_facade.OptimizerSafetyGate"
+        ) as mock_gate,
+        patch(
+            "custom_components.localshift.engine.optimizer_facade._find_current_slot_index",
+            return_value=0,
+        ),
+        patch(
+            "custom_components.localshift.engine.optimizer_facade._derive_runtime_apply_plan",
+            return_value={"battery_mode": "not-a-mode", "action": "hold"},
+        ),
+    ):
+        mock_gate.return_value.check_admission.return_value = SimpleNamespace(
+            allowed=True,
+            block_reason=None,
+        )
+        facade._assign_active_mode(data, result, optimizer_config, {})
+
+    assert data.active_mode == BatteryMode.SELF_CONSUMPTION
+    assert data.optimizer_last_apply_status == "fallback"


### PR DESCRIPTION
## Summary
- add additive solar bias tracking, persistence, weighted context aggregation, and combined correction logic alongside the existing multiplicative correction
- apply the combined correction in `OptimizerFacade`, including zero-forecast learning/application and backfillable forecast recording behavior
- expand tracker and facade tests to cover clamping, zero-floor behavior, half-life weighting, load recomputation, and optimizer integration paths

## Testing
- `uv run pytest`
- `uv run pytest --cov=custom_components.localshift.forecast.solar_accuracy --cov=custom_components.localshift.engine.optimizer_facade --cov-report=term-missing`
- `uv run ruff check custom_components/localshift/forecast/solar_accuracy.py custom_components/localshift/engine/optimizer_facade.py tests/forecast/test_solar_accuracy.py tests/test_optimizer_facade.py`
- `uv run ruff format --check custom_components/localshift/forecast/solar_accuracy.py custom_components/localshift/engine/optimizer_facade.py tests/forecast/test_solar_accuracy.py tests/test_optimizer_facade.py`

Closes #682