### PR TITLE
Add LocalShift-specific skills

### DIFF
--- a/.opencode/skills/defensive-debugging/SKILL.md
+++ b/.opencode/skills/defensive-debugging/SKILL.md
@@ -1,0 +1,229 @@
+---
+name: defensive-debugging
+description: Use when debugging fails - initial fix makes things worse, type migrations break existing code, or thresholds need tuning based on observation
+---
+
+# Defensive Debugging
+
+## Overview
+
+Debugging is iterative. The key insight from real failures: **know when to revert vs iterate**. Three proven patterns from production debugging: revert discipline, type migration safety, and empirical tuning.
+
+## Pattern 1: Revert Discipline
+
+### The Problem
+
+When an initial fix makes things worse, the instinct is to "just add another condition to fix it." This compounds complexity until the code is unreadable.
+
+### The Fix
+
+**Revert first, redesign second.**
+
+| Signal | Action |
+|--------|--------|
+| First fix causes new failure | Revert immediately |
+| "I'll just add one more condition" | Revert and redesign |
+| Fix is bigger than the original code | Revert and start over |
+| You're explaining more than fixing | Revert |
+
+### Real Example: Negative-FIT Avoidance
+
+```bash
+# First implementation was reverted
+commit 154dbf1: "Revert 'feat: implement negative FIT avoidance algorithm...'"
+# 325 lines removed, started over with recoverability model
+
+# Second attempt - redesigned from scratch
+commit a0efe5c: "fix: redesign negative-FIT avoidance with recoverability model"
+# Replace fixed floor with dynamic recoverability floor
+# 458 insertions, 130 deletions - but now it worked
+```
+
+**Why it worked:** First attempt made incorrect assumptions about risk. Second attempt computed actual recovery potential from future solar.
+
+### Red Flags
+
+- First fix causes regressions elsewhere
+- You're adding more conditions than the original code
+- Tests pass but production fails
+- The "simple fix" requires explaining for 10+ minutes
+
+---
+
+## Pattern 2: Type Migration Safety
+
+### The Problem
+
+Introducing new types (dataclasses, objects) breaks existing code that assumes dicts or primitives. The compiler doesn't catch it - runtime does.
+
+### The Fix
+
+**Add dict compatibility, never assume callers updated.**
+
+| Strategy | When |
+|---------|------|
+| Add `.get()` method | New object replaces dict usage |
+| Helper functions | Gradual migration needed |
+| Keep returning dicts | Full codebase not yet migrated |
+| Type aliases | When migration is optional |
+
+### Real Example: ForecastSlot Migration
+
+```bash
+# What happened:
+# 1. New ForecastSlot dataclass introduced
+# 2. Changed code to return ForecastSlot instead of dict
+# 3. 21+ places in codebase still called .get() on forecasts
+# 4. Runtime AttributeError: 'ForecastSlot' has no attribute 'get'
+
+# The fix (first attempt - incomplete):
+# Added .get() method to ForecastSlot
+commit a18119d: "feat: add .get() method to ForecastSlot for dict compatibility"
+
+# But more places still assumed dict...
+
+# The fix (worked):
+# Reverted to always returning dicts for backwards compatibility
+# Added helper function _get_slot_attr for gradual migration
+commit 88d03b3: "Fix AttributeError: ForecastSlot has no attribute 'get'"
+```
+
+**Why it worked:** Reverted the big-bang refactor, added helper function for code that needed gradual migration.
+
+### Red Flags
+
+- "The type is better, callers should update"
+- Adding type checks in 10+ places
+- Tests need updating but tests were passing before
+- You're fixing the same error in multiple places
+
+---
+
+## Pattern 3: Empirical Debugging
+
+### The Problem
+
+Thresholds and constants are often set to "obvious" values that don't match reality. Without observation, you're guessing.
+
+### The Fix
+
+**Measure first, tune second.**
+
+| Step | Action |
+|------|--------|
+| 1. Observe | What's the actual value/behavior? |
+| 2. Measure | Get concrete numbers, not "seems" |
+| 3. Tune | Adjust based on observation |
+| 4. Verify | Confirm improvement |
+
+### Real Example: Solcast Staleness Threshold
+
+```bash
+# Original: 1 hour threshold
+# Problem: Shows "degraded" status frequently
+
+# Investigation:
+# commit c11bd42: "Based on observed update frequency of 1-2 hours"
+# - Solcast actually updates every 1-2 hours
+# - 1 hour was too aggressive (false positives)
+# - Increased to 2 hours to match reality
+
+# Result: Reduced false degraded status while maintaining planning functionality
+```
+
+### Real Example: Load Forecasting Blend
+
+```bash
+# Problem: Load forecaster underestimated when instantaneous was low
+
+# Investigation:
+# commit 013cd72: "Load forecaster used instantaneous load directly"
+# - Instantaneous: 0.526 kW
+# - Recent 1hr avg: 1.272 kW
+# - Old forecast: 0.526 kW (too low!)
+
+# Fix: Blend 30% instantaneous + 70% recent
+# - New forecast: 1.048 kW (accurate)
+
+# Result: Prevented incorrect solar surplus predictions
+```
+
+### Red Flags
+
+- "Should be fine at X" without observation
+- Threshold chosen arbitrarily
+- "Seems to work" without metrics
+- Different values in different places
+
+---
+
+## Combined Pattern
+
+Real debugging often requires all three:
+
+1. **Observe** what's actually happening (empirical)
+2. **Revert** if your fix made it worse (revert discipline)
+3. **Migrate safely** if you're changing types (type safety)
+
+Example flow:
+
+```
+Bug reported → Measure actual behavior → Try fix → 
+  If broken: Revert → Redesign based on observation → 
+  If changing types: Add compatibility layer → Verify
+```
+
+---
+
+## Quick Reference
+
+| Situation | Pattern | Key Action |
+|-----------|---------|------------|
+| Fix causes new failures | Revert discipline | Revert immediately |
+| Type changes break callers | Type migration | Add .get() or helpers |
+| Threshold feels wrong | Empirical | Measure before tuning |
+| Multiple places broken | Type migration | Check all callers |
+| First fix didn't work | Revert discipline | Start over with new design |
+
+---
+
+## Common Mistakes
+
+### Mistake 1: "I'll Just Add a Condition"
+
+```python
+# BAD: Piling on complexity
+if condition_a:
+    do_something()
+elif condition_b:
+    do_something_else()
+elif condition_c and condition_d:
+    do_third_thing()
+# ... 10 more conditions later
+```
+
+**Fix:** Revert. The design is wrong.
+
+### Mistake 2: "The Type Is Better"
+
+```python
+# BAD: Breaking existing callers
+def get_forecast() -> ForecastSlot:
+    return ForecastSlot(...)
+    
+# Caller: forecast.get('price', 0)  # AttributeError!
+```
+
+**Fix:** Add dict compatibility or keep returning dicts.
+
+### Mistake 3: "One Hour Should Be Fine"
+
+```bash
+# BAD: No observation
+STALENESS_THRESHOLD = timedelta(hours=1)  # Why 1? shrug
+
+# GOOD: Based on observation  
+STALENESS_THRESHOLD = timedelta(hours=2)  # Solcast updates every 1-2 hours
+```
+
+**Fix:** Measure actual behavior before setting constants.

