### PR TITLE
Add doc-first skill and documentation index

### DIFF
--- a/.opencode/skills/doc-first/SKILL.md
+++ b/.opencode/skills/doc-first/SKILL.md
@@ -1,0 +1,193 @@
+---
+name: doc-first
+description: Automatically check relevant documentation before code analysis tasks
+compatibility: opencode
+metadata:
+  triggers:
+    - "analyze"
+    - "review"
+    - "refactor"
+    - "explain"
+    - "understand"
+    - "how does"
+    - "what is"
+    - "why"
+    - "change optimizer"
+    - "modify optimizer"
+    - "add entity"
+    - "remove entity"
+    - "update entity"
+  actions:
+    - determine_context
+    - identify_relevant_docs
+    - read_docs
+    - summarize_constraints
+    - proceed_with_context
+---
+
+## What I Do
+
+I enforce a documentation-first workflow. When you ask an agent to analyze, review, refactor, or modify code, I automatically:
+
+1. Determine what domain you're working in (optimizer, entities, state machine, etc.)
+2. Identify the critical docs you must read first
+3. Read those docs and extract key constraints
+4. Present a summary before any code analysis begins
+
+This prevents agents from diving into code without understanding the architectural constraints and patterns.
+
+## When to Use Me
+
+My triggers are broad - I activate on almost any code-related question:
+
+- "Analyze this function"
+- "Review the optimizer code"
+- "Refactor the state machine"
+- "Explain how entities work"
+- "How does the DP solver work?"
+- "What constraints exist for grid charging?"
+- "Add a new sensor entity"
+- "Change the planning model"
+
+If you're asking about code, I'll make sure docs are consulted first.
+
+## How I Work
+
+### Step 1: Context Determination
+
+I examine the task to identify the domain:
+- Keywords: "optimizer", "DP", "planner", "feasible_actions" → optimizer domain
+- Keywords: "entity", "sensor", "switch", "binary_sensor" → entity domain
+- Keywords: "state", "machine", "transition", "mode" → state machine domain
+- Keywords: "forecast", "prediction", "solar", "load" → forecast domain
+- Keywords: "config", "flow", "options" → config flow domain
+
+### Step 2: Doc Identification
+
+Based on domain, I consult the documentation index:
+
+| Domain | Must-Read Docs | Also Useful |
+|--------|---------------|-------------|
+| Optimizer | PLANNING_MODEL.md | OPTIMIZER_DP_ROLLOUT.md, TROUBLESHOOTING.md |
+| Entities | ENTITY_REFERENCE.md, AGENTS.md | ARCHITECTURE.md |
+| State Machine | ARCHITECTURE.md | TROUBLESHOOTING.md |
+| Forecast | ARCHITECTURE.md, FORECAST_DRIVEN_CONTROL.md | LOAD_FORECASTING.md |
+| General | ARCHITECTURE.md | DEVELOPER_GUIDE.md |
+
+### Step 3: Extract Key Constraints
+
+I don't just dump the whole doc. I extract specific constraints:
+
+**For optimizer changes:**
+- Hard constraints → `feasible_actions()`
+- Deadlines → `terminal_cost()`
+- Preferences → `stage_cost()` penalties
+- Pure/stateless requirement
+
+**For entities:**
+- Platform file patterns (sensor.py, switch.py)
+- Entity count limits
+- Coordinator-read-only pattern
+- Update ENTITY_REFERENCE.md requirement
+
+**For state machine:**
+- Debounce timer rules
+- Validation timeout values
+- Health check cooldowns
+- Transition safety gates
+
+### Step 4: Present Summary
+
+Before analysis, I'll tell you:
+- "This task involves the DP optimizer. You must consult PLANNING_MODEL.md first."
+- "Key constraints: [bullet list of critical rules]"
+- "Required pattern: [specific implementation pattern]"
+- "Anti-patterns to avoid: [list]"
+
+Then the agent proceeds with code analysis INFORMED by the docs.
+
+## Example Workflow
+
+**User:** "Can you refactor the optimizer to simplify stage_cost()?"
+
+**Me:**
+```
+📚 Documentation Check Required
+
+Domain: DP Optimizer
+Must-read: docs/PLANNING_MODEL.md
+
+Key constraints extracted:
+• Hard constraints → feasible_actions() only
+• stage_cost() is for soft preferences (penalties)
+• Keep optimizer pure (deterministic, stateless)
+• terminal_cost() encodes deadline requirements
+
+Required pattern:
+- Use penalties in stage_cost() to discourage undesirable timing
+- Do NOT add hard constraints to stage_cost()
+- Maintain pure function (no side effects)
+
+Anti-patterns:
+✗ Don't modify feasible_actions() for preferences
+✗ Don't introduce state into optimizer
+✗ Don't forget to update terminal_cost() if changing stage_cost()
+
+Proceeding with refactoring analysis...
+```
+
+**Agent:** Now analyzes with doc constraints in mind.
+
+## Why This Matters
+
+Without this skill, agents:
+1. See complex code
+2. Start proposing changes based on code smells alone
+3. Violate critical constraints because they didn't know them
+4. Create PRs that get rejected or introduce bugs
+
+With this skill:
+1. Agent reads constraints first
+2. Proposals respect architectural boundaries
+3. Changes align with system design principles
+4. Fewer review cycles, higher quality
+
+## Configuration
+
+The skill uses these file mappings (in `docs/AGENTS.md`):
+
+```yaml
+domain_mappings:
+  optimizer:
+    must_read: [PLANNING_MODEL.md, OPTIMIZER_DP_ROLLOUT.md]
+    key_constraints:
+      - feasible_actions: hard constraints only
+      - stage_cost: soft penalties only
+      - terminal_cost: deadline requirements
+      - pure: stateless and deterministic
+  entities:
+    must_read: [ENTITY_REFERENCE.md, AGENTS.md]
+    key_constraints:
+      - update_reference: always update ENTITY_REFERENCE.md
+      - pattern: entities read from coordinator only
+      - platforms: create in sensor.py, switch.py, etc.
+      - count: aware of entity limits
+```
+
+## Integration with SymDex
+
+I use `symdex_search_text()` to quickly find relevant sections in indexed docs. This is fast and precise.
+
+## Fallback
+
+If a doc isn't indexed in SymDex yet, I'll use `Read` to fetch it directly. No configuration needed.
+
+## Override
+
+If you explicitly say "skip documentation check" or "I know the constraints", I'll respect that. But you'll need to be explicit.
+
+## See Also
+
+- `docs/AGENTS.md` - Documentation index that maps domains to docs
+- `AGENTS.md` (root) - Existing rule that optimizer changes must consult PLANNING_MODEL.md
+- `custom_components/localshift/AGENTS.md` - Entity patterns and rules

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,10 +51,24 @@ Use SymDex instead of grep/read:
 | `custom_components/localshift/AGENTS.md` | Entity/platform changes |
 | `custom_components/localshift/engine/AGENTS.md` | Optimizer changes |
 | `tests/AGENTS.md` | Test patterns |
