### PR TITLE
Add tool hints to AGENTS.md and doc-first skill

### DIFF
--- a/.opencode/skills/doc-first/SKILL.md
+++ b/.opencode/skills/doc-first/SKILL.md
@@ -178,6 +178,19 @@ domain_mappings:
 
 I use `symdex_search_text()` to quickly find relevant sections in indexed docs. This is fast and precise.
 
+## Integration with OpenViking
+
+For semantic code understanding, I also use OpenViking:
+
+- **When to use:** "explain how X works", "find patterns", "analyze code structure"
+- **Start if not running:** `~/.local/bin/ov-start`
+- **Commands:**
+  - `ov search "query" --uri viking://resources/localshift` - semantic search
+  - `ov grep "exact_text" --uri viking://resources/localshift` - keyword search
+  - `ov tree viking://resources/localshift -L 2` - explore structure
+
+OpenViking provides AI-generated summaries and is particularly useful for understanding code intent and patterns across the codebase.
+
 ## Fallback
 
 If a doc isn't indexed in SymDex yet, I'll use `Read` to fetch it directly. No configuration needed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,18 @@ Use SymDex instead of grep/read:
 - `symdex_get_file_outline("file.py")` - file structure
 - `symdex_search_text("text")` - search content
 
+## Additional Tools
+
+**OpenViking** - Semantic search for code understanding:
+- Use for: "explain how X works", "find patterns", "analyze code"
+- Commands: `ov search "query"`, `ov read viking://...`
+- Start if not running: `~/.local/bin/ov-start`
+
+**context-mode** - Efficient large file handling:
+- Use for: log files, large data files, full file analysis
+- Commands: `ctx_execute_file`, `ctx_batch_execute`
+- Better than Read for files >100 lines
+
 ## Reference Files (load when needed)
 
 | File | When |


### PR DESCRIPTION
## Summary
Add documentation hints for OpenViking and context-mode tools to help agents use them more effectively.

## Changes
- AGENTS.md: Added "Additional Tools" section documenting OpenViking and context-mode
- doc-first skill: Added OpenViking integration section

## Testing
- [ ] Verified AGENTS.md updated correctly
- [ ] Verified doc-first skill updated correctly