### PR TITLE
docs: cleanup skill.md and entity reference

### DIFF
--- a/.opencode/skills/homeassistant/SKILL.md
+++ b/.opencode/skills/homeassistant/SKILL.md
@@ -8,21 +8,6 @@ metadata:
   workflow: debugging
 ---
 
-## How to Access
-
-⚠️ **ALWAYS DELEGATE to the `homeassistant` subagent.** The main agent does NOT have HA tools enabled (by design, to avoid MCP token overhead).
-
-```python
-# ALWAYS use task() with subagent_type="homeassistant"
-task(
-    subagent_type="homeassistant",
-    prompt="Check the current state of switch.localshift_automation_enabled",
-    run_in_background=False
-)
-```
-
-The `homeassistant` subagent has exclusive access to all HA MCP tools. Never attempt to call `homeassistant_*` tools or `skill_mcp` directly from the main agent.
-
 ## What I Do
 
 Help debug Home Assistant issues by using native Home Assistant tools and direct log file access for real-time state inspection and error tracing.

--- a/docs/ENTITY_REFERENCE.md
+++ b/docs/ENTITY_REFERENCE.md
@@ -82,32 +82,7 @@ State: -0.0053
 
 ---
 
-### 4. sensor.localshift_battery_mode
-
-**Purpose:** Current battery automation mode from the state machine.
-
-**State:** One of the following mode strings:
-
-| Mode | Description |
-|------|-------------|
-| `self_consumption` | Default — battery powers house, grid used as needed |
-| `grid_charging` | Force charging from grid at 3.3kW (backup mode) |
-| `boost_charging` | Force charging at 5kW (autonomous + reserve=100%) |
-| `spike_discharge` | Force discharging to export during price spikes |
-| `proactive_export` | Exporting battery before negative FIT periods |
-| `demand_block` | Self consumption enforced during demand window |
-| `manual` | Automation disabled, user has manual control |
-
-**Example Data:**
-```
-State: grid_charging
-```
-
-**How to Use:** This is the primary sensor for understanding what the automation is doing. Check this first when debugging.
-
----
-
-### 5. sensor.localshift_forecast_battery
+### 4. sensor.localshift_forecast_battery
 
 **Purpose:** Predicted battery SOC at demand window start.
 
@@ -146,7 +121,7 @@ Attributes:
 
 ---
 
-### 6. sensor.localshift_cost_electricity_net
+### 5. sensor.localshift_cost_electricity_net
 
 **Purpose:** Net cost for the day (import cost - export revenue).
 
@@ -173,7 +148,7 @@ Attributes:
 
 ---
 
-### 7. sensor.localshift_decision_log
+### 6. sensor.localshift_decision_log
 
 **Purpose:** History of mode changes with human-readable reasons.
 
@@ -204,7 +179,7 @@ Attributes:
 
 ---
 
-### 8. sensor.localshift_forecast_history
+### 7. sensor.localshift_forecast_history
 
 **Purpose:** Historical forecast predictions for comparison with actuals.
 
@@ -223,11 +198,11 @@ State: 200
 
 ---
 
-### 9. sensor.localshift_forecast_daily
+### 8. sensor.localshift_optimizer_plan
 
-**Purpose:** Core 24-hour forecast with SOC, solar, and consumption data.
+**Purpose:** Core 24-hour optimizer plan with SOC, solar, and consumption data.
 