-| `docs/AGENTS.md` | Documentation index |
+| `docs/INDEX.md` | **Primary documentation index (use this first!)** |
+| `docs/AGENTS.md` | Documentation index (legacy, see INDEX.md) |
 | `.agents/rules/tdd-workflow.md` | Detailed TDD guide |
 | `.agents/rules/pr-ci-checks.md` | CI/PR workflow |
 | `.agents/rules/worktrees.md` | Git worktree details |
+
+## Documentation-First Workflow
+
+**NEW:** The `doc-first` skill automatically checks relevant documentation before any code analysis. It activates on tasks like "analyze", "review", "refactor", "explain", and related queries. The skill:
+
+1. Determines domain (optimizer, entities, state machine, etc.)
+2. Identifies required docs from `docs/INDEX.md`
+3. Extracts key constraints and patterns
+4. Presents summary before analysis begins
+
+**Manual override:** If you need to skip this, say "skip documentation check" explicitly.
+
+**When manual review needed:** Always consult `docs/INDEX.md` to understand which docs apply to your task.
 
 ## Verification Commands
 

--- a/custom_components/localshift/AGENTS.md
+++ b/custom_components/localshift/AGENTS.md
@@ -48,7 +48,10 @@ class LocalShiftSensor(SensorEntity):
 
 ## See Also
 