--- a/.opencode/skills/dp-optimizer-modification/SKILL.md
+++ b/.opencode/skills/dp-optimizer-modification/SKILL.md
@@ -1,0 +1,224 @@
+---
+name: dp-optimizer-modification
+description: Use when modifying the DP optimizer - adding constraints, penalties, or terminal costs
+---
+
+# DP Optimizer Modification
+
+## Overview
+
+The LocalShift DP optimizer uses a three-layer system. Where you add code determines its behavior:
+
+| Question | Answer | Layer |
+|----------|--------|-------|
+| Impossible/forbidden? | Add to `feasible_actions()` | Hard constraints |
+| Required by deadline? | Add to `terminal_cost()` | Terminal cost |
+| Discouraged/preferred? | Add penalty to `stage_cost()` | Soft penalties |
+
+## The Three Layers
+
+### Layer 1: Hard Constraints (`feasible_actions()`)
+
+**What it does:** Determines which actions are physically/legal possible.
+
+**Add here when:**
+- Physical impossibility: Battery cannot charge when full
+- Safety requirements: Never drop below minimum SOC
+- Regulatory/contractual: Demand window has no grid import
+- Feature gates: Disable certain actions based on configuration
+
+**Current constraints:**
+| Constraint | Effect |
+|------------|--------|
+| SOC floor/ceiling | Can't charge if full, can't discharge if empty |
+| Demand window | No grid import during DW slots |
+| Price thresholds | Only charge if price is cheap |
+| Solar sufficiency | Suppress grid charging when solar covers deficit |
+| Export profitability | Only export if sell price exceeds threshold |
+| Negative-FIT DW guardrail | DW export only if net benefit >= $0.02/kWh |
+
+**Example:**
+```python
+@staticmethod
+def feasible_actions(...) -> list[PlannerAction]:
+    actions = []
+    
+    # ... existing constraints ...
+    
+    # Quiet hours constraint (new)
+    slot_hour = datetime.fromisoformat(slot.timestamp_iso).hour
+    is_quiet_hours = slot_hour >= 22 or slot_hour < 6
+    
+    if can_discharge and not is_quiet_hours:
+        if config.optimization_mode == "self_consumption":
+            if slot.sell_price >= min_profitable_sell:
+                actions.append(PlannerAction.EXPORT_PROACTIVE)
+    
+    return actions
+```
+
+### Layer 2: Soft Penalties (`stage_cost()`)
+
+**What it does:** Encodes preferences and costs into a scalar cost.
+
+**Add here when:**
+- Economic trade-offs: Cost vs. benefit analysis
+- Behavioral bias: Encourage/discourage certain patterns
+- Risk management: Account for uncertainty
+- Multi-objective optimization: Balance competing goals
+
+**Current penalties:**
+| Penalty | Formula | Purpose |
+|---------|---------|---------|
+| `import_cost` | `grid_import × buy_price` | Direct cost |
+| `export_revenue` | `grid_export × sell_price` | Revenue |
+| `cycle_penalty` | `(import + export) × $0.05/kWh` | Anti-wear |
+| `switching_penalty` | `$0.02` if action ≠ current | Stability |
+| `uncertainty_penalty` | Scales with horizon gap | Risk aversion |
+| `self_consumption_value` | `battery_for_load × $0.15/kWh` | Opportuniy cost |
+
+**Net cost formula:**
+```python
+net_cost = (
+    import_cost 
+    - export_revenue 
+    + cycle_penalty 
+    + switching_penalty 
+    + uncertainty_penalty 
+    - self_consumption_value
+    + solar_opportunity_penalty
+)
+```
+
+**Example:**
+```python
+@staticmethod
+def stage_cost(...) -> ObjectiveTerms:
+    # ... existing terms ...
+    
+    # Peak demand penalty (new)
+    peak_demand_penalty = 0.0
+    if action in (PlannerAction.CHARGE_GRID_NORMAL, PlannerAction.CHARGE_GRID_BOOST):
+        slot_hour = datetime.fromisoformat(slot.timestamp_iso).hour
+        is_peak_hour = slot_hour in range(17, 21)  # 5 PM - 9 PM
+        if is_peak_hour:
+            peak_demand_penalty = grid_import_kwh * 0.02
+    
+    return ObjectiveTerms(
+        # ... existing fields ...
+        peak_demand_penalty=peak_demand_penalty,
+        net_cost=net_cost + peak_demand_penalty,
+    )
+```
+
+### Layer 3: Terminal Cost (`terminal_cost()`)
+
+**What it does:** Creates forward-looking incentive for goal states.
+
+**Add here when:**
+- Requirements: What MUST be achieved by a specific point
+- Deadlines: Goal state that must be reached by a time
+
+**Current terminal costs:**
+| Requirement | Formula | Applied At |
+|------------|---------|------------|
+| Demand window target | `max(0, target - SOC) × $0.03/%` | DW entry slot |
+
+**Why it works:** Creates backwards incentive through DP:
+```
+At DW entry (slot T):
+  penalty = shortfall × rate
+
+At slot T-1:
+  DP considers: "If I don't charge now, I'll pay penalty at T"
+  Result: Charge if penalty > cost of charging
+```
+
+## Decision Flowchart
+
+```dot
+digraph optimizer_decision {
+    "What are you adding?" [shape=diamond];
+    "Impossible?" [shape=diamond];
+    "Required by deadline?" [shape=diamond];
+    "Discouraged/preferred?" [shape=diamond];
+    
+    "feasible_actions()" [shape=box, style=filled, fillcolor=lightblue];
+    "terminal_cost()" [shape=box, style=filled, fillcolor=lightgreen];
+    "stage_cost()" [shape=box, style=filled, fillcolor=lightyellow];
+    
+    "What are you adding?" -> "Impossible?";
+    "Impossible?" -> "feasible_actions()" [label="yes"];
+    "Impossible?" -> "Required by deadline?";
+    "Required by deadline?" -> "terminal_cost()" [label="yes"];
+    "Required by deadline?" -> "stage_cost()" [label="no"];
+}
+```
+
+## Code Locations
+
+| Layer | File | Line |
+|-------|------|------|
+| Hard Constraints | `optimizer_dp.py` | ~1341 |
+| Soft Penalties | `optimizer_dp.py` | ~1721 |
+| Terminal Cost | `optimizer_dp.py` | ~1818 |
+
+## Common Mistakes
+
+### Mistake 1: Adding soft constraint as hard constraint
+
+```python
+# BAD: Adding preference as hard constraint
+def feasible_actions(...):
+    if price > expensive_threshold:
+        return []  # Never charge at expensive prices
+```
+
+**Fix:** Use stage_cost() penalty instead:
+```python
+# GOOD: Discourage but don't forbid
+expensive_price_penalty = grid_import_kwh * (price - cheap_threshold) * 0.5
+```
+
+### Mistake 2: Forgetting to update ObjectiveTerms
+
+```python
+# BAD: Adding penalty without updating return type
+def stage_cost(...) -> ObjectiveTerms:
+    new_penalty = calculate_penalty()
+    return ObjectiveTerms(
+        # ... forgot to include new_penalty ...
+    )
+```
+
+**Fix:** Add field to ObjectiveTerms dataclass first.
+
+### Mistake 3: Using stage_cost for hard safety limits
+
+```python
+# BAD: Safety limit as penalty (might be violated)
+def stage_cost(...):
+    if soc < min_soc:
+        penalty = 1000  # Huge penalty - but might still be chosen!
+```
+
+**Fix:** Use feasible_actions() for hard limits:
+```python
+# GOOD: Hard constraint - physically impossible
+def feasible_actions(...):
+    if soc <= min_soc:
+        # Remove discharge options
+        actions = [a for a in actions if a != PlannerAction.DISCHARGE]
+```
+
+## Testing
+
+After modifying any layer:
+1. Run `uv run pytest` - all tests must pass
+2. Check coverage: `uv run pytest --cov=custom_components/localshift --cov-report=term-missing`
+3. Verify shadow mode still works (if applicable)
+
+## See Also
+
+- `docs/PLANNING_MODEL.md` - Full planning model documentation
+- `custom_components/localshift/engine/AGENTS.md` - Engine rules

