### PR TITLE
Add gitignore patterns for pytest temp dirs and uv lock files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,8 +28,12 @@ Thumbs.db
 
 # Testing
 .pytest_cache/
+.pytest-of-*/
 .coverage
 htmlcov/
+
+# uv temporary files
+uv-*.lock
 
 # Pre-commit
 .pre-commit-config.yaml.cache


### PR DESCRIPTION
## Summary
Added `.gitignore` patterns for common temporary files that were appearing as untracked:
- `.pytest-of-*/` - pytest temporary test directories
- `uv-*.lock` - uv package manager lock files

## Changes
- Added `.pytest-of-*/` pattern under Testing section
- Added `uv-*.lock` pattern for uv temp files

## Testing
- [x] Verified patterns match existing untracked files