### PR TITLE
Fix battery mode select to show actual mode when automation enabled

### DIFF
--- a/custom_components/localshift/dashboard.yaml
+++ b/custom_components/localshift/dashboard.yaml
@@ -134,10 +134,11 @@ views:
           - type: markdown
             content: >
               {% set mode = states('select.localshift_battery_mode') %}
+              {% set automation = states('switch.localshift_automation_enabled') %}
               {% set soc = states('sensor.my_home_percentage_charged') | int(0) %}
               {% set target = states('number.localshift_battery_target') | int(100) %}
 
-              {% if mode == 'manual' %}
+              {% if automation == 'off' %}
               🟠 **Manual control active** — automation disabled
 
               {% elif mode == 'spike_discharge' %}
@@ -154,6 +155,9 @@ views:
 
               {% elif mode == 'demand_block' %}
               🟠 **Demand window active** — protecting from grid imports
+
+              {% elif mode == 'hold' %}
+              ⏸️ **Hold** — temporary pause
 
               {% else %}
               ⚪ **Self consumption** — normal operation
@@ -725,9 +729,9 @@ views:
 
               Max Buy Forecast Price: ${{ state_attr('binary_sensor.localshift_price_spike_coming', 'max_buy_forecast_price') | default(0) }}/kWh
 
-              Force Discharge Active: {{ states('select.localshift_battery_mode') == 'force_discharge' }}
+              Force Discharge Active: {{ states('binary_sensor.localshift_force_discharge_active') == 'on' }}
 
-              Force Charge Active: {{ states('select.localshift_battery_mode') == 'force_charge' }}
+              Force Charge Active: {{ states('binary_sensor.localshift_force_charge_active') == 'on' }}
 
               Boost Charge Active: {{ states('select.localshift_battery_mode') == 'boost_charging' }}
 

--- a/custom_components/localshift/select.py
+++ b/custom_components/localshift/select.py
@@ -93,9 +93,17 @@ class BatteryModeSelect(SelectEntity):
 
     @property
     def current_option(self) -> str | None:
-        """Return the current selected option."""
+        """Return the current selected option.
+
+        When automation is ON, shows the actual mode from the optimizer
+        (SELF_CONSUMPTION, GRID_CHARGING, DEMAND_BLOCK, HOLD, etc.).
+        When automation is OFF, shows the user's manual mode selection.
+        """
         if self.coordinator.get_switch_state(SWITCH_AUTOMATION_ENABLED):
-            return "automatic"
+            mode = self.coordinator.data.active_mode
+            if mode is not None:
+                return mode.value
+            return "self_consumption"
         return self._manual_mode
 
     async def async_select_option(self, option: str) -> None:

--- a/docs/ENTITY_REFERENCE.md
+++ b/docs/ENTITY_REFERENCE.md
@@ -1308,6 +1308,7 @@ Added in Issue #382 to replace manual control buttons with a single select entit
 
 | Option | Description |
 |--------|-------------|
+| `automatic` | Enable automation — optimizer controls mode selection |
 | `self_consumption` | Default — battery powers house, grid used as needed |
 | `grid_charging` | Force charging from grid at 3.3kW (backup mode) |
 | `boost_charging` | Force charging at 5kW (autonomous + reserve=100%) |
@@ -1315,16 +1316,20 @@ Added in Issue #382 to replace manual control buttons with a single select entit
 | `proactive_export` | Exporting battery before negative FIT periods |
 
 **Behavior:**
-- When automation is enabled: Select shows current automated mode (read-only display)
-- When user changes select: Automation automatically disables, user's choice is honored
-- When automation is re-enabled: System takes control of select immediately
+- When automation is ON: Select displays the actual mode from the optimizer (`self_consumption`, `grid_charging`, `demand_block`, `hold`, etc.)
+- When automation is OFF: Select displays the user's manually chosen mode
+- When user selects a mode (not "automatic"): Automation disables, user's choice is applied
+- When user selects "automatic": Automation enables, optimizer takes control
+
+**Displayed Values:** The select may show modes not in the options list (e.g., `demand_block`, `hold`) when the optimizer transitions to internal states. This reflects the actual system state.
 
 **Example Data:**
 ```
-State: grid_charging
+State: spike_discharge
+State: demand_block  (internal optimizer mode, shown when automation ON)
 ```
 
