### PR TITLE
fix(#739): track weather_adjustment_applied flag accurately

### DIFF
--- a/custom_components/localshift/engine/weather_diagnostics.py
+++ b/custom_components/localshift/engine/weather_diagnostics.py
@@ -62,8 +62,6 @@ class WeatherDiagnosticsEngine:
         if has_medium_confidence:
             data.weather_correlation_confidence = "medium"
 
-        data.weather_adjustment_applied = False
-
         # Issue #681: Weather anomaly detection for rollback protection
         current_temp = weather_correlation.get_current_temperature()
         if current_temp is not None:

--- a/custom_components/localshift/forecast/load.py
+++ b/custom_components/localshift/forecast/load.py
@@ -40,6 +40,7 @@ class LoadForecaster:
         self._weather_correlation = weather_correlation
         self._adaptive_params = None  # Issue #170 Phase 2: Adaptive parameters
         self._forecast_corrections: ForecastCorrectionProvider | None = None
+        self._weather_adjustment_applied = False  # Track if weather adjustment was used
 
     def set_weather_correlation(self, weather_correlation: Any | None) -> None:
         """Set or clear WeatherCorrelation dependency at runtime."""
@@ -59,6 +60,14 @@ class LoadForecaster:
         self, provider: ForecastCorrectionProvider | None
     ) -> None:
         self._forecast_corrections = provider
+
+    def get_weather_adjustment_applied(self) -> bool:
+        """Return whether weather adjustment was applied in last forecast."""
+        return self._weather_adjustment_applied
+
+    def reset_weather_adjustment_applied(self) -> None:
+        """Reset weather adjustment flag before new forecast computation."""
+        self._weather_adjustment_applied = False
 
     def parse_time_option(self, key: str, default: str) -> time:
         """Parse a time string option (HH:MM:SS) into a time object."""
@@ -354,6 +363,7 @@ class LoadForecaster:
             "low_confidence",
             "invalid_hour",
         ):
+            self._weather_adjustment_applied = True
             return weather_adjusted, adjustment_source
 
         return adjusted_load_kw, adjusted_source

--- a/custom_components/localshift/forecast/pipeline.py
+++ b/custom_components/localshift/forecast/pipeline.py
@@ -50,6 +50,8 @@ class ForecastPipeline:
         base_slot = now_dt.replace(minute=current_5min, second=0, microsecond=0)
         current_hour = base_slot.hour
 
+        self._load_forecaster.reset_weather_adjustment_applied()
+
         slots: list[float] = []
         for i in range(total_slots):
             slot_start = base_slot + timedelta(minutes=15 * i)
@@ -72,6 +74,9 @@ class ForecastPipeline:
             slots.append(load_kw)
 
         data.load_forecast_slots = slots
