### PR TITLE
Replace DCP plugin with context-mode

### DIFF
--- a/opencode.json
+++ b/opencode.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://opencode.ai/config.json",
+  "plugin": ["context-mode"],
   "instructions": [
     ".opencode/rules",
     ".agents/rules/worktrees.md"
@@ -10,7 +11,6 @@
       ".opencode/skills/python-refactoring"
     ]
   },
-  "plugin": ["@tarquinen/opencode-dcp@latest"],
   "mcp": {
     "symdex": {
       "type": "local",


### PR DESCRIPTION
## Summary
- Replace `@tarquinen/opencode-dcp@latest` plugin with `context-mode`
- Context-mode provides sandbox execution, FTS5 content indexing, and session continuity
- DCP configuration preserved in `~/.config/opencode/dcp.jsonc` for easy re-enablement

## Changes
- Updated `opencode.json` plugin array from DCP to context-mode
- Context-mode installed globally via npm

## Testing
- `context-mode doctor` passes all checks (except SessionStart which is an OpenCode limitation)
- MCP server initializes correctly
- Plugin registration verified

## Notes
- SessionStart hook not supported by OpenCode yet (issues #14808, #5409)
- This is a configuration change only - no production code affected