### PR TITLE
Remove additive bias correction from SolarAccuracyTracker (issue #760)

### DIFF
--- a/custom_components/localshift/forecast/solar_accuracy.py
+++ b/custom_components/localshift/forecast/solar_accuracy.py
@@ -25,7 +25,6 @@ _LOGGER = logging.getLogger(__name__)
 
 MAX_PERIOD_RECORDS = 1440
 BIAS_HALF_LIFE_DAYS = 7.0
-MAX_ADDITIVE_OFFSET_KWH = 2.0
 MIN_SOLAR_CORRECTION_SAMPLES = 20
 
 
@@ -546,20 +545,12 @@ class SolarAccuracyTracker:
     ) -> float:
         """Get additive correction offset for given context.
 
-        Returns 0.0 if insufficient samples (< MIN_SOLAR_CORRECTION_SAMPLES).
+        .. deprecated::
+            Additive correction is deprecated as of issue #760. This method
+            always returns 0.0 and is retained only for backward compatibility.
+            Use get_bias_correction() for multiplicative-only correction.
         """
-        result = self._compute_context_additive_bias(time_of_day, weather, season)
-        if result is None:
-            return 0.0
-
-        weighted_bias, sample_count = result
-        if sample_count < MIN_SOLAR_CORRECTION_SAMPLES:
-            return 0.0
-
-        return max(
-            -MAX_ADDITIVE_OFFSET_KWH,
-            min(MAX_ADDITIVE_OFFSET_KWH, weighted_bias),
-        )
+        return 0.0
 
     def apply_bias_correction(
         self,
@@ -568,6 +559,19 @@ class SolarAccuracyTracker:
         weather: str,
         season: str | None = None,
     ) -> float:
+        """Apply bias correction to a solar forecast.
+
+        Uses multiplicative correction only (issue #760 removed additive).
+        Returns 1.0 (no correction) if insufficient samples.
+
+        Args:
+            forecast_kwh: Raw forecast from Solcast
+            time_of_day: Time bucket for context
+            weather: Weather condition for context
+            season: Season for context (optional)
+
+        Returns:
+            Corrected forecast kWh (minimum 0.0)
+        """
         multiplier = self.get_bias_correction(time_of_day, weather, season)
-        additive_offset = self.get_additive_correction(time_of_day, weather, season)
-        return max(0.0, forecast_kwh * multiplier - additive_offset)
+        return max(0.0, forecast_kwh * multiplier)

--- a/tests/forecast/test_solar_accuracy.py
+++ b/tests/forecast/test_solar_accuracy.py
@@ -432,10 +432,12 @@ class TestSolarAccuracyTracker:
         assert correction == pytest.approx(1.5, rel=0.1)
 
     def test_get_additive_correction_no_data(self, tracker):
+        """Test get_additive_correction returns 0.0 (deprecated, always returns 0)."""
         correction = tracker.get_additive_correction("morning", "sunny", "summer")
         assert correction == 0.0
 
     def test_get_additive_correction_with_data(self, tracker):
+        """Test get_additive_correction still returns 0.0 (deprecated, always returns 0)."""
         # Add historical data (need 20+ samples)
         # Use month 1 (January) = summer in Southern hemisphere
         for i in range(20):
@@ -443,10 +445,12 @@ class TestSolarAccuracyTracker:
             tracker.record_forecast(period_start, 2.0, "sunny")
             tracker.backfill_actual(period_start, 1.5)
 
+        # Deprecated - always returns 0.0 regardless of data
         correction = tracker.get_additive_correction("morning", "sunny", "summer")
-        assert correction == pytest.approx(0.5, rel=0.1)
+        assert correction == 0.0
 
     def test_get_additive_correction_clamps_to_bounds(self, tracker):
+        """Test get_additive_correction returns 0.0 (deprecated, always returns 0)."""
         # Add historical data with extreme bias (need 20+ samples)
         # Use month 1 (January) = summer in Southern hemisphere
         for i in range(20):
@@ -454,10 +458,12 @@ class TestSolarAccuracyTracker:
             tracker.record_forecast(period_start, 3.0, "sunny")
             tracker.backfill_actual(period_start, 0.0)
 
+        # Deprecated - always returns 0.0 regardless of data
         correction = tracker.get_additive_correction("morning", "sunny", "summer")
-        assert correction == pytest.approx(2.0)
+        assert correction == 0.0
 
-    def test_apply_bias_correction_combines_multiplicative_and_additive(self, tracker):
+    def test_apply_bias_correction_uses_multiplicative_only(self, tracker):
+        """Test apply_bias_correction uses multiplicative only (issue #760)."""
         # Add historical data (need 20+ samples)
         # Use month 1 (January) = summer in Southern hemisphere
         for i in range(20):
