### PR TITLE
Fix load deviation forecast-slot indexing (issue #732)

### DIFF
--- a/custom_components/localshift/forecast/load_deviation.py
+++ b/custom_components/localshift/forecast/load_deviation.py
@@ -122,9 +122,28 @@ class LoadDeviationDetector:
         self, data: Any, current_slot_index: int
     ) -> float | None:
         load_forecast_slots = getattr(data, "load_forecast_slots", []) or []
-        if current_slot_index < 0 or current_slot_index >= len(load_forecast_slots):
+        if not load_forecast_slots:
             return None
-        return float(load_forecast_slots[current_slot_index])
+
+        decisions = getattr(data, "optimizer_decisions", []) or []
+        if not decisions or current_slot_index < 0:
+            return None
+
+        try:
+            base_slot = datetime.fromisoformat(decisions[0]["timestamp_iso"])
+            active_slot = datetime.fromisoformat(
+                decisions[current_slot_index]["timestamp_iso"]
+            )
+        except (KeyError, ValueError, TypeError):
+            return None
+
+        elapsed_min = (active_slot - base_slot).total_seconds() / 60.0
+        max_forecast_index = len(load_forecast_slots) - 1
+        mapped_idx = max(0, min(int(elapsed_min // 15), max_forecast_index))
+
+        if mapped_idx < 0 or mapped_idx >= len(load_forecast_slots):
+            return None
+        return float(load_forecast_slots[mapped_idx])
 
     def _update_window(
         self, breach_name: str, breach_active: bool, now: datetime

--- a/tests/forecast/test_load_deviation.py
+++ b/tests/forecast/test_load_deviation.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
+from zoneinfo import ZoneInfo
 
 from custom_components.localshift.coordinator import CoordinatorData
 from custom_components.localshift.forecast.load_deviation import LoadDeviationDetector
@@ -105,3 +106,191 @@ def test_detector_retriggers_after_cooldown_with_new_window() -> None:
     diagnostics = data.load_deviation_diagnostics
     assert diagnostics["breach_type"] == "spike"
     assert diagnostics["triggered"] is True
+
+
+def _make_multi_decision_data(
+    *,
+    now: datetime,
+    actual_kw: float,
+    load_forecast_slots: list[float],
+    decision_timestamps: list[datetime],
+) -> CoordinatorData:
+    """Create test data with multiple optimizer decisions at different times."""
+    data = CoordinatorData()
+    data.load_power_kw = actual_kw
+    data.load_forecast_slots = load_forecast_slots
+    data.optimizer_decisions = [
+        {
+            "timestamp_iso": ts.isoformat(),
+            "slot_interval_minutes": 5 if i < 8 else 30,
+        }
+        for i, ts in enumerate(decision_timestamps)
+    ]
+    data.optimizer_last_apply_status = "ready_to_apply"
+    data.optimizer_apply_plan = {"battery_mode": "grid_charging"}
+    data.load_deviation_diagnostics = {}
+    return data
+
+
+def test_detector_uses_time_based_forecast_mapping_for_5min_decisions() -> None:
+    """Regression: multiple 5-minute decisions should map to same 15-minute forecast slot.
+
+    The bug was: detector used decision index directly instead of time-based mapping,
+    causing incorrect forecast lookup (decision 4 read forecast slot 4 instead of slot 1).
+
+    This test verifies that decision at index 4 reads from time-mapped forecast slot.
+    """
+    from unittest.mock import patch
+
+    aus_tz = ZoneInfo("Australia/Sydney")
+
+    base_time = datetime(2026, 3, 15, 11, 5, 0, tzinfo=aus_tz)
+
+    load_forecast_slots = [1.0, 1.5, 2.0, 2.5, 3.0, 3.5] + [1.0] * 90
+
+    decision_times = [
+        base_time,
+        base_time + timedelta(minutes=5),
+        base_time + timedelta(minutes=10),
+        base_time + timedelta(minutes=15),
+        base_time + timedelta(minutes=20),
+        base_time + timedelta(minutes=25),
+    ]
+
+    data = _make_multi_decision_data(
+        now=base_time,
+        actual_kw=2.0,
+        load_forecast_slots=load_forecast_slots,
+        decision_timestamps=decision_times,
+    )
+
+    def mock_find_slot(data):
+        return 4
+
+    with patch(
+        "custom_components.localshift.forecast.load_deviation._find_current_slot_index",
+        mock_find_slot,
+    ):
+        detector = LoadDeviationDetector()
+        result = detector.evaluate(data, base_time)
+
+    diagnostics = data.load_deviation_diagnostics
+    assert diagnostics["current_slot_index"] == 4, (
+        f"Expected decision index 4, got {diagnostics['current_slot_index']}"
+    )
+
+    decision_4_time = decision_times[4]
+    elapsed = (decision_4_time - base_time).total_seconds() / 60.0
+    expected_forecast_idx = min(int(elapsed // 15), len(load_forecast_slots) - 1)
+    expected_forecast_kw = load_forecast_slots[expected_forecast_idx]
+    assert diagnostics["forecast_kw"] == expected_forecast_kw, (
+        f"Expected {expected_forecast_kw} (time-mapped index {expected_forecast_idx}), "
+        f"got {diagnostics['forecast_kw']} (bug: using direct index 4 -> {load_forecast_slots[4]})"
+    )
+
+
+def test_detector_15min_boundary_crossing() -> None:
+    """Decision at 11:35 (25 min from base 11:05) should map to forecast slot 1, not slot 2."""
+    from unittest.mock import patch
+
+    base_time = datetime(2026, 3, 15, 11, 5, 0, tzinfo=ZoneInfo("Australia/Sydney"))
+
+    load_forecast_slots = [1.0, 1.5, 2.0, 2.5, 3.0, 3.5] + [1.0] * 90
+
+    decision_times = [
+        base_time,
+        base_time + timedelta(minutes=25),
+    ]
+
+    data = _make_multi_decision_data(
+        now=base_time,
+        actual_kw=2.5,
+        load_forecast_slots=load_forecast_slots,
+        decision_timestamps=decision_times,
+    )
+
+    def mock_find_slot(data):
+        return 1
+
+    with patch(
+        "custom_components.localshift.forecast.load_deviation._find_current_slot_index",
+        mock_find_slot,
+    ):
+        detector = LoadDeviationDetector()
+        detector.evaluate(data, base_time)
+
+    diagnostics = data.load_deviation_diagnostics
+    assert diagnostics["forecast_kw"] == 1.5
+
+
+def test_detector_later_decision_would_fail_with_direct_indexing() -> None:
+    """Decision index 4 should map to forecast slot 1 (time-based), not slot 4.
+
+    With direct indexing: forecast_kw = load_forecast_slots[4] = 1.768
+    With time-based mapping: forecast_kw = load_forecast_slots[1] = 1.651
+    """
+    from unittest.mock import patch
+
+    base_time = datetime(2026, 3, 15, 11, 5, 0, tzinfo=ZoneInfo("Australia/Sydney"))
+
+    load_forecast_slots = [1.651] * 4 + [1.768] * 4 + [1.509] * 88
+
+    decision_times = [
+        base_time,
+        base_time + timedelta(minutes=25),
+    ]
+
+    data = _make_multi_decision_data(
+        now=base_time,
+        actual_kw=1.8,
+        load_forecast_slots=load_forecast_slots,
+        decision_timestamps=decision_times,
+    )
+
+    def mock_find_slot(data):
+        return 1
+
+    with patch(
+        "custom_components.localshift.forecast.load_deviation._find_current_slot_index",
+        mock_find_slot,
+    ):
+        detector = LoadDeviationDetector()
+        detector.evaluate(data, base_time + timedelta(minutes=25))
+
+    diagnostics = data.load_deviation_diagnostics
+    assert diagnostics["current_slot_index"] == 1
+    assert diagnostics["forecast_kw"] == 1.651
+
+
+def test_detector_out_of_range_mapped_index_clamps() -> None:
+    """Late decision timestamp should clamp to last valid forecast slot."""
+    from unittest.mock import patch
+
+    base_time = datetime(2026, 3, 15, 11, 5, 0, tzinfo=ZoneInfo("Australia/Sydney"))
+
+    load_forecast_slots = [1.0, 2.0, 3.0]
+
+    decision_times = [
+        base_time,
+        base_time + timedelta(hours=24),
+    ]
+
+    data = _make_multi_decision_data(
+        now=base_time,
+        actual_kw=3.5,
+        load_forecast_slots=load_forecast_slots,
+        decision_timestamps=decision_times,
+    )
+
+    def mock_find_slot(data):
+        return 1
+
+    with patch(
+        "custom_components.localshift.forecast.load_deviation._find_current_slot_index",
+        mock_find_slot,
+    ):
+        detector = LoadDeviationDetector()
+        detector.evaluate(data, base_time + timedelta(hours=24))
+
+    diagnostics = data.load_deviation_diagnostics
+    assert diagnostics["forecast_kw"] == 3.0


### PR DESCRIPTION
## Summary
Fixes load deviation detector using direct index into forecast slots instead of time-based mapping.

The bug: `LoadDeviationDetector._current_slot_forecast()` used `load_forecast_slots[current_slot_index]` directly, treating optimizer decision index as forecast slot index. This is wrong when there are multiple 5-minute decisions per 15-minute forecast slot.

The fix: Use decision timestamps to compute elapsed time from base slot, map to correct 15-minute forecast index using `floor(elapsed_minutes / 15)`, with clamping to valid range.

## Changes
- `custom_components/localshift/forecast/load_deviation.py`: Changed `_current_slot_forecast()` to use time-based mapping
- `tests/forecast/test_load_deviation.py`: Added regression tests for the bug scenario

## Testing
- All 10 load_deviation tests pass
- New tests cover: multiple 5-min decisions sharing forecast slot, 15-min boundary crossing, later decision index mismatch, out-of-range clamping

## Related Issue
Closes #732