### PR TITLE
chore: increase Solcast today forecast staleness threshold to 2 hours

### DIFF
--- a/custom_components/localshift/utils/entity_configs.py
+++ b/custom_components/localshift/utils/entity_configs.py
@@ -133,7 +133,7 @@ STALENESS_THRESHOLDS: dict[str, timedelta] = {
     CONF_TESLEMETRY_OPERATION_MODE: timedelta(minutes=5),
     CONF_PRICING_GENERAL_PRICE: timedelta(minutes=10),
     CONF_PRICING_FEED_IN_PRICE: timedelta(minutes=10),
-    CONF_SOLCAST_FORECAST_TODAY: timedelta(hours=1),
+    CONF_SOLCAST_FORECAST_TODAY: timedelta(hours=2),
     CONF_SOLCAST_FORECAST_TOMORROW: timedelta(hours=6),
 }
 


### PR DESCRIPTION
## Summary
Increase Solcast today forecast staleness threshold from 1h to 2h to reduce false degraded status alerts.

## Related Issue
Closes #739

## Changes
- Updated `CONF_SOLCAST_FORECAST_TODAY` staleness threshold in `entity_configs.py`
- No code logic changes; only threshold adjustment

## Testing
- All tests pass with 100% coverage
- TDD compliance verified
- No impact on planning functionality