-- `../AGENTS.md` - Root rules
+- `../AGENTS.md` - Root rules (includes doc-first skill)
 - `engine/AGENTS.md` - Optimizer rules
 - `../../tests/AGENTS.md` - Testing
-- `../../docs/PLANNING_MODEL.md` - Planner guide
+- `../../docs/INDEX.md` - **Primary documentation index (use this first!)**
+- `../../docs/PLANNING_MODEL.md` - Optimizer constraints (legacy, see INDEX.md)
+- `../../docs/ENTITY_REFERENCE.md` - Entity catalog
+- `../../docs/ARCHITECTURE.md` - System architecture

--- a/custom_components/localshift/engine/AGENTS.md
+++ b/custom_components/localshift/engine/AGENTS.md
@@ -28,6 +28,8 @@ terminal_cost()    → What MUST I achieve? (deadline)
 
 **MUST consult** `docs/PLANNING_MODEL.md` before changes.
 
+**See also:** `docs/INDEX.md` for complete documentation map.
+
 ## Key Concepts
 
 - **Slots**: 15-minute intervals

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,6 +1,19 @@
 # Documentation Index
 
-## Critical Docs
+**Note:** This file is legacy. The primary index is now **[INDEX.md](../INDEX.md)** which provides comprehensive, domain-specific guidance.
+
+## Quick Reference
+
+| Domain | Primary Doc | Also Useful |
+|--------|-------------|-------------|
+| Optimizer (DP) | `PLANNING_MODEL.md` | `OPTIMIZER_DP_ROLLOUT.md`, `TROUBLESHOOTING.md` |
+| Entities | `ENTITY_REFERENCE.md` + `AGENTS.md` (root) | `ARCHITECTURE.md` |
+| State Machine | `ARCHITECTURE.md` | `TROUBLESHOOTING.md` |
+| Forecasts | `ARCHITECTURE.md`, `FORECAST_DRIVEN_CONTROL.md` | `LOAD_FORECASTING.md` |
+| Learning System | `LEARNING_SYSTEM.md` | `OPTIMIZER_DP_ROLLOUT.md` |
+| General | `ARCHITECTURE.md` | `DEVELOPER_GUIDE.md` |
+
+## Critical Docs (Legacy)
 
 | Document | When Needed |
 |----------|-------------|
@@ -17,5 +30,6 @@ When adding/removing entities:
 
 ## See Also
 