-**Use Case:** Manual control of battery mode. Select a mode to disable automation and apply that mode to the battery. Re-enable automation to return to automated control.
+**Use Case:** Manual control of battery mode. Select a mode to disable automation and apply that mode to the battery. Select "automatic" to return to automated control. Use `switch.localshift_automation_enabled` to toggle automation directly.
 
 ---
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -229,7 +229,7 @@ For specific entity issues:
 **Solutions:**
 1. Check `sensor.localshift_decision_history` count — needs to be 50+
 2. Enable `switch.localshift_enable_learning`
-3. Verify state machine is running — check `sensor.localshift_battery_mode` for changes
+3. Verify state machine is running — check `select.localshift_battery_mode` for mode changes
 4. Wait 2-3 days for warm-up period to complete
 
 **Expected Timeline:**

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -75,11 +75,12 @@ class TestBatteryModeSelect:
         assert select.current_option == "self_consumption"
 
     def test_current_option_grid_charging(self, mock_coordinator, mock_entry):
-        """Test current option returns automatic when automation is on."""
+        """Test current option returns actual mode when automation is on."""
         mock_coordinator.get_switch_state.return_value = True
+        mock_coordinator.data.active_mode = BatteryMode.GRID_CHARGING
         select = BatteryModeSelect(mock_coordinator, mock_entry)
 
-        assert select.current_option == "automatic"
+        assert select.current_option == "grid_charging"
 
     def test_current_option_returns_manual_mode_when_automation_off(
         self, mock_coordinator, mock_entry
@@ -91,14 +92,33 @@ class TestBatteryModeSelect:
 
         assert select.current_option == "grid_charging"
 
-    def test_current_option_returns_automatic_when_automation_on(
+    def test_current_option_returns_actual_mode_when_automation_on(
         self, mock_coordinator, mock_entry
     ):
-        """Test current option returns automatic when automation is enabled."""
+        """Test current option returns actual mode when automation is enabled."""
         mock_coordinator.get_switch_state.return_value = True
+        mock_coordinator.data.active_mode = BatteryMode.SPIKE_DISCHARGE
         select = BatteryModeSelect(mock_coordinator, mock_entry)
 
-        assert select.current_option == "automatic"
+        assert select.current_option == "spike_discharge"
+
+    def test_current_option_returns_demand_block_when_automation_on(
+        self, mock_coordinator, mock_entry
+    ):
+        """Test current option returns internal modes like demand_block when automation is on."""
+        mock_coordinator.get_switch_state.return_value = True
+        mock_coordinator.data.active_mode = BatteryMode.DEMAND_BLOCK
+        select = BatteryModeSelect(mock_coordinator, mock_entry)
+
+        assert select.current_option == "demand_block"
+
+    def test_current_option_falls_back_on_none_mode(self, mock_coordinator, mock_entry):
+        """Test current option falls back to self_consumption when active_mode is None."""
+        mock_coordinator.get_switch_state.return_value = True
+        mock_coordinator.data.active_mode = None
+        select = BatteryModeSelect(mock_coordinator, mock_entry)
+
+        assert select.current_option == "self_consumption"
 
     @pytest.mark.asyncio
     async def test_select_automatic_enables_automation_and_clears_manual_override(


### PR DESCRIPTION
## Summary

Fixes #758 - The battery mode select now displays the actual optimizer mode (SELF_CONSUMPTION, GRID_CHARGING, DEMAND_BLOCK, HOLD, etc.) when automation is enabled, instead of the static string "automatic".

This allows the logbook to correctly track all mode transitions, including internal optimizer modes.

## Problem

Previously, when automation was ON, the select's `current_option` returned `"automatic"` - a static value that never changed. This meant:
- The logbook never saw state changes
- Users couldn't see what mode the optimizer had chosen
- Internal modes like DEMAND_BLOCK and HOLD were invisible

## Solution

Modified `current_option` to return `data.active_mode.value` when automation is ON. The select now shows:
- Actual optimizer modes when automation enabled (including internal modes)
- User's manual selection when automation disabled

The "automatic" option remains in the dropdown for users to re-enable automation.

## Changes

| File | Change |
|------|--------|
| `select.py` | `current_option` returns actual mode from `data.active_mode` |
| `dashboard.yaml` | Fixed mode template to check automation switch; added handling for demand_block/hold |
| `tests/test_select.py` | Added tests for actual mode behavior |
| `docs/*.md` | Updated documentation |

## Testing

- All 31 select tests pass
- 100% coverage on modified file
- TDD compliance verified

## Related Issue

Closes #758