--- a/.opencode/skills/entity-addition/SKILL.md
+++ b/.opencode/skills/entity-addition/SKILL.md
@@ -1,0 +1,258 @@
+---
+name: entity-addition
+description: Use when adding new entities to the LocalShift integration - sensors, switches, numbers, selects, or buttons
+---
+
+# Entity Addition
+
+## Overview
+
+Adding entities to LocalShift follows a consistent pattern. The key steps:
+
+1. Create the entity class in the appropriate `sensors/` module
+2. Add to platform file (`sensor.py`, `switch.py`, etc.)
+3. Add to coordinator data if it needs computed values
+4. Update `docs/ENTITY_REFERENCE.md`
+5. Write tests
+
+## Entity Types
+
+| Type | Platform File | Location |
+|------|--------------|----------|
+| Sensor (30) | `sensor.py` | `sensors/` directory |
+| Binary Sensor (10) | `binary_sensor.py` | `sensors/` directory |
+| Switch (8) | `switch.py` | Root or sensors/ |
+| Number (4) | `number.py` | Root or sensors/ |
+| Select (2) | `select.py` | Root or sensors/ |
+| Button (2) | `button.py` | Root or sensors/ |
+
+## Step 1: Create Entity Class
+
+### Base Pattern
+
+All entities extend `LocalShiftSensorBase`:
+
+```python
+from __future__ import annotations
+from homeassistant.components.sensor import SensorEntity
+from .base import LocalShiftSensorBase
+
+class MyNewSensor(LocalShiftSensorBase, SensorEntity):
+    """Description of what this sensor does."""
+    
+    def _update_from_coordinator(self) -> None:
+        self._attr_native_value = self.coordinator.data.get("my_new_key")
+```
+
+### For Binary Sensors
+
+```python
+from homeassistant.components.binary_sensor import BinarySensorEntity
+
+class MyNewBinarySensor(LocalShiftSensorBase, BinarySensorEntity):
+    """Description."""
+    
+    def _update_from_coordinator(self) -> None:
+        self._attr_is_on = self.coordinator.data.get("my_new_key")
+```
+
+### For Switches/Numbers/Selects
+
+```python
+from homeassistant.components.switch import SwitchEntity
+
+class MyNewSwitch(LocalShiftSensorBase, SwitchEntity):
+    """Description."""
+    
+    @property
+    def is_on(self) -> bool:
+        return self.coordinator.data.get("my_new_key", False)
+    
+    async def async_turn_on(self) -> None:
+        # Update coordinator data
+        self.coordinator.data["my_new_key"] = True
+        # Trigger update
+        await self.coordinator.async_request_refresh()
+```
+
+## Step 2: Add to Platform File
+
+### For Sensors (`sensor.py`)
+
+```python
+# Import at top
+from .sensors import (
+    # ... existing imports ...
+    MyNewSensor,
+)
+
+# In async_setup_entry
+async def async_setup_entry(hass, entry, async_add_entities):
+    # ... existing setup ...
+    entities.append(MyNewSensor(coordinator, entry))
+    async_add_entities(entities)
+```
+
+### For Other Types
+
+Similar pattern in `switch.py`, `number.py`, `select.py`, `button.py`.
+
+## Step 3: Add to Coordinator Data
+
+If the entity needs computed data (not just reading from coordinator):
+
+### Option A: Add to CoordinatorData (`coordinator/data.py`)
+
+```python
+@dataclass
+class CoordinatorData:
+    # ... existing fields ...
+    my_new_value: float | None = None
+    
+    def to_dict(self) -> dict:
+        return {
+            # ... existing ...
+            "my_new_key": self.my_new_value,
+        }
+```
+
+### Option B: Add computed property
+
+```python
+@property
+def my_new_computed(self) -> float:
+    # Compute from existing data
+    return self.solar_power + self.battery_power
+```
+
+## Step 4: Update Documentation
+
+Add to `docs/ENTITY_REFERENCE.md`:
+
+```markdown
+### N. sensor.localshift_my_new
+
+**Purpose:** Description of what this sensor provides.
+
+**State:** Current value and unit
+
+**Example Data:**
+```
+State: 1.23
+```
+
+**Calculation:** How the value is computed.
+
+**Attributes:**
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `attr_name` | type | Description |
+```
+
+## Step 5: Write Tests
+
+### Unit Test Pattern
+
+```python
+class TestMyNewSensor:
+    def test_native_value(self):
+        # Create coordinator with mock data
+        coordinator = MockCoordinator()
+        coordinator.data["my_new_key"] = 1.23
+        
+        # Create sensor
+        sensor = MyNewSensor(coordinator, MockEntry())
+        
+        # Assert
+        assert sensor.native_value == 1.23
+```
+
+### Integration Test Pattern
+
+```python
+async def test_my_new_sensor(hass: HomeAssistant, setup_local_shift):
+    """Test my new sensor works."""
+    # Get entity
+    entity = hass.states.get("sensor.localshift_my_new")
+    
+    # Assert
+    assert entity is not None
+    assert entity.state == "1.23"
+```
+
+## Quick Reference
+
+| Task | File to Edit |
+|------|--------------|
+| Create sensor | `sensors/*.py` (choose appropriate module) |
+| Register sensor | `sensor.py` |
+| Add computed data | `coordinator/data.py` |
+| Document entity | `docs/ENTITY_REFERENCE.md` |
+| Add test | `tests/test_*.py` |
+
+## Common Mistakes
+
+### Mistake 1: Computing in entity instead of coordinator
+
+```python
+# BAD: Entity computes its own value
+def _update_from_coordinator(self) -> None:
+    # Expensive computation in entity!
+    self._attr_native_value = expensive_compute()
+```
+
+**Fix:** Compute in coordinator, entity just reads:
+```python
+# GOOD: Entity reads pre-computed value
+def _update_from_coordinator(self) -> None:
+    self._attr_native_value = self.coordinator.data.get("my_new_key")
+```
+
+### Mistake 2: Forgetting to add to coordinator.to_dict()
+
+```python
+# BAD: Value available in coordinator but not exposed
+def to_dict(self) -> dict:
+    return {
+        "existing_key": self.existing_value,
+        # Forgot my_new_key!
+    }
+```
+
+**Fix:** Always add to to_dict():
+```python
+def to_dict(self) -> dict:
+    return {
+        "existing_key": self.existing_value,
+        "my_new_key": self.my_new_value,  # Added
+    }
+```
+
+### Mistake 3: Not updating ENTITY_REFERENCE.md
+
+```python
+# BAD: Entity added but not documented
+# Other developers can't find it!
+```
+
+**Fix:** Always document new entities.
+
+## Entity Counts (Current)
+
+| Type | Count | Max before review |
+|------|-------|-------------------|
+| Sensors | 30 | 35 |
+| Binary Sensors | 10 | 12 |
+| Switches | 8 | 10 |
+| Numbers | 4 | 6 |
+| Selects | 2 | 4 |
+| Buttons | 2 | 4 |
+
+If exceeding limits, consider splitting into separate integrations.
+
+## See Also
+
+- `custom_components/localshift/AGENTS.md` - Integration rules
+- `docs/ENTITY_REFERENCE.md` - Entity catalog
+- `tests/AGENTS.md` - Testing patterns


### PR DESCRIPTION
## Summary
Add three domain-specific skills for LocalShift:
- `defensive-debugging`: For debugging when initial fixes make things worse
- `dp-optimizer-modification`: For modifying the DP optimizer
- `entity-addition`: For adding new entities to the integration

## Changes
- Add `.opencode/skills/defensive-debugging/SKILL.md`
- Add `.opencode/skills/dp-optimizer-modification/SKILL.md`
- Add `.opencode/skills/entity-addition/SKILL.md`

## Testing
- [ ] Skills are properly formatted
- [ ] Tested in worktree