-- `../AGENTS.md` - Root rules
+- `../INDEX.md` — **Primary documentation index (use this first!)**
+- `../AGENTS.md` - Root rules (includes doc-first skill)
 - `../custom_components/localshift/AGENTS.md` - Integration

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -1,0 +1,284 @@
+# Documentation Index for Agents
+
+## Quick Reference
+
+Use this index to quickly determine which documentation files to consult before working on different parts of the codebase.
+
+---
+
+## Optimizer Changes (DP Planner)
+
+**Any modification to `engine/optimizer_dp.py`, `engine/constraints.py`, or related planning logic.**
+
+### Must Read (Critical)
+- **[PLANNING_MODEL.md](PLANNING_MODEL.md)** — Core principles and constraint guide
+  - Defines the soft-constrained DP pattern: `feasible_actions()` / `stage_cost()` / `terminal_cost()`
+  - When to add to each function
+  - Pure/stateless requirements
+
+### Should Read
+- **[OPTIMIZER_DP_ROLLOUT.md](OPTIMIZER_DP_ROLLOUT.md)** — Rollout patterns and safety gates
+- **[TROUBLESHOOTING.md](TROUBLESHOOTING.md)** — Common optimizer issues
+
+### Key Constraints
+
+| Constraint | Location | Description |
+|------------|----------|-------------|
+| Hard constraints only | `feasible_actions()` | What the optimizer CAN do |
+| Soft preferences | `stage_cost()` | Penalties for undesirable choices |
+| Deadline requirements | `terminal_cost()` | Must-achieve goals by horizon end |
+| Purity | All optimizer code | Deterministic, stateless, no side effects |
+| Feasibility check | All changes | Ask: "Does this belong in feasible_actions(), stage_cost(), or terminal_cost()?" |
+
+### Anti-Patterns
+- ✗ Adding soft preferences to `feasible_actions()` (hard constraints only)
+- ✗ Modifying cost without adjusting `terminal_cost()` (imbalance)
+- ✗ Introducing state or randomness (breaks determinism)
+- ✗ Forgetting to document constraint changes
+
+### Related Files
+- `engine/optimizer_dp.py` — Main DP solver
+- `engine/constraints.py` — Hard constraint functions
+- `engine/optimizer_runner.py` — Coordinator integration
+- `tests/test_optimizer_dp_solve.py` — Test patterns
+
+---
+
+## Entity Platform Changes
+
+**Adding, removing, or modifying sensor, binary_sensor, switch, number, select, or button entities.**
+
+### Must Read
+- **[ENTITY_REFERENCE.md](ENTITY_REFERENCE.md)** — Complete entity catalog with descriptions
+- **[AGENTS.md](../AGENTS.md)** — Root agent rules (Critical section)
+
+### Should Read
+- **[ARCHITECTURE.md](ARCHITECTURE.md)** — Entity platform responsibilities
+
+### Key Constraints
+
+| Constraint | Description |
+|------------|-------------|
+| Entity count limits | Sensors: 30, Binary: 10, Switches: 8, Numbers: 4, Selects: 2, Buttons: 2 |
+| Read-only pattern | Entities read from `self.coordinator.data`, don't compute |
+| Platform files | Each platform in its own file (sensor.py, switch.py, etc.) |
+| Documentation required | MUST update `ENTITY_REFERENCE.md` for every add/remove |
+| Architecture changes | If entity dependencies change, update `ARCHITECTURE.md` |
+| Async only | All platform setup uses `async_forward_entry_setups()` |
+
+### Entity Pattern
+```python
+class LocalShiftSensor(SensorEntity):
+    def __init__(self, coordinator, key: str) -> None:
+        self.coordinator = coordinator
+        self._key = key
+
+    @property
+    def native_value(self) -> Any:
+        return self.coordinator.data.get(self._key)
+```
+
+### Related Files
+- `sensor.py`, `binary_sensor.py`, `switch.py`, `number.py`, `select.py`, `button.py`
+- `coordinator/data.py` — `CoordinatorData` structure
+- `tests/` — Test patterns in `tests/AGENTS.md`
+
+---
+
+## State Machine Changes
+
+**Modifying `state/machine.py`, transition logic, or debounce behavior.**
+
+### Must Read
+- **[ARCHITECTURE.md](ARCHITECTURE.md)** — State machine section (lines 415-527)
+
+### Should Read
+- **[TROUBLESHOOTING.md](TROUBLESHOOTING.md)** — State transition issues
+
+### Key Constraints
+
+| Mechanism | Value | Purpose |
+|-----------|-------|---------|
+| Debounce timers | 2-5 minutes | Prevent rapid oscillations |
+| Validation timeout | 10 seconds | Wait for hardware confirmation |
+| Health check cooldown | 5 minutes | Avoid command spam |
+| State change handling | Synchronous notify + async evaluate | Race-free transitions |
+
+### Critical Rules
+- Debounce timers reset when mode changes away (full debounce from continuous stable period)
+- Validation timeout reduced from 20s → 10s (early-exit on success)
+- Health check only re-issues correction if `_MIN_CORRECTION_INTERVAL` elapsed
+- Always notify HA listeners in `try/finally` blocks
+
+### Anti-Patterns
+- ✗ Short-circuiting debounce (must serve full timer from stable period)
+- ✗ Blocking notify in exception paths (use `try/finally`)
+- ✗ Ignoring Teslemetry state lag (15-30s cloud delay)
+
+---
+
+## Forecast System Changes
+
+**Modifying forecast computation, solar/load prediction, or accuracy tracking.**
+
+### Must Read
+- **[ARCHITECTURE.md](ARCHITECTURE.md)** — Forecast computer and data flow
+- **[FORECAST_DRIVEN_CONTROL.md](FORECAST_DRIVEN_CONTROL.md)** — Design rationale
+
+### Should Read
+- **[LOAD_FORECASTING.md](LOAD_FORECASTING.md)** — Load prediction methods
+- **[CHANGE_DETECTION.md](CHANGE_DETECTION.md)** — When forecasts trigger recompute
+
+### Key Constraints
+
+| Principle | Description |
+|-----------|-------------|
+| Forecast as plan | The forecast IS the battery control plan |
+| Change detection | Only recompute on significant changes (price, SOC, forecast age, solar updates) |
+| Near-term correction | 1-minute fast tick detects load deviation (>1kW for 10min, >3kW for 5min) |
+| Granularity | 5-minute slots for near-term (2h), 15-minute for long-term (22h) |
+| Multi-horizon | Two-tier slot structure (5-min + 15-min) in one timeline |
+
+### Change Detection Triggers
+- Price change (any change in buy/sell)
+- SOC change (≥1% threshold)
+- Forecast age (>5 minutes)
+- Solar forecast updates
+
+### Anti-Patterns
+- ✗ Recomputing on every state change (wasteful)
+- ✗ Ignoring near-term deviation (misses correction opportunities)
+- ✗ Single granularity for entire horizon (inefficient)
+
+---
+
+## Learning System Changes
+
+**Modifying the adaptive learning system (`learning/`, `engine/parameter_optimizer.py`, etc.).**
+
+### Must Read
+- **[LEARNING_SYSTEM.md](LEARNING_SYSTEM.md)** — Complete architecture and data flow
+- **[ARCHITECTURE.md](ARCHITECTURE.md)** — Learning system section (lines 593-723)
+
+### Should Read
+- **[OPTIMIZER_DP_ROLLOUT.md](OPTIMIZER_DP_ROLLOUT.md)** — Shadow mode patterns
+
+### Key Constraints
+
+| Component | Purpose |
+|-----------|---------|
+| DecisionOutcomeTracker | Records decisions and backfills outcomes |
+| ParameterOptimizer | Thompson sampling for parameter tuning |
+| PatternAnalyzer | Detects systematic biases (weekly) |
+| OptimizationController | Real-time contextual adjustments |
+
+### Safety Rails
+- Warm-up: No adjustments until 50+ decisions
+- Step limits: Max 1 step per daily update
+- Bounds: All parameters within defined min/max
+- Rollback: Revert if 7-day score decreases for 3 consecutive days
+
+### Adaptive Parameters
+```yaml
+cheap_price_bias: [-5.0, +5.0] c/kWh
+solar_confidence_factor: [0.5, 1.5]
+overnight_drain_safety_margin: [-5.0, +10.0] %
+grid_charge_soc_headroom: [-5.0, +10.0] %
+export_threshold_adjustment: [-3.0, +3.0] c/kWh
+consumption_forecast_bias: [-0.5, +0.5] kW
+```
+
+### Multi-Objective Scoring
+```
+score = 0.50 × cost_score
+      + 0.20 × export_avoidance_score
+      + 0.20 × target_achievement_score
+      + 0.10 × cycle_reduction_score
+```
+
+### Anti-Patterns
+- ✗ Adjusting parameters before warm-up period
+- ✗ Ignoring step limits (causes instability)
+- ✗ Breaking purity (learning system must be side-effect-free)
+
+---
+
+## Config Flow / Integration Changes
+
+**Modifying `config_flow/` or integration options.**
+
+### Must Read
+- **[DEVELOPER_GUIDE.md](DEVELOPER_GUIDE.md)** — Development patterns
+- **[docs/AGENTS.md](AGENTS.md)** — Reference index
+
+### Should Read
+- **[ARCHITECTURE.md](ARCHITECTURE.md)** — Config flow placement
+
+### Key Constraints
+- Config flow is mandatory for HA integrations
+- Options flow handles runtime configuration changes
+- Validation in `validators.py`, schemas in `schemas.py`
+- User-facing strings in `strings.json`
+
+---
+
+## General Development
+
+**Any other code change.**
+
+### Must Read
+- **[AGENTS.md](../AGENTS.md)** — Root rules (worktree, TDD, coverage)
+- **[docs/AGENTS.md](AGENTS.md)** — This index
+
+### Should Read
+- **[ARCHITECTURE.md](ARCHITECTURE.md)** — System overview
+- **[DEVELOPER_GUIDE.md](DEVELOPER_GUIDE.md)** — Patterns and conventions
+
+### Critical Rules (All Tasks)
+
+1. **Worktree required** — Never work on `main` or `test` directly
+2. **TDD required** — Write failing test first, then implement
+3. **Coverage ≥95%** — `uv run pytest --cov=custom_components/localshift --cov-report=term-missing`
+4. **Python 3.13+** — With `from __future__ import annotations`
+5. **Type hints required** — On all public APIs
+6. **SymDex navigation** — Use `symdex_search_symbols()` instead of grep
+
+---
+
+## How to Use This Index
+
+**As an agent:** When tasked with code modification, consult this index first to determine which docs are mandatory. Use `symdex_search_text()` to quickly extract key constraints from those docs.
+
+**As a developer:** Keep this file updated when adding new subsystems. Add new sections with "Must Read" and "Key Constraints" tables.
+
+**As a reviewer:** Verify that the agent consulted relevant docs before proposing changes.
+
+---
+
+## Quick Commands
+
+```bash
+# Search indexed docs
+symdex_search_text("feasible_actions constraint")
+symdex_search_text("debounce timer")
+
+# Read full doc if needed
+Read docs/PLANNING_MODEL.md
+Read docs/ARCHITECTURE.md
+
+# Verify documentation requirements
+# (Check that relevant sections above were followed)
+```
+
+---
+
+## Updating This Index
+
+When adding new subsystems or major features:
+
+1. Add a new section with "Must Read" and "Should Read"
+2. Create a "Key Constraints" table summarizing critical rules
+3. Add an "Anti-Patterns" list if needed
+4. Reference specific file locations where applicable
+
+Keep it concise — agents use this to decide what to read, not to learn everything.


### PR DESCRIPTION
## Summary

Adds automatic documentation-first workflow to ensure agents consult relevant docs before code analysis.

**Key Changes:**

- **`.opencode/skills/doc-first/SKILL.md`** - New skill that activates on analyze/refactor/review tasks, determines domain, extracts constraints from docs, and presents summary before analysis
- **`docs/INDEX.md`** - Primary documentation index mapping domains to required docs with key constraints and anti-patterns
- Updated **all `AGENTS.md`** files to reference `docs/INDEX.md` as the first-stop for documentation

## Why This?

Previously, agents would dive into code without checking architectural constraints, leading to:
- Violations of optimizer patterns (`feasible_actions()` vs `stage_cost()` misuse)
- Missing entity count limits and platform patterns
- Ignoring state machine debounce/timeout rules

The doc-first skill enforces a documentation-first approach automatically.

## Testing

The skill is active immediately. Test triggers:
- "Analyze the optimizer"
- "Refactor the state machine"
- "Review entity patterns"
- "Explain how forecasts work"

Each should produce a pre-analysis summary with domain-specific constraints.

## No Code Changes

All changes are documentation/skill infrastructure. No production code modified.

## Related Issue

Closes #<issue-number> (to be linked)