+        data.weather_adjustment_applied = (
+            self._load_forecaster.get_weather_adjustment_applied()
+        )
         _LOGGER.info(
             "ISSUE_500 load_forecast_slots: %d slots, indices 4-8 = %s, recent_load=%.3f, hourly_avg_12=%.3f",
             len(slots),

--- a/tests/forecast/test_load.py
+++ b/tests/forecast/test_load.py
@@ -539,3 +539,96 @@ def mock_adaptive_params():
     mock = MagicMock()
     mock.get.return_value = 0.1  # +0.1 bias
     return mock
+
+
+class TestWeatherAdjustmentTracking:
+    """Tests for weather_adjustment_applied tracking (Issue #739)."""
+
+    def test_get_weather_adjustment_applied_defaults_to_false(self):
+        forecaster = _create_load_forecaster()
+        assert forecaster.get_weather_adjustment_applied() is False
+
+    def test_reset_weather_adjustment_applied_sets_flag_false(self):
+        forecaster = _create_load_forecaster()
+        forecaster._weather_adjustment_applied = True
+        forecaster.reset_weather_adjustment_applied()
+        assert forecaster.get_weather_adjustment_applied() is False
+
+    def test_weather_adjustment_flag_set_when_applied(self):
+        mock_entry = _create_mock_entry()
+        weather = MagicMock()
+        weather.get_coefficients_for_hour.return_value = MagicMock(confidence="medium")
+        weather.predict_load.return_value = (1.5, "weather_adjusted")
+
+        forecaster = LoadForecaster(mock_entry, weather_correlation=weather)
+        forecaster.reset_weather_adjustment_applied()
+
+        forecaster.estimate_hourly_consumption_kw(
+            hourly_avg_kw={11: 1.0},
+            slot_hour=11,
+            current_hour=10,
+            current_load_kw=0.5,
+            recent_load_kw=0.6,
+            temperature=30.0,
+        )
+
+        assert forecaster.get_weather_adjustment_applied() is True
+
+    def test_weather_adjustment_flag_not_set_for_low_confidence(self):
+        mock_entry = _create_mock_entry()
+        weather = MagicMock()
+        weather.get_coefficients_for_hour.return_value = MagicMock(confidence="low")
+        weather.predict_load.return_value = (1.5, "weather_adjusted")
+
+        forecaster = LoadForecaster(mock_entry, weather_correlation=weather)
+        forecaster.reset_weather_adjustment_applied()
+
+        forecaster.estimate_hourly_consumption_kw(
+            hourly_avg_kw={11: 1.0},
+            slot_hour=11,
+            current_hour=10,
+            current_load_kw=0.5,
+            recent_load_kw=0.6,
+            temperature=30.0,
+        )
+
+        assert forecaster.get_weather_adjustment_applied() is False
+
+    def test_weather_adjustment_flag_not_set_when_no_temperature(self):
+        mock_entry = _create_mock_entry()
+        weather = MagicMock()
+        weather.get_coefficients_for_hour.return_value = MagicMock(confidence="medium")
+
+        forecaster = LoadForecaster(mock_entry, weather_correlation=weather)
+        forecaster.reset_weather_adjustment_applied()
+
+        forecaster.estimate_hourly_consumption_kw(
+            hourly_avg_kw={11: 1.0},
+            slot_hour=11,
+            current_hour=10,
+            current_load_kw=0.5,
+            recent_load_kw=0.6,
+            temperature=None,
+        )
+
+        assert forecaster.get_weather_adjustment_applied() is False
+
+    def test_weather_adjustment_flag_not_set_for_invalid_source(self):
+        mock_entry = _create_mock_entry()
+        weather = MagicMock()
+        weather.get_coefficients_for_hour.return_value = MagicMock(confidence="medium")
+        weather.predict_load.return_value = (0.99, "no_coefficients")
+
+        forecaster = LoadForecaster(mock_entry, weather_correlation=weather)
+        forecaster.reset_weather_adjustment_applied()
+
+        forecaster.estimate_hourly_consumption_kw(
+            hourly_avg_kw={11: 1.0},
+            slot_hour=11,
+            current_hour=10,
+            current_load_kw=0.5,
+            recent_load_kw=0.6,
+            temperature=30.0,
+        )
+
+        assert forecaster.get_weather_adjustment_applied() is False

--- a/tests/forecast/test_pipeline.py
+++ b/tests/forecast/test_pipeline.py
@@ -18,6 +18,12 @@ class _StubLoadForecaster:
         self.calls.append(_kwargs)
         return self._value, "stub"
 
+    def reset_weather_adjustment_applied(self) -> None:
+        pass
+
+    def get_weather_adjustment_applied(self) -> bool:
+        return False
+
 
 class _StubPriceSignals:
     @staticmethod


### PR DESCRIPTION
## Summary
- Fix `weather_adjustment_applied` diagnostic flag that was always showing `False` even when weather correlation was being applied
- Add proper tracking in `LoadForecaster` and propagate to `CoordinatorData` via `ForecastPipeline`

## Related Issue
Closes #739

## Changes
- `LoadForecaster`: Added `_weather_adjustment_applied` flag with `get/reset` methods
- `_apply_weather_correlation()`: Set flag to `True` when weather adjustment is successfully applied
- `ForecastPipeline.compute_load_forecast_slots()`: Propagate flag to `CoordinatorData`
- `weather_diagnostics.py`: Removed hardcoded `False` assignment that was overwriting the correct value
- Tests: Added 6 new tests for weather adjustment tracking

## Testing
- [x] All 48 related tests pass
- [x] Coverage ≥95% for all modified files (97% overall)
- [x] TDD workflow followed (tests written first)