### PR TITLE
Enable HomeAssistant MCP tools globally

### DIFF
--- a/opencode.json
+++ b/opencode.json
@@ -27,7 +27,7 @@
     }
   },
   "tools": {
-    "homeassistant_*": false
+    "homeassistant_*": true
   },
   "agent": {
     "homeassistant": {


### PR DESCRIPTION
## Summary
Enable HomeAssistant MCP tools for all agents by default.

## Changes
- Changed `tools.homeassistant_*` from `false` to `true` in `opencode.json`
- The subagent scaffold remains in place for future use

## Rationale
Previously HA tools were disabled globally and only enabled in a subagent to avoid MCP token overhead. User requested global availability for now with manual toggle capability.

## Testing
- Configuration validated