### PR TITLE
fix: Exclude decisions attribute from recorder to avoid 16KB limit

### DIFF
--- a/custom_components/localshift/sensors/optimizer.py
+++ b/custom_components/localshift/sensors/optimizer.py
@@ -14,6 +14,7 @@ class OptimizerPlanDetailedSensor(LocalShiftSensorBase):
     _attr_unique_id = "localshift_optimizer_plan_detailed"
     _attr_name = "Optimizer Plan Detailed"
     _attr_icon = "mdi:format-list-bulleted"
+    _unrecorded_attributes = frozenset({"decisions"})
 
     def _update_from_coordinator(self) -> None:
         summary = self.coordinator.data.optimizer_summary or {}

--- a/docs/ENTITY_REFERENCE.md
+++ b/docs/ENTITY_REFERENCE.md
@@ -811,11 +811,13 @@ Attributes:
 
 ---
 
-### 26. sensor.localshift_optimizer_shadow_plan
+### 26. sensor.localshift_optimizer_plan_detailed
 
 **Purpose:** Detailed DP optimizer plan with full decision breakdown.
 
 **Note:** Phase 5 (#447) renamed from `sensor.localshift_optimizer_shadow_plan`. Removed "shadow" naming since DP optimizer is now the active planner.
+
+**Recorder Note (#467):** The `decisions` attribute is excluded from database recording because it can exceed 26KB (larger than the 16KB recorder limit). The attribute remains available in real-time for dashboard charts, but historical queries will not include it. Other attributes (`enabled`, `success`, `total_slots`, `computed_at`) are recorded normally.
 
 **State:** One of: `computed`, `error`, `disabled`
 

--- a/tests/sensors/test_optimizer.py
+++ b/tests/sensors/test_optimizer.py
@@ -141,6 +141,26 @@ class TestOptimizerPlanDetailedSensor:
 
         assert sensor.icon == "mdi:minus-circle-outline"
 
+    def test_unrecorded_attributes_includes_decisions(self):
+        """Test that 'decisions' is excluded from recorder to avoid 16KB limit.
+
+        Issue #467: The decisions array can exceed 26KB, which exceeds the
+        Home Assistant recorder's 16KB attribute limit. By excluding 'decisions'
+        from recording, we ensure:
+        1. The sensor state and other attributes are recorded for history
+        2. The dashboard can still access decisions in real-time
+        3. No "State attributes exceed maximum size" warnings
+        """
+        mock_coordinator, data = create_mock_coordinator_with_data(
+            optimizer_summary={"enabled": True, "success": True}
+        )
+        mock_entry = MagicMock()
+
+        sensor = OptimizerPlanDetailedSensor(mock_coordinator, mock_entry)
+
+        assert hasattr(sensor, "_unrecorded_attributes")
+        assert "decisions" in sensor._unrecorded_attributes
+
 
 class TestOptimizerSummarySensor:
     """Tests for OptimizerSummarySensor."""


### PR DESCRIPTION
## Summary

The `sensor.localshift_optimizer_plan_detailed` sensor's `decisions` attribute can exceed 26KB (53+ slots × ~500 bytes each), which exceeds Home Assistant's 16KB recorder limit. This caused warnings and prevented history from being recorded.

**Fix:** Add `_unrecorded_attributes = frozenset({"decisions"})` to exclude the large decisions array from database recording while keeping it available for real-time dashboard access.

## Related Issue

Closes #467

## Changes

- Added `_unrecorded_attributes = frozenset({"decisions"})` to `OptimizerPlanDetailedSensor`
- Added test verifying the attribute is excluded from recording
- Updated `docs/ENTITY_REFERENCE.md` with recorder note

## Benefits

- ✅ No more "State attributes exceed maximum size" warnings
- ✅ Sensor state and summary attributes now recorded to history
- ✅ Dashboard SOC chart and slot table continue to work (real-time access)
- ✅ Future-proof for #686 (100 SOC bins won't compound the issue)
- ✅ Uses standard Home Assistant pattern (`_unrecorded_attributes`)

## Testing

- [x] TDD: Test written first (fails) → implementation → test passes
- [x] All 2134 tests pass
- [x] Coverage: 98% on modified file (threshold: 95%)
- [x] Ruff linting clean

## Technical Details

The `_unrecorded_attributes` frozenset tells Home Assistant's recorder to skip specific attributes when persisting state to the database. The attributes remain available in real-time via `extra_state_attributes` for dashboard charts and tables.

This is the same pattern used by core integrations like `mobile_app` to exclude large/frequently-changing attributes from recording.