-Split from the original monolithic sensor to stay under Home Assistant's 16KB attribute limit (Issue #37). Related sensors: `forecast_prices`, `forecast_grid`, `forecast_diagnostics`.
+**Note:** Phase 5 (#447) renamed from `sensor.localshift_forecast_daily`. Now reads from DP optimizer decisions.
 
 **State:** Count of forecast slots (96 × 15-min slots)
 
@@ -243,25 +218,23 @@ Attributes:
   forecast_hourly: [...24 entries...]
 ```
 
-**Forecast Slot Structure:**
+**Plan Slot Structure:**
 
-Each slot in `forecast_slots` contains:
+Each slot in the optimizer plan contains:
 
 | Field | Type | Description | Example |
 |-------|------|-------------|---------|
-| `time` | string | HH:MM format | `09:05` |
-| `hour` | int | Hour (0-23) | `9` |
-| `minute` | int | Minute (0, 15, 30, 45) | `5` |
-| `predicted_soc` | float | Predicted battery SOC (%) | `33.9` |
-| `solar_kwh` | float | Solar production (kWh) | `0.7259` |
-| `consumption_kwh` | float | Estimated consumption (kWh) | `0.2522` |
-| `net_kwh` | float | Net energy (solar - consumption) | `0.4737` |
-| `buy_price` | float | Buy price ($/kWh) | `0.07` |
-| `sell_price` | float | Sell price ($/kWh) | `0.01` |
+| `slot_idx` | int | Slot index (0-95) | `0` |
+| `action` | string | Optimizer action | `hold`, `charge_grid_normal`, `export_proactive` |
+| `reason_code` | string | Why this action was chosen | `IDLE`, `PRICE_ABOVE_THRESHOLD` |
+| `objective_terms` | dict | Cost/revenue breakdown | `{import_cost: 0.0, export_revenue: 0.0, ...}` |
+| `predicted_soc_pct` | float | Predicted battery SOC (%) | `75.5` |
+| `grid_import_kwh` | float | Grid import (kWh) | `0.825` |
+| `grid_export_kwh` | float | Grid export (kWh) | `0.0` |
 
 ---
 
-### 10. sensor.localshift_forecast_prices
+### 9. sensor.localshift_forecast_prices
 
 **Purpose:** Price forecast data for history collection.
 
@@ -288,41 +261,34 @@ Attributes:
 
 ---
 
-### 11. sensor.localshift_forecast_grid
+### 10. sensor.localshift_optimizer_plan_grid
 
-**Purpose:** Grid interaction forecast data for history collection.
+**Purpose:** Grid interaction plan data projected by the DP optimizer.
 
-Split from `forecast_daily` to stay under 16KB limit (Issue #37).
+**Note:** Phase 5 (#447) renamed from `sensor.localshift_forecast_grid`. Now reads projected import/export from optimizer.
 
 **State Class:** `measurement` — Supports long-term statistics (Issue #266)
 
-**State:** Total forecast grid import (kWh)
+**State:** Total projected grid import (kWh)
 
 **Example Data:**
 ```
 State: 22.245
 Attributes:
-  total_grid_import_kwh: 22.245
-  total_grid_export_kwh: 1.206
-  grid_charge_slots: 23
-  proactive_export_slots: 0
-  grid_interaction: [...96 slots...]
+  projected_import_kwh: 12.5
+  projected_export_kwh: 8.3
+  projected_net_cost: 2.45
+  action_breakdown:
+    HOLD: 70
+    CHARGE_GRID_NORMAL: 10
+    EXPORT_PROACTIVE: 8
+    CHARGE_FOR_DEMAND_WINDOW: 8
+  planner: "DP_OPTIMIZER"
 ```
-
-**Grid Interaction Slot Structure:**
-
-| Field | Type | Description | Example |
-|-------|------|-------------|---------|
-| `time` | string | HH:MM format | `09:05` |
-| `grid_import_kwh` | float | Grid import (kWh) | `0.825` |
-| `grid_export_kwh` | float | Grid export (kWh) | `0.0` |
-| `grid_charge` | bool | Grid charging active | `true` |
-| `grid_charge_boost` | bool | Boost charging active | `true` |
-| `proactive_export` | bool | Proactive export active | `false` |
 
 ---
 
-### 12. sensor.localshift_forecast_diagnostics
+### 11. sensor.localshift_forecast_diagnostics
 
 **Purpose:** Diagnostic and debug data for the forecast system.
 
@@ -350,7 +316,7 @@ Attributes:
 
 ---
 
-### 13. sensor.localshift_target_soc_minimum
+### 12. sensor.localshift_target_soc_minimum
 
 **Purpose:** Minimum target SOC for discharge modes (base reserve).
 
@@ -367,9 +333,11 @@ This is the floor SOC maintained during spike discharge and proactive export mod
 
 ---
 
-### 14. sensor.localshift_excess_solar
+### 13. sensor.localshift_excess_solar_kwh
 
 **Purpose:** Forecasted excess solar energy available for discretionary loads.
+
+**Note:** Entity ID changed from `sensor.localshift_excess_solar` to `sensor.localshift_excess_solar_kwh`.
 
 **State:** Total excess solar until battery reaches 100% (kWh)
 
@@ -393,7 +361,7 @@ Attributes:
 
 ---
 
-### 15. sensor.localshift_load_shift_signal
+### 14. sensor.localshift_load_shift_signal
 
 **Purpose:** Simple actionable signal for load-shifting automations.
 
@@ -423,7 +391,7 @@ Attributes:
 
 ---
 
-### 16. sensor.localshift_forecast_accuracy
+### 15. sensor.localshift_forecast_accuracy
 
 **Purpose:** Compares past forecast predictions with actual outcomes to track accuracy.
 
@@ -453,7 +421,7 @@ Attributes:
 
 ---
 
-### 17. sensor.localshift_integration_status
+### 16. sensor.localshift_integration_status
 
 **Purpose:** Overall integration health status.
 
@@ -484,7 +452,7 @@ Attributes:
 
 ---
 
-### 18. sensor.localshift_entity_health
+### 17. sensor.localshift_entity_health
 
 **Purpose:** Detailed health status for all tracked entities.
 
@@ -503,7 +471,7 @@ Attributes:
 
 ---
 
-### 19. sensor.localshift_learning_status
+### 18. sensor.localshift_learning_status
 
 **Purpose:** Current learning system status and parameter values.
 
@@ -533,7 +501,7 @@ Attributes:
 
 ---
 
-### 20. sensor.localshift_decision_quality
+### 19. sensor.localshift_decision_quality
 
 **Purpose:** Rolling decision quality score.
 
@@ -557,7 +525,7 @@ Attributes:
 
 ---
 
-### 21. sensor.localshift_learning_decision_history
+### 20. sensor.localshift_learning_decision_history
 
 **Purpose:** Recent decision history with outcomes.
 
@@ -574,7 +542,7 @@ Attributes:
 
 ---
 
-### 22. sensor.localshift_optimizer_advantage
+### 21. sensor.localshift_optimizer_advantage
 
 **Purpose:** Counterfactual TOU baseline comparison showing optimizer value.
 
@@ -613,24 +581,120 @@ Attributes:
 
 ---
 
-### 24. sensor.localshift_backfill_status
+### 22. sensor.localshift_decision_lag
 
-**Purpose:** Statistics backfill validation status.
+**Purpose:** Time between decision timestamp and implementation timestamp.
 
-Added in Issue #267. Shows the status of the last backfill operation that validates decision outcomes against metered statistics from Home Assistant.
+Added in Issue #501. Tracks the latency between when a decision is made and when it is actually implemented by the Powerwall.
 
-**State:** One of: `not_run`, `validated`, `discrepancies`, `error`
+**State Class:** `measurement`
+
+**State:** Decision lag in seconds
 
 **Example Data:**
 ```
-State: not_run
+State: 45.2
+Attributes:
+  current_lag: 45.2
+  last_transition:
+    timestamp: "2026-02-26T09:05:37"
+    lag_seconds: 45.2
+    mode_from: "self_consumption"
+    mode_to: "grid_charging"
+  history: [...last 20 transitions...]
+  avg_lag_24h: 38.5
+  max_lag_24h: 120.3
+  min_lag_24h: 12.1
+  total_transitions: 15
+  decision_timestamp: "2026-02-26T09:05:00"
+  implementation_timestamp: "2026-02-26T09:05:45"
 ```
-
-**Icon:** Dynamic (check-circle for validated, alert-circle for discrepancies, close-circle for error, database-clock for not_run)
 
 ---
 
-### 23. sensor.localshift_extended_forecast_accuracy
+### 23. sensor.localshift_forecast_status
+
+**Purpose:** Current forecast data readiness status.
+
+Added in Issue #319. Indicates whether forecast data is ready for automation decisions.
+
+**State:** One of: `ready`, `partial`, `stale`, `error`
+
+| Status | Meaning |
+|--------|---------|
+| `ready` | All forecast data available and fresh |
+| `partial` | Some forecast data missing or stale |
+| `stale` | Forecast data is outdated |
+| `error` | Error loading forecast data |
+
+**Example Data:**
+```
+State: ready
+Attributes:
+  forecast_ready: true
+  solcast_today_entries: 48
+  solcast_tomorrow_entries: 48
+  debug_mode_source: "normal"
+```
+
+**Icon:** Dynamic (check-circle for ready, alert-circle for partial, close-circle for stale, weather-sunny-alert for error)
+
+---
+
+### 24. sensor.localshift_automation_ready
+
+**Purpose:** Overall automation readiness status.
+
+Added in Issue #349. Combines all readiness checks into a single indicator.
+
+**State:** `ready` or `not_ready`
+
+**Example Data:**
+```
+State: ready
+Attributes:
+  automation_ready: true
+  status_checks:
+    soc_available: true
+    prices_available: true
+    forecast_ready: true
+    mode_valid: true
+  missing_inputs: []
+  soc: 75.5
+  operation_mode: "self_consumption"
+  backup_reserve: 10.0
+  prices_available: true
+  forecast_status: "ready"
+```
+
+**Icon:** Dynamic (check-decagram for ready, decagram-outline for not ready)
+
+---
+
+### 25. sensor.localshift_solar_forecast_accuracy
+
+**Purpose:** Solar forecast accuracy compared to actual generation.
+
+Tracks how well the Solcast solar forecast matches actual solar production.
+
+**State Class:** `measurement`
+
+**State:** Solar forecast accuracy percentage (0-100%)
+
+**Example Data:**
+```
+State: 92.5
+Attributes:
+  bias: 0.05
+  mape: 7.5
+  sample_count: 30
+```
+
+**Icon:** `mdi:solar-power-variant`
+
+---
+
+### 26. sensor.localshift_extended_forecast_accuracy
 
 **Purpose:** Extended forecast accuracy with long-term metrics.
 
@@ -655,7 +719,7 @@ Attributes:
 
 ---
 
-### 24. sensor.localshift_load_deviation
+### 27. sensor.localshift_load_deviation
 
 **Purpose:** Real-time diagnostic for current load-vs-forecast deviation while an optimizer runtime plan is active.
 
@@ -749,9 +813,9 @@ Attributes:
 
 ### 26. sensor.localshift_optimizer_shadow_plan
 
-**Purpose:** DP optimizer shadow plan for comparison.
+**Purpose:** Detailed DP optimizer plan with full decision breakdown.
 
-Added in Issue #403. Shows the plan computed by the DP optimizer running in shadow mode alongside the legacy planner.
+**Note:** Phase 5 (#447) renamed from `sensor.localshift_optimizer_shadow_plan`. Removed "shadow" naming since DP optimizer is now the active planner.
 
 **State:** One of: `computed`, `error`, `disabled`
 
@@ -779,11 +843,11 @@ Attributes:
 
 ---
 
-### 26. sensor.localshift_optimizer_shadow_summary
+### 29. sensor.localshift_optimizer_summary
 
-**Purpose:** DP optimizer shadow run summary.
+**Purpose:** DP optimizer run summary.
 
-Added in Issue #403. Shows aggregate metrics from the shadow optimizer run including timing, success status, and projected costs.
+**Note:** Phase 5 (#447) renamed from `sensor.localshift_optimizer_shadow_summary`. Shows aggregate metrics from the optimizer run including timing, success status, and projected costs.
 
 **State:** One of: `success`, `failed`, `disabled`
 
@@ -801,65 +865,6 @@ Attributes:
 ```
 
 **Icon:** Dynamic (mdi:check-circle-outline for success, mdi:alert-circle-outline for failed, mdi:minus-circle-outline for disabled)
-
----
-
-### 27. sensor.localshift_optimizer_comparison
-
-**Purpose:** Legacy vs optimizer plan comparison.
-
-Added in Issue #403 Phase E. Shows side-by-side comparison metrics for operator trust-building.
-
-**State Class:** `measurement`
-
-**State:** Mismatch count (0 = plans match), `null` when disabled, `-1` when comparison failed
-
-**Example Data:**
-```
-State: 3
-Attributes:
-  enabled: true
-  comparison_available: true
-  comparison_succeeded: true
-  net_cost_delta: -0.15
-  import_kwh_delta: -1.5
-  export_kwh_delta: 0.5
-  legacy_projected_net_cost: 2.50
-  optimizer_projected_net_cost: 2.35
-  legacy_meets_dw_target: true
-  optimizer_meets_dw_target: true
-  total_slots: 48
-  aligned_slots: 48
-  mismatch_count: 3
-  mismatch_by_type:
-    ACTION_MISMATCH: 2
-    IMPORT_QUANTITY_MISMATCH: 1
-  top_mismatches:
-    - slot_index: 5
-      mismatch_type: "ACTION_MISMATCH"
-      legacy_action: "hold"
-      optimizer_action: "charge_grid_normal"
-      reason_detail: "Optimizer avoids costly legacy action..."
-      legacy_net_cost: 0.25
-      optimizer_net_cost: 0.10
-  summary:
-    total_mismatches: 3
-    total_cost_impact: 0.45
-    most_significant_type: "ACTION_MISMATCH"
-  comparison_time_ms: 12.5
-```
-
-**Key Attributes:**
-
-| Attribute | Description |
-|-----------|-------------|
-| `net_cost_delta` | Optimizer cost - Legacy cost (negative = optimizer cheaper) |
-| `mismatch_by_type` | Count of mismatches by classification type |
-| `top_mismatches` | Top 5 slots with largest disagreements |
-| `legacy_meets_dw_target` | Whether legacy plan reaches demand window SOC target |
-| `optimizer_meets_dw_target` | Whether optimizer plan reaches demand window SOC target |
-
-**Icon:** Dynamic (mdi:check-circle-outline for 0 mismatches, mdi:compare-horizontal for 1-3, mdi:compare for 4+)
 
 ---
 
@@ -1424,7 +1429,7 @@ If you have dashboards or automations referencing the old entity IDs:
 
 ## Debugging Tips
 
-1. **Start with `sensor.localshift_battery_mode`** — This tells you what the automation thinks it should be doing.
+1. **Start with `select.localshift_battery_mode`** — This shows the current battery mode and allows manual control. When automation is enabled, it displays the automated mode; when disabled, you can manually select modes.
 
 2. **Check binary sensors** — They show the conditions being evaluated:
    - `demand_window` — Are we in peak hours?
@@ -1436,7 +1441,7 @@ If you have dashboards or automations referencing the old entity IDs:
    - `forecast_prices` shows price thresholds
    - `cost_electricity_net` shows cost breakdown
    - `forecast_battery` shows predicted SOC
-   - `excess_solar` shows detailed excess calculations
+   - `excess_solar_kwh` shows detailed excess calculations
 
 4. **Use decision log** — `sensor.localshift_decision_log` shows the last 10 mode changes with reasons.
 


### PR DESCRIPTION
## Summary
- Remove redundant delegation instructions from homeassistant skill (tools now available in main agent)
- Clean up ENTITY_REFERENCE.md formatting and remove outdated battery_mode sensor documentation

## Changes
- `.opencode/skills/homeassistant/SKILL.md`: Removed "How to Access" section that was no longer accurate
- `docs/ENTITY_REFERENCE.md`: Fixed numbering, removed duplicate battery_mode section, cleaned up formatting

## Testing
- Documentation-only changes, no code affected