### PR TITLE
Enable DCP plugin for context management

### DIFF
--- a/opencode.json
+++ b/opencode.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://opencode.ai/config.json",
-  "plugin": ["context-mode"],
+  "plugin": ["context-mode", "@tarquinen/opencode-dcp@latest"],
   "instructions": [
     ".opencode/rules",
     ".agents/rules/worktrees.md"
@@ -24,7 +24,7 @@
         "HOMEASSISTANT_URL": "https://homeassistant.nectaron.jackmcintyre.net",
         "HOMEASSISTANT_TOKEN": "{env:HA_LONG_LIVED_TOKEN}"
       },
-      "enabled": true
+      "enabled": false
     }
   },
   "agent": {


### PR DESCRIPTION
## Summary
Enables Dynamic Context Pruning (DCP) plugin to help manage context limits in long coding sessions and disables main homeassistant MCP (keeping it enabled for subagent only).

## Changes
- Add `@tarquinen/opencode-dcp@latest` to plugins array
- Disable `homeassistant` MCP in main config (`enabled: false`)
- Keep `homeassistant` MCP enabled for the `homeassistant` subagent

## Rationale
- Hitting context limits that context-mode alone doesn't solve
- DCP provides intelligent compression, deduplication, and error pruning
- Complements context-mode (preventative vs reactive approaches)
- Disabling main HA MCP reduces token overhead while preserving subagent functionality

## Testing
- [ ] Restart OpenCode to load DCP
- [ ] Verify DCP initializes with `/dcp context`
- [ ] Monitor compression behavior in long sessions

## Documentation
- DCP repo: https://github.com/Opencode-DCP/opencode-dynamic-context-pruning
- No conflicts identified with existing plugins (context-mode, symdex)