### PR TITLE
fix(optimizer): use realistic solar simulation for global gate (Issue #701)

### DIFF
--- a/custom_components/localshift/engine/constraints.py
+++ b/custom_components/localshift/engine/constraints.py
@@ -107,14 +107,11 @@ def check_global_solar_sufficiency(
 ) -> bool:
     """Check if remaining solar in the full horizon covers the SOC deficit to target.
 
-    Unlike the demand-window-based solar gate, this check works across the
-    entire remaining horizon regardless of whether a demand window (and its
-    terminal_penalty_idx) exists. It prevents nighttime grid charging when
-    tomorrow's solar will naturally fill the battery to the demand window target.
+    Uses realistic simulation that accounts for charge rate limits and efficiency,
+    ensuring consistency with solar_can_reach_target sensor.
 
-    Fixes Issue #559 Root Cause 1: the original _solar_covers_deficit gate is
-    skipped entirely when terminal_penalty_idx is None (no demand window), so
-    the optimizer was free to panic-buy grid power overnight.
+    Fixes Issue #701: Previous implementation used raw surplus without rate limits,
+    incorrectly blocking cheap grid charging when solar was insufficient in reality.
 
     Args:
         soc_pct: Current battery SOC percentage.
@@ -123,23 +120,25 @@ def check_global_solar_sufficiency(
         config: Optimizer configuration.
 
     Returns:
-        True if projected solar SURPLUS (max(0, solar - consumption)) from slot_idx
-        to end of horizon is sufficient to raise SOC from soc_pct to demand_window_target_soc_pct.
+        True if realistic solar simulation can raise SOC from soc_pct to demand_window_target_soc_pct.
 
     """
     if not slots:
         return False
 
-    # Only suppress charging if we have a meaningful deficit to the target.
     soc_deficit_pct = config.demand_window_target_soc_pct - soc_pct
     if soc_deficit_pct <= 0:
         return False
 
-    projected_surplus_kwh = sum(
-        max(0.0, s.solar_kwh - s.consumption_kwh) for s in slots[slot_idx:]
+    from custom_components.localshift.engine.dp_math import (
+        _simulate_solar_only_terminal_soc,
     )
-    potential_gain_pct = (projected_surplus_kwh / config.battery_capacity_kwh) * 100.0
-    return potential_gain_pct >= soc_deficit_pct
+
+    remaining_slots = slots[slot_idx:]
+    simulated_terminal_soc = _simulate_solar_only_terminal_soc(
+        soc_pct, remaining_slots, None, config
+    )
+    return simulated_terminal_soc >= config.demand_window_target_soc_pct
 
 
 def is_cheap_import_window(

--- a/custom_components/localshift/engine/core.py
+++ b/custom_components/localshift/engine/core.py
@@ -1155,14 +1155,11 @@ class DPPlanner:
     ) -> bool:
         """Check if remaining solar in the full horizon covers the SOC deficit to target.
 
-        Unlike the demand-window-based solar gate, this check works across the
-        entire remaining horizon regardless of whether a demand window (and its
-        terminal_penalty_idx) exists.  It prevents nighttime grid charging when
-        tomorrow's solar will naturally fill the battery to the demand window target.
+        Uses realistic simulation that accounts for charge rate limits and efficiency,
+        ensuring consistency with solar_can_reach_target sensor.
 
-        Fixes Issue #559 Root Cause 1: the original _solar_covers_deficit gate is
-        skipped entirely when terminal_penalty_idx is None (no demand window), so
-        the optimizer was free to panic-buy grid power overnight.
+        Fixes Issue #701: Previous implementation used raw surplus without rate limits,
+        incorrectly blocking cheap grid charging when solar was insufficient in reality.
 
         Args:
             soc_pct: Current battery SOC percentage.
@@ -1171,26 +1168,25 @@ class DPPlanner:
             config: Optimizer configuration.
 
         Returns:
-            True if projected solar SURPLUS (max(0, solar - consumption)) from slot_idx
-            to end of horizon is sufficient to raise SOC from soc_pct to demand_window_target_soc_pct.
+            True if realistic solar simulation can raise SOC from soc_pct to demand_window_target_soc_pct.
 
         """
         if not slots:
             return False
 
-        # Only suppress charging if we have a meaningful deficit to the target.
-        # If we're already at or above target, the existing price-based logic handles it.
         soc_deficit_pct = config.demand_window_target_soc_pct - soc_pct
         if soc_deficit_pct <= 0:
             return False
 
-        projected_surplus_kwh = sum(
-            max(0.0, s.solar_kwh - s.consumption_kwh) for s in slots[slot_idx:]
+        from custom_components.localshift.engine.dp_math import (
+            _simulate_solar_only_terminal_soc,
         )
-        potential_gain_pct = (
-            projected_surplus_kwh / config.battery_capacity_kwh
-        ) * 100.0
-        return potential_gain_pct >= soc_deficit_pct
+
+        remaining_slots = slots[slot_idx:]
+        simulated_terminal_soc = _simulate_solar_only_terminal_soc(
+            soc_pct, remaining_slots, None, config
+        )
+        return simulated_terminal_soc >= config.demand_window_target_soc_pct
 
     @staticmethod
     def feasible_actions(

--- a/tests/engine/test_constraints.py
+++ b/tests/engine/test_constraints.py
@@ -361,6 +361,136 @@ class TestCheckGlobalSolarSufficiency:
         result = check_global_solar_sufficiency(50.0, 0, [], config)
         assert result is False
 
+    def test_rate_limited_solar_returns_false(self):
+        """Returns False when charge rate limit prevents capturing all solar.
+
+        This is the bug from Issue #701: the raw surplus calculation ignores
+        charge rate limits and efficiency, incorrectly reporting solar sufficiency.
+
+        Scenario:
+        - Battery: 10 kWh capacity, 50% SOC, target 80% (need 3 kWh = 30%)
+        - Charge rate: 5 kW (max 2.5 kWh per 30-min slot)
+        - Efficiency: 90%
+        - 1 slot with 10 kWh surplus (far more than needed on paper)
+
+        Raw calculation: 10 kWh surplus > 3 kWh needed → TRUE (WRONG)
+        Realistic calculation: 2.5 kWh * 0.9 = 2.25 kWh < 3 kWh → FALSE (CORRECT)
+        """
+        from custom_components.localshift.engine.constraints import (
+            check_global_solar_sufficiency,
+        )
+
+        config = OptimizerConfig(
+            battery_capacity_kwh=10.0,
+            demand_window_target_soc_pct=80.0,
+            solar_charge_rate_kw=5.0,  # 5 kW max charge rate
+            charge_efficiency=0.9,  # 90% efficiency
+        )
+        # One slot with huge surplus (10 kWh) but rate limited
+        slots = [
+            SlotContext(
+                slot_index=0,
+                slot_interval_minutes=30,  # 0.5 hours
+                timestamp_iso="2024-01-01T00:00:00+00:00",
+                buy_price=30.0,
+                sell_price=10.0,
+                solar_kwh=10.0,  # Huge surplus on paper
+                consumption_kwh=0.0,  # No consumption
+                is_demand_window_slot=False,
+            )
+        ]
+
+        # At 50% SOC, need 30% = 3 kWh
+        # Raw calculation: 10 kWh > 3 kWh → TRUE (but wrong due to rate limit)
+        # Realistic: 5 kW * 0.5h * 0.9 = 2.25 kWh < 3 kWh → FALSE
+        result = check_global_solar_sufficiency(50.0, 0, slots, config)
+        # This test will FAIL with the current implementation (returns True)
+        # and PASS after the fix (returns False)
+        assert result is False
+
+    def test_multiple_slots_rate_limited_returns_false(self):
+        """Returns False when rate limits prevent capturing multi-slot solar.
+
+        Scenario:
+        - Battery: 10 kWh, 50% SOC, target 80% (need 3 kWh)
+        - 4 slots with 2 kWh surplus each (8 kWh total on paper)
+        - Charge rate: 5 kW, efficiency 90%
+        - Per slot: 5 kW * 0.5h * 0.9 = 2.25 kWh max capture
+
+        Raw: 8 kWh > 3 kWh → TRUE
+        Realistic: 4 * 2.25 = 9 kWh but... wait, 2 kWh per slot < 2.25 max
+        So realistic should be: 4 * 2 * 0.9 = 7.2 kWh > 3 kWh → TRUE
+
+        This test validates that realistic simulation works correctly.
+        """
+        from custom_components.localshift.engine.constraints import (
+            check_global_solar_sufficiency,
+        )
+
+        config = OptimizerConfig(
+            battery_capacity_kwh=10.0,
+            demand_window_target_soc_pct=80.0,
+            solar_charge_rate_kw=5.0,
+            charge_efficiency=0.9,
+        )
+        # 4 slots with moderate surplus
+        slots = [
+            SlotContext(
+                slot_index=i,
+                slot_interval_minutes=30,
+                timestamp_iso="2024-01-01T00:00:00+00:00",
+                buy_price=30.0,
+                sell_price=10.0,
+                solar_kwh=2.0,  # 2 kWh surplus each
+                consumption_kwh=0.0,
+                is_demand_window_slot=False,
+            )
+            for i in range(4)
+        ]
+
+        # 4 * 2 kWh * 0.9 = 7.2 kWh > 3 kWh → should be TRUE
+        result = check_global_solar_sufficiency(50.0, 0, slots, config)
+        assert result is True
+
+    def test_efficiency_loss_reduces_effective_gain(self):
+        """Returns False when efficiency loss makes solar insufficient.
+
+        Scenario:
+        - Battery: 10 kWh, 30% SOC, target 80% (need 5 kWh)
+        - 3 slots with 2 kWh surplus each (6 kWh on paper)
+        - Efficiency: 80% (10% loss)
+        - Realistic: 3 * 2 * 0.8 = 4.8 kWh < 5 kWh → FALSE
+        """
+        from custom_components.localshift.engine.constraints import (
+            check_global_solar_sufficiency,
+        )
+
+        config = OptimizerConfig(
+            battery_capacity_kwh=10.0,
+            demand_window_target_soc_pct=80.0,
+            solar_charge_rate_kw=10.0,  # High enough to not limit
+            charge_efficiency=0.8,  # 80% efficiency
+        )
+        slots = [
+            SlotContext(
+                slot_index=i,
+                slot_interval_minutes=30,
+                timestamp_iso="2024-01-01T00:00:00+00:00",
+                buy_price=30.0,
+                sell_price=10.0,
+                solar_kwh=2.0,
+                consumption_kwh=0.0,
+                is_demand_window_slot=False,
+            )
+            for i in range(3)
+        ]
+
+        # At 30% SOC, need 50% = 5 kWh
+        # Raw: 6 kWh > 5 kWh → TRUE
+        # Realistic: 6 * 0.8 = 4.8 kWh < 5 kWh → FALSE
+        result = check_global_solar_sufficiency(30.0, 0, slots, config)
+        assert result is False
+
 
 class TestIsCheapImportWindow:
     """Test _is_cheap_import_window helper."""

--- a/tests/test_optimizer_dp_solve.py
+++ b/tests/test_optimizer_dp_solve.py
@@ -1553,35 +1553,40 @@ def test_global_solar_gate_allows_charge_when_solar_insufficient():
 
 
 # ---------------------------------------------------------------------------
-# Issue #638: Global Solar Gate Uses Net Instead of Surplus
+# Issue #701: Global Solar Gate Uses Realistic Simulation
 # ---------------------------------------------------------------------------
 
 
-def test_global_solar_sufficiency_uses_surplus_not_net():
-    """Issue #638: Gate should use SURPLUS (max(0, solar-consumption)), not NET.
+def test_global_solar_sufficiency_uses_realistic_simulation():
+    """Issue #701: Gate should use realistic simulation with rate limits and efficiency.
 
-    The bug: overnight slots with consumption>0 have negative net, which drags
-    down the total even when daytime solar is abundant. The gate returns False
-    when it should return True.
+    The bug (Issue #638 regression): the gate used raw surplus without accounting
+    for charge rate limits and efficiency losses. This incorrectly blocked cheap
+    grid charging when solar couldn't actually reach the target.
 
-    Example:
-    - 8 overnight slots: solar=0, consumption=0.3 kWh → net=-0.3, surplus=0
-    - 8 daytime slots: solar=1.0, consumption=0.2 kWh → net=0.8, surplus=0.8
-    - Total net: 8*(-0.3) + 8*0.8 = -2.4 + 6.4 = 4.0 kWh
-    - Total surplus: 8*0 + 8*0.8 = 6.4 kWh
+    This test verifies the realistic simulation:
+    - Overnight consumption depletes the battery
+    - Daytime solar has enough surplus to recover AND reach target
+    - Realistic simulation accounts for efficiency losses
 
-    With NET formula: 4.0 kWh / 13.5 * 100 = 29.6% gain
-    With SURPLUS formula: 6.4 kWh / 13.5 * 100 = 47.4% gain
+    Scenario:
+    - Start at 60% SOC, target 80% (need 20% = 2.7 kWh)
+    - 8 overnight slots: 0.2 kWh consumption each = 1.6 kWh total discharge
+    - 8 daytime slots: 1.8 kWh surplus each = 14.4 kWh total surplus
+    - With 90% efficiency: 14.4 * 0.9 = 12.96 kWh effective charge
 
-    For 30% deficit: NET formula says 29.6% < 30% → gate FALSE (wrong!)
-                      SURPLUS formula says 47.4% > 30% → gate TRUE (correct!)
+    Realistic simulation:
+    - Overnight: SOC drops by 1.6 / 13.5 * 100 = 11.9% → 48.1%
+    - Daytime: SOC rises by 12.96 / 13.5 * 100 = 96% → capped at 100%
+
+    Since 100% >= 80% target, result should be TRUE.
     """
     overnight = [
-        _make_slot(slot_index=i, buy_price=0.08, solar_kwh=0.0, consumption_kwh=0.3)
+        _make_slot(slot_index=i, buy_price=0.08, solar_kwh=0.0, consumption_kwh=0.2)
         for i in range(8)
     ]
     daytime = [
-        _make_slot(slot_index=i + 8, buy_price=0.08, solar_kwh=1.0, consumption_kwh=0.2)
+        _make_slot(slot_index=i + 8, buy_price=0.08, solar_kwh=2.0, consumption_kwh=0.2)
         for i in range(8)
     ]
     slots = overnight + daytime
@@ -1592,12 +1597,56 @@ def test_global_solar_sufficiency_uses_surplus_not_net():
         effective_cheap_price=0.10,
         optimization_mode="self_consumption",
         soc_bins=20,
+        charge_efficiency=0.9,
+        discharge_efficiency=0.95,
     )
 
-    result = DPPlanner._check_global_solar_sufficiency(50.0, 0, slots, config)
+    result = DPPlanner._check_global_solar_sufficiency(60.0, 0, slots, config)
     assert result is True, (
-        "Gate should return True when solar SURPLUS covers deficit, "
-        "even if NET is reduced by overnight consumption"
+        "Gate should return True when realistic simulation reaches target"
+    )
+
+
+def test_global_solar_sufficiency_realistic_returns_false_when_insufficient():
+    """Issue #701: Gate should return False when rate limits prevent reaching target.
+
+    This test verifies that realistic simulation correctly handles rate limits.
+    Even with abundant surplus, if charge rate limits prevent capturing enough,
+    the gate should return False.
+
+    Scenario:
+    - Start at 30% SOC, target 80% (need 50% = 6.75 kWh)
+    - 4 daytime slots: 10 kWh surplus each = 40 kWh raw surplus
+    - But charge rate of 5 kW = 2.5 kWh max per 30-min slot
+    - Per slot: min(10, 2.5) * 0.9 = 2.25 kWh captured
+    - Total captured: 4 * 2.25 = 9 kWh
+
+    Realistic: 9 kWh > 6.75 kWh needed → TRUE (enough despite rate limit)
+
+    But if we need more (e.g., start at 20% → need 60% = 8.1 kWh):
+    - 9 kWh > 8.1 kWh → still TRUE
+
+    Let's make it fail: start at 10%, target 80% (need 70% = 9.45 kWh)
+    - 9 kWh < 9.45 kWh → FALSE
+    """
+    daytime = [
+        _make_slot(slot_index=i, buy_price=0.08, solar_kwh=10.0, consumption_kwh=0.0)
+        for i in range(4)
+    ]
+
+    config = OptimizerConfig(
+        battery_capacity_kwh=13.5,
+        demand_window_target_soc_pct=80.0,
+        effective_cheap_price=0.10,
+        optimization_mode="self_consumption",
+        soc_bins=20,
+        charge_efficiency=0.9,
+        solar_charge_rate_kw=5.0,
+    )
+
+    result = DPPlanner._check_global_solar_sufficiency(10.0, 0, daytime, config)
+    assert result is False, (
+        "Gate should return False when rate limits prevent reaching target"
     )
 
 


### PR DESCRIPTION
## Summary
Fixes a regression from Issue #638 where the `_check_global_solar_sufficiency` gate used raw solar surplus without accounting for charge rate limits and efficiency losses, incorrectly blocking cheap grid charging.

## Changes
- `constraints.py` and `core.py`: Use `_simulate_solar_only_terminal_soc()` for realistic simulation
- Ensures consistency with `solar_can_reach_target` sensor
- Added 5 new tests covering rate limits and efficiency scenarios

## Testing
- ✅ All 1902 tests pass
- ✅ Coverage: constraints.py 98%, core.py 98%, dp_math.py 99%
- ✅ Ruff lint clean

Fixes #701