### PR TITLE
feat(learning): reduce pattern analysis interval by phase

### DIFF
--- a/.githooks/scripts/check-tdd.sh
+++ b/.githooks/scripts/check-tdd.sh
@@ -85,9 +85,11 @@ for FILE in "${SOURCE_FILE_PATHS[@]}"; do
 done
 
 PARALLEL_FLAG=""
-if check_xdist_available; then
+if [ "${LOCALSHIFT_PRECOMMIT_USE_XDIST:-0}" = "1" ] && check_xdist_available; then
     PARALLEL_FLAG="-n logical"
     echo "🚀 Using parallel execution (pytest-xdist)"
+else
+    echo "🚶 Using serial execution"
 fi
 
 TEST_FILES="${TEST_FILE_PATHS[*]}"
@@ -97,13 +99,18 @@ echo ""
 echo "🔍 Running tests with coverage for modified files..."
 
 if [ -n "$COV_FLAGS" ]; then
-    if ! uv run pytest $TEST_FILES $COV_FLAGS \
+    set +e
+    env -u GIT_DIR -u GIT_WORK_TREE -u GIT_INDEX_FILE -u GIT_PREFIX \
+        uv run python -m pytest $TEST_FILES $COV_FLAGS \
         $PARALLEL_FLAG \
         --cov-report=json:"$COVERAGE_JSON" \
         --cov-report=term-missing \
-        -v --tb=short 2>&1; then
+        -v --tb=short 2>&1
+    PYTEST_EXIT=$?
+    set -e
+    if [ "$PYTEST_EXIT" -ne 0 ]; then
         echo ""
-        echo "❌ ERROR: Tests failed"
+        echo "❌ ERROR: Tests failed (exit $PYTEST_EXIT)"
         echo ""
         echo "All tests must pass before commit (TDD GREEN phase)"
         echo "See: .agents/rules/tdd-workflow.md"
@@ -121,11 +128,16 @@ if [ -n "$COV_FLAGS" ]; then
         fi
     else
         echo "⚠️  coverage_checker.py not found, falling back to --cov-fail-under"
-        if ! uv run pytest $TEST_FILES $COV_FLAGS \
+        set +e
+        env -u GIT_DIR -u GIT_WORK_TREE -u GIT_INDEX_FILE -u GIT_PREFIX \
+            uv run python -m pytest $TEST_FILES $COV_FLAGS \
             --cov-fail-under=95 \
-            -q 2>&1; then
+            -q 2>&1
+        PYTEST_EXIT=$?
+        set -e
+        if [ "$PYTEST_EXIT" -ne 0 ]; then
             echo ""
-            echo "❌ ERROR: Coverage below 95%"
+            echo "❌ ERROR: Coverage below 95% (exit $PYTEST_EXIT)"
             rm -f "$COVERAGE_JSON"
             exit 1
         fi

--- a/custom_components/localshift/learning/orchestrator.py
+++ b/custom_components/localshift/learning/orchestrator.py
@@ -19,6 +19,12 @@ _LOGGER = logging.getLogger(__name__)
 class LearningOrchestrator:
     """Manage learning initialization, persistence, and periodic updates."""
 
+    _PATTERN_ANALYSIS_INTERVALS = {
+        "observing": 7,
+        "tuning": 5,
+        "optimizing": 3,
+    }
+
     def __init__(
         self,
         hass: HomeAssistant,
@@ -186,10 +192,13 @@ class LearningOrchestrator:
             )
 
         self._days_since_pattern_analysis += 1
+        analysis_interval = self._get_pattern_analysis_interval(
+            getattr(data, "learning_status", "observing")
+        )
         if (
             self.pattern_analyzer is not None
             and self.decision_tracker is not None
-            and self._days_since_pattern_analysis >= 7
+            and self._days_since_pattern_analysis >= analysis_interval
         ):
             self._days_since_pattern_analysis = 0
             self.hass.async_create_task(
@@ -202,6 +211,9 @@ class LearningOrchestrator:
                 self.pattern_analyzer.async_save(),
                 "localshift_save_pattern_analyzer",
             )
+
+    def _get_pattern_analysis_interval(self, learning_status: str) -> int:
+        return self._PATTERN_ANALYSIS_INTERVALS.get(learning_status, 7)
 
     def update_medium_tick(self, data) -> None:
         """Run learning and monitoring tasks on medium tick."""

