### PR TITLE
feat: add load deviation re-optimization trigger

### DIFF
--- a/custom_components/localshift/coordinator/data.py
+++ b/custom_components/localshift/coordinator/data.py
@@ -452,6 +452,8 @@ class CoordinatorData:
     Contains: action, battery_mode, target_soc, reason.
     """
 
+    load_deviation_diagnostics: dict[str, Any] = field(default_factory=dict)
+
     # ---------------------------------------------------------------------------
     # --- Decision-to-Implementation Lag Tracking (Issue #501) ---
     # ---------------------------------------------------------------------------

--- a/custom_components/localshift/forecast/load_deviation.py
+++ b/custom_components/localshift/forecast/load_deviation.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Any
+
+from ..engine.optimizer_runner import _find_current_slot_index
+
+
+class LoadDeviationDetector:
+    def __init__(
+        self,
+        *,
+        sustained_threshold_kw: float = 1.0,
+        sustained_duration: timedelta = timedelta(minutes=10),
+        spike_threshold_kw: float = 3.0,
+        spike_duration: timedelta = timedelta(minutes=5),
+        cooldown: timedelta = timedelta(minutes=15),
+    ) -> None:
+        self._sustained_threshold_kw = sustained_threshold_kw
+        self._sustained_duration = sustained_duration
+        self._spike_threshold_kw = spike_threshold_kw
+        self._spike_duration = spike_duration
+        self._cooldown = cooldown
+        self._sustained_started_at: datetime | None = None
+        self._spike_started_at: datetime | None = None
+        self._last_triggered_at: datetime | None = None
+
+    def evaluate(self, data: Any, now: datetime) -> bool:
+        if not self._runtime_is_active(data):
+            self._reset_windows()
+            self._write_diagnostics(
+                data,
+                status="inactive",
+                triggered=False,
+                breach_type=None,
+                actual_kw=float(getattr(data, "load_power_kw", 0.0) or 0.0),
+                forecast_kw=None,
+                deviation_kw=0.0,
+                current_slot_index=None,
+                cooldown_remaining_seconds=0,
+            )
+            return False
+
+        current_slot_index = _find_current_slot_index(data)
+        forecast_kw = self._current_slot_forecast(data, current_slot_index)
+        actual_kw = float(getattr(data, "load_power_kw", 0.0) or 0.0)
+
+        if forecast_kw is None:
+            self._reset_windows()
+            self._write_diagnostics(
+                data,
+                status="no_current_slot",
+                triggered=False,
+                breach_type=None,
+                actual_kw=actual_kw,
+                forecast_kw=None,
+                deviation_kw=0.0,
+                current_slot_index=None,
+                cooldown_remaining_seconds=0,
+            )
+            return False
+
+        deviation_kw = abs(actual_kw - forecast_kw)
+        sustained_active = deviation_kw > self._sustained_threshold_kw
+        spike_active = deviation_kw > self._spike_threshold_kw
+        self._update_window("sustained", sustained_active, now)
+        self._update_window("spike", spike_active, now)
+
+        cooldown_remaining = self._cooldown_remaining_seconds(now)
+        if cooldown_remaining > 0:
+            self._reset_windows()
+            self._write_diagnostics(
+                data,
+                status="cooldown",
+                triggered=False,
+                breach_type=self._breach_type(sustained_active, spike_active),
+                actual_kw=actual_kw,
+                forecast_kw=forecast_kw,
+                deviation_kw=deviation_kw,
+                current_slot_index=current_slot_index,
+                cooldown_remaining_seconds=cooldown_remaining,
+            )
+            return False
+
+        triggered_breach = self._triggered_breach(now)
+        if triggered_breach is not None:
+            self._last_triggered_at = now
+            self._reset_windows()
+            self._write_diagnostics(
+                data,
+                status="triggered",
+                triggered=True,
+                breach_type=triggered_breach,
+                actual_kw=actual_kw,
+                forecast_kw=forecast_kw,
+                deviation_kw=deviation_kw,
+                current_slot_index=current_slot_index,
+                cooldown_remaining_seconds=int(self._cooldown.total_seconds()),
+            )
+            return True
+
+        self._write_diagnostics(
+            data,
+            status=self._status(sustained_active, spike_active),
+            triggered=False,
+            breach_type=self._breach_type(sustained_active, spike_active),
+            actual_kw=actual_kw,
+            forecast_kw=forecast_kw,
+            deviation_kw=deviation_kw,
+            current_slot_index=current_slot_index,
+            cooldown_remaining_seconds=0,
+        )
+        return False
+
+    def _runtime_is_active(self, data: Any) -> bool:
+        return (
+            getattr(data, "optimizer_last_apply_status", "") == "ready_to_apply"
+            and getattr(data, "optimizer_apply_plan", None) is not None
+        )
+
+    def _current_slot_forecast(
+        self, data: Any, current_slot_index: int
+    ) -> float | None:
+        load_forecast_slots = getattr(data, "load_forecast_slots", []) or []
+        if current_slot_index < 0 or current_slot_index >= len(load_forecast_slots):
+            return None
+        return float(load_forecast_slots[current_slot_index])
+
+    def _update_window(
+        self, breach_name: str, breach_active: bool, now: datetime
+    ) -> None:
+        started_at_attr = f"_{breach_name}_started_at"
+        if breach_active:
+            if getattr(self, started_at_attr) is None:
+                setattr(self, started_at_attr, now)
+            return
+        setattr(self, started_at_attr, None)
+
+    def _triggered_breach(self, now: datetime) -> str | None:
+        if (
+            self._spike_started_at is not None
+            and now - self._spike_started_at > self._spike_duration
+        ):
+            return "spike"
+        if (
+            self._sustained_started_at is not None
+            and now - self._sustained_started_at > self._sustained_duration
+        ):
+            return "sustained"
+        return None
+
+    def _cooldown_remaining_seconds(self, now: datetime) -> int:
+        if self._last_triggered_at is None:
+            return 0
+        remaining = self._cooldown - (now - self._last_triggered_at)
+        return max(0, int(remaining.total_seconds()))
+
+    def _status(self, sustained_active: bool, spike_active: bool) -> str:
+        if spike_active:
+            return "spike_pending"
+        if sustained_active:
+            return "sustained_pending"
+        return "normal"
+
+    def _breach_type(self, sustained_active: bool, spike_active: bool) -> str | None:
+        if spike_active:
+            return "spike"
+        if sustained_active:
+            return "sustained"
+        return None
+
+    def _reset_windows(self) -> None:
+        self._sustained_started_at = None
+        self._spike_started_at = None
+
+    def _write_diagnostics(
+        self,
+        data: Any,
+        *,
+        status: str,
+        triggered: bool,
+        breach_type: str | None,
+        actual_kw: float,
+        forecast_kw: float | None,
+        deviation_kw: float,
+        current_slot_index: int | None,
+        cooldown_remaining_seconds: int,
+    ) -> None:
+        cooldown_until = None
+        if self._last_triggered_at is not None:
+            cooldown_until = self._serialize_timestamp(
+                self._last_triggered_at + self._cooldown
+            )
+
+        data.load_deviation_diagnostics = {
+            "status": status,
+            "triggered": triggered,
+            "breach_type": breach_type,
+            "deviation_kw": round(deviation_kw, 3),
+            "actual_kw": round(actual_kw, 3),
+            "forecast_kw": round(forecast_kw, 3) if forecast_kw is not None else None,
+            "current_slot_index": current_slot_index,
+            "sustained_started_at": self._serialize_timestamp(
+                self._sustained_started_at
+            ),
+            "spike_started_at": self._serialize_timestamp(self._spike_started_at),
+            "last_triggered_at": self._serialize_timestamp(self._last_triggered_at),
+            "cooldown_until": cooldown_until,
+            "cooldown_remaining_seconds": cooldown_remaining_seconds,
+        }
+
+    def _serialize_timestamp(self, value: datetime | None) -> str | None:
+        return value.isoformat() if value is not None else None

--- a/custom_components/localshift/sensor.py
+++ b/custom_components/localshift/sensor.py
@@ -18,6 +18,7 @@ from .sensors import (
     IntegrationStatusSensor,
     LearningDecisionHistorySensor,
     LearningStatusSensor,
+    LoadDeviationSensor,
     LoadShiftSignalSensor,
     MinimumTargetSOCSensor,
     NetElectricityCostSensor,
@@ -44,6 +45,7 @@ __all__ = [
     "OptimizerPlanSensor",
     "ForecastPricesSensor",
     "OptimizerPlanGridSensor",
+    "LoadDeviationSensor",
     "ForecastDiagnosticsSensor",
     "MinimumTargetSOCSensor",
     "ExcessSolarSensor",
@@ -85,6 +87,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
         IntegrationStatusSensor,
         LearningDecisionHistorySensor,
         LearningStatusSensor,
+        LoadDeviationSensor,
         LoadShiftSignalSensor,
         MinimumTargetSOCSensor,
         NetElectricityCostSensor,
@@ -113,6 +116,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
         # Price and grid sensors
         ForecastPricesSensor(coordinator, entry),
         OptimizerPlanGridSensor(coordinator, entry),  # Was ForecastGridSensor
+        LoadDeviationSensor(coordinator, entry),
         ForecastDiagnosticsSensor(coordinator, entry),
         MinimumTargetSOCSensor(coordinator, entry),
         # Excess solar load shifting sensors (backlog-high-017)

--- a/custom_components/localshift/sensors/__init__.py
+++ b/custom_components/localshift/sensors/__init__.py
@@ -17,6 +17,7 @@ from .learning import (
     LearningDecisionHistorySensor,
     LearningStatusSensor,
 )
+from .load_deviation import LoadDeviationSensor
 from .misc import (
     ExcessSolarSensor,
     LoadShiftSignalSensor,
@@ -56,6 +57,7 @@ __all__ = [
     "OptimizerPlanSensor",
     "ForecastPricesSensor",
     "OptimizerPlanGridSensor",
+    "LoadDeviationSensor",
     "ForecastDiagnosticsSensor",
     "MinimumTargetSOCSensor",
     # Optimizer

--- a/custom_components/localshift/sensors/load_deviation.py
+++ b/custom_components/localshift/sensors/load_deviation.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.sensor import SensorStateClass
+
+from .base import LocalShiftSensorBase
+
+
+class LoadDeviationSensor(LocalShiftSensorBase):
+    _attr_unique_id = "localshift_load_deviation"
+    _attr_name = "Load Deviation"
+    _attr_icon = "mdi:chart-bell-curve-cumulative"
+    _attr_native_unit_of_measurement = "kW"
+    _attr_state_class = SensorStateClass.MEASUREMENT
+
+    def _update_from_coordinator(self) -> None:
+        diagnostics = self.coordinator.data.load_deviation_diagnostics
+        self._attr_native_value = round(diagnostics.get("deviation_kw", 0.0), 3)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        return dict(self.coordinator.data.load_deviation_diagnostics)

--- a/custom_components/localshift/services/evaluation_dispatcher.py
+++ b/custom_components/localshift/services/evaluation_dispatcher.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Callable
+from collections.abc import Callable, Coroutine
 from datetime import datetime
+from typing import Any
 
 from homeassistant.core import Event, HomeAssistant, callback
 
 from ..const import CONF_PRICING_GENERAL_PRICE
+from ..forecast.load_deviation import LoadDeviationDetector
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -22,7 +24,7 @@ class EvaluationDispatcher:
         get_entity_id: Callable[[str], str],
         read_state_func: Callable[[], None],
         notify_listeners_func: Callable[[], None],
-        evaluate_state_machine_func: Callable[[], object],
+        evaluate_state_machine_func: Callable[[], Coroutine[Any, Any, Any]],
         state_machine,
         stale_price_threshold,
     ) -> None:
@@ -33,6 +35,7 @@ class EvaluationDispatcher:
         self._evaluate_state_machine = evaluate_state_machine_func
         self._state_machine = state_machine
         self._stale_price_threshold = stale_price_threshold
+        self._load_deviation_detector = LoadDeviationDetector()
 
     @callback
     def on_state_change(self, _event: Event) -> None:
@@ -58,6 +61,9 @@ class EvaluationDispatcher:
 
         Returns True if stale price was detected.
         """