@@ -465,13 +471,13 @@ class TestSolarAccuracyTracker:
             tracker.record_forecast(period_start, 4.0, "sunny")
             tracker.backfill_actual(period_start, 3.0)
 
-        # With bias=0.25 (25% overestimate), multiplier = 0.75, clamped to [0.5, 1.5]
-        # additive = 1.0 kWh
-        # corrected = 2.0 * 0.75 - 1.0 = 0.5
+        # With bias=0.25 (25% overestimate), multiplier = 0.75
+        # corrected = 2.0 * 0.75 = 1.5 (no additive subtraction)
         corrected = tracker.apply_bias_correction(2.0, "morning", "sunny", "summer")
-        assert corrected == pytest.approx(0.5, rel=0.1)
+        assert corrected == pytest.approx(1.5, rel=0.1)
 
     def test_apply_bias_correction_floors_at_zero(self, tracker):
+        """Test apply_bias_correction floors at zero with multiplicative-only."""
         # Add historical data (need 20+ samples)
         # Use month 1 (January) = summer in Southern hemisphere
         for i in range(20):
@@ -480,26 +486,12 @@ class TestSolarAccuracyTracker:
             tracker.backfill_actual(period_start, 0.4)
 
         # Bias = 0.6 (60% overestimate), multiplier = 0.4, clamped to 0.5
-        # corrected = 0.2 * 0.5 - additive = should floor at 0
+        # corrected = 0.2 * 0.5 = 0.1 (floors at 0.0 is still valid edge case)
         corrected = tracker.apply_bias_correction(0.2, "morning", "sunny", "summer")
-        assert corrected == 0.0
-
-    def test_apply_bias_correction_can_raise_zero_forecast_from_additive_history(
-        self, tracker
-    ):
-        # Add historical data (need 20+ samples)
-        # Use month 1 (January) = summer in Southern hemisphere
-        for i in range(20):
-            period_start = datetime(2026, 1, 1 + i, 10, 0, tzinfo=UTC)
-            tracker.record_forecast(period_start, 0.0, "sunny")
-            tracker.backfill_actual(period_start, 0.5)
-
-        # With 20+ samples, additive correction IS applied
-        assert tracker.get_additive_correction(
-            "morning", "sunny", "summer"
-        ) == pytest.approx(-0.5, rel=0.1)
+        assert corrected == pytest.approx(0.1, rel=0.1)
 
     def test_get_additive_correction_is_context_specific(self, tracker):
+        """Test get_additive_correction returns 0.0 (deprecated, always returns 0)."""
         # Add historical data for different contexts (need 20+ samples for each)
         # Use month 1 (January) = summer in Southern hemisphere
         for i in range(20):
@@ -511,13 +503,14 @@ class TestSolarAccuracyTracker:
             tracker.record_forecast(afternoon, 2.0, "cloudy")
             tracker.backfill_actual(afternoon, 1.9)
 
+        # Deprecated - always returns 0.0 regardless of context
         sunny_correction = tracker.get_additive_correction("morning", "sunny", "summer")
         cloudy_correction = tracker.get_additive_correction(
             "afternoon", "cloudy", "summer"
         )
 
-        assert sunny_correction == pytest.approx(0.5, rel=0.1)
-        assert cloudy_correction == pytest.approx(0.1, rel=0.1)
+        assert sunny_correction == 0.0
+        assert cloudy_correction == 0.0
 
     @pytest.mark.asyncio
     async def test_async_load_no_data(self, tracker, mock_hass):


### PR DESCRIPTION
## Summary

Issue #760: Removes additive bias correction from `SolarAccuracyTracker`, keeping multiplicative-only correction.

## Problem

The solar bias correction system had two types of correction:
1. **Multiplicative**: `forecast * (1.0 - bias)`
2. **Additive**: `forecast - additive_offset`

This caused:
- **Double-counting**: Both corrections addressed the same underlying error
- **Edge cases**: At low forecast values, subtracting an offset produced negative values
- **Inconsistency**: Other correction systems in LocalShift use multiplicative only

## Changes

1. **`solar_accuracy.py`**:
   - Remove `MAX_ADDITIVE_OFFSET_KWH` constant
   - Simplify `apply_bias_correction()` to use multiplicative-only: `return max(0.0, forecast_kwh * multiplier)`
   - Deprecate `get_additive_correction()` - now always returns 0.0 with deprecation docstring

2. **`test_solar_accuracy.py`**:
   - Update tests for new multiplicative-only behavior
   - Verify deprecated methods still return 0.0

## Testing

- All 2660 tests pass
- All lint checks pass
- 97% code coverage on modified file
- Multiplicative correction still respects `MIN_SOLAR_CORRECTION_SAMPLES` (20 samples)

## Related Issues

- #756: Original bug report (solar forecast discrepancy)
- #757: Root cause analysis and proposed fix (added minimum sample gate)
- #760: This RFC to remove additive correction