### PR TITLE
fix: Exclude large attributes from recorder (correct sensors)

### DIFF
--- a/custom_components/localshift/sensors/forecast.py
+++ b/custom_components/localshift/sensors/forecast.py
@@ -91,6 +91,7 @@ class OptimizerPlanSensor(LocalShiftSensorBase):
     _attr_unique_id = "localshift_optimizer_plan"
     _attr_name = "Optimizer Plan"
     _attr_icon = "mdi:chart-bar"
+    _unrecorded_attributes = frozenset({"slots"})
 
     def _update_from_coordinator(self) -> None:
         self._attr_native_value = len(self.coordinator.data.optimizer_decisions or [])

--- a/custom_components/localshift/sensors/status.py
+++ b/custom_components/localshift/sensors/status.py
@@ -46,6 +46,13 @@ class EntityHealthSensor(LocalShiftSensorBase):
     _attr_unique_id = "localshift_entity_health"
     _attr_name = "Entity Health"
     _attr_icon = "mdi:heart-pulse"
+    _unrecorded_attributes = frozenset({
+        "entities",
+        "dependencies",
+        "localshift_entities",
+        "errors",
+        "warnings",
+    })
 
     def _update_from_coordinator(self) -> None:
         dep_health = self.coordinator.data.entity_health

--- a/tests/sensors/test_forecast.py
+++ b/tests/sensors/test_forecast.py
@@ -316,6 +316,21 @@ class TestOptimizerPlanSensor:
         assert attrs["forecast_horizon_hours"] == 24
         assert attrs["planner"] == "DP_OPTIMIZER"
 
+    def test_unrecorded_attributes_includes_slots(self):
+        """Test that 'slots' is excluded from recorder to avoid 16KB limit.
+
+        Issue #467: The slots array can exceed 16KB with many slots.
+        """
+        mock_coordinator, data = create_mock_coordinator_with_data(
+            optimizer_decisions=[{"action": "CHARGE"}]
+        )
+        mock_entry = MagicMock()
+
+        sensor = OptimizerPlanSensor(mock_coordinator, mock_entry)
+
+        assert hasattr(sensor, "_unrecorded_attributes")
+        assert "slots" in sensor._unrecorded_attributes
+
 
 class TestForecastPricesSensor:
     """Tests for ForecastPricesSensor."""

--- a/tests/sensors/test_status.py
+++ b/tests/sensors/test_status.py
@@ -92,6 +92,22 @@ class TestEntityHealthSensor:
         assert attrs["summary"]["dependencies"]["total"] == 1
         assert attrs["summary"]["localshift"]["healthy"] == 1
 
+    def test_unrecorded_attributes_excludes_large_dicts(self):
+        """Test that large entity dicts are excluded from recorder.
+
+        Issue #467: Entity health dicts can exceed 16KB limit.
+        """
+        sensor = _sensor(
+            EntityHealthSensor, entity_health={}, localshift_entity_health={}
+        )
+
+        assert hasattr(sensor, "_unrecorded_attributes")
+        assert "entities" in sensor._unrecorded_attributes
+        assert "dependencies" in sensor._unrecorded_attributes
+        assert "localshift_entities" in sensor._unrecorded_attributes
+        assert "errors" in sensor._unrecorded_attributes
+        assert "warnings" in sensor._unrecorded_attributes
+
 
 class TestForecastAccuracySensor:
     def test_update_with_value(self):


### PR DESCRIPTION
## Summary

Fixes the correct sensors that were causing 16KB recorder limit warnings:

- `sensor.localshift_optimizer_plan` - `slots` attribute excluded
- `sensor.localshift_entity_health` - `entities`, `dependencies`, `localshift_entities`, `errors`, `warnings` excluded

The previous PR #716 fixed `optimizer_plan_detailed` but the actual warnings were from these two sensors.

## Related Issue

Closes #467

## Changes

| Sensor | Excluded Attributes |
|--------|---------------------|
| `OptimizerPlanSensor` | `slots` |
| `EntityHealthSensor` | `entities`, `dependencies`, `localshift_entities`, `errors`, `warnings` |

## Testing

- [x] TDD: Tests written for `_unrecorded_attributes` on both sensors
- [x] All 64 tests pass for modified test files
- [x] Coverage: 99% on both modified files
- [x] Ruff linting clean

## Verification

After merging, restart Home Assistant and check logs for the warning:
```
State attributes for sensor.localshift_optimizer_plan exceed maximum size of 16384 bytes
```
Should no longer appear.