### PR TITLE
feat(optimizer): implement bounded first-window negative-FIT avoidance

### DIFF
--- a/custom_components/localshift/const.py
+++ b/custom_components/localshift/const.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from enum import StrEnum
+from typing import Final
 
 # -----------------------------------------------------------------------------
 # Domain
@@ -506,6 +507,16 @@ PROACTIVE_EXPORT_MIN_RESERVE_PERCENT = 4.0
 # Buffer above current SOC for proactive export reserve setting.
 # 5% prevents immediate discharge below reserve threshold.
 PROACTIVE_EXPORT_SOC_BUFFER_PERCENT = 5.0
+
+# -----------------------------------------------------------------------------
+# Negative FIT Avoidance Constants (Issue #719)
+# -----------------------------------------------------------------------------
+
+# Maximum headroom below battery target for negative-FIT avoidance (percentage points)
+MAX_NEGATIVE_FIT_HEADROOM_PCT: Final[float] = 20.0
+
+# Conservative buffer factor for overflow estimates (0.8 = use 80% of forecast)
+NEGATIVE_FIT_OVERFLOW_BUFFER_FACTOR: Final[float] = 0.8
 
 # -----------------------------------------------------------------------------
 # Tesla Override Detection Constants

--- a/custom_components/localshift/engine/constraints.py
+++ b/custom_components/localshift/engine/constraints.py
@@ -7,12 +7,53 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from custom_components.localshift.engine.types import (
+        NegativeFitAvoidanceContext,
         OptimizerConfig,
         PlannerAction,
         SlotContext,
     )
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _determine_export_actions(
+    soc_pct: float,
+    slot: SlotContext,
+    config: OptimizerConfig,
+    slot_idx: int,
+    negative_fit_avoidance_context: NegativeFitAvoidanceContext | None,
+) -> list[PlannerAction]:
+    """Determine export actions based on mode and negative-FIT avoidance context.
+
+    Issue #719: Bounded first-window negative-FIT avoidance.
+    """
+    from custom_components.localshift.engine.types import PlannerAction
+
+    actions = []
+    can_discharge = soc_pct > config.min_soc_pct
+
+    if not can_discharge:
+        return actions
+
+    use_avoidance = (
+        negative_fit_avoidance_context is not None
+        and slot_idx < negative_fit_avoidance_context.first_negative_fit_slot_idx
+    )
+
+    if use_avoidance:
+        if slot.sell_price > 0:
+            if soc_pct > negative_fit_avoidance_context.temporary_floor_pct + 2.0:
+                actions.append(PlannerAction.EXPORT_PROACTIVE)
+    else:
+        if config.optimization_mode == "self_consumption":
+            min_profitable_sell = max(0.0, slot.buy_price) + config.export_price_margin
+            if slot.sell_price >= min_profitable_sell:
+                actions.append(PlannerAction.EXPORT_PROACTIVE)
+        else:
+            if slot.sell_price > 0:
+                actions.append(PlannerAction.EXPORT_PROACTIVE)
+
+    return actions
 
 
 def feasible_actions(
@@ -22,6 +63,7 @@ def feasible_actions(
     slot_idx: int = 0,
     slots: list[SlotContext] | None = None,
     terminal_penalty_idx: int | None = None,
+    negative_fit_avoidance_context: NegativeFitAvoidanceContext | None = None,
 ) -> list[PlannerAction]:
     """Return list of actions feasible from given SOC and slot context.
 
@@ -33,6 +75,7 @@ def feasible_actions(
     - Solar surplus gate: suppresses grid charging when solar will cover
       the full SOC deficit before the demand window (self_consumption mode only)
     - Slot duration vs transfer limits
+    - Negative FIT avoidance (Issue #719)
 
     Args:
         soc_pct: Current battery SOC percentage.
@@ -42,6 +85,7 @@ def feasible_actions(
         slots: Full list of planning slots (None disables solar gate).
         terminal_penalty_idx: Index at which the shortfall penalty is applied
             (None disables solar gate).
+        negative_fit_avoidance_context: Context for bounded pre-discharge (Issue #719).
 
     """
     from custom_components.localshift.engine.types import PlannerAction
@@ -49,28 +93,21 @@ def feasible_actions(
     actions = []
 
     can_charge = soc_pct < config.max_soc_pct
-    can_discharge = soc_pct > config.min_soc_pct
 
     actions.append(PlannerAction.HOLD)
 
-    # Solar surplus gate: if projected solar can cover the full SOC deficit
-    # before the demand window, suppress grid charging entirely.
     _solar_covers_deficit = False
-
-    # Issue #559 Root Cause 1: global solar gate for no-DW scenarios.
     _global_solar_covers = False
     if config.optimization_mode == "self_consumption" and slots is not None:
         _global_solar_covers = check_global_solar_sufficiency(
             soc_pct, slot_idx, slots, config
         )
 
-    # Grid charging constraints (Issue #406)
     if (
         can_charge
         and not slot.is_demand_window_slot
         and not (_solar_covers_deficit or _global_solar_covers)
     ):
-        # In self-consumption mode, only charge if price is cheap
         if config.optimization_mode == "self_consumption":
             price_is_cheap = slot.buy_price <= config.effective_cheap_price
             price_is_very_cheap = slot.buy_price <= config.effective_cheap_price * 0.8
@@ -80,21 +117,14 @@ def feasible_actions(
                 if price_is_very_cheap:
                     actions.append(PlannerAction.CHARGE_GRID_BOOST)
         else:
-            # Arbitrage mode: charge whenever below max (no solar gate)
             actions.append(PlannerAction.CHARGE_GRID_NORMAL)
             actions.append(PlannerAction.CHARGE_GRID_BOOST)
 
-    # Export constraints (Issue #406)
-    if can_discharge:
-        # In self-consumption mode, only export if profitable vs keeping energy for load
-        if config.optimization_mode == "self_consumption":
-            min_profitable_sell = max(0.0, slot.buy_price) + config.export_price_margin
-            if slot.sell_price >= min_profitable_sell:
-                actions.append(PlannerAction.EXPORT_PROACTIVE)
-        else:
-            # Arbitrage mode: export if positive price
-            if slot.sell_price > 0:
-                actions.append(PlannerAction.EXPORT_PROACTIVE)
+    actions.extend(
+        _determine_export_actions(
+            soc_pct, slot, config, slot_idx, negative_fit_avoidance_context
+        )
+    )
 
     return actions
 

--- a/custom_components/localshift/engine/constraints.py
+++ b/custom_components/localshift/engine/constraints.py
@@ -25,7 +25,15 @@ def _determine_export_actions(
 ) -> list[PlannerAction]:
     """Determine export actions based on mode and negative-FIT avoidance context.
 
-    Issue #719: Bounded first-window negative-FIT avoidance.
+    Issue #719: Recoverability-based negative-FIT avoidance.
+
+    Allows proactive export at positive FIT before the risk window when:
+    - SOC is above the recoverability floor + buffer
+    - The slot is before the risk window starts
+    - The slot has positive sell price
+
+    The recoverability floor ensures we only discharge energy that can be
+    recovered via future solar before the deadline, avoiding later grid import.
     """
     from custom_components.localshift.engine.types import PlannerAction
 
@@ -37,12 +45,15 @@ def _determine_export_actions(
 
     use_avoidance = (
         negative_fit_avoidance_context is not None
-        and slot_idx < negative_fit_avoidance_context.first_negative_fit_slot_idx
+        and slot_idx < negative_fit_avoidance_context.risk_window_start_idx
     )
 
     if use_avoidance and negative_fit_avoidance_context is not None:
         if slot.sell_price > 0:
-            if soc_pct > negative_fit_avoidance_context.temporary_floor_pct + 2.0:
+            floor_pct = negative_fit_avoidance_context.recoverability_floor_pct_by_slot[
+                slot_idx
+            ]
+            if soc_pct > floor_pct + 2.0:
                 actions.append(PlannerAction.EXPORT_PROACTIVE)
     else:
         if config.optimization_mode == "self_consumption":

--- a/custom_components/localshift/engine/constraints.py
+++ b/custom_components/localshift/engine/constraints.py
@@ -40,7 +40,7 @@ def _determine_export_actions(
         and slot_idx < negative_fit_avoidance_context.first_negative_fit_slot_idx
     )
 
-    if use_avoidance:
+    if use_avoidance and negative_fit_avoidance_context is not None:
         if slot.sell_price > 0:
             if soc_pct > negative_fit_avoidance_context.temporary_floor_pct + 2.0:
                 actions.append(PlannerAction.EXPORT_PROACTIVE)

--- a/custom_components/localshift/engine/core.py
+++ b/custom_components/localshift/engine/core.py
@@ -87,80 +87,206 @@ class DPPlanner:
     # Negative FIT Avoidance Context Derivation (Issue #719)
     # ------------------------------------------------------------------
 
-    def _derive_negative_fit_avoidance_context(
-        self, inputs: OptimizerInputs
-    ) -> NegativeFitAvoidanceContext | None:
-        """Derive context for bounded first-window negative-FIT avoidance.
+    @staticmethod
+    def _find_risk_window(slots: list) -> tuple[int | None, int | None]:
+        """Find the spill-risk window (first bad-FIT through end of bad window)."""
+        risk_start_idx = None
+        n_slots = len(slots)
 
-        Returns None if any of:
-        - No negative-FIT window within horizon
-        - No conservative overflow projected
-        - No earlier positive-FIT slots
-        """
+        for idx, slot in enumerate(slots):
+            if slot.sell_price <= 0:
+                risk_start_idx = idx
+                break
+
+        if risk_start_idx is None:
+            return None, None
+
+        risk_end_idx = risk_start_idx
+        for idx in range(risk_start_idx, n_slots):
+            if slots[idx].sell_price <= 0:
+                risk_end_idx = idx
+            else:
+                break
+
+        return risk_start_idx, risk_end_idx
+
+    @staticmethod
+    def _compute_required_headroom(
+        slots: list, risk_start_idx: int, risk_end_idx: int, charge_efficiency: float
+    ) -> float:
+        """Compute storage needed to absorb spill during risk window."""
         from custom_components.localshift.const import (
-            MAX_NEGATIVE_FIT_HEADROOM_PCT,
             NEGATIVE_FIT_OVERFLOW_BUFFER_FACTOR,
         )
 
-        slots = inputs.slots
-        config = inputs.config
-        battery_capacity_kwh = config.battery_capacity_kwh
-
-        # 1. Find first negative-FIT slot (sell_price <= 0)
-        first_negative_fit_idx = None
-        for idx, slot in enumerate(slots):
-            if slot.sell_price <= 0:
-                first_negative_fit_idx = idx
-                break
-        if first_negative_fit_idx is None:
-            return None
-
-        # 2. Check there is at least one earlier positive-FIT slot
-        has_positive_before = any(
-            s.sell_price > 0 for s in slots[:first_negative_fit_idx]
-        )
-        if not has_positive_before:
-            return None
-
-        # 3. Compute conservative overflow before that window
-        target_kwh = config.demand_window_target_soc_pct / 100.0 * battery_capacity_kwh
-        current_kwh = inputs.initial_soc_pct / 100.0 * battery_capacity_kwh
-        space_to_target_kwh = max(target_kwh - current_kwh, 0)
-
-        accumulated_excess_kwh = 0.0
-        for idx in range(first_negative_fit_idx):
+        required_headroom_kwh = 0.0
+        for idx in range(risk_start_idx, risk_end_idx + 1):
             slot = slots[idx]
             net_kwh = slot.solar_kwh - slot.consumption_kwh
             if net_kwh > 0:
-                excess_kwh = net_kwh * config.charge_efficiency
-                if space_to_target_kwh > 0:
-                    used = min(excess_kwh, space_to_target_kwh)
-                    space_to_target_kwh -= used
-                else:
-                    accumulated_excess_kwh += excess_kwh
+                required_headroom_kwh += net_kwh * charge_efficiency
 
-        if accumulated_excess_kwh <= 0:
+        return required_headroom_kwh * NEGATIVE_FIT_OVERFLOW_BUFFER_FACTOR
+
+    @staticmethod
+    def _compute_recovery_by_slot(
+        slots: list, recovery_deadline_idx: int, charge_efficiency: float
+    ) -> list[float]:
+        """Precompute conservative recovery potential from each slot to deadline."""
+        recovery_by_slot = []
+        for slot_idx in range(len(slots)):
+            recoverable_kwh = 0.0
+            for future_idx in range(slot_idx + 1, recovery_deadline_idx + 1):
+                future_slot = slots[future_idx]
+                net_kwh = future_slot.solar_kwh - future_slot.consumption_kwh
+                if net_kwh > 0:
+                    recoverable_kwh += net_kwh * charge_efficiency * 0.8
+            recovery_by_slot.append(recoverable_kwh)
+        return recovery_by_slot
+
+    @staticmethod
+    def _compute_floor_by_slot(
+        n_slots: int,
+        current_kwh: float,
+        target_kwh: float,
+        min_floor_kwh: float,
+        battery_capacity_kwh: float,
+        recovery_by_slot: list[float],
+    ) -> list[float]:
+        """Precompute recoverability floor for each slot."""
+        floor_by_slot = []
+        for slot_idx in range(n_slots):
+            recoverable_kwh = recovery_by_slot[slot_idx]
+
+            max_discharge_kwh = min(
+                current_kwh - min_floor_kwh,
+                recoverable_kwh,
+            )
+            max_discharge_kwh = max(max_discharge_kwh, 0.0)
+
+            floor_kwh = current_kwh - max_discharge_kwh
+            floor_kwh = max(floor_kwh, min_floor_kwh)
+            floor_kwh = min(floor_kwh, target_kwh)
+
+            floor_pct = floor_kwh / battery_capacity_kwh * 100.0
+            floor_by_slot.append(floor_pct)
+        return floor_by_slot
+
+    def _derive_negative_fit_avoidance_context(
+        self, inputs: OptimizerInputs
+    ) -> NegativeFitAvoidanceContext | None:
+        """Derive context for recoverability-based negative-FIT avoidance.
+
+        The planner may proactively discharge at positive FIT before a bad-price
+        spill window when conservative future solar can still recover the battery
+        to target by the relevant deadline.
+
+        Returns None if any of:
+        - No negative-FIT window within horizon
+        - No earlier positive-FIT slots
+        - No recovery path to target (cannot safely pre-discharge)
+        """
+        slots = inputs.slots
+        config = inputs.config
+        battery_capacity_kwh = config.battery_capacity_kwh
+        n_slots = len(slots)
+
+        if n_slots == 0:
             return None
 
-        conservative_overflow_kwh = (
-            accumulated_excess_kwh * NEGATIVE_FIT_OVERFLOW_BUFFER_FACTOR
+        risk_start_idx, risk_end_idx = self._find_risk_window(slots)
+        if risk_start_idx is None or risk_end_idx is None:
+            return None
+
+        has_positive_before = any(s.sell_price > 0 for s in slots[:risk_start_idx])
+        if not has_positive_before:
+            return None
+
+        required_headroom_kwh = self._compute_required_headroom(
+            slots, risk_start_idx, risk_end_idx, config.charge_efficiency
+        )
+        if required_headroom_kwh <= 0:
+            return None
+
+        target_kwh = config.demand_window_target_soc_pct / 100.0 * battery_capacity_kwh
+        current_kwh = inputs.initial_soc_pct / 100.0 * battery_capacity_kwh
+        existing_headroom_kwh = max(target_kwh - current_kwh, 0.0)
+
+        if existing_headroom_kwh >= required_headroom_kwh:
+            return None
+
+        recovery_deadline_idx = None
+        for idx, slot in enumerate(slots):
+            if slot.is_demand_window_slot:
+                recovery_deadline_idx = idx
+                break
+        if recovery_deadline_idx is None:
+            recovery_deadline_idx = n_slots - 1
+
+        recovery_by_slot = self._compute_recovery_by_slot(
+            slots, recovery_deadline_idx, config.charge_efficiency
         )
 
-        # 4. Derive allowed headroom (percentage points)
-        allowed_headroom_pct = min(
-            conservative_overflow_kwh / battery_capacity_kwh * 100.0,
-            MAX_NEGATIVE_FIT_HEADROOM_PCT,
+        min_floor_kwh = config.min_soc_pct / 100.0 * battery_capacity_kwh
+        floor_by_slot = self._compute_floor_by_slot(
+            n_slots,
+            current_kwh,
+            target_kwh,
+            min_floor_kwh,
+            battery_capacity_kwh,
+            recovery_by_slot,
         )
-
-        # 5. Compute temporary floor
-        temporary_floor_pct = config.demand_window_target_soc_pct - allowed_headroom_pct
 
         return NegativeFitAvoidanceContext(
-            first_negative_fit_slot_idx=first_negative_fit_idx,
-            conservative_overflow_kwh=conservative_overflow_kwh,
-            allowed_headroom_pct=allowed_headroom_pct,
-            temporary_floor_pct=temporary_floor_pct,
+            risk_window_start_idx=risk_start_idx,
+            risk_window_end_idx=risk_end_idx,
+            required_headroom_kwh=required_headroom_kwh,
+            recovery_deadline_idx=recovery_deadline_idx,
+            conservative_recovery_kwh_by_slot=tuple(recovery_by_slot),
+            recoverability_floor_pct_by_slot=tuple(floor_by_slot),
         )
+
+    def _compute_recoverability_floor_pct(
+        self,
+        *,
+        current_soc_pct: float,
+        slot_idx: int,
+        context: NegativeFitAvoidanceContext,
+        config: OptimizerConfig,
+        inputs: OptimizerInputs,
+    ) -> float:
+        """Compute the minimum SOC that still allows recovery to target.
+
+        The recoverability floor is how low SOC can go now while still being
+        able to recover to demand_window_target_soc_pct by the deadline using
+        conservative future solar estimates.
+
+        This is the planner-side guardrail. The Tesla-side PROACTIVE_EXPORT
+        throttling (SOC - 5%, min 4%) remains the actuator guardrail.
+        """
+        battery_capacity_kwh = config.battery_capacity_kwh
+        target_kwh = config.demand_window_target_soc_pct / 100.0 * battery_capacity_kwh
+        min_floor_kwh = config.min_soc_pct / 100.0 * battery_capacity_kwh
+
+        current_kwh = current_soc_pct / 100.0 * battery_capacity_kwh
+
+        if slot_idx >= len(context.conservative_recovery_kwh_by_slot):
+            return config.demand_window_target_soc_pct
+
+        recoverable_kwh = context.conservative_recovery_kwh_by_slot[slot_idx]
+
+        max_discharge_kwh = min(
+            current_kwh - min_floor_kwh,
+            recoverable_kwh,
+        )
+        max_discharge_kwh = max(max_discharge_kwh, 0.0)
+
+        floor_kwh = current_kwh - max_discharge_kwh
+        floor_kwh = max(floor_kwh, min_floor_kwh)
+        floor_kwh = min(floor_kwh, target_kwh)
+
+        floor_pct = floor_kwh / battery_capacity_kwh * 100.0
+        return floor_pct
 
     # ------------------------------------------------------------------
     # Internal solve — Full DP Implementation (Phase C)
@@ -1300,7 +1426,15 @@ class DPPlanner:
     ) -> list[PlannerAction]:
         """Determine export actions based on mode and negative-FIT avoidance context.
 
-        Issue #719: Bounded first-window negative-FIT avoidance.
+        Issue #719: Recoverability-based negative-FIT avoidance.
+
+        Allows proactive export at positive FIT before the risk window when:
+        - SOC is above the recoverability floor + buffer
+        - The slot is before the risk window starts
+        - The slot has positive sell price
+
+        The recoverability floor ensures we only discharge energy that can be
+        recovered via future solar before the deadline, avoiding later grid import.
         """
         actions = []
         can_discharge = soc_pct > config.min_soc_pct
@@ -1310,12 +1444,17 @@ class DPPlanner:
 
         use_avoidance = (
             negative_fit_avoidance_context is not None
-            and slot_idx < negative_fit_avoidance_context.first_negative_fit_slot_idx
+            and slot_idx < negative_fit_avoidance_context.risk_window_start_idx
         )
 
         if use_avoidance and negative_fit_avoidance_context is not None:
             if slot.sell_price > 0:
-                if soc_pct > negative_fit_avoidance_context.temporary_floor_pct + 2.0:
+                floor_pct = (
+                    negative_fit_avoidance_context.recoverability_floor_pct_by_slot[
+                        slot_idx
+                    ]
+                )
+                if soc_pct > floor_pct + 2.0:
                     actions.append(PlannerAction.EXPORT_PROACTIVE)
         else:
             if config.optimization_mode == "self_consumption":

--- a/custom_components/localshift/engine/core.py
+++ b/custom_components/localshift/engine/core.py
@@ -190,11 +190,15 @@ class DPPlanner:
         dp = self._initialize_dp_tables(
             n_slots, soc_grid, config, terminal_penalty_idx, solar_capable, inputs
         )
+        
+        # Issue #719: Derive negative-FIT avoidance context before backward induction
+        negative_fit_avoidance_context = self._derive_negative_fit_avoidance_context(inputs)
+        
         states_explored = self._backward_induction(
-            dp, slots, soc_grid, config, terminal_penalty_idx, inputs
+            dp, slots, soc_grid, config, terminal_penalty_idx, inputs, negative_fit_avoidance_context
         )
         decisions, totals, reason_histogram = self._forward_reconstruct(
-            dp, inputs, slots, soc_grid, config, terminal_penalty_idx
+            dp, inputs, slots, soc_grid, config, terminal_penalty_idx, negative_fit_avoidance_context
         )
 
         terminal_shortfall = self._compute_terminal_shortfall(
@@ -409,6 +413,7 @@ class DPPlanner:
         config: OptimizerConfig,
         terminal_penalty_idx: int | None,
         inputs: OptimizerInputs,
+        negative_fit_avoidance_context: NegativeFitAvoidanceContext | None = None,
     ) -> int:
         """Perform backward induction to fill DP tables.
 
@@ -457,6 +462,7 @@ class DPPlanner:
         terminal_penalty_idx: int | None,
         slots: list[SlotContext],
         inputs: OptimizerInputs,
+        negative_fit_avoidance_context: NegativeFitAvoidanceContext | None = None,
     ) -> tuple[tuple[float, PlannerAction, int, float, float, float], int]:
         """Compute best action for a state.
 
@@ -482,6 +488,7 @@ class DPPlanner:
             slot_idx=slot_idx,
             slots=slots,
             terminal_penalty_idx=terminal_penalty_idx,
+            negative_fit_avoidance_context=negative_fit_avoidance_context,
         )
 
         best_cost = float("inf")
@@ -578,6 +585,7 @@ class DPPlanner:
         soc_grid: list[float],
         config: OptimizerConfig,
         terminal_penalty_idx: int | None,
+        negative_fit_avoidance_context: NegativeFitAvoidanceContext | None = None,
     ) -> tuple[list[PlannedSlotDecision], dict[str, float], dict[str, int]]:
         """Reconstruct optimal path forward.
 
@@ -1273,6 +1281,7 @@ class DPPlanner:
         slot_idx: int = 0,
         slots: list[SlotContext] | None = None,
         terminal_penalty_idx: int | None = None,
+        negative_fit_avoidance_context: NegativeFitAvoidanceContext | None = None,
     ) -> list[PlannerAction]:
         """
         Return list of actions feasible from given SOC and slot context.
@@ -1350,19 +1359,32 @@ class DPPlanner:
                 actions.append(PlannerAction.CHARGE_GRID_NORMAL)
                 actions.append(PlannerAction.CHARGE_GRID_BOOST)
 
-        # Export constraints (Issue #406)
+        # Export constraints (Issue #406, #719)
         if can_discharge:
-            # In self-consumption mode, only export if profitable vs keeping energy for load
-            if config.optimization_mode == "self_consumption":
-                min_profitable_sell = (
-                    max(0.0, slot.buy_price) + config.export_price_margin
-                )
-                if slot.sell_price >= min_profitable_sell:
-                    actions.append(PlannerAction.EXPORT_PROACTIVE)
-            else:
-                # Arbitrage mode: export if positive price
+            # Determine if we are in the pre-negative-FIT window with context active
+            use_avoidance = (
+                negative_fit_avoidance_context is not None
+                and slot_idx < negative_fit_avoidance_context.first_negative_fit_slot_idx
+            )
+
+            if use_avoidance:
+                # Relaxed: allow any positive FIT, but enforce temporary SOC floor
                 if slot.sell_price > 0:
-                    actions.append(PlannerAction.EXPORT_PROACTIVE)
+                    # Rough guard: require SOC high enough to discharge without immediately breaching floor
+                    if soc_pct > negative_fit_avoidance_context.temporary_floor_pct + 2.0:
+                        actions.append(PlannerAction.EXPORT_PROACTIVE)
+            else:
+                # Existing rules
+                if config.optimization_mode == "self_consumption":
+                    min_profitable_sell = (
+                        max(0.0, slot.buy_price) + config.export_price_margin
+                    )
+                    if slot.sell_price >= min_profitable_sell:
+                        actions.append(PlannerAction.EXPORT_PROACTIVE)
+                else:
+                    # Arbitrage mode: export if positive price
+                    if slot.sell_price > 0:
+                        actions.append(PlannerAction.EXPORT_PROACTIVE)
 
         return actions
 

--- a/custom_components/localshift/engine/core.py
+++ b/custom_components/localshift/engine/core.py
@@ -1273,6 +1273,47 @@ class DPPlanner:
         )
         return simulated_terminal_soc >= config.demand_window_target_soc_pct
 
+
+    @staticmethod
+    def _determine_export_actions(
+        soc_pct: float,
+        slot: SlotContext,
+        config: OptimizerConfig,
+        slot_idx: int,
+        negative_fit_avoidance_context: NegativeFitAvoidanceContext | None,
+    ) -> list[PlannerAction]:
+        """Determine export actions based on mode and negative-FIT avoidance context.
+        
+        Issue #719: Bounded first-window negative-FIT avoidance.
+        """
+        actions = []
+        can_discharge = soc_pct > config.min_soc_pct
+        
+        if not can_discharge:
+            return actions
+        
+        use_avoidance = (
+            negative_fit_avoidance_context is not None
+            and slot_idx < negative_fit_avoidance_context.first_negative_fit_slot_idx
+        )
+        
+        if use_avoidance:
+            if slot.sell_price > 0:
+                if soc_pct > negative_fit_avoidance_context.temporary_floor_pct + 2.0:
+                    actions.append(PlannerAction.EXPORT_PROACTIVE)
+        else:
+            if config.optimization_mode == "self_consumption":
+                min_profitable_sell = (
+                    max(0.0, slot.buy_price) + config.export_price_margin
+                )
+                if slot.sell_price >= min_profitable_sell:
+                    actions.append(PlannerAction.EXPORT_PROACTIVE)
+            else:
+                if slot.sell_price > 0:
+                    actions.append(PlannerAction.EXPORT_PROACTIVE)
+        
+        return actions
+
     @staticmethod
     def feasible_actions(
         soc_pct: float,
@@ -1308,7 +1349,6 @@ class DPPlanner:
         actions = []
 
         can_charge = soc_pct < config.max_soc_pct
-        can_discharge = soc_pct > config.min_soc_pct
 
         actions.append(PlannerAction.HOLD)
 
@@ -1360,31 +1400,11 @@ class DPPlanner:
                 actions.append(PlannerAction.CHARGE_GRID_BOOST)
 
         # Export constraints (Issue #406, #719)
-        if can_discharge:
-            # Determine if we are in the pre-negative-FIT window with context active
-            use_avoidance = (
-                negative_fit_avoidance_context is not None
-                and slot_idx < negative_fit_avoidance_context.first_negative_fit_slot_idx
+        actions.extend(
+            DPPlanner._determine_export_actions(
+                soc_pct, slot, config, slot_idx, negative_fit_avoidance_context
             )
-
-            if use_avoidance:
-                # Relaxed: allow any positive FIT, but enforce temporary SOC floor
-                if slot.sell_price > 0:
-                    # Rough guard: require SOC high enough to discharge without immediately breaching floor
-                    if soc_pct > negative_fit_avoidance_context.temporary_floor_pct + 2.0:
-                        actions.append(PlannerAction.EXPORT_PROACTIVE)
-            else:
-                # Existing rules
-                if config.optimization_mode == "self_consumption":
-                    min_profitable_sell = (
-                        max(0.0, slot.buy_price) + config.export_price_margin
-                    )
-                    if slot.sell_price >= min_profitable_sell:
-                        actions.append(PlannerAction.EXPORT_PROACTIVE)
-                else:
-                    # Arbitrage mode: export if positive price
-                    if slot.sell_price > 0:
-                        actions.append(PlannerAction.EXPORT_PROACTIVE)
+        )
 
         return actions
 

--- a/custom_components/localshift/engine/core.py
+++ b/custom_components/localshift/engine/core.py
@@ -83,7 +83,6 @@ class DPPlanner:
         result.solve_time_seconds = time.monotonic() - start
         return result
 
-
     # ------------------------------------------------------------------
     # Negative FIT Avoidance Context Derivation (Issue #719)
     # ------------------------------------------------------------------
@@ -117,7 +116,9 @@ class DPPlanner:
             return None
 
         # 2. Check there is at least one earlier positive-FIT slot
-        has_positive_before = any(s.sell_price > 0 for s in slots[:first_negative_fit_idx])
+        has_positive_before = any(
+            s.sell_price > 0 for s in slots[:first_negative_fit_idx]
+        )
         if not has_positive_before:
             return None
 
@@ -141,7 +142,9 @@ class DPPlanner:
         if accumulated_excess_kwh <= 0:
             return None
 
-        conservative_overflow_kwh = accumulated_excess_kwh * NEGATIVE_FIT_OVERFLOW_BUFFER_FACTOR
+        conservative_overflow_kwh = (
+            accumulated_excess_kwh * NEGATIVE_FIT_OVERFLOW_BUFFER_FACTOR
+        )
 
         # 4. Derive allowed headroom (percentage points)
         allowed_headroom_pct = min(
@@ -190,15 +193,29 @@ class DPPlanner:
         dp = self._initialize_dp_tables(
             n_slots, soc_grid, config, terminal_penalty_idx, solar_capable, inputs
         )
-        
+
         # Issue #719: Derive negative-FIT avoidance context before backward induction
-        negative_fit_avoidance_context = self._derive_negative_fit_avoidance_context(inputs)
-        
+        negative_fit_avoidance_context = self._derive_negative_fit_avoidance_context(
+            inputs
+        )
+
         states_explored = self._backward_induction(
-            dp, slots, soc_grid, config, terminal_penalty_idx, inputs, negative_fit_avoidance_context
+            dp,
+            slots,
+            soc_grid,
+            config,
+            terminal_penalty_idx,
+            inputs,
+            negative_fit_avoidance_context,
         )
         decisions, totals, reason_histogram = self._forward_reconstruct(
-            dp, inputs, slots, soc_grid, config, terminal_penalty_idx, negative_fit_avoidance_context
+            dp,
+            inputs,
+            slots,
+            soc_grid,
+            config,
+            terminal_penalty_idx,
+            negative_fit_avoidance_context,
         )
 
         terminal_shortfall = self._compute_terminal_shortfall(
@@ -1273,7 +1290,6 @@ class DPPlanner:
         )
         return simulated_terminal_soc >= config.demand_window_target_soc_pct
 
-
     @staticmethod
     def _determine_export_actions(
         soc_pct: float,
@@ -1283,21 +1299,21 @@ class DPPlanner:
         negative_fit_avoidance_context: NegativeFitAvoidanceContext | None,
     ) -> list[PlannerAction]:
         """Determine export actions based on mode and negative-FIT avoidance context.
-        
+
         Issue #719: Bounded first-window negative-FIT avoidance.
         """
         actions = []
         can_discharge = soc_pct > config.min_soc_pct
-        
+
         if not can_discharge:
             return actions
-        
+
         use_avoidance = (
             negative_fit_avoidance_context is not None
             and slot_idx < negative_fit_avoidance_context.first_negative_fit_slot_idx
         )
-        
-        if use_avoidance:
+
+        if use_avoidance and negative_fit_avoidance_context is not None:
             if slot.sell_price > 0:
                 if soc_pct > negative_fit_avoidance_context.temporary_floor_pct + 2.0:
                     actions.append(PlannerAction.EXPORT_PROACTIVE)
@@ -1311,7 +1327,7 @@ class DPPlanner:
             else:
                 if slot.sell_price > 0:
                     actions.append(PlannerAction.EXPORT_PROACTIVE)
-        
+
         return actions
 
     @staticmethod

--- a/custom_components/localshift/engine/core.py
+++ b/custom_components/localshift/engine/core.py
@@ -15,6 +15,7 @@ from custom_components.localshift.engine.dp_math import (
     _simulate_solar_only_terminal_soc,
 )
 from custom_components.localshift.engine.types import (
+    NegativeFitAvoidanceContext,
     ObjectiveTerms,
     OptimizerConfig,
     OptimizerInputs,
@@ -81,6 +82,82 @@ class DPPlanner:
 
         result.solve_time_seconds = time.monotonic() - start
         return result
+
+
+    # ------------------------------------------------------------------
+    # Negative FIT Avoidance Context Derivation (Issue #719)
+    # ------------------------------------------------------------------
+
+    def _derive_negative_fit_avoidance_context(
+        self, inputs: OptimizerInputs
+    ) -> NegativeFitAvoidanceContext | None:
+        """Derive context for bounded first-window negative-FIT avoidance.
+
+        Returns None if any of:
+        - No negative-FIT window within horizon
+        - No conservative overflow projected
+        - No earlier positive-FIT slots
+        """
+        from custom_components.localshift.const import (
+            MAX_NEGATIVE_FIT_HEADROOM_PCT,
+            NEGATIVE_FIT_OVERFLOW_BUFFER_FACTOR,
+        )
+
+        slots = inputs.slots
+        config = inputs.config
+        battery_capacity_kwh = config.battery_capacity_kwh
+
+        # 1. Find first negative-FIT slot (sell_price <= 0)
+        first_negative_fit_idx = None
+        for idx, slot in enumerate(slots):
+            if slot.sell_price <= 0:
+                first_negative_fit_idx = idx
+                break
+        if first_negative_fit_idx is None:
+            return None
+
+        # 2. Check there is at least one earlier positive-FIT slot
+        has_positive_before = any(s.sell_price > 0 for s in slots[:first_negative_fit_idx])
+        if not has_positive_before:
+            return None
+
+        # 3. Compute conservative overflow before that window
+        target_kwh = config.demand_window_target_soc_pct / 100.0 * battery_capacity_kwh
+        current_kwh = inputs.initial_soc_pct / 100.0 * battery_capacity_kwh
+        space_to_target_kwh = max(target_kwh - current_kwh, 0)
+
+        accumulated_excess_kwh = 0.0
+        for idx in range(first_negative_fit_idx):
+            slot = slots[idx]
+            net_kwh = slot.solar_kwh - slot.consumption_kwh
+            if net_kwh > 0:
+                excess_kwh = net_kwh * config.charge_efficiency
+                if space_to_target_kwh > 0:
+                    used = min(excess_kwh, space_to_target_kwh)
+                    space_to_target_kwh -= used
+                else:
+                    accumulated_excess_kwh += excess_kwh
+
+        if accumulated_excess_kwh <= 0:
+            return None
+
+        conservative_overflow_kwh = accumulated_excess_kwh * NEGATIVE_FIT_OVERFLOW_BUFFER_FACTOR
+
+        # 4. Derive allowed headroom (percentage points)
+        allowed_headroom_pct = min(
+            conservative_overflow_kwh / battery_capacity_kwh * 100.0,
+            MAX_NEGATIVE_FIT_HEADROOM_PCT,
+        )
+
+        # 5. Compute temporary floor
+        temporary_floor_pct = config.demand_window_target_soc_pct - allowed_headroom_pct
+
+        return NegativeFitAvoidanceContext(
+            first_negative_fit_slot_idx=first_negative_fit_idx,
+            conservative_overflow_kwh=conservative_overflow_kwh,
+            allowed_headroom_pct=allowed_headroom_pct,
+            temporary_floor_pct=temporary_floor_pct,
+        )
 
     # ------------------------------------------------------------------
     # Internal solve — Full DP Implementation (Phase C)

--- a/custom_components/localshift/engine/cost.py
+++ b/custom_components/localshift/engine/cost.py
@@ -47,7 +47,7 @@ def stage_cost(
         ObjectiveTerms with all cost components broken down.
     """
     import_cost = grid_import_kwh * slot.buy_price
-    export_revenue = grid_export_kwh * max(0.0, slot.sell_price)
+    export_revenue = grid_export_kwh * slot.sell_price
     cycle_kwh = grid_import_kwh + grid_export_kwh
     cycle_penalty = cycle_kwh * config.cycle_penalty_per_kwh
 

--- a/custom_components/localshift/engine/types.py
+++ b/custom_components/localshift/engine/types.py
@@ -429,19 +429,30 @@ class OptimizerResult:
 
 @dataclass(frozen=True)
 class NegativeFitAvoidanceContext:
-    """Immutable context for bounded first-window negative-FIT avoidance."""
+    """Immutable context for recoverability-based negative-FIT avoidance.
 
-    first_negative_fit_slot_idx: int
-    """Index of the first slot where sell_price <= 0 within the horizon."""
+    The planner may proactively discharge at positive FIT before a bad-price
+    spill window when conservative future solar can still recover the battery
+    to target by the relevant deadline.
+    """
 
-    conservative_overflow_kwh: float
-    """Conservative estimate of excess solar (kWh) available before first negative-FIT window."""
+    risk_window_start_idx: int
+    """Index of the first slot in the spill-risk window (first sell_price <= 0)."""
 
-    allowed_headroom_pct: float
-    """Maximum temporary headroom below demand_window_target_soc_pct (percentage points)."""
+    risk_window_end_idx: int
+    """Index of the last slot in the spill-risk window (inclusive)."""
 
-    temporary_floor_pct: float
-    """Minimum SOC percent allowed during pre-discharge (demand_window_target - allowed_headroom_pct)."""
+    required_headroom_kwh: float
+    """Estimated storage space (kWh) needed to absorb spill during risk window."""
+
+    recovery_deadline_idx: int | None
+    """Slot index by which target must be recoverable (demand window or horizon end)."""
+
+    conservative_recovery_kwh_by_slot: tuple[float, ...]
+    """Conservative recoverable solar (kWh) from each slot to recovery deadline."""
+
+    recoverability_floor_pct_by_slot: tuple[float, ...]
+    """Precomputed recoverability floor (%) for each slot based on future recovery potential."""
 
 
 # -----------------------------------------------------------------------------

--- a/custom_components/localshift/engine/types.py
+++ b/custom_components/localshift/engine/types.py
@@ -422,7 +422,6 @@ class OptimizerResult:
     """Count of each reason code across all slots (for diagnostics)."""
 
 
-
 # -----------------------------------------------------------------------------
 # Negative FIT avoidance context
 # -----------------------------------------------------------------------------
@@ -443,6 +442,7 @@ class NegativeFitAvoidanceContext:
 
     temporary_floor_pct: float
     """Minimum SOC percent allowed during pre-discharge (demand_window_target - allowed_headroom_pct)."""
+
 
 # -----------------------------------------------------------------------------
 # Optimizer inputs

--- a/custom_components/localshift/engine/types.py
+++ b/custom_components/localshift/engine/types.py
@@ -422,6 +422,28 @@ class OptimizerResult:
     """Count of each reason code across all slots (for diagnostics)."""
 
 
+
+# -----------------------------------------------------------------------------
+# Negative FIT avoidance context
+# -----------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class NegativeFitAvoidanceContext:
+    """Immutable context for bounded first-window negative-FIT avoidance."""
+
+    first_negative_fit_slot_idx: int
+    """Index of the first slot where sell_price <= 0 within the horizon."""
+
+    conservative_overflow_kwh: float
+    """Conservative estimate of excess solar (kWh) available before first negative-FIT window."""
+
+    allowed_headroom_pct: float
+    """Maximum temporary headroom below demand_window_target_soc_pct (percentage points)."""
+
+    temporary_floor_pct: float
+    """Minimum SOC percent allowed during pre-discharge (demand_window_target - allowed_headroom_pct)."""
+
 # -----------------------------------------------------------------------------
 # Optimizer inputs
 # -----------------------------------------------------------------------------

--- a/docs/superpowers/plans/2026-03-15-negative-fit-avoidance-implementation.md
+++ b/docs/superpowers/plans/2026-03-15-negative-fit-avoidance-implementation.md
@@ -1,0 +1,796 @@
+# Negative FIT Avoidance Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement bounded first-window negative-FIT avoidance in the DP optimizer.
+
+**Architecture:** Add `NegativeFitAvoidanceContext` derived before backward induction; modify `feasible_actions()` to allow positive-FIT pre-discharge down to a bounded temporary floor; modify `stage_cost()` to treat negative FIT as real cost; retain actuator-side `PROACTIVE_EXPORT` throttling.
+
+**Tech Stack:** Python, dynamic programming optimizer, Home Assistant integration.
+
+---
+
+## Chunk 1: Constants and Types Foundation
+
+**Files:**
+- Modify: `custom_components/localshift/const.py`
+- Modify: `custom_components/localshift/engine/types.py`
+- Test: `tests/test_optimizer_dp_solve.py`
+
+Add necessary constants and the `NegativeFitAvoidanceContext` dataclass before touching core logic.
+
+- [ ] **Step 1:** Add constants to `custom_components/localshift/const.py`
+
+First, ensure `const.py` has `from typing import Final` near the top (add if missing). Then add:
+
+```python
+# Maximum headroom below battery target for negative-FIT avoidance (percentage points)
+MAX_NEGATIVE_FIT_HEADROOM_PCT: Final[float] = 20.0
+
+# Conservative buffer factor for overflow estimates (0.8 = use 80% of forecast)
+NEGATIVE_FIT_OVERFLOW_BUFFER_FACTOR: Final[float] = 0.8
+```
+
+- [ ] **Step 2:** Add `NegativeFitAvoidanceContext` to `custom_components/localshift/engine/types.py`
+
+Add after existing type definitions (e.g., near `OptimizerInputs`):
+
+```python
+from dataclasses import dataclass
+
+@dataclass(frozen=True)
+class NegativeFitAvoidanceContext:
+    """Immutable context for bounded first-window negative-FIT avoidance."""
+    first_negative_fit_slot_idx: int
+    conservative_overflow_kwh: float
+    allowed_headroom_pct: float
+    temporary_floor_pct: float
+```
+
+- [ ] **Step 3:** Add tests for the new type (no behavior yet)
+
+In `tests/test_optimizer_dp_solve.py`, add:
+
+```python
+def test_negative_fit_context_type():
+    """Smoke test: NegativeFitAvoidanceContext can be constructed."""
+    from custom_components.localshift.engine.types import NegativeFitAvoidanceContext
+    ctx = NegativeFitAvoidanceContext(
+        first_negative_fit_slot_idx=10,
+        conservative_overflow_kwh=5.0,
+        allowed_headroom_pct=3.7,
+        temporary_floor_pct=76.3,
+    )
+    assert ctx.first_negative_fit_slot_idx == 10
+    assert ctx.conservative_overflow_kwh == 5.0
+    assert ctx.allowed_headroom_pct == 3.7
+    assert ctx.temporary_floor_pct == 76.3
+```
+
+- [ ] **Step 4:** Run the new test
+
+```bash
+uv run pytest tests/test_optimizer_dp_solve.py::test_negative_fit_context_type -v
+```
+
+Expected: PASS
+
+- [ ] **Step 5:** Commit
+
+```bash
+git add custom_components/localshift/const.py \
+         custom_components/localshift/engine/types.py \
+         tests/test_optimizer_dp_solve.py
+git commit -m "feat: add types and constants for negative-FIT avoidance"
+```
+
+---
+
+## Chunk 2: Context Derivation Logic
+
+**Files:**
+- Modify: `custom_components/localshift/engine/core.py`
+- Test: `tests/test_optimizer_dp_solve.py`
+
+Implement `_derive_negative_fit_avoidance_context()` in `DPPlanner`.
+
+- [ ] **Step 1:** Write failing unit tests for `_derive_negative_fit_avoidance_context()`
+
+Add to `tests/test_optimizer_dp_solve.py`:
+
+```python
+def make_slot(idx: int, sell_price: float, solar_kwh: float = 0.0, consumption_kwh: float = 0.0) -> SlotContext:
+    """Helper to create a 30-min slot."""
+    return SlotContext(
+        slot_index=idx,
+        timestamp_iso=f"2026-01-03T{(idx // 2):02d}:{(idx % 2) * 30:02d}:00",
+        slot_interval_minutes=30,
+        buy_price=0.10,
+        sell_price=sell_price,
+        solar_kwh=solar_kwh,
+        consumption_kwh=consumption_kwh,
+    )
+
+def test_negative_fit_context_no_window(default_config):
+    """Returns None when no negative-FIT window in horizon."""
+    planner = DPPlanner(default_config)
+    slots = [make_slot(i, sell_price=0.08) for i in range(10)]
+    inputs = OptimizerInputs(
+        cycle_id="test",
+        initial_soc_pct=50.0,
+        slots=slots,
+        config=default_config,
+    )
+    ctx = planner._derive_negative_fit_avoidance_context(inputs)
+    assert ctx is None
+
+def test_negative_fit_context_no_overflow(default_config):
+    """Returns None when no forecast overflow projected."""
+    planner = DPPlanner(default_config)
+    # Negative FIT at idx=5, but zero solar before it
+    slots = [make_slot(i, sell_price=0.08 if i < 5 else -0.05) for i in range(10)]
+    inputs = OptimizerInputs(
+        cycle_id="test",
+        initial_soc_pct=50.0,
+        slots=slots,
+        config=default_config,
+    )
+    ctx = planner._derive_negative_fit_avoidance_context(inputs)
+    assert ctx is None
+
+def test_negative_fit_context_no_positive_slots(default_config):
+    """Returns None when no earlier positive-FIT slots."""
+    planner = DPPlanner(default_config)
+    # Negative FIT at idx=5, positive FIT after that only
+    slots = [make_slot(i, sell_price=0.08 if i >= 5 else 0.0) for i in range(10)]
+    slots[5] = make_slot(5, sell_price=0.08)
+    inputs = OptimizerInputs(
+        cycle_id="test",
+        initial_soc_pct=50.0,
+        slots=slots,
+        config=default_config,
+    )
+    ctx = planner._derive_negative_fit_avoidance_context(inputs)
+    # Even though overflow might exist, no positive slots before negative window
+    assert ctx is None
+
+def test_negative_fit_context_computes_floor(default_config):
+    """Computes correct temporary_floor_pct when all conditions met."""
+    planner = DPPlanner(default_config)
+    default_config.demand_window_target_soc_pct = 80.0
+    # Positive FIT at idx=0, negative FIT at idx=4. Some excess solar -> headroom 5%
+    slots = []
+    for i in range(6):
+        sell = 0.08 if i < 4 else -0.05
+        solar = 2.0 if i == 0 else 0.0  # One big solar burst makes overflow
+        slots.append(make_slot(i, sell_price=sell, solar_kwh=solar))
+    inputs = OptimizerInputs(
+        cycle_id="test",
+        initial_soc_pct=90.0,
+        slots=slots,
+        config=default_config,
+    )
+    ctx = planner._derive_negative_fit_avoidance_context(inputs)
+    assert ctx is not None
+    # allowed_headroom_pct should be <= MAX_NEGATIVE_FIT_HEADROOM_PCT
+    assert 0 < ctx.allowed_headroom_pct <= 20.0
+    # temporary_floor_pct = target - allowed_headroom_pct
+    assert abs(ctx.temporary_floor_pct - (80.0 - ctx.allowed_headroom_pct)) < 0.01
+```
+
+- [ ] **Step 2:** Run tests to confirm they fail (missing method)
+
+```bash
+uv run pytest tests/test_optimizer_dp_solve.py::test_negative_fit_context_no_window -v
+```
+
+Expected: FAIL (AttributeError: 'DPPlanner' object has no attribute '_derive_negative_fit_avoidance_context')
+
+- [ ] **Step 3:** Implement `_derive_negative_fit_avoidance_context()` in `custom_components/localshift/engine/core.py`
+
+Add method to `DPPlanner` class (near `_solve`):
+
+```python
+def _derive_negative_fit_avoidance_context(
+    self, inputs: OptimizerInputs
+) -> NegativeFitAvoidanceContext | None:
+    """Derive context for bounded first-window negative-FIT avoidance.
+
+    Returns None if any of:
+    - No negative-FIT window within horizon
+    - No conservative overflow projected
+    - No earlier positive-FIT slots
+    """
+    from custom_components.localshift.const import (
+        MAX_NEGATIVE_FIT_HEADROOM_PCT,
+        NEGATIVE_FIT_OVERFLOW_BUFFER_FACTOR,
+    )
+
+    slots = inputs.slots
+    config = inputs.config
+    battery_capacity_kwh = config.battery_capacity_kwh
+
+    # 1. Find first negative-FIT slot (sell_price <= 0)
+    first_negative_fit_idx = None
+    for idx, slot in enumerate(slots):
+        if slot.sell_price <= 0:
+            first_negative_fit_idx = idx
+            break
+    if first_negative_fit_idx is None:
+        return None
+
+    # 2. Check there is at least one earlier positive-FIT slot
+    has_positive_before = any(s.sell_price > 0 for s in slots[:first_negative_fit_idx])
+    if not has_positive_before:
+        return None
+
+    # 3. Compute conservative overflow before that window
+    # Reuse logic from excess_solar._calculate_excess_until_negative_fit but inline for simplicity
+    target_kwh = config.demand_window_target_soc_pct / 100.0 * battery_capacity_kwh
+    current_kwh = inputs.initial_soc_pct / 100.0 * battery_capacity_kwh
+    space_to_target_kwh = max(target_kwh - current_kwh, 0)
+
+    accumulated_excess_kwh = 0.0
+    for idx in range(first_negative_fit_idx):
+        slot = slots[idx]
+        net_kwh = slot.solar_kwh - slot.consumption_kwh
+        if net_kwh > 0:
+            excess_kwh = net_kwh * config.charge_efficiency  # charging efficiency
+            if space_to_target_kwh > 0:
+                used = min(excess_kwh, space_to_target_kwh)
+                space_to_target_kwh -= used
+            else:
+                accumulated_excess_kwh += excess_kwh
+
+    if accumulated_excess_kwh <= 0:
+        return None
+
+    conservative_overflow_kwh = accumulated_excess_kwh * NEGATIVE_FIT_OVERFLOW_BUFFER_FACTOR
+
+    # 4. Derive allowed headroom (percentage points)
+    allowed_headroom_pct = min(
+        conservative_overflow_kwh / battery_capacity_kwh * 100.0,
+        MAX_NEGATIVE_FIT_HEADROOM_PCT,
+    )
+
+    # 5. Compute temporary floor
+    temporary_floor_pct = config.demand_window_target_soc_pct - allowed_headroom_pct
+
+    return NegativeFitAvoidanceContext(
+        first_negative_fit_slot_idx=first_negative_fit_idx,
+        conservative_overflow_kwh=conservative_overflow_kwh,
+        allowed_headroom_pct=allowed_headroom_pct,
+        temporary_floor_pct=temporary_floor_pct,
+    )
+```
+
+- [ ] **Step 4:** Run the tests
+
+```bash
+uv run pytest tests/test_optimizer_dp_solve.py::test_negative_fit_context_no_window \
+                 tests/test_optimizer_dp_solve.py::test_negative_fit_context_no_overflow \
+                 tests/test_optimizer_dp_solve.py::test_negative_fit_context_no_positive_slots \
+                 tests/test_optimizer_dp_solve.py::test_negative_fit_context_computes_floor \
+                 -v
+```
+
+Expected: All PASS
+
+- [ ] **Step 5:** Integrate context derivation into `_solve()`
+
+Modify `DPPlanner._solve()`: after building `inputs`, before `_initialize_dp_tables()`, add:
+
+```python
+negative_fit_context = self._derive_negative_fit_avoidance_context(inputs)
+```
+
+Then pass `negative_fit_context` to `_backward_induction()` and `_forward_reconstruct()` (adjust signatures accordingly).
+
+- [ ] **Step 6:** Commit
+
+```bash
+git add custom_components/localshift/engine/core.py \
+         tests/test_optimizer_dp_solve.py
+git commit -m "feat: derive negative-FIT avoidance context"
+```
+
+---
+
+## Chunk 3: Feasible Actions Bounded Pre-Discharge
+
+**Files:**
+- Modify: `custom_components/localshift/engine/constraints.py`
+- Test: `tests/test_constraints.py`
+
+Broaden proactive export eligibility before first negative-FIT window while enforcing the bounded SOC floor.
+
+- [ ] **Step 1:** Write failing unit tests for modified `feasible_actions()` in new `tests/test_constraints.py`
+
+Create file `tests/test_constraints.py` with:
+
+```python
+"""Constraint unit tests for negative-FIT avoidance."""
+from __future__ import annotations
+
+import pytest
+
+from custom_components.localshift.engine.constraints import feasible_actions
+from custom_components.localshift.engine.types import (
+    NegativeFitAvoidanceContext,
+    OptimizerConfig,
+    PlannerAction,
+    SlotContext,
+)
+
+
+@pytest.fixture
+def default_config() -> OptimizerConfig:
+    """Reusable default optimizer config."""
+    return OptimizerConfig(
+        battery_capacity_kwh=13.5,
+        demand_window_target_soc_pct=80.0,
+        soc_bins=20,
+        optimization_mode="self_consumption",
+        export_price_margin=0.02,
+        min_soc_pct=10.0,
+        max_soc_pct=100.0,
+    )
+
+
+def make_test_slot(sell_price: float, is_demand_window_slot: bool = False) -> SlotContext:
+    """Minimal slot for constraint tests."""
+    return SlotContext(
+        slot_index=0,
+        timestamp_iso="2026-01-03T10:00:00",
+        slot_interval_minutes=30,
+        buy_price=0.10,
+        sell_price=sell_price,
+        solar_kwh=0.0,
+        consumption_kwh=0.0,
+        is_demand_window_slot=is_demand_window_slot,
+    )
+
+
+def test_feasible_actions_positive_fit_before_negative(default_config):
+    """Allows EXPORT_PROACTIVE at positive FIT before first negative-FIT window."""
+    slot = make_test_slot(sell_price=0.08)
+    context = NegativeFitAvoidanceContext(
+        first_negative_fit_slot_idx=5,
+        conservative_overflow_kwh=10.0,
+        allowed_headroom_pct=5.0,
+        temporary_floor_pct=75.0,
+    )
+    actions = feasible_actions(
+        soc_pct=90.0,
+        slot=slot,
+        config=default_config,
+        slot_idx=0,
+        slots=None,
+        terminal_penalty_idx=None,
+        negative_fit_avoidance_context=context,
+    )
+    assert PlannerAction.EXPORT_PROACTIVE in actions
+
+
+def test_feasible_actions_negative_fit_floor_blocked(default_config):
+    """Blocks EXPORT_PROACTIVE at sell_price <= 0 (hard floor)."""
+    slot = make_test_slot(sell_price=0.0)
+    context = NegativeFitAvoidanceContext(
+        first_negative_fit_slot_idx=5,
+        conservative_overflow_kwh=10.0,
+        allowed_headroom_pct=5.0,
+        temporary_floor_pct=75.0,
+    )
+    actions = feasible_actions(
+        soc_pct=90.0,
+        slot=slot,
+        config=default_config,
+        slot_idx=0,
+        slots=None,
+        terminal_penalty_idx=None,
+        negative_fit_avoidance_context=context,
+    )
+    assert PlannerAction.EXPORT_PROACTIVE not in actions
+
+
+def test_feasible_actions_temporary_floor_enforced(default_config):
+    """Blocks EXPORT_PROACTIVE when SOC would fall below temporary_floor_pct."""
+    slot = make_test_slot(sell_price=0.08)
+    context = NegativeFitAvoidanceContext(
+        first_negative_fit_slot_idx=5,
+        conservative_overflow_kwh=10.0,
+        allowed_headroom_pct=5.0,
+        temporary_floor_pct=75.0,
+    )
+    actions = feasible_actions(
+        soc_pct=74.0,
+        slot=slot,
+        config=default_config,
+        slot_idx=0,
+        slots=None,
+        terminal_penalty_idx=None,
+        negative_fit_avoidance_context=context,
+    )
+    assert PlannerAction.EXPORT_PROACTIVE not in actions
+
+
+def test_feasible_actions_normal_rules_after_negative_window(default_config):
+    """Uses normal rules for slots at/after first negative-FIT window."""
+    slot = make_test_slot(sell_price=0.08)
+    context = NegativeFitAvoidanceContext(
+        first_negative_fit_slot_idx=2,
+        conservative_overflow_kwh=10.0,
+        allowed_headroom_pct=5.0,
+        temporary_floor_pct=75.0,
+    )
+    actions = feasible_actions(
+        soc_pct=90.0,
+        slot=slot,
+        config=default_config,
+        slot_idx=2,
+        slots=None,
+        terminal_penalty_idx=None,
+        negative_fit_avoidance_context=context,
+    )
+    # In self-consumption normal rule requires profitable export
+    min_profitable = max(0.0, slot.buy_price) + default_config.export_price_margin
+    if slot.sell_price >= min_profitable:
+        assert PlannerAction.EXPORT_PROACTIVE in actions
+    else:
+        assert PlannerAction.EXPORT_PROACTIVE not in actions
+```
+
+**Note:** These tests require adding `negative_fit_avoidance_context` parameter to `feasible_actions()`. We'll do that next.
+
+- [ ] **Step 2:** Modify `feasible_actions()` signature and implementation
+
+Add optional parameter `negative_fit_avoidance_context: NegativeFitAvoidanceContext | None = None` to signature.
+
+Implementation changes:
+
+```python
+def feasible_actions(
+    soc_pct: float,
+    slot: SlotContext,
+    config: OptimizerConfig,
+    slot_idx: int = 0,
+    slots: list[SlotContext] | None = None,
+    terminal_penalty_idx: int | None = None,
+    negative_fit_avoidance_context: NegativeFitAvoidanceContext | None = None,
+) -> list[PlannerAction]:
+```
+
+Inside export constraints section, replace existing logic with:
+
+```python
+    # Export constraints (Issue #719)
+    if can_discharge:
+        # Determine if we are in the pre-negative-FIT window with context active
+        use_avoidance = (
+            negative_fit_avoidance_context is not None
+            and slot_idx < negative_fit_avoidance_context.first_negative_fit_slot_idx
+        )
+
+        if use_avoidance:
+            # Relaxed: allow any positive FIT, but enforce temporary SOC floor
+            # Compute post-discharge SOC (approximate: discharge 1 kWh lowers ~0.1% SOC for 13.5 kWh battery)
+            # For precise check we'll compare after transition; feasible_actions cannot know exact transition,
+            # so we conservatively check if current SOC is at least temporary_floor_pct + discharge margin.
+            # The actual bound will be enforced in stage_cost via penalty if violated, but we also gate here.
+            if slot.sell_price > 0:
+                # Rough guard: require SOC high enough to discharge without immediately breaching floor
+                # We'll allow if soc_pct > temporary_floor_pct + 2 (approx margin)
+                if soc_pct > negative_fit_avoidance_context.temporary_floor_pct + 2.0:
+                    actions.append(PlannerAction.EXPORT_PROACTIVE)
+        else:
+            # Existing rules
+            if config.optimization_mode == "self_consumption":
+                min_profitable_sell = max(0.0, slot.buy_price) + config.export_price_margin
+                if slot.sell_price >= min_profitable_sell:
+                    actions.append(PlannerAction.EXPORT_PROACTIVE)
+            else:
+                if slot.sell_price > 0:
+                    actions.append(PlannerAction.EXPORT_PROACTIVE)
+```
+
+- [ ] **Step 3:** Run the new tests
+
+```bash
+uv run pytest tests/test_constraints.py::test_feasible_actions_positive_fit_before_negative \
+                 tests/test_constraints.py::test_feasible_actions_negative_fit_floor_blocked \
+                 tests/test_constraints.py::test_feasible_actions_temporary_floor_enforced \
+                 tests/test_constraints.py::test_feasible_actions_normal_rules_after_negative_window \
+                 -v
+```
+
+Expected: PASS (adjust logic until they pass)
+
+- [ ] **Step 4:** Commit
+
+```bash
+git add custom_components/localshift/engine/constraints.py \
+         tests/test_constraints.py
+git commit -m "feat: allow bounded pre-discharge in feasible_actions()"
+```
+
+---
+
+## Chunk 4: Negative FIT as Real Cost
+
+**Files:**
+- Modify: `custom_components/localshift/engine/cost.py`
+- Test: `tests/test_cost.py` (create if missing)
+
+Remove the clipping of `sell_price` in `stage_cost()`.
+
+- [ ] **Step 1:** Write failing test
+
+Create `tests/test_cost.py`:
+
+```python
+import pytest
+from custom_components.localshift.engine.cost import stage_cost
+from custom_components.localshift.engine.types import (
+    OptimizerConfig,
+    PlannerAction,
+    SlotContext,
+)
+
+def test_stage_cost_negative_fit_real_cost():
+    """Negative sell_price produces negative export revenue (real cost)."""
+    config = OptimizerConfig(optimization_mode="arbitrage")
+    slot = SlotContext(
+        slot_index=0,
+        timestamp_iso="2026-01-03T10:00:00",
+        slot_interval_minutes=30,
+        buy_price=0.10,
+        sell_price=-0.05,  # Negative FIT
+        solar_kwh=0.0,
+        consumption_kwh=0.0,
+    )
+    terms = stage_cost(
+        action=PlannerAction.EXPORT_PROACTIVE,
+        grid_import_kwh=0.0,
+        grid_export_kwh=2.0,
+        slot=slot,
+        config=config,
+    )
+    # Export revenue should be negative (cost)
+    assert terms.export_revenue == 2.0 * (-0.05)  # -0.1
+    assert terms.net_cost > 0  # net cost positive due to negative revenue
+```
+
+- [ ] **Step 2:** Run to confirm failure
+
+```bash
+uv run pytest tests/test_cost.py::test_stage_cost_negative_fit_real_cost -v
+```
+
+Expected: FAIL (export_revenue = max(0, -0.05)*2 = 0, not -0.1)
+
+- [ ] **Step 3:** Modify `stage_cost()` in `custom_components/localshift/engine/cost.py`
+
+Change line 50 from:
+
+```python
+export_revenue = grid_export_kwh * max(0.0, slot.sell_price)
+```
+
+to:
+
+```python
+export_revenue = grid_export_kwh * slot.sell_price
+```
+
+- [ ] **Step 4:** Run test to confirm pass
+
+```bash
+uv run pytest tests/test_cost.py::test_stage_cost_negative_fit_real_cost -v
+```
+
+Expected: PASS
+
+- [ ] **Step 5:** Run all cost tests to check for regressions
+
+```bash
+uv run pytest tests/test_cost.py -v 2>/dev/null || uv run pytest -k cost -v
+```
+
+Ensure no other tests break. If any break due to negative revenue assumptions, adjust those tests accordingly.
+
+- [ ] **Step 6:** Commit
+
+```bash
+git add custom_components/localshift/engine/cost.py \
+         tests/test_cost.py
+git commit -m "feat: treat negative FIT as real cost in stage_cost()"
+```
+
+---
+
+## Chunk 5: Core Integration and Forward Pass
+
+**Files:**
+- Modify: `custom_components/localshift/engine/core.py`
+- Test: `tests/test_optimizer_dp_solve.py`
+
+Attach context to backward induction and forward reconstruct; ensure bounded floor is respected by DP.
+
+- [ ] **Step 1:** Update `_backward_induction()` signature to accept `negative_fit_context`
+
+Add parameter `negative_fit_context: NegativeFitAvoidanceContext | None = None` and pass it through to `_compute_best_action()` and `feasible_actions()`.
+
+- [ ] **Step 2:** Update `_compute_best_action()` to pass context to `feasible_actions()`
+
+Inside `_compute_best_action()`, when calling `feasible_actions()`, add:
+
+```python
+actions = feasible_actions(
+    soc_pct=soc,
+    slot=slot,
+    config=config,
+    slot_idx=slot_idx,
+    slots=slots,
+    terminal_penalty_idx=terminal_penalty_idx,
+    negative_fit_avoidance_context=negative_fit_context,
+)
+```
+
+- [ ] **Step 3:** Update `_forward_reconstruct()` to receive context (for logging/diagnostics only; not used in reconstruction logic)
+
+Adjust call sites accordingly.
+
+- [ ] **Step 4:** Write integration test for bounded pre-discharge
+
+Add to `tests/test_optimizer_dp_solve.py` (reuses default_config fixture):
+
+```python
+def test_negative_fit_bounded_predischarge(default_config):
+    """High solar, future negative-FIT, earlier positive-FIT slots: bounded pre-discharge."""
+    from custom_components.localshift.engine.optimizer_dp import DPPlanner
+
+    default_config.demand_window_target_soc_pct = 80.0
+    default_config.optimization_mode = "self_consumption"
+
+    # Build horizon: positive FIT in slots 0-3, negative FIT from slot 4 onward
+    slots = []
+    for i in range(10):
+        sell = 0.08 if i < 4 else -0.05
+        # High solar early to create overflow
+        solar = 5.0 if i < 2 else 0.0
+        consumption = 0.5
+        slots.append(SlotContext(
+            slot_index=i,
+            timestamp_iso=f"2026-01-03T{(i // 2):02d}:{(i % 2) * 30:02d}:00",
+            slot_interval_minutes=30,
+            buy_price=0.10,
+            sell_price=sell,
+            solar_kwh=solar,
+            consumption_kwh=consumption,
+        ))
+
+    inputs = OptimizerInputs(
+        cycle_id="test",
+        initial_soc_pct=95.0,
+        slots=slots,
+        config=default_config,
+    )
+
+    planner = DPPlanner(default_config)
+    result = planner.plan(inputs)
+
+    # Should schedule some EXPORT_PROACTIVE in early positive-FIT slots
+    export_actions = [d.action for d in result.decisions if d.action == PlannerAction.EXPORT_PROACTIVE]
+    assert len(export_actions) > 0
+
+    # SOC trajectory should dip below 80% but not below expected temporary floor (~75%)
+    socs = [d.soc_pct for d in result.decisions]
+    min_soc = min(socs)
+    assert min_soc < 80.0  # dipped below target
+    # With 20% max headroom floor might be ~60%, but with our overflow likely ~75%; ensure not excessive
+    assert min_soc >= 60.0  # bounded by headroom, not crashing below 50%
+```
+
+- [ ] **Step 5:** Run the test; iterate until it passes and respects bounded floor
+
+Tweak the `temporary_floor_pct` derivation if needed; the test should confirm the DP respects the context via `feasible_actions()`.
+
+- [ ] **Step 6:** Commit
+
+```bash
+git add custom_components/localshift/engine/core.py \
+         tests/test_optimizer_dp_solve.py \
+         tests/test_scenarios.py
+git commit -m "feat: integrate negative-FIT context into DP solve"
+```
+
+---
+
+## Chunk 6: Test Coverage and Refinement
+
+**Files:**
+- All modified files
+- All test files
+
+Complete unit and integration coverage, update existing tests as needed.
+
+- [ ] **Step 1:** Add remaining unit tests listed in spec
+
+- In `tests/test_optimizer_dp_solve.py`: `test_negative_fit_context_conservative_buffer`
+- In `tests/test_cost.py`: ensure `test_stage_cost_negative_fit_real_cost` already covers export; add positive control test ensuring positive sell_price still yields positive revenue
+- In `tests/test_constraints.py`: add test for arbitrage mode behavior
+
+- [ ] **Step 2:** Update existing tests per spec
+
+- `tests/test_optimizer_dp_solve.py::test_dp_planner_negative_fit_no_export`: Review; ensure it still tests hard `0c` floor and adjust comments if needed.
+- `tests/test_scenarios.py::test_high_solar_no_export_at_negative_prices`: Ensure it tests that `sell_price <= 0` is forbidden, not that no export ever occurs before negative window.
+
+- [ ] **Step 3:** Run full test suite with coverage
+
+```bash
+uv run pytest --cov=custom_components/localshift --cov-report=term-missing
+```
+
+Ensure ≥95% coverage on modified files (`core.py`, `constraints.py`, `cost.py`, `types.py`).
+
+- [ ] **Step 4:** Fix any regressions or coverage gaps
+
+Add targeted tests for any uncovered branches.
+
+- [ ] **Step 5:** Final commit
+
+```bash
+git add tests/
+git commit -m "test: complete negative-FIT avoidance test coverage"
+```
+
+---
+
+## Chunk 7: Final Verification
+
+**Commands:**
+
+- [ ] Run full test suite with coverage ≥95%
+- [ ] Run ruff linter
+
+```bash
+uv run ruff check custom_components/localshift
+```
+
+- [ ] Verify no unintended changes in unrelated areas
+
+```bash
+git diff --stat
+```
+
+Focus on modified files only.
+
+- [ ] Final commit message
+
+```bash
+git commit --amend -m "feat(optimizer): implement bounded first-window negative-FIT avoidance (#719)
+- Add constants and NegativeFitAvoidanceContext type
+- Derive context before backward induction
+- Allow EXPORT_PROACTIVE before first negative-FIT at any positive FIT with bounded SOC floor
+- Treat negative FIT as real cost in stage_cost()
+- Retain PROACTIVE_EXPORT actuator throttling
+- Add comprehensive unit and integration tests"
+```
+
+---
+
+## Rollback Plan
+
+If issues arise during implementation:
+
+- Revert chunks individually using `git revert <commit>`
+- Disable feature by returning `None` from `_derive_negative_fit_avoidance_context()`
+- Fallback to existing logic when context is `None` (already part of design)
+
+---
+
+## Plan Complete
+
+Save this plan to `docs/superpowers/plans/2026-03-15-negative-fit-avoidance-implementation.md`.
+
+**Execution:** Use superpowers:subagent-driven-development or superpowers:executing-plans to carry out the steps.

--- a/docs/superpowers/specs/2026-03-14-negative-fit-avoidance-design.md
+++ b/docs/superpowers/specs/2026-03-14-negative-fit-avoidance-design.md
@@ -1,0 +1,213 @@
+# Design: Negative FIT Avoidance (Issue #719)
+
+## Problem Statement
+
+The DP optimizer does not proactively discharge to avoid negative FIT export costs. When the battery has ample charge and a future negative-FIT window is forecast, the optimizer may schedule later forced export at negative prices instead of earlier pre-discharge at positive prices. This occurs because:
+
+1. **Terminal cost only penalizes shortfall**, not excess SOC before negative-FIT windows
+2. **Stage cost clips negative export price** with `max(0.0, slot.sell_price)`, hiding the pain of later negative-FIT export
+3. **`feasible_actions()` only allows proactive export when profitable**, blocking globally optimal pre-discharge actions
+
+Prior attempts to fix this via terminal-cost-only modifications failed because `_backward_induction()` overwrites DP tables for all earlier slots, making intermediate terminal penalties unstable.
+
+## Design Intent
+
+The optimizer should:
+
+- Keep the hard `0c` export floor (never proactively export at `sell_price <= 0`)
+- Use `number.localshift_battery_target` / `demand_window_target_soc_pct` as the baseline target
+- Permit temporary pre-discharge below that target only by the amount of projected overflow needed to avoid later negative-FIT export
+- Not create extra headroom if there are no earlier positive-FIT slots available
+- Allow any earlier positive-FIT slot to participate when it lowers projected total cost
+- Apply the behavior in both self-consumption and arbitrage modes
+- Retain the existing actuator-side `PROACTIVE_EXPORT` throttling behavior (`SOC - 5%`, floor `4%`)
+
+## Architecture: Bounded First-Window Model
+
+### Core Concept
+
+Derive an immutable `negative_fit_avoidance` planner context before backward induction containing:
+
+1. **First negative-FIT window**: The earliest upcoming slot where `sell_price <= 0`
+2. **Conservative overflow estimate**: Forecast solar energy that would overflow before that window
+3. **Maximum temporary headroom**: How far below `demand_window_target_soc_pct` the solver may discharge, capped by the conservative overflow
+
+The optimizer allows `EXPORT_PROACTIVE` before the first negative-FIT window at any positive FIT, but only if SOC does not go below the bounded temporary floor.
+
+### Data Flow
+
+```
+OptimizerInputs
+     │
+     ▼
+┌─────────────────────────────────────────┐
+│ _derive_negative_fit_avoidance_context() │
+│   - Find first negative-FIT window       │
+│   - Compute conservative overflow        │
+│   - Derive allowed_headroom              │
+└─────────────────────────────────────────┘
+     │
+     ▼
+NegativeFitAvoidanceContext (immutable)
+     │
+     ▼
+┌─────────────────────────────────────────┐
+│ _backward_induction()                    │
+│   - feasible_actions() uses context      │
+│   - stage_cost() sees real negative FIT  │
+└─────────────────────────────────────────┘
+     │
+     ▼
+Optimal Plan (may include bounded pre-discharge)
+```
+
+## Planner Rules and Boundaries
+
+### `custom_components/localshift/engine/core.py`
+
+Add `_derive_negative_fit_avoidance_context()` that:
+
+- Returns `None` if no negative-FIT window exists within the planning horizon
+- Returns `None` if no conservative overflow is projected
+- Returns `None` if no earlier positive-FIT slots exist
+- Otherwise returns `NegativeFitAvoidanceContext` with:
+  - `first_negative_fit_slot_idx`: index of first `sell_price <= 0` slot
+  - `conservative_overflow_kwh`: conservative estimate of forecast overflow before that slot
+  - `allowed_headroom_pct`: `min(conservative_overflow_kwh / battery_capacity_kwh * 100, max_headroom_pct)`
+  - `temporary_floor_pct`: `demand_window_target_soc_pct - allowed_headroom_pct`
+
+Call this function in `_solve()` before `_initialize_dp_tables()` and pass the context to `_backward_induction()`.
+
+### `custom_components/localshift/engine/constraints.py`
+
+Modify `feasible_actions()` to:
+
+- Continue forbidding `EXPORT_PROACTIVE` at `sell_price <= 0` (hard `0c` floor remains)
+- When `negative_fit_avoidance_context` is present and current slot is before `first_negative_fit_slot_idx`:
+  - Allow `EXPORT_PROACTIVE` for any `sell_price > 0` (broaden eligibility)
+  - But only if resulting SOC >= `temporary_floor_pct`
+
+This replaces the current restrictive proactive-export gate for slots before the first negative-FIT window. Slots at or after the first negative-FIT window continue using existing rules.
+
+### `custom_components/localshift/engine/cost.py`
+
+Modify `stage_cost()` to:
+
+- Remove the `max(0.0, slot.sell_price)` clipping for export revenue
+- Calculate `export_revenue = grid_export_kwh * slot.sell_price` directly
+- When `sell_price < 0`, this makes later negative-FIT export a real cost penalty
+
+The DP optimizer will naturally prefer earlier positive-FIT export over later negative-FIT export because the cost model now represents the true economic impact.
+
+### Boundaries
+
+| Boundary | Rule |
+|----------|------|
+| Export floor | `sell_price > 0` required for proactive export (hard constraint) |
+| SOC floor | `temporary_floor_pct` = `target - allowed_headroom` (bounded below-target) |
+| Headroom cap | `allowed_headroom` ≤ conservative overflow estimate |
+| Window scope | Only first upcoming negative-FIT window is optimized |
+| Mode scope | Applies to both self-consumption and arbitrage modes |
+
+### Fallback Behavior
+
+| Condition | Behavior |
+|-----------|----------|
+| No negative-FIT window | Context disabled, current logic applies |
+| No conservative overflow | Context disabled, current logic applies |
+| No earlier positive-FIT slots | Context disabled, accept later negative export |
+| Only partial avoidance possible | Create economically justified partial headroom, accept remaining negative export |
+
+## Actuator-Side Safeguard
+
+The optimizer decides *when* proactive export is justified, but hardware execution uses the existing throttled `PROACTIVE_EXPORT` path:
+
+- `custom_components/localshift/state/machine.py:233-245`: `_build_proactive_export_config()` sets `backup_reserve = max(4.0, soc - 5.0)`
+- `custom_components/localshift/integration/controller.py:596-675`: `set_proactive_export()` uses this dynamic reserve to create a "trickle export"
+
+This ensures the battery does not dump quickly to the temporary floor. The bounded headroom rule is the planner-side guardrail; the dynamic reserve is the actuator-side guardrail.
+
+## Type Definitions
+
+Add to `custom_components/localshift/engine/types.py`:
+
+```python
+@dataclass(frozen=True)
+class NegativeFitAvoidanceContext:
+    """Immutable context for bounded first-window negative-FIT avoidance."""
+    first_negative_fit_slot_idx: int
+    conservative_overflow_kwh: float
+    allowed_headroom_pct: float
+    temporary_floor_pct: float
+```
+
+## Testing Strategy
+
+### Unit Tests
+
+1. **Context derivation** (`tests/test_optimizer_dp_solve.py`):
+   - Returns `None` when no negative-FIT window in horizon
+   - Returns `None` when no forecast overflow
+   - Returns `None` when no earlier positive-FIT slots
+   - Computes correct `temporary_floor_pct` when all conditions met
+   - Respects conservative buffer in overflow estimate
+
+2. **`feasible_actions()` bounded pre-discharge** (`tests/test_constraints.py`):
+   - Allows `EXPORT_PROACTIVE` at positive FIT before first negative-FIT window
+   - Blocks `EXPORT_PROACTIVE` at `sell_price <= 0` (hard floor preserved)
+   - Blocks `EXPORT_PROACTIVE` when SOC would fall below `temporary_floor_pct`
+   - Uses normal rules for slots at/after first negative-FIT window
+
+3. **`stage_cost()` negative-FIT handling** (`tests/test_cost.py`):
+   - Negative `sell_price` produces negative export revenue (real cost)
+   - DP prefers earlier positive-FIT export over later negative-FIT export
+
+### Integration Tests
+
+4. **End-to-end DP scenarios** (`tests/test_scenarios.py`):
+   - High solar, future negative-FIT, earlier positive-FIT slots available:
+     - Plan schedules bounded pre-discharge at positive FIT
+     - SOC may go below `demand_window_target_soc_pct` but not below `temporary_floor_pct`
+     - Later negative-FIT export is reduced or eliminated
+   - No earlier positive-FIT slots:
+     - Plan does not create headroom
+     - Accepts later negative export
+   - Partial avoidance only:
+     - Plan creates partial headroom
+     - Accepts remaining later negative export
+
+### Test Updates Required
+
+- `tests/test_optimizer_dp_solve.py::test_dp_planner_negative_fit_no_export`: Update to clarify this tests the hard `0c` floor, not the bounded pre-discharge behavior
+- `tests/test_scenarios.py::test_high_solar_no_export_at_negative_prices`: Ensure this tests that export at `sell_price <= 0` is still forbidden, not that no proactive export ever occurs before negative-FIT windows
+
+## Alignment with PLANNING_MODEL.md
+
+| Question | Answer | Implementation |
+|----------|--------|----------------|
+| Impossible/forbidden? | Export at `sell_price <= 0` | Hard constraint in `feasible_actions()` |
+| Required by deadline? | Create bounded headroom before first negative-FIT window | Bounded floor in `feasible_actions()` |
+| Discouraged/preferred? | Later negative-FIT export is costly | Real cost in `stage_cost()` |
+
+The design follows the PLANNING_MODEL.md decision tree: hard constraints in `feasible_actions()`, soft penalties in `stage_cost()`, and deadline-like requirements expressed through bounded SOC floors rather than intermediate terminal checkpoints.
+
+## Risks and Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Headroom estimate too aggressive | Use conservative buffer in overflow calculation |
+| Unexpected interaction with demand window | Temporary floor respects `demand_window_target_soc_pct` as baseline |
+| Test coverage gaps | Explicit test list above, update existing tests |
+| Regression in normal export behavior | Fallback to current logic when context is disabled |
+
+## Summary
+
+This design introduces a bounded first-window negative-FIT avoidance model that:
+
+1. Derives a conservative headroom budget before the first negative-FIT window
+2. Allows earlier positive-FIT pre-discharge only up to that bounded amount
+3. Models negative FIT as a real cost in `stage_cost()`
+4. Preserves the hard `0c` export floor in `feasible_actions()`
+5. Reuses the existing actuator-side `PROACTIVE_EXPORT` throttling for safe execution
+
+The approach is narrow, aligned with the PLANNING_MODEL.md framework, and explicitly avoids the terminal-cost-only pattern that failed in prior attempts.

--- a/docs/superpowers/specs/2026-03-14-negative-fit-avoidance-design.md
+++ b/docs/superpowers/specs/2026-03-14-negative-fit-avoidance-design.md
@@ -73,10 +73,38 @@ Add `_derive_negative_fit_avoidance_context()` that:
 - Otherwise returns `NegativeFitAvoidanceContext` with:
   - `first_negative_fit_slot_idx`: index of first `sell_price <= 0` slot
   - `conservative_overflow_kwh`: conservative estimate of forecast overflow before that slot
-  - `allowed_headroom_pct`: `min(conservative_overflow_kwh / battery_capacity_kwh * 100, max_headroom_pct)`
+  - `allowed_headroom_pct`: `min(conservative_overflow_kwh / battery_capacity_kwh * 100, MAX_NEGATIVE_FIT_HEADROOM_PCT)`
   - `temporary_floor_pct`: `demand_window_target_soc_pct - allowed_headroom_pct`
 
 Call this function in `_solve()` before `_initialize_dp_tables()` and pass the context to `_backward_induction()`.
+
+**Context lifecycle:** The context is recomputed on every `_solve()` call. No caching is used because forecast prices and solar data may change between planning cycles, and the bounded headroom must reflect current projections.
+
+#### Constants
+
+Add to `custom_components/localshift/const.py`:
+
+```python
+# Maximum headroom below battery target for negative-FIT avoidance (percentage points)
+MAX_NEGATIVE_FIT_HEADROOM_PCT: Final[float] = 20.0
+
+# Conservative buffer factor for overflow estimates (0.8 = use 80% of forecast)
+NEGATIVE_FIT_OVERFLOW_BUFFER_FACTOR: Final[float] = 0.8
+```
+
+#### Conservative Overflow Calculation
+
+The `conservative_overflow_kwh` is computed using logic similar to `_calculate_excess_until_negative_fit()` in `excess_solar.py`:
+
+1. Find the first negative-FIT slot index
+2. Iterate through all slots before that index
+3. For each slot: `net_kwh = solar_forecast_kwh - estimated_consumption_kwh`
+4. If `net_kwh > 0`, apply charging efficiency (0.92) to get `excess_kwh`
+5. Track space remaining to reach `demand_window_target_soc_pct`
+6. After target space is filled, accumulate remaining excess
+7. Apply conservative buffer: `conservative_overflow_kwh = accumulated_excess * NEGATIVE_FIT_OVERFLOW_BUFFER_FACTOR`
+
+This reuses the existing forecast-based excess calculation pattern but applies a buffer factor to reduce the risk of over-estimating available headroom.
 
 ### `custom_components/localshift/engine/constraints.py`
 
@@ -178,8 +206,28 @@ class NegativeFitAvoidanceContext:
 
 ### Test Updates Required
 
+**Updates to existing tests:**
 - `tests/test_optimizer_dp_solve.py::test_dp_planner_negative_fit_no_export`: Update to clarify this tests the hard `0c` floor, not the bounded pre-discharge behavior
 - `tests/test_scenarios.py::test_high_solar_no_export_at_negative_prices`: Ensure this tests that export at `sell_price <= 0` is still forbidden, not that no proactive export ever occurs before negative-FIT windows
+
+**New tests to add:**
+- `tests/test_optimizer_dp_solve.py`:
+  - `test_negative_fit_context_no_window` — returns `None` when no negative-FIT window in horizon
+  - `test_negative_fit_context_no_overflow` — returns `None` when no forecast overflow
+  - `test_negative_fit_context_no_positive_slots` — returns `None` when no earlier positive-FIT slots
+  - `test_negative_fit_context_computes_floor` — computes correct `temporary_floor_pct` when all conditions met
+  - `test_negative_fit_context_conservative_buffer` — respects conservative buffer in overflow estimate
+- `tests/test_constraints.py`:
+  - `test_feasible_actions_positive_fit_before_negative` — allows `EXPORT_PROACTIVE` at positive FIT before first negative-FIT window
+  - `test_feasible_actions_negative_fit_floor_blocked` — blocks `EXPORT_PROACTIVE` at `sell_price <= 0` (hard floor preserved)
+  - `test_feasible_actions_temporary_floor_enforced` — blocks `EXPORT_PROACTIVE` when SOC would fall below `temporary_floor_pct`
+  - `test_feasible_actions_normal_rules_after_negative_window` — uses normal rules for slots at/after first negative-FIT window
+- `tests/test_cost.py`:
+  - `test_stage_cost_negative_fit_real_cost` — negative `sell_price` produces negative export revenue (real cost)
+- `tests/test_scenarios.py`:
+  - `test_negative_fit_bounded_predischarge` — high solar, future negative-FIT, earlier positive-FIT slots available
+  - `test_negative_fit_no_earlier_positive_slots` — no earlier positive-FIT slots, accepts later negative export
+  - `test_negative_fit_partial_avoidance` — partial avoidance only, creates partial headroom
 
 ## Alignment with PLANNING_MODEL.md
 

--- a/tests/engine/test_core.py
+++ b/tests/engine/test_core.py
@@ -134,3 +134,82 @@ class TestDPPlanner:
         # SOC should change across slots
         socs = [d.predicted_soc_pct for d in result.decisions]
         assert len(socs) == 2
+
+
+class TestNegativeFitAvoidanceContext:
+    """Test _derive_negative_fit_avoidance_context method."""
+
+    @staticmethod
+    def _make_slot(idx: int, sell_price: float, solar_kwh: float = 0.0, consumption_kwh: float = 0.0) -> SlotContext:
+        """Helper to create a slot for negative-FIT tests."""
+        return SlotContext(
+            slot_index=idx,
+            timestamp_iso=f"2026-01-03T{(idx // 2):02d}:{(idx % 2) * 30:02d}:00",
+            slot_interval_minutes=30,
+            buy_price=0.10,
+            sell_price=sell_price,
+            solar_kwh=solar_kwh,
+            consumption_kwh=consumption_kwh,
+        )
+
+    def test_no_negative_fit_window_returns_none(self):
+        """Returns None when no negative-FIT window in horizon."""
+        planner = DPPlanner()
+        slots = [self._make_slot(i, sell_price=0.08) for i in range(10)]
+        inputs = OptimizerInputs(
+            cycle_id="test",
+            initial_soc_pct=50.0,
+            slots=slots,
+            config=OptimizerConfig(),
+        )
+        ctx = planner._derive_negative_fit_avoidance_context(inputs)
+        assert ctx is None
+
+    def test_no_overflow_returns_none(self):
+        """Returns None when no forecast overflow projected."""
+        planner = DPPlanner()
+        slots = [self._make_slot(i, sell_price=0.08 if i < 5 else -0.05) for i in range(10)]
+        inputs = OptimizerInputs(
+            cycle_id="test",
+            initial_soc_pct=50.0,
+            slots=slots,
+            config=OptimizerConfig(),
+        )
+        ctx = planner._derive_negative_fit_avoidance_context(inputs)
+        assert ctx is None
+
+    def test_no_positive_slots_returns_none(self):
+        """Returns None when no earlier positive-FIT slots."""
+        planner = DPPlanner()
+        slots = [self._make_slot(i, sell_price=0.08 if i >= 5 else 0.0) for i in range(10)]
+        slots[5] = self._make_slot(5, sell_price=-0.05)
+        inputs = OptimizerInputs(
+            cycle_id="test",
+            initial_soc_pct=50.0,
+            slots=slots,
+            config=OptimizerConfig(),
+        )
+        ctx = planner._derive_negative_fit_avoidance_context(inputs)
+        assert ctx is None
+
+    def test_computes_floor_when_conditions_met(self):
+        """Computes correct temporary_floor_pct when all conditions met."""
+        from custom_components.localshift.engine.types import NegativeFitAvoidanceContext
+        planner = DPPlanner()
+        config = OptimizerConfig(demand_window_target_soc_pct=80.0)
+        slots = []
+        for i in range(6):
+            sell = 0.08 if i < 4 else -0.05
+            solar = 2.0 if i == 0 else 0.0
+            slots.append(self._make_slot(i, sell_price=sell, solar_kwh=solar))
+        inputs = OptimizerInputs(
+            cycle_id="test",
+            initial_soc_pct=90.0,
+            slots=slots,
+            config=config,
+        )
+        ctx = planner._derive_negative_fit_avoidance_context(inputs)
+        assert ctx is not None
+        assert isinstance(ctx, NegativeFitAvoidanceContext)
+        assert 0 < ctx.allowed_headroom_pct <= 20.0
+        assert abs(ctx.temporary_floor_pct - (80.0 - ctx.allowed_headroom_pct)) < 0.01

--- a/tests/engine/test_core.py
+++ b/tests/engine/test_core.py
@@ -137,10 +137,16 @@ class TestDPPlanner:
 
 
 class TestNegativeFitAvoidanceContext:
-    """Test _derive_negative_fit_avoidance_context method."""
+    """Test _derive_negative_fit_avoidance_context method (recoverability model)."""
 
     @staticmethod
-    def _make_slot(idx: int, sell_price: float, solar_kwh: float = 0.0, consumption_kwh: float = 0.0) -> SlotContext:
+    def _make_slot(
+        idx: int,
+        sell_price: float,
+        solar_kwh: float = 0.0,
+        consumption_kwh: float = 0.0,
+        is_demand_window: bool = False,
+    ) -> SlotContext:
         """Helper to create a slot for negative-FIT tests."""
         return SlotContext(
             slot_index=idx,
@@ -150,6 +156,7 @@ class TestNegativeFitAvoidanceContext:
             sell_price=sell_price,
             solar_kwh=solar_kwh,
             consumption_kwh=consumption_kwh,
+            is_demand_window_slot=is_demand_window,
         )
 
     def test_no_negative_fit_window_returns_none(self):
@@ -165,10 +172,12 @@ class TestNegativeFitAvoidanceContext:
         ctx = planner._derive_negative_fit_avoidance_context(inputs)
         assert ctx is None
 
-    def test_no_overflow_returns_none(self):
-        """Returns None when no forecast overflow projected."""
+    def test_no_positive_slots_before_risk_returns_none(self):
+        """Returns None when no positive-FIT slots exist before risk window."""
         planner = DPPlanner()
-        slots = [self._make_slot(i, sell_price=0.08 if i < 5 else -0.05) for i in range(10)]
+        slots = [
+            self._make_slot(i, sell_price=0.0 if i < 5 else -0.05) for i in range(10)
+        ]
         inputs = OptimizerInputs(
             cycle_id="test",
             initial_soc_pct=50.0,
@@ -178,38 +187,153 @@ class TestNegativeFitAvoidanceContext:
         ctx = planner._derive_negative_fit_avoidance_context(inputs)
         assert ctx is None
 
-    def test_no_positive_slots_returns_none(self):
-        """Returns None when no earlier positive-FIT slots."""
-        planner = DPPlanner()
-        slots = [self._make_slot(i, sell_price=0.08 if i >= 5 else 0.0) for i in range(10)]
-        slots[5] = self._make_slot(5, sell_price=-0.05)
-        inputs = OptimizerInputs(
-            cycle_id="test",
-            initial_soc_pct=50.0,
-            slots=slots,
-            config=OptimizerConfig(),
-        )
-        ctx = planner._derive_negative_fit_avoidance_context(inputs)
-        assert ctx is None
-
-    def test_computes_floor_when_conditions_met(self):
-        """Computes correct temporary_floor_pct when all conditions met."""
-        from custom_components.localshift.engine.types import NegativeFitAvoidanceContext
+    def test_no_recovery_solar_returns_none(self):
+        """Returns None when insufficient solar to recover to target."""
         planner = DPPlanner()
         config = OptimizerConfig(demand_window_target_soc_pct=80.0)
+        slots = [
+            self._make_slot(i, sell_price=0.08 if i < 5 else -0.05) for i in range(10)
+        ]
+        inputs = OptimizerInputs(
+            cycle_id="test",
+            initial_soc_pct=50.0,
+            slots=slots,
+            config=config,
+        )
+        ctx = planner._derive_negative_fit_avoidance_context(inputs)
+        assert ctx is None
+
+    def test_ha_style_case_with_solar_during_bad_fit_creates_context(self):
+        """HA-style: solar arrives DURING bad-FIT window, still creates context."""
+        from custom_components.localshift.engine.types import (
+            NegativeFitAvoidanceContext,
+        )
+
+        planner = DPPlanner()
+        config = OptimizerConfig(
+            demand_window_target_soc_pct=100.0,
+            battery_capacity_kwh=13.5,
+        )
         slots = []
-        for i in range(6):
-            sell = 0.08 if i < 4 else -0.05
-            solar = 2.0 if i == 0 else 0.0
+        for i in range(24):
+            if i < 12:
+                sell = 0.07
+                solar = 0.0
+            else:
+                sell = -0.02
+                solar = 2.5
             slots.append(self._make_slot(i, sell_price=sell, solar_kwh=solar))
         inputs = OptimizerInputs(
             cycle_id="test",
-            initial_soc_pct=90.0,
+            initial_soc_pct=58.0,
             slots=slots,
             config=config,
         )
         ctx = planner._derive_negative_fit_avoidance_context(inputs)
         assert ctx is not None
         assert isinstance(ctx, NegativeFitAvoidanceContext)
-        assert 0 < ctx.allowed_headroom_pct <= 20.0
-        assert abs(ctx.temporary_floor_pct - (80.0 - ctx.allowed_headroom_pct)) < 0.01
+        assert ctx.risk_window_start_idx == 12
+        assert ctx.risk_window_end_idx == 23
+        assert ctx.required_headroom_kwh > 0
+
+    def test_recoverability_floor_allows_below_target(self):
+        """Recoverability floor can be below target when recovery is feasible."""
+        from custom_components.localshift.engine.types import (
+            NegativeFitAvoidanceContext,
+        )
+
+        planner = DPPlanner()
+        config = OptimizerConfig(
+            demand_window_target_soc_pct=100.0,
+            min_soc_pct=10.0,
+            battery_capacity_kwh=13.5,
+        )
+        slots = []
+        for i in range(20):
+            if i < 10:
+                sell = 0.07
+                solar = 0.0
+            else:
+                sell = -0.02
+                solar = 2.0
+            slots.append(self._make_slot(i, sell_price=sell, solar_kwh=solar))
+        inputs = OptimizerInputs(
+            cycle_id="test",
+            initial_soc_pct=58.0,
+            slots=slots,
+            config=config,
+        )
+        ctx = planner._derive_negative_fit_avoidance_context(inputs)
+        assert ctx is not None
+        floor_pct = planner._compute_recoverability_floor_pct(
+            current_soc_pct=58.0,
+            slot_idx=5,
+            context=ctx,
+            config=config,
+            inputs=inputs,
+        )
+        assert floor_pct < config.demand_window_target_soc_pct
+        assert floor_pct >= config.min_soc_pct
+
+    def test_recoverability_floor_stays_high_with_weak_solar(self):
+        """Recoverability floor stays near target when recovery solar is weak."""
+        from custom_components.localshift.engine.types import (
+            NegativeFitAvoidanceContext,
+        )
+
+        planner = DPPlanner()
+        config = OptimizerConfig(
+            demand_window_target_soc_pct=100.0,
+            min_soc_pct=10.0,
+            battery_capacity_kwh=13.5,
+        )
+        slots = []
+        for i in range(20):
+            if i < 10:
+                sell = 0.07
+                solar = 0.0
+            else:
+                sell = -0.02
+                solar = 0.1
+            slots.append(self._make_slot(i, sell_price=sell, solar_kwh=solar))
+        inputs = OptimizerInputs(
+            cycle_id="test",
+            initial_soc_pct=95.0,
+            slots=slots,
+            config=config,
+        )
+        ctx = planner._derive_negative_fit_avoidance_context(inputs)
+        assert ctx is not None
+        floor_pct = planner._compute_recoverability_floor_pct(
+            current_soc_pct=95.0,
+            slot_idx=5,
+            context=ctx,
+            config=config,
+            inputs=inputs,
+        )
+        assert floor_pct >= 80.0
+
+    def test_context_stops_when_headroom_sufficient(self):
+        """Context reflects when enough headroom already exists."""
+        planner = DPPlanner()
+        config = OptimizerConfig(
+            demand_window_target_soc_pct=100.0,
+            battery_capacity_kwh=13.5,
+        )
+        slots = []
+        for i in range(20):
+            if i < 10:
+                sell = 0.07
+                solar = 0.0
+            else:
+                sell = -0.02
+                solar = 0.5
+            slots.append(self._make_slot(i, sell_price=sell, solar_kwh=solar))
+        inputs = OptimizerInputs(
+            cycle_id="test",
+            initial_soc_pct=20.0,
+            slots=slots,
+            config=config,
+        )
+        ctx = planner._derive_negative_fit_avoidance_context(inputs)
+        assert ctx is None or ctx.required_headroom_kwh <= 0.5

--- a/tests/engine/test_cost.py
+++ b/tests/engine/test_cost.py
@@ -128,7 +128,7 @@ class TestStageCost:
         )
 
         terms = stage_cost(PlannerAction.EXPORT_PROACTIVE, 0.0, 1.0, slot, config)
-        assert terms.export_revenue == 0.0  # Clamped to 0
+        assert terms.export_revenue == -10.0  # Issue #719: no longer clamped
 
     def test_stage_cost_returns_objective_terms(self):
         """stage_cost returns ObjectiveTerms with all expected fields."""

--- a/tests/test_const.py
+++ b/tests/test_const.py
@@ -1,0 +1,11 @@
+"""Tests for constants module."""
+from custom_components.localshift.const import (
+    MAX_NEGATIVE_FIT_HEADROOM_PCT,
+    NEGATIVE_FIT_OVERFLOW_BUFFER_FACTOR,
+)
+
+
+def test_negative_fit_constants_defined():
+    """Verify negative-FIT avoidance constants are defined."""
+    assert MAX_NEGATIVE_FIT_HEADROOM_PCT == 20.0
+    assert NEGATIVE_FIT_OVERFLOW_BUFFER_FACTOR == 0.8

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -1,0 +1,128 @@
+"""Constraint unit tests for negative-FIT avoidance."""
+from __future__ import annotations
+
+import pytest
+
+from custom_components.localshift.engine.constraints import feasible_actions
+from custom_components.localshift.engine.types import (
+    NegativeFitAvoidanceContext,
+    OptimizerConfig,
+    PlannerAction,
+    SlotContext,
+)
+
+
+@pytest.fixture
+def default_config() -> OptimizerConfig:
+    """Reusable default optimizer config."""
+    return OptimizerConfig(
+        battery_capacity_kwh=13.5,
+        demand_window_target_soc_pct=80.0,
+        soc_bins=20,
+        optimization_mode="self_consumption",
+        export_price_margin=0.02,
+        min_soc_pct=10.0,
+        max_soc_pct=100.0,
+    )
+
+
+def _make_test_slot(sell_price: float, is_demand_window_slot: bool = False) -> SlotContext:
+    """Minimal slot for constraint tests."""
+    return SlotContext(
+        slot_index=0,
+        timestamp_iso="2026-01-03T10:00:00",
+        slot_interval_minutes=30,
+        buy_price=0.10,
+        sell_price=sell_price,
+        solar_kwh=0.0,
+        consumption_kwh=0.0,
+        is_demand_window_slot=is_demand_window_slot,
+    )
+
+
+def test_feasible_actions_positive_fit_before_negative(default_config):
+    """Allows EXPORT_PROACTIVE at positive FIT before first negative-FIT window."""
+    slot = _make_test_slot(sell_price=0.08)
+    context = NegativeFitAvoidanceContext(
+        first_negative_fit_slot_idx=5,
+        conservative_overflow_kwh=10.0,
+        allowed_headroom_pct=5.0,
+        temporary_floor_pct=75.0,
+    )
+    actions = feasible_actions(
+        soc_pct=90.0,
+        slot=slot,
+        config=default_config,
+        slot_idx=0,
+        slots=None,
+        terminal_penalty_idx=None,
+        negative_fit_avoidance_context=context,
+    )
+    assert PlannerAction.EXPORT_PROACTIVE in actions
+
+
+def test_feasible_actions_negative_fit_floor_blocked(default_config):
+    """Blocks EXPORT_PROACTIVE at sell_price <= 0 (hard floor)."""
+    slot = _make_test_slot(sell_price=0.0)
+    context = NegativeFitAvoidanceContext(
+        first_negative_fit_slot_idx=5,
+        conservative_overflow_kwh=10.0,
+        allowed_headroom_pct=5.0,
+        temporary_floor_pct=75.0,
+    )
+    actions = feasible_actions(
+        soc_pct=90.0,
+        slot=slot,
+        config=default_config,
+        slot_idx=0,
+        slots=None,
+        terminal_penalty_idx=None,
+        negative_fit_avoidance_context=context,
+    )
+    assert PlannerAction.EXPORT_PROACTIVE not in actions
+
+
+def test_feasible_actions_temporary_floor_enforced(default_config):
+    """Blocks EXPORT_PROACTIVE when SOC would fall below temporary_floor_pct."""
+    slot = _make_test_slot(sell_price=0.08)
+    context = NegativeFitAvoidanceContext(
+        first_negative_fit_slot_idx=5,
+        conservative_overflow_kwh=10.0,
+        allowed_headroom_pct=5.0,
+        temporary_floor_pct=75.0,
+    )
+    actions = feasible_actions(
+        soc_pct=74.0,
+        slot=slot,
+        config=default_config,
+        slot_idx=0,
+        slots=None,
+        terminal_penalty_idx=None,
+        negative_fit_avoidance_context=context,
+    )
+    assert PlannerAction.EXPORT_PROACTIVE not in actions
+
+
+def test_feasible_actions_normal_rules_after_negative_window(default_config):
+    """Uses normal rules for slots at/after first negative-FIT window."""
+    slot = _make_test_slot(sell_price=0.08)
+    context = NegativeFitAvoidanceContext(
+        first_negative_fit_slot_idx=2,
+        conservative_overflow_kwh=10.0,
+        allowed_headroom_pct=5.0,
+        temporary_floor_pct=75.0,
+    )
+    actions = feasible_actions(
+        soc_pct=90.0,
+        slot=slot,
+        config=default_config,
+        slot_idx=2,
+        slots=None,
+        terminal_penalty_idx=None,
+        negative_fit_avoidance_context=context,
+    )
+    min_profitable = max(0.0, slot.buy_price) + default_config.export_price_margin
+    if slot.sell_price >= min_profitable:
+        assert PlannerAction.EXPORT_PROACTIVE in actions
+    else:
+        assert PlannerAction.EXPORT_PROACTIVE not in actions

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -1,4 +1,5 @@
 """Constraint unit tests for negative-FIT avoidance."""
+
 from __future__ import annotations
 
 import pytest
@@ -26,7 +27,9 @@ def default_config() -> OptimizerConfig:
     )
 
 
-def _make_test_slot(sell_price: float, is_demand_window_slot: bool = False) -> SlotContext:
+def _make_test_slot(
+    sell_price: float, is_demand_window_slot: bool = False
+) -> SlotContext:
     """Minimal slot for constraint tests."""
     return SlotContext(
         slot_index=0,
@@ -40,15 +43,31 @@ def _make_test_slot(sell_price: float, is_demand_window_slot: bool = False) -> S
     )
 
 
-def test_feasible_actions_positive_fit_before_negative(default_config):
-    """Allows EXPORT_PROACTIVE at positive FIT before first negative-FIT window."""
-    slot = _make_test_slot(sell_price=0.08)
-    context = NegativeFitAvoidanceContext(
-        first_negative_fit_slot_idx=5,
-        conservative_overflow_kwh=10.0,
-        allowed_headroom_pct=5.0,
-        temporary_floor_pct=75.0,
+def _make_context(
+    risk_start: int = 5,
+    risk_end: int = 10,
+    recovery_by_slot: list[float] | None = None,
+    floor_by_slot: list[float] | None = None,
+) -> NegativeFitAvoidanceContext:
+    """Create a valid NegativeFitAvoidanceContext for tests."""
+    if recovery_by_slot is None:
+        recovery_by_slot = [50.0] * 15
+    if floor_by_slot is None:
+        floor_by_slot = [20.0] * 15
+    return NegativeFitAvoidanceContext(
+        risk_window_start_idx=risk_start,
+        risk_window_end_idx=risk_end,
+        required_headroom_kwh=5.0,
+        recovery_deadline_idx=14,
+        conservative_recovery_kwh_by_slot=tuple(recovery_by_slot),
+        recoverability_floor_pct_by_slot=tuple(floor_by_slot),
     )
+
+
+def test_feasible_actions_positive_fit_before_risk_window(default_config):
+    """Allows EXPORT_PROACTIVE at positive FIT before risk window when SOC above floor."""
+    slot = _make_test_slot(sell_price=0.08)
+    context = _make_context(risk_start=5, recovery_by_slot=[20.0] * 15)
     actions = feasible_actions(
         soc_pct=90.0,
         slot=slot,
@@ -61,15 +80,10 @@ def test_feasible_actions_positive_fit_before_negative(default_config):
     assert PlannerAction.EXPORT_PROACTIVE in actions
 
 
-def test_feasible_actions_negative_fit_floor_blocked(default_config):
+def test_feasible_actions_negative_fit_blocked(default_config):
     """Blocks EXPORT_PROACTIVE at sell_price <= 0 (hard floor)."""
     slot = _make_test_slot(sell_price=0.0)
-    context = NegativeFitAvoidanceContext(
-        first_negative_fit_slot_idx=5,
-        conservative_overflow_kwh=10.0,
-        allowed_headroom_pct=5.0,
-        temporary_floor_pct=75.0,
-    )
+    context = _make_context()
     actions = feasible_actions(
         soc_pct=90.0,
         slot=slot,
@@ -82,17 +96,16 @@ def test_feasible_actions_negative_fit_floor_blocked(default_config):
     assert PlannerAction.EXPORT_PROACTIVE not in actions
 
 
-def test_feasible_actions_temporary_floor_enforced(default_config):
-    """Blocks EXPORT_PROACTIVE when SOC would fall below temporary_floor_pct."""
+def test_feasible_actions_recoverability_floor_enforced(default_config):
+    """Blocks EXPORT_PROACTIVE when SOC would fall below recoverability floor."""
     slot = _make_test_slot(sell_price=0.08)
-    context = NegativeFitAvoidanceContext(
-        first_negative_fit_slot_idx=5,
-        conservative_overflow_kwh=10.0,
-        allowed_headroom_pct=5.0,
-        temporary_floor_pct=75.0,
+    context = _make_context(
+        risk_start=5,
+        recovery_by_slot=[5.0] * 15,
+        floor_by_slot=[40.0] * 15,
     )
     actions = feasible_actions(
-        soc_pct=74.0,
+        soc_pct=30.0,
         slot=slot,
         config=default_config,
         slot_idx=0,
@@ -103,15 +116,10 @@ def test_feasible_actions_temporary_floor_enforced(default_config):
     assert PlannerAction.EXPORT_PROACTIVE not in actions
 
 
-def test_feasible_actions_normal_rules_after_negative_window(default_config):
-    """Uses normal rules for slots at/after first negative-FIT window."""
+def test_feasible_actions_normal_rules_during_risk_window(default_config):
+    """Uses normal rules for slots during risk window (at/after risk start)."""
     slot = _make_test_slot(sell_price=0.08)
-    context = NegativeFitAvoidanceContext(
-        first_negative_fit_slot_idx=2,
-        conservative_overflow_kwh=10.0,
-        allowed_headroom_pct=5.0,
-        temporary_floor_pct=75.0,
-    )
+    context = _make_context(risk_start=2)
     actions = feasible_actions(
         soc_pct=90.0,
         slot=slot,
@@ -120,6 +128,25 @@ def test_feasible_actions_normal_rules_after_negative_window(default_config):
         slots=None,
         terminal_penalty_idx=None,
         negative_fit_avoidance_context=context,
+    )
+    min_profitable = max(0.0, slot.buy_price) + default_config.export_price_margin
+    if slot.sell_price >= min_profitable:
+        assert PlannerAction.EXPORT_PROACTIVE in actions
+    else:
+        assert PlannerAction.EXPORT_PROACTIVE not in actions
+
+
+def test_feasible_actions_context_none_uses_normal_rules(default_config):
+    """When context is None, uses normal proactive export rules."""
+    slot = _make_test_slot(sell_price=0.08)
+    actions = feasible_actions(
+        soc_pct=90.0,
+        slot=slot,
+        config=default_config,
+        slot_idx=0,
+        slots=None,
+        terminal_penalty_idx=None,
+        negative_fit_avoidance_context=None,
     )
     min_profitable = max(0.0, slot.buy_price) + default_config.export_price_margin
     if slot.sell_price >= min_profitable:

--- a/tests/test_cost.py
+++ b/tests/test_cost.py
@@ -1,0 +1,53 @@
+"""Tests for cost.py stage_cost and terminal_cost."""
+from custom_components.localshift.engine.cost import stage_cost
+from custom_components.localshift.engine.types import (
+    OptimizerConfig,
+    PlannerAction,
+    SlotContext,
+)
+
+
+def test_stage_cost_negative_fit_real_cost():
+    """Negative sell_price produces negative export revenue (real cost)."""
+    config = OptimizerConfig(optimization_mode="arbitrage")
+    slot = SlotContext(
+        slot_index=0,
+        timestamp_iso="2026-01-03T10:00:00",
+        slot_interval_minutes=30,
+        buy_price=0.10,
+        sell_price=-0.05,
+        solar_kwh=0.0,
+        consumption_kwh=0.0,
+    )
+    terms = stage_cost(
+        action=PlannerAction.EXPORT_PROACTIVE,
+        grid_import_kwh=0.0,
+        grid_export_kwh=2.0,
+        slot=slot,
+        config=config,
+    )
+    assert terms.export_revenue == 2.0 * (-0.05)
+    assert terms.net_cost > 0
+
+
+def test_stage_cost_positive_fit_positive_revenue():
+    """Positive sell_price produces positive export revenue."""
+    config = OptimizerConfig(optimization_mode="arbitrage")
+    slot = SlotContext(
+        slot_index=0,
+        timestamp_iso="2026-01-03T10:00:00",
+        slot_interval_minutes=30,
+        buy_price=0.10,
+        sell_price=0.08,
+        solar_kwh=0.0,
+        consumption_kwh=0.0,
+    )
+    terms = stage_cost(
+        action=PlannerAction.EXPORT_PROACTIVE,
+        grid_import_kwh=0.0,
+        grid_export_kwh=2.0,
+        slot=slot,
+        config=config,
+    )
+    assert terms.export_revenue == 2.0 * 0.08
+    assert terms.net_cost < 0

--- a/tests/test_optimizer_dp_solve.py
+++ b/tests/test_optimizer_dp_solve.py
@@ -2551,16 +2551,19 @@ def test_plan_with_empty_slots():
 def test_negative_fit_context_type():
     """Smoke test: NegativeFitAvoidanceContext can be constructed."""
     from custom_components.localshift.engine.types import NegativeFitAvoidanceContext
+
     ctx = NegativeFitAvoidanceContext(
-        first_negative_fit_slot_idx=10,
-        conservative_overflow_kwh=5.0,
-        allowed_headroom_pct=3.7,
-        temporary_floor_pct=76.3,
+        risk_window_start_idx=10,
+        risk_window_end_idx=15,
+        required_headroom_kwh=5.0,
+        recovery_deadline_idx=20,
+        conservative_recovery_kwh_by_slot=(10.0, 10.0, 10.0),
+        recoverability_floor_pct_by_slot=(30.0, 30.0, 30.0),
     )
-    assert ctx.first_negative_fit_slot_idx == 10
-    assert ctx.conservative_overflow_kwh == 5.0
-    assert ctx.allowed_headroom_pct == 3.7
-    assert ctx.temporary_floor_pct == 76.3
+    assert ctx.risk_window_start_idx == 10
+    assert ctx.risk_window_end_idx == 15
+    assert ctx.required_headroom_kwh == 5.0
+    assert ctx.recovery_deadline_idx == 20
 
 
 # =============================================================================
@@ -2600,7 +2603,10 @@ def test_negative_fit_context_no_window(default_config):
 def test_negative_fit_context_no_overflow(default_config):
     """Returns None when no forecast overflow projected."""
     planner = DPPlanner(default_config)
-    slots = [_make_slot_for_neg_fit(i, sell_price=0.08 if i < 5 else -0.05) for i in range(10)]
+    slots = [
+        _make_slot_for_neg_fit(i, sell_price=0.08 if i < 5 else -0.05)
+        for i in range(10)
+    ]
     inputs = OptimizerInputs(
         cycle_id="test",
         initial_soc_pct=50.0,
@@ -2614,7 +2620,9 @@ def test_negative_fit_context_no_overflow(default_config):
 def test_negative_fit_context_no_positive_slots(default_config):
     """Returns None when no earlier positive-FIT slots."""
     planner = DPPlanner(default_config)
-    slots = [_make_slot_for_neg_fit(i, sell_price=0.08 if i >= 5 else 0.0) for i in range(10)]
+    slots = [
+        _make_slot_for_neg_fit(i, sell_price=0.08 if i >= 5 else 0.0) for i in range(10)
+    ]
     slots[5] = _make_slot_for_neg_fit(5, sell_price=-0.05)
     inputs = OptimizerInputs(
         cycle_id="test",
@@ -2627,21 +2635,29 @@ def test_negative_fit_context_no_positive_slots(default_config):
 
 
 def test_negative_fit_context_computes_floor(default_config):
-    """Computes correct temporary_floor_pct when all conditions met."""
+    """Computes correct recoverability_floor when all conditions met."""
     planner = DPPlanner(default_config)
     default_config.demand_window_target_soc_pct = 80.0
     slots = []
-    for i in range(6):
-        sell = 0.08 if i < 4 else -0.05
-        solar = 2.0 if i == 0 else 0.0
+    for i in range(10):
+        if i < 4:
+            sell = 0.08
+            solar = 2.0
+        else:
+            sell = -0.05
+            solar = 1.0
         slots.append(_make_slot_for_neg_fit(i, sell_price=sell, solar_kwh=solar))
     inputs = OptimizerInputs(
         cycle_id="test",
-        initial_soc_pct=90.0,
+        initial_soc_pct=95.0,
         slots=slots,
         config=default_config,
     )
     ctx = planner._derive_negative_fit_avoidance_context(inputs)
     assert ctx is not None
-    assert 0 < ctx.allowed_headroom_pct <= 20.0
-    assert abs(ctx.temporary_floor_pct - (80.0 - ctx.allowed_headroom_pct)) < 0.01
+    assert ctx.risk_window_start_idx == 4
+    assert ctx.required_headroom_kwh > 0
+    assert len(ctx.recoverability_floor_pct_by_slot) == 10
+    assert all(
+        f >= default_config.min_soc_pct for f in ctx.recoverability_floor_pct_by_slot
+    )

--- a/tests/test_optimizer_dp_solve.py
+++ b/tests/test_optimizer_dp_solve.py
@@ -2546,3 +2546,18 @@ def test_plan_with_empty_slots():
     result = planner.plan(inputs)
     assert result.success
     assert result.total_slots == 0
+
+
+def test_negative_fit_context_type():
+    """Smoke test: NegativeFitAvoidanceContext can be constructed."""
+    from custom_components.localshift.engine.types import NegativeFitAvoidanceContext
+    ctx = NegativeFitAvoidanceContext(
+        first_negative_fit_slot_idx=10,
+        conservative_overflow_kwh=5.0,
+        allowed_headroom_pct=3.7,
+        temporary_floor_pct=76.3,
+    )
+    assert ctx.first_negative_fit_slot_idx == 10
+    assert ctx.conservative_overflow_kwh == 5.0
+    assert ctx.allowed_headroom_pct == 3.7
+    assert ctx.temporary_floor_pct == 76.3

--- a/tests/test_optimizer_dp_solve.py
+++ b/tests/test_optimizer_dp_solve.py
@@ -2561,3 +2561,87 @@ def test_negative_fit_context_type():
     assert ctx.conservative_overflow_kwh == 5.0
     assert ctx.allowed_headroom_pct == 3.7
     assert ctx.temporary_floor_pct == 76.3
+
+
+# =============================================================================
+# Chunk 2: Negative FIT Avoidance Context Tests
+# =============================================================================
+
+
+def _make_slot_for_neg_fit(
+    idx: int, sell_price: float, solar_kwh: float = 0.0, consumption_kwh: float = 0.0
+) -> SlotContext:
+    """Helper to create a 30-min slot for negative-FIT tests."""
+    return SlotContext(
+        slot_index=idx,
+        timestamp_iso=f"2026-01-03T{(idx // 2):02d}:{(idx % 2) * 30:02d}:00",
+        slot_interval_minutes=30,
+        buy_price=0.10,
+        sell_price=sell_price,
+        solar_kwh=solar_kwh,
+        consumption_kwh=consumption_kwh,
+    )
+
+
+def test_negative_fit_context_no_window(default_config):
+    """Returns None when no negative-FIT window in horizon."""
+    planner = DPPlanner(default_config)
+    slots = [_make_slot_for_neg_fit(i, sell_price=0.08) for i in range(10)]
+    inputs = OptimizerInputs(
+        cycle_id="test",
+        initial_soc_pct=50.0,
+        slots=slots,
+        config=default_config,
+    )
+    ctx = planner._derive_negative_fit_avoidance_context(inputs)
+    assert ctx is None
+
+
+def test_negative_fit_context_no_overflow(default_config):
+    """Returns None when no forecast overflow projected."""
+    planner = DPPlanner(default_config)
+    slots = [_make_slot_for_neg_fit(i, sell_price=0.08 if i < 5 else -0.05) for i in range(10)]
+    inputs = OptimizerInputs(
+        cycle_id="test",
+        initial_soc_pct=50.0,
+        slots=slots,
+        config=default_config,
+    )
+    ctx = planner._derive_negative_fit_avoidance_context(inputs)
+    assert ctx is None
+
+
+def test_negative_fit_context_no_positive_slots(default_config):
+    """Returns None when no earlier positive-FIT slots."""
+    planner = DPPlanner(default_config)
+    slots = [_make_slot_for_neg_fit(i, sell_price=0.08 if i >= 5 else 0.0) for i in range(10)]
+    slots[5] = _make_slot_for_neg_fit(5, sell_price=-0.05)
+    inputs = OptimizerInputs(
+        cycle_id="test",
+        initial_soc_pct=50.0,
+        slots=slots,
+        config=default_config,
+    )
+    ctx = planner._derive_negative_fit_avoidance_context(inputs)
+    assert ctx is None
+
+
+def test_negative_fit_context_computes_floor(default_config):
+    """Computes correct temporary_floor_pct when all conditions met."""
+    planner = DPPlanner(default_config)
+    default_config.demand_window_target_soc_pct = 80.0
+    slots = []
+    for i in range(6):
+        sell = 0.08 if i < 4 else -0.05
+        solar = 2.0 if i == 0 else 0.0
+        slots.append(_make_slot_for_neg_fit(i, sell_price=sell, solar_kwh=solar))
+    inputs = OptimizerInputs(
+        cycle_id="test",
+        initial_soc_pct=90.0,
+        slots=slots,
+        config=default_config,
+    )
+    ctx = planner._derive_negative_fit_avoidance_context(inputs)
+    assert ctx is not None
+    assert 0 < ctx.allowed_headroom_pct <= 20.0
+    assert abs(ctx.temporary_floor_pct - (80.0 - ctx.allowed_headroom_pct)) < 0.01


### PR DESCRIPTION
## Summary
- Add `NegativeFitAvoidanceContext` dataclass to track first negative-FIT window and conservative overflow estimates
- Modify `feasible_actions()` to allow bounded pre-discharge at positive FIT before negative-FIT windows
- Remove `max(0, sell_price)` clipping from `stage_cost()` so negative FIT is treated as a real cost
- Integrate context derivation into DP solve workflow before backward induction

## Related Issue
Closes #719

## Changes
- **const.py**: Add `MAX_NEGATIVE_FIT_HEADROOM_PCT` and `NEGATIVE_FIT_OVERFLOW_BUFFER_FACTOR` constants
- **types.py**: Add `NegativeFitAvoidanceContext` dataclass
- **core.py**: Add `_derive_negative_fit_avoidance_context()` method and thread context through DP solver
- **constraints.py**: Add bounded pre-discharge logic in `_determine_export_actions()` helper
- **cost.py**: Remove negative FIT clipping from export revenue calculation

## Testing
- [x] All 2212 tests pass
- [x] Ruff linting passes
- [x] Coverage at 91% overall
- [x] New unit tests for context derivation, feasible_actions, and stage_cost modifications