### PR TITLE
docs: clarify homeassistant skill delegation pattern

### DIFF
--- a/.opencode/skills/homeassistant/SKILL.md
+++ b/.opencode/skills/homeassistant/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: ha-mcp
+name: homeassistant
 description: Debug Home Assistant issues using native tools and direct log access
 license: MIT
 compatibility: opencode
@@ -7,6 +7,21 @@ metadata:
   audience: developers
   workflow: debugging
 ---
+
+## How to Access
+
+⚠️ **ALWAYS DELEGATE to the `homeassistant` subagent.** The main agent does NOT have HA tools enabled (by design, to avoid MCP token overhead).
+
+```python
+# ALWAYS use task() with subagent_type="homeassistant"
+task(
+    subagent_type="homeassistant",
+    prompt="Check the current state of switch.localshift_automation_enabled",
+    run_in_background=False
+)
+```
+
+The `homeassistant` subagent has exclusive access to all HA MCP tools. Never attempt to call `homeassistant_*` tools or `skill_mcp` directly from the main agent.
 
 ## What I Do
 
@@ -19,7 +34,9 @@ Help debug Home Assistant issues by using native Home Assistant tools and direct
 - "What's the current state of my battery?"
 - "Debug why my sensor shows unavailable"
 
-## Native Home Assistant Tools
+## Native Home Assistant Tools (Subagent Only)
+
+These tools are available ONLY within the `homeassistant` subagent. The main agent must delegate to use them.
 
 ### State & Entity Inspection
 

--- a/opencode.json
+++ b/opencode.json
@@ -6,9 +6,8 @@
   ],
   "skills": {
     "paths": [
-      ".opencode/skills/ha-mcp-debug",
-      ".opencode/skills/python-refactoring",
-      ".opencode/skills/ha-integration-testing"
+      ".opencode/skills/homeassistant",
+      ".opencode/skills/python-refactoring"
     ]
   },
   "plugin": ["@tarquinen/opencode-dcp@latest"],
@@ -31,9 +30,19 @@
     "homeassistant_*": false
   },
   "agent": {
-    "ha-debug": {
+    "homeassistant": {
       "description": "Agent with HomeAssistant MCP enabled for debugging",
-      "mode": "primary",
+      "mode": "subagent",
+      "mcp": {
+        "homeassistant": {
+          "type": "remote",
+          "url": "https://homeassistant.nectaron.jackmcintyre.net/api/mcp",
+          "enabled": true,
+          "headers": {
+            "Authorization": "Bearer {env:HA_LONG_LIVED_TOKEN}"
+          }
+        }
+      },
       "tools": {
         "homeassistant_*": true
       }


### PR DESCRIPTION
## Summary
- Rename `ha-mcp` skill to `homeassistant` for consistency with subagent name
- Add explicit ⚠️ warning that main agent must ALWAYS delegate to subagent
- Explain reason: MCP token overhead is avoided by delegation pattern

## Changes
- Updated skill header with unambiguous delegation instructions
- Renamed tool section to "Native Home Assistant Tools (Subagent Only)"
- Updated `opencode.json` skill paths and agent configuration

## Testing
- Verified skill loads correctly with new path
- Tested delegation to `homeassistant` subagent for `GetDateTime` call