+        if self._trigger_load_deviation_reoptimization(_now):
+            return False
+
         stale_price = self._check_stale_price()
 
         if stale_price:
@@ -136,6 +142,20 @@ class EvaluationDispatcher:
                 self._evaluate_state_machine(),
                 "localshift_evaluate_startup_ready",
             )
+
+    def _trigger_load_deviation_reoptimization(self, now: datetime) -> bool:
+        coordinator = getattr(self._read_state, "__self__", None)
+        if coordinator is None:
+            return False
+
+        if not self._load_deviation_detector.evaluate(coordinator.data, now):
+            return False
+
+        self.hass.async_create_task(
+            coordinator.async_recompute_and_evaluate(),
+            "localshift_reoptimize_load_deviation",
+        )
+        return True
 
     def _check_stale_price(self) -> bool:
         """Check if price sensor hasn't updated in the stale threshold."""

--- a/custom_components/localshift/utils/entity_configs.py
+++ b/custom_components/localshift/utils/entity_configs.py
@@ -181,6 +181,11 @@ LOCALSHIFT_ENTITY_CONFIG: dict[str, dict[str, Any]] = {
         "expected_type": float,
         "staleness_minutes": 15,
     },
+    "sensor.localshift_load_deviation": {
+        "category": EntityCategory.REQUIRED,
+        "expected_type": float,
+        "staleness_minutes": 15,
+    },
     "sensor.localshift_forecast_diagnostics": {
         "category": EntityCategory.REQUIRED,
         "expected_type": str,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -123,6 +123,7 @@ custom_components/localshift/
 │   ├── pipeline.py           # Forecast orchestration
 │   ├── history.py            # Historical data fetching
 │   ├── load.py               # Load forecasting
+│   ├── load_deviation.py     # Real-time load deviation detection
 │   ├── solar.py              # Solar calculations
 │   ├── solar_accuracy.py     # Solar accuracy tracking
 │   ├── accuracy.py           # Forecast accuracy engine
@@ -156,7 +157,7 @@ custom_components/localshift/
 │   └── validators.py         # Config validators
 │
 ├── *.py (entities)           # Entity platforms at root (HA requires this)
-│   ├── sensor.py             # 27 sensor entities
+│   ├── sensor.py             # 28 sensor entities
 │   ├── binary_sensor.py      # 10 binary sensor entities
 │   ├── switch.py             # 8 switch entities
 │   ├── number.py             # 4 number entities
@@ -287,6 +288,7 @@ Control follows optimizer plan
 4. **Change Detection**: Only recompute forecast when inputs change significantly
 5. **Extensibility**: New features follow the same pattern
 6. **Spot Price Priority**: Current spot prices preferred over forecasts for decisions
+7. **Near-Term Load Correction**: Fast-tick deviation detection can request a fresh optimizer recompute when live load diverges materially from the current forecast slot
 
 ### Price Decision Logic
 
@@ -362,6 +364,8 @@ The `ForecastChangeTracker` determines when to re-run the optimizer:
 - SOC changes (≥1% threshold)
 - Forecast age (>5 minutes)
 - Solar forecast updates
+
+Separately, `forecast/load_deviation.py` performs a 1-minute fast-tick check against the current forecast slot while an optimizer runtime apply plan is active. A sustained deviation of more than 1.0 kW for more than 10 minutes, or a spike of more than 3.0 kW for more than 5 minutes, triggers `LocalShiftCoordinator.async_recompute_and_evaluate()`. The detector enforces a 15-minute cooldown and only corrects the near-term plan; longer-horizon slots still rely on the normal forecast pipeline.
 
 This ensures efficient computation without missing critical changes.
 

--- a/docs/ENTITY_REFERENCE.md
+++ b/docs/ENTITY_REFERENCE.md
@@ -4,11 +4,11 @@ Complete reference for all Home Assistant entities provided by the LocalShift in
 
 ## Overview
 
-The integration creates **52 entities** grouped under a single "LocalShift" device:
+The integration creates **54 entities** grouped under a single "LocalShift" device:
 
 | Category | Count | Entity Type |
 |----------|-------|-------------|
-| Sensors | 26 | `sensor` |
+| Sensors | 28 | `sensor` |
 | Binary Sensors | 10 | `binary_sensor` |
 | Switches | 8 | `switch` |
 | Numbers | 4 | `number` |
@@ -613,6 +613,46 @@ Attributes:
   sample_count: 0
   last_updated: null
 ```
+
+---
+
+### 24. sensor.localshift_load_deviation
+
+**Purpose:** Real-time diagnostic for current load-vs-forecast deviation while an optimizer runtime plan is active.
+
+Added in Issue #678. This sensor tracks the absolute deviation between live household load and the current forecast slot, along with the sustained/spike breach window and re-optimization cooldown state.
+
+**State Class:** `measurement`
+
+**State:** Absolute load deviation in kW for the current optimizer slot
+
+**Example Data:**
+```
+State: 1.25
+Attributes:
+  status: triggered
+  triggered: true
+  breach_type: sustained
+  actual_kw: 2.25
+  forecast_kw: 1.0
+  current_slot_index: 0
+  sustained_started_at: 2026-03-12T12:00:00+00:00
+  spike_started_at: null
+  last_triggered_at: 2026-03-12T12:11:00+00:00
+  cooldown_until: 2026-03-12T12:26:00+00:00
+  cooldown_remaining_seconds: 900
+```
+
+**Status values:**
+
+| Status | Meaning |
+|--------|---------|
+| `inactive` | Optimizer runtime plan is not currently active |
+| `no_current_slot` | No forecast slot matches the current time |
+| `normal` | Deviation is below all trigger thresholds |
+| `pending` | A sustained or spike breach window is accumulating |
+| `cooldown` | Re-optimization is temporarily blocked after a recent trigger |
+| `triggered` | A sustained/spike breach exceeded its duration and re-optimization was requested |
 
 ---
 

--- a/tests/coordinator/test_data.py
+++ b/tests/coordinator/test_data.py
@@ -1,0 +1,28 @@
+from custom_components.localshift.coordinator.data import (
+    AdaptiveParameters,
+    CoordinatorData,
+)
+
+
+def test_adaptive_parameters_from_dict_ignores_invalid_last_updated():
+    parameters = AdaptiveParameters.from_dict({
+        "values": {"threshold": 1.5},
+        "confidence": {"threshold": 0.9},
+        "last_updated": "not-a-datetime",
+        "update_count": 3,
+    })
+
+    assert parameters.values == {"threshold": 1.5}
+    assert parameters.confidence == {"threshold": 0.9}
+    assert parameters.last_updated is None
+    assert parameters.update_count == 3
+
+
+def test_coordinator_data_has_independent_load_deviation_diagnostics():
+    first = CoordinatorData()
+    second = CoordinatorData()
+
+    first.load_deviation_diagnostics["status"] = "triggered"
+
+    assert first.load_deviation_diagnostics == {"status": "triggered"}
+    assert second.load_deviation_diagnostics == {}

--- a/tests/forecast/test_load_deviation.py
+++ b/tests/forecast/test_load_deviation.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from custom_components.localshift.coordinator import CoordinatorData
+from custom_components.localshift.forecast.load_deviation import LoadDeviationDetector
+
+
+def _make_current_slot_data(*, now: datetime, actual_kw: float, forecast_kw: float):
+    data = CoordinatorData()
+    data.load_power_kw = actual_kw
+    data.load_forecast_slots = [forecast_kw]
+    data.optimizer_decisions = [
+        {
+            "timestamp_iso": (now - timedelta(minutes=1)).isoformat(),
+            "slot_interval_minutes": 30,
+        }
+    ]
+    data.optimizer_last_apply_status = "ready_to_apply"
+    data.optimizer_apply_plan = {"battery_mode": "grid_charging"}
+    data.load_deviation_diagnostics = {}
+    return data
+
+
+def test_detector_skips_when_optimizer_runtime_is_inactive() -> None:
+    now = datetime(2026, 3, 12, 12, 0, tzinfo=UTC)
+    data = _make_current_slot_data(now=now, actual_kw=2.5, forecast_kw=1.0)
+    data.optimizer_last_apply_status = "blocked"
+    data.optimizer_apply_plan = None
+
+    detector = LoadDeviationDetector()
+
+    assert detector.evaluate(data, now) is False
+    diagnostics = data.load_deviation_diagnostics
+    assert diagnostics["status"] == "inactive"
+    assert diagnostics["triggered"] is False
+
+
+def test_detector_skips_without_current_slot_forecast() -> None:
+    now = datetime(2026, 3, 12, 12, 0, tzinfo=UTC)
+    data = _make_current_slot_data(now=now, actual_kw=2.5, forecast_kw=1.0)
+    data.load_forecast_slots = []
+
+    detector = LoadDeviationDetector()
+
+    assert detector.evaluate(data, now) is False
+    diagnostics = data.load_deviation_diagnostics
+    assert diagnostics["status"] == "no_current_slot"
+    assert diagnostics["triggered"] is False
+
+
+def test_detector_triggers_after_sustained_deviation_window() -> None:
+    now = datetime(2026, 3, 12, 12, 0, tzinfo=UTC)
+    data = _make_current_slot_data(now=now, actual_kw=2.2, forecast_kw=1.0)
+    detector = LoadDeviationDetector()
+
+    assert detector.evaluate(data, now) is False
+    assert detector.evaluate(data, now + timedelta(minutes=10)) is False
+    assert detector.evaluate(data, now + timedelta(minutes=11)) is True
+
+    diagnostics = data.load_deviation_diagnostics
+    assert diagnostics["status"] == "triggered"
+    assert diagnostics["breach_type"] == "sustained"
+    assert diagnostics["triggered"] is True
+
+
+def test_detector_triggers_after_spike_window() -> None:
+    now = datetime(2026, 3, 12, 12, 0, tzinfo=UTC)
+    data = _make_current_slot_data(now=now, actual_kw=4.5, forecast_kw=1.0)
+    detector = LoadDeviationDetector()
+
+    assert detector.evaluate(data, now) is False
+    assert detector.evaluate(data, now + timedelta(minutes=5)) is False
+    assert detector.evaluate(data, now + timedelta(minutes=6)) is True
+
+    diagnostics = data.load_deviation_diagnostics
+    assert diagnostics["breach_type"] == "spike"
+    assert diagnostics["triggered"] is True
+
+
+def test_detector_enforces_cooldown_before_retrigger() -> None:
+    now = datetime(2026, 3, 12, 12, 0, tzinfo=UTC)
+    data = _make_current_slot_data(now=now, actual_kw=4.5, forecast_kw=1.0)
+    detector = LoadDeviationDetector()
+
+    detector.evaluate(data, now)
+    assert detector.evaluate(data, now + timedelta(minutes=6)) is True
+    assert detector.evaluate(data, now + timedelta(minutes=7)) is False
+
+    diagnostics = data.load_deviation_diagnostics
+    assert diagnostics["status"] == "cooldown"
+    assert diagnostics["triggered"] is False
+
+
+def test_detector_retriggers_after_cooldown_with_new_window() -> None:
+    now = datetime(2026, 3, 12, 12, 0, tzinfo=UTC)
+    data = _make_current_slot_data(now=now, actual_kw=4.5, forecast_kw=1.0)
+    detector = LoadDeviationDetector()
+
+    detector.evaluate(data, now)
+    assert detector.evaluate(data, now + timedelta(minutes=6)) is True
+    assert detector.evaluate(data, now + timedelta(minutes=21)) is False
+    assert detector.evaluate(data, now + timedelta(minutes=27)) is True
+
+    diagnostics = data.load_deviation_diagnostics
+    assert diagnostics["breach_type"] == "spike"
+    assert diagnostics["triggered"] is True

--- a/tests/sensors/test_load_deviation.py
+++ b/tests/sensors/test_load_deviation.py
@@ -1,0 +1,21 @@
+from unittest.mock import MagicMock
+
+from custom_components.localshift.sensors import LoadDeviationSensor
+
+
+def test_load_deviation_sensor_reports_state_and_attributes():
+    coordinator = MagicMock()
+    coordinator.data.load_deviation_diagnostics = {
+        "status": "triggered",
+        "deviation_kw": 1.25,
+        "actual_kw": 4.0,
+        "forecast_kw": 2.75,
+        "breach_type": "sustained",
+        "triggered": True,
+    }
+
+    sensor = LoadDeviationSensor(coordinator, MagicMock())
+    sensor._update_from_coordinator()
+
+    assert sensor.native_value == 1.25
+    assert sensor.extra_state_attributes == coordinator.data.load_deviation_diagnostics

--- a/tests/sensors/test_sensors.py
+++ b/tests/sensors/test_sensors.py
@@ -4,34 +4,36 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from custom_components.localshift import sensor as sensor_platform
 from custom_components.localshift.sensors import (
-    EffectiveCheapPriceSensor,
-    CheapChargeStopPriceSensor,
-    SolarWeightedAvgFITSensor,
-    SolarBatteryForecastSensor,
-    NetElectricityCostSensor,
-    DecisionLogSensor,
-    ForecastHistorySensor,
-    OptimizerPlanSensor,
-    ForecastPricesSensor,
-    OptimizerPlanGridSensor,
-    ForecastDiagnosticsSensor,
-    MinimumTargetSOCSensor,
-    ExcessSolarSensor,
-    LoadShiftSignalSensor,
-    ForecastAccuracySensor,
-    IntegrationStatusSensor,
-    EntityHealthSensor,
-    LearningStatusSensor,
-    DecisionQualitySensor,
-    LearningDecisionHistorySensor,
-    DecisionLagSensor,
-    ExtendedForecastAccuracySensor,
-    ForecastStatusSensor,
     AutomationReadySensor,
+    CheapChargeStopPriceSensor,
+    DecisionLagSensor,
+    DecisionLogSensor,
+    DecisionQualitySensor,
+    EffectiveCheapPriceSensor,
+    EntityHealthSensor,
+    ExcessSolarSensor,
+    ExtendedForecastAccuracySensor,
+    ForecastAccuracySensor,
+    ForecastDiagnosticsSensor,
+    ForecastHistorySensor,
+    ForecastPricesSensor,
+    ForecastStatusSensor,
+    IntegrationStatusSensor,
+    LearningDecisionHistorySensor,
+    LearningStatusSensor,
+    LoadDeviationSensor,
+    LoadShiftSignalSensor,
+    MinimumTargetSOCSensor,
+    NetElectricityCostSensor,
     OptimizerPlanDetailedSensor,
+    OptimizerPlanGridSensor,
+    OptimizerPlanSensor,
     OptimizerSummarySensor,
+    SolarBatteryForecastSensor,
     SolarForecastAccuracySensor,
+    SolarWeightedAvgFITSensor,
 )
 
 
@@ -131,6 +133,16 @@ class Fixtures:
         data.weather_heating_coefficient = 0.05
         data.weather_sample_count = 100
         data.load_forecast_slots = [1.0, 1.2, 1.5, 1.3, 1.1, 1.0, 0.9, 0.8, 0.7]
+        data.load_deviation_diagnostics = {
+            "status": "triggered",
+            "deviation_kw": 1.25,
+            "actual_kw": 2.25,
+            "forecast_kw": 1.0,
+            "breach_type": "sustained",
+            "current_slot_index": 0,
+            "last_triggered_at": "2026-03-12T12:11:00+00:00",
+            "triggered": True,
+        }
         data.adaptive_params = MagicMock()
         data.adaptive_params.values = {"param1": 1.0, "param2": 2.0}
         data.excess_until_battery_full_kwh = 3.5
@@ -288,6 +300,14 @@ class TestForecastSensors(Fixtures):
         sensor._update_from_coordinator()
         assert sensor.native_value == "history"
 
+    def test_load_deviation(self, mock_coordinator, mock_entry):
+        sensor = LoadDeviationSensor(mock_coordinator, mock_entry)
+        sensor._update_from_coordinator()
+        assert sensor.native_value == 1.25
+        attrs = sensor.extra_state_attributes
+        assert attrs["status"] == "triggered"
+        assert attrs["breach_type"] == "sustained"
+
     def test_minimum_target_soc(self, mock_coordinator, mock_entry):
         sensor = MinimumTargetSOCSensor(mock_coordinator, mock_entry)
         sensor._update_from_coordinator()
@@ -391,3 +411,18 @@ class TestOptimizerSensors(Fixtures):
         assert sensor.native_value == 85.0
         attrs = sensor.extra_state_attributes
         assert attrs == {"bias": 0.5}
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_registers_load_deviation_sensor():
+    coordinator = MagicMock()
+    coordinator.data = Fixtures()._make_mock_data()
+    entry = MagicMock()
+    entry.runtime_data = coordinator
+
+    async_add_entities = MagicMock()
+
+    await sensor_platform.async_setup_entry(MagicMock(), entry, async_add_entities)
+
+    entities = async_add_entities.call_args.args[0]
+    assert any(isinstance(entity, LoadDeviationSensor) for entity in entities)

--- a/tests/services/test_evaluation_dispatcher.py
+++ b/tests/services/test_evaluation_dispatcher.py
@@ -3,11 +3,22 @@
 from datetime import timedelta
 from unittest.mock import AsyncMock, MagicMock
 
+from homeassistant.util import dt as dt_util
+
+from custom_components.localshift.coordinator.data import CoordinatorData
 from custom_components.localshift.services.evaluation_dispatcher import (
     EvaluationDispatcher,
 )
-from homeassistant.util import dt as dt_util
 from tests.fixtures.ha_entities import MockState, MockStates
+
+
+class StubCoordinator:
+    def __init__(self) -> None:
+        self.data = CoordinatorData()
+        self.async_recompute_and_evaluate = AsyncMock()
+
+    def read_state(self) -> None:
+        return None
 
 
 def test_state_change_dispatches_evaluation():
@@ -57,6 +68,25 @@ def test_state_change_skips_during_transition():
         MagicMock(),
         AsyncMock(),
         state_machine,
+        timedelta(minutes=10),
+    )
+
+    dispatcher.on_state_change(MagicMock())
+
+    hass.async_create_task.assert_not_called()
+
+
+def test_state_change_skips_when_state_machine_missing():
+    hass = MagicMock()
+    hass.async_create_task = MagicMock()
+
+    dispatcher = EvaluationDispatcher(
+        hass,
+        lambda _key: "sensor.price",
+        MagicMock(),
+        MagicMock(),
+        AsyncMock(),
+        None,
         timedelta(minutes=10),
     )
 
@@ -124,4 +154,127 @@ def test_fast_tick_triggers_periodic_evaluation_when_fresh():
 
     dispatcher.on_fast_tick(now)
 
+    assert hass.async_create_task.call_args.args[1] == "localshift_evaluate_periodic"
+
+
+def test_fast_tick_ignores_missing_price_entity():
+    hass = MagicMock()
+    hass.async_create_task = MagicMock()
+    hass.states.get = MagicMock(return_value=None)
+
+    now = dt_util.now()
+    dispatcher = EvaluationDispatcher(
+        hass,
+        lambda _key: "sensor.price",
+        MagicMock(),
+        MagicMock(),
+        AsyncMock(),
+        MagicMock(in_mode_transition=False),
+        timedelta(minutes=10),
+    )
+    dispatcher._load_deviation_detector = MagicMock()
+    dispatcher._load_deviation_detector.evaluate.return_value = False
+
+    stale_price = dispatcher.on_fast_tick(now)
+
+    assert stale_price is False
+    assert hass.async_create_task.call_args.args[1] == "localshift_evaluate_periodic"
+
+
+def test_fast_tick_ignores_invalid_price_state():
+    hass = MagicMock()
+    hass.async_create_task = MagicMock()
+
+    now = dt_util.now()
+    states = MockStates({
+        "sensor.price": MockState(
+            entity_id="sensor.price",
+            state="unknown",
+            attributes={},
+            last_updated=now - timedelta(minutes=2),
+        )
+    })
+    hass.states.get = states.get
+
+    dispatcher = EvaluationDispatcher(
+        hass,
+        lambda _key: "sensor.price",
+        MagicMock(),
+        MagicMock(),
+        AsyncMock(),
+        MagicMock(in_mode_transition=False),
+        timedelta(minutes=10),
+    )
+    dispatcher._load_deviation_detector = MagicMock()
+    dispatcher._load_deviation_detector.evaluate.return_value = False
+
+    stale_price = dispatcher.on_fast_tick(now)
+
+    assert stale_price is False
+    assert hass.async_create_task.call_args.args[1] == "localshift_evaluate_periodic"
+
+
+def test_fast_tick_triggers_load_deviation_reoptimization():
+    hass = MagicMock()
+    hass.async_create_task = MagicMock()
+
+    coordinator = StubCoordinator()
+
+    dispatcher = EvaluationDispatcher(
+        hass,
+        lambda _key: "sensor.price",
+        coordinator.read_state,
+        MagicMock(),
+        AsyncMock(),
+        MagicMock(in_mode_transition=False),
+        timedelta(minutes=10),
+    )
+    dispatcher._load_deviation_detector = MagicMock()
+    dispatcher._load_deviation_detector.evaluate.return_value = True
+
+    now = dt_util.now()
+    dispatcher.on_fast_tick(now)
+
+    dispatcher._load_deviation_detector.evaluate.assert_called_once_with(
+        coordinator.data, now
+    )
+    assert (
+        hass.async_create_task.call_args.args[1]
+        == "localshift_reoptimize_load_deviation"
+    )
+
+
+def test_fast_tick_uses_periodic_evaluation_when_no_load_deviation_trigger():
+    hass = MagicMock()
+    hass.async_create_task = MagicMock()
+
+    now = dt_util.now()
+    states = MockStates({
+        "sensor.price": MockState(
+            entity_id="sensor.price",
+            state="0.25",
+            attributes={},
+            last_updated=now - timedelta(minutes=2),
+        )
+    })
+    hass.states.get = states.get
+
+    coordinator = StubCoordinator()
+    dispatcher = EvaluationDispatcher(
+        hass,
+        lambda _key: "sensor.price",
+        coordinator.read_state,
+        MagicMock(),
+        AsyncMock(),
+        MagicMock(in_mode_transition=False),
+        timedelta(minutes=10),
+    )
+    dispatcher._load_deviation_detector = MagicMock()
+    dispatcher._load_deviation_detector.evaluate.return_value = False
+
+    dispatcher.on_fast_tick(now)
+
+    dispatcher._load_deviation_detector.evaluate.assert_called_once_with(
+        coordinator.data, now
+    )
     assert hass.async_create_task.call_args.args[1] == "localshift_evaluate_periodic"

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -30,7 +30,10 @@ class TestSensorAsyncSetup:
 
         mock_async_add_entities.assert_called_once()
         entities = mock_async_add_entities.call_args[0][0]
-        assert len(entities) == 27
+        assert len(entities) == 28
+        assert any(
+            type(entity).__name__ == "LoadDeviationSensor" for entity in entities
+        )
 
     @pytest.mark.asyncio
     async def test_async_setup_entry_creates_all_sensors(


### PR DESCRIPTION
## Summary
- add a load deviation detector that watches active optimizer runtime slots and triggers recompute when sustained or spike thresholds are breached
- move the fast-tick re-optimization seam into `EvaluationDispatcher` and expose a dedicated `LoadDeviationSensor`
- update docs and test coverage so the new runtime path is validated and meets the modified-file coverage gate

## Testing
- uv run pytest
- uv run pytest --cov=custom_components/localshift --cov-report=term-missing
- uv run ruff check custom_components/localshift/coordinator/data.py custom_components/localshift/sensor.py custom_components/localshift/sensors/__init__.py custom_components/localshift/sensors/load_deviation.py custom_components/localshift/services/evaluation_dispatcher.py custom_components/localshift/utils/entity_configs.py tests/coordinator/test_data.py tests/forecast/test_load_deviation.py tests/sensors/test_load_deviation.py tests/sensors/test_sensors.py tests/services/test_evaluation_dispatcher.py tests/test_sensor.py
- uv run ruff format --check custom_components/localshift/coordinator/data.py custom_components/localshift/sensor.py custom_components/localshift/sensors/__init__.py custom_components/localshift/sensors/load_deviation.py custom_components/localshift/services/evaluation_dispatcher.py custom_components/localshift/utils/entity_configs.py tests/coordinator/test_data.py tests/forecast/test_load_deviation.py tests/sensors/test_load_deviation.py tests/sensors/test_sensors.py tests/services/test_evaluation_dispatcher.py tests/test_sensor.py

Closes #678