--- a/tests/learning/test_learning_integration.py
+++ b/tests/learning/test_learning_integration.py
@@ -9,24 +9,24 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from custom_components.localshift.engine.outcomes import (
-    DecisionOutcomeTracker,
-    DecisionRecord,
+from custom_components.localshift.coordinator import (
+    AdaptiveParameters,
+    CoordinatorData,
+    PerformanceMetrics,
 )
 from custom_components.localshift.engine.optimization_controller import (
     OptimizationController,
+)
+from custom_components.localshift.engine.optimizer_dp import PlannerAction
+from custom_components.localshift.engine.outcomes import (
+    DecisionOutcomeTracker,
+    DecisionRecord,
 )
 from custom_components.localshift.engine.parameters import (
     ParameterOptimizer,
 )
 from custom_components.localshift.engine.pattern_analyzer import (
     PatternAnalyzer,
-)
-from custom_components.localshift.engine.optimizer_dp import PlannerAction
-from custom_components.localshift.coordinator import (
-    AdaptiveParameters,
-    CoordinatorData,
-    PerformanceMetrics,
 )
 from custom_components.localshift.learning.orchestrator import LearningOrchestrator
 
@@ -347,7 +347,26 @@ class TestLearningOrchestratorForecastCorrections:
         if hasattr(coro, "close"):
             coro.close()
 
-    def test_handle_midnight_reset_schedules_tasks(self, mock_hass, mock_entry):
+    @pytest.mark.parametrize(
+        ("learning_status", "starting_days", "expects_analysis", "expected_days"),
+        [
+            ("observing", 5, False, 6),
+            ("observing", 6, True, 0),
+            ("tuning", 3, False, 4),
+            ("tuning", 4, True, 0),
+            ("optimizing", 1, False, 2),
+            ("optimizing", 2, True, 0),
+        ],
+    )
+    def test_handle_midnight_reset_uses_phase_specific_interval(
+        self,
+        mock_hass,
+        mock_entry,
+        learning_status,
+        starting_days,
+        expects_analysis,
+        expected_days,
+    ):
         orchestrator = LearningOrchestrator(mock_hass, mock_entry, lambda _key: False)
         orchestrator.decision_tracker = MagicMock(
             async_save=MagicMock(return_value=None)
@@ -358,9 +377,10 @@ class TestLearningOrchestratorForecastCorrections:
         orchestrator.pattern_analyzer = MagicMock(
             async_save=MagicMock(return_value=None)
         )
-        orchestrator._days_since_pattern_analysis = 6
+        orchestrator._days_since_pattern_analysis = starting_days
 
         data = CoordinatorData()
+        data.learning_status = learning_status
         orchestrator.handle_midnight_reset(data)
 
         task_names = [
@@ -368,9 +388,50 @@ class TestLearningOrchestratorForecastCorrections:
         ]
         assert "localshift_save_decision_outcomes" in task_names
         assert "localshift_save_param_optimizer" in task_names
-        assert "localshift_pattern_analysis" in task_names
         assert "localshift_save_pattern_analyzer" in task_names
-        assert orchestrator._days_since_pattern_analysis == 0
+        assert ("localshift_pattern_analysis" in task_names) is expects_analysis
+        assert orchestrator._days_since_pattern_analysis == expected_days
+
+        for call in mock_hass.async_create_task.call_args_list:
+            coro = call.args[0]
+            if hasattr(coro, "close"):
+                coro.close()
+        mock_hass.async_create_task.reset_mock()
+
+    def test_handle_midnight_reset_keeps_counter_across_phase_changes(
+        self, mock_hass, mock_entry
+    ):
+        orchestrator = LearningOrchestrator(mock_hass, mock_entry, lambda _key: False)
+        orchestrator.decision_tracker = MagicMock(
+            async_save=MagicMock(return_value=None)
+        )
+        orchestrator.param_optimizer = MagicMock(
+            async_save=MagicMock(return_value=None)
+        )
+        orchestrator.pattern_analyzer = MagicMock(
+            async_save=MagicMock(return_value=None)
+        )
+        orchestrator._days_since_pattern_analysis = 1
+
+        data = CoordinatorData()
+        data.learning_status = "observing"
+        orchestrator.handle_midnight_reset(data)
+        assert orchestrator._days_since_pattern_analysis == 2
+
+        for call in mock_hass.async_create_task.call_args_list:
+            coro = call.args[0]
+            if hasattr(coro, "close"):
+                coro.close()
+        mock_hass.async_create_task.reset_mock()
+
+        data.learning_status = "tuning"
+        orchestrator.handle_midnight_reset(data)
+
+        task_names = [
+            call.args[1] for call in mock_hass.async_create_task.call_args_list
+        ]
+        assert "localshift_pattern_analysis" not in task_names
+        assert orchestrator._days_since_pattern_analysis == 3
 
         for call in mock_hass.async_create_task.call_args_list:
             coro = call.args[0]
@@ -454,11 +515,14 @@ class TestLearningOrchestratorForecastCorrections:
 
         await orchestrator._run_pattern_analysis(data)
 
-        orchestrator.pattern_analyzer = MagicMock()
+        orchestrator.pattern_analyzer = MagicMock(analyze=MagicMock())
         orchestrator.decision_tracker = MagicMock(
-            get_recent_decisions=MagicMock(return_value=[1] * 10)
+            get_recent_decisions=MagicMock(return_value=[1] * 49)
         )
         await orchestrator._run_pattern_analysis(data)
+
+        orchestrator.pattern_analyzer.analyze.assert_not_called()
+        assert orchestrator._last_pattern_analysis is None
 
     @pytest.mark.asyncio
     async def test_run_pattern_analysis_updates_status_and_biases(


### PR DESCRIPTION
## Summary
- reduce `LearningOrchestrator` pattern-analysis cadence based on `learning_status` so observing stays at 7 days, tuning moves to 5 days, and optimizing moves to 3 days without resetting the counter on phase changes
- keep the existing 50-decision minimum gate intact and expand integration coverage for phase-specific scheduling, phase transitions, and insufficient-data behavior
- harden the local pre-commit TDD hook by running pytest via `python -m pytest`, sanitizing Git hook env vars for the subprocess, and defaulting to serial execution after repeated noninteractive hook crashes

## Testing
- `uv run pytest`
- `uv run ruff check custom_components/localshift`
- `uv run ruff format --check custom_components/localshift`
- `.githooks/scripts/check-tdd.sh </dev/null`