### PR TITLE
Fix: Wire terminal diagnostics to OptimizerSummarySensor

### DIFF
--- a/custom_components/localshift/engine/core.py
+++ b/custom_components/localshift/engine/core.py
@@ -366,6 +366,49 @@ class DPPlanner:
             inputs, slots, config, terminal_penalty_idx
         )
 
+        # Compute terminal diagnostics (PR #789 wiring fix)
+        terminal_diags: dict[str, Any] = {}
+        forecast_accuracy_val: float | None = None
+
+        if terminal_penalty_idx is not None and not solar_capable:
+            # Recompute terminal context values for diagnostics
+            future_solar_gain_pct = 0.0
+            if inputs.all_solcast and inputs.slots:
+                last_slot = inputs.slots[-1]
+                last_slot_start = datetime.fromisoformat(last_slot.timestamp_iso)
+                last_slot_end = last_slot_start + timedelta(
+                    minutes=last_slot.slot_interval_minutes
+                )
+                target_slot = inputs.slots[terminal_penalty_idx]
+                target_time = datetime.fromisoformat(target_slot.timestamp_iso)
+                future_solar_gain_pct = DPPlanner._projected_solcast_gain_pct(
+                    inputs.all_solcast,
+                    start_time=last_slot_end,
+                    end_time=target_time,
+                    battery_capacity_kwh=config.battery_capacity_kwh,
+                )
+
+            projected_solar_gain_pct = DPPlanner._projected_solar_soc_gain_pct(
+                slot_idx=0,
+                slots=inputs.slots,
+                terminal_penalty_idx=terminal_penalty_idx,
+                battery_capacity_kwh=config.battery_capacity_kwh,
+            )
+            forecast_accuracy_val = self._get_forecast_accuracy(
+                inputs.solar_accuracy_tracker
+            )
+            accuracy_discount = max(0.5, min(1.0, forecast_accuracy_val))
+
+            terminal_diags = self._get_terminal_diagnostics(
+                soc_pct=inputs.initial_soc_pct,
+                target=config.demand_window_target_soc_pct,
+                projected_solar_gain_pct=projected_solar_gain_pct,
+                accuracy_discount=accuracy_discount,
+                future_solar_gain_pct=future_solar_gain_pct,
+                decisions=decisions,
+                terminal_penalty_idx=terminal_penalty_idx,
+            )
+
         return OptimizerResult(
             success=True,
             planner_version=self.VERSION,
@@ -379,6 +422,14 @@ class DPPlanner:
             can_solar_reach_target=can_solar,
             can_solar_reach_target_in_dw=solar_capable,
             reason_code_histogram=reason_histogram,
+            # Terminal diagnostics (PR #789 wiring fix)
+            forecast_accuracy=forecast_accuracy_val,
+            projected_solar_gain_pct=terminal_diags.get("projected_solar_gain_pct"),
+            accuracy_discount_factor=terminal_diags.get("accuracy_discount_factor"),
+            adjusted_solar_gain_pct=terminal_diags.get("adjusted_solar_gain_pct"),
+            effective_soc_at_terminal=terminal_diags.get("effective_soc_at_terminal"),
+            peak_soc_pct=terminal_diags.get("peak_soc_pct"),
+            dw_entry_soc_pct=terminal_diags.get("dw_entry_soc_pct"),
         )
 
     def _empty_result(self) -> OptimizerResult:

--- a/custom_components/localshift/engine/optimizer_runner.py
+++ b/custom_components/localshift/engine/optimizer_runner.py
@@ -579,6 +579,15 @@ def _build_summary(
         if alignment.get("warnings"):
             summary["alignment_warnings"] = alignment["warnings"]
 
+    # Terminal diagnostics (PR #789)
+    summary["forecast_accuracy"] = result.forecast_accuracy
+    summary["projected_solar_gain_pct"] = result.projected_solar_gain_pct
+    summary["accuracy_discount_factor"] = result.accuracy_discount_factor
+    summary["adjusted_solar_gain_pct"] = result.adjusted_solar_gain_pct
+    summary["effective_soc_at_terminal"] = result.effective_soc_at_terminal
+    summary["peak_soc_pct"] = result.peak_soc_pct
+    summary["dw_entry_soc_pct"] = result.dw_entry_soc_pct
+
     return summary
 
 

--- a/custom_components/localshift/engine/types.py
+++ b/custom_components/localshift/engine/types.py
@@ -426,6 +426,28 @@ class OptimizerResult:
     reason_code_histogram: dict[str, int] = field(default_factory=dict)
     """Count of each reason code across all slots (for diagnostics)."""
 
+    # Terminal cost diagnostic fields (PR #789 wiring)
+    forecast_accuracy: float | None = None
+    """Forecast accuracy (0-1.0) used for solar discount. None if no terminal penalty."""
+
+    projected_solar_gain_pct: float | None = None
+    """Raw projected solar SOC gain (%) within horizon."""
+
+    accuracy_discount_factor: float | None = None
+    """Discount factor applied to solar gain (0.5-1.0)."""
+
+    adjusted_solar_gain_pct: float | None = None
+    """Solar gain after accuracy discount."""
+
+    effective_soc_at_terminal: float | None = None
+    """Effective SOC (%) at terminal considering solar gains."""
+
+    peak_soc_pct: float | None = None
+    """Peak SOC (%) across all planned slots."""
+
+    dw_entry_soc_pct: float | None = None
+    """SOC (%) at demand window entry slot. None if no DW."""
+
 
 # -----------------------------------------------------------------------------
 # Negative FIT avoidance context

--- a/tests/engine/test_terminal_cost_accuracy.py
+++ b/tests/engine/test_terminal_cost_accuracy.py
@@ -1,6 +1,14 @@
+from datetime import datetime, timedelta, timezone
 from unittest.mock import Mock
 
+import pytest
+
 from custom_components.localshift.engine.core import DPPlanner
+from custom_components.localshift.engine.types import (
+    OptimizerConfig,
+    OptimizerInputs,
+    SlotContext,
+)
 
 
 class TestGetForecastAccuracy:
@@ -213,3 +221,106 @@ class TestOptimizerResultDiagnosticFields:
         assert result.effective_soc_at_terminal == 85.0
         assert result.peak_soc_pct == 92.0
         assert result.dw_entry_soc_pct == 88.0
+
+
+class TestSolveDiagnostics:
+    """Integration tests: _solve() populates diagnostic fields on OptimizerResult."""
+
+    def _make_inputs(self, *, accuracy: float | None = 75.0) -> OptimizerInputs:
+        """Build minimal OptimizerInputs for a 4-slot horizon with a demand window."""
+        base = datetime(2026, 3, 20, 14, 0, tzinfo=timezone.utc)
+        slots = []
+        for i in range(4):
+            ts = base + timedelta(minutes=30 * i)
+            slots.append(
+                SlotContext(
+                    slot_index=i,
+                    timestamp_iso=ts.isoformat(),
+                    slot_interval_minutes=30,
+                    buy_price=0.30,
+                    sell_price=0.05,
+                    consumption_kwh=0.5,
+                    solar_kwh=1.0,
+                    is_demand_window_entry=i == 3,  # last slot is DW entry
+                    is_demand_window_slot=i >= 3,  # last slot is DW
+                ),
+            )
+
+        tracker = None
+        if accuracy is not None:
+            tracker = Mock()
+            tracker.metrics.accuracy = accuracy
+
+        return OptimizerInputs(
+            cycle_id="test_cycle",
+            initial_soc_pct=60.0,
+            slots=slots,
+            config=self._make_config(),
+            solar_accuracy_tracker=tracker,
+            all_solcast=[],
+        )
+
+    def _make_config(self) -> OptimizerConfig:
+        """Build minimal OptimizerConfig."""
+        return OptimizerConfig(
+            battery_capacity_kwh=13.5,
+            charge_rate_kw=3.3,
+            discharge_rate_kw=5.0,
+            demand_window_target_soc_pct=95.0,
+            optimization_mode="self_consumption",
+            allow_dw_entry_under_target=False,
+            switching_penalty=0.02,
+            cycle_penalty_per_kwh=0.08,
+            target_shortfall_penalty_per_pct=0.015,
+        )
+
+    def test_diagnostic_fields_populated_with_terminal_penalty(self):
+        """When terminal penalty exists, diagnostic fields should be populated."""
+        inputs = self._make_inputs(accuracy=75.0)
+        planner = DPPlanner()
+        result = planner._solve(inputs)
+
+        assert result.success is True
+        assert result.forecast_accuracy is not None
+        assert result.forecast_accuracy == pytest.approx(0.75)
+        assert result.accuracy_discount_factor is not None
+        assert result.projected_solar_gain_pct is not None
+        assert result.adjusted_solar_gain_pct is not None
+        assert result.effective_soc_at_terminal is not None
+        assert result.peak_soc_pct is not None
+        # dw_entry_soc_pct may or may not be None depending on terminal_penalty_idx
+
+    def test_diagnostic_fields_none_without_demand_window(self):
+        """When no demand window, diagnostic fields should remain None."""
+        # Build inputs with NO demand window slots
+        base = datetime(2026, 3, 20, 14, 0, tzinfo=timezone.utc)
+        slots = []
+        for i in range(4):
+            ts = base + timedelta(minutes=30 * i)
+            slots.append(
+                SlotContext(
+                    slot_index=i,
+                    timestamp_iso=ts.isoformat(),
+                    slot_interval_minutes=30,
+                    buy_price=0.30,
+                    sell_price=0.05,
+                    consumption_kwh=0.5,
+                    solar_kwh=1.0,
+                    is_demand_window_entry=False,
+                    is_demand_window_slot=False,
+                ),
+            )
+        inputs = OptimizerInputs(
+            cycle_id="test_no_dw",
+            initial_soc_pct=60.0,
+            slots=slots,
+            config=self._make_config(),
+            solar_accuracy_tracker=None,
+            all_solcast=[],
+        )
+        planner = DPPlanner()
+        result = planner._solve(inputs)
+
+        assert result.success is True
+        assert result.forecast_accuracy is None
+        assert result.projected_solar_gain_pct is None

--- a/tests/engine/test_terminal_cost_accuracy.py
+++ b/tests/engine/test_terminal_cost_accuracy.py
@@ -173,3 +173,43 @@ class TestTerminalDiagnostics:
         )
 
         assert result["peak_soc_pct"] == 90.0  # max of 75, 90, 85
+
+
+class TestOptimizerResultDiagnosticFields:
+    """Tests for diagnostic fields on OptimizerResult."""
+
+    def test_diagnostic_fields_default_to_none(self):
+        """New diagnostic fields should default to None."""
+        from custom_components.localshift.engine.optimizer_dp import OptimizerResult
+
+        result = OptimizerResult(success=True, total_slots=3)
+        assert result.forecast_accuracy is None
+        assert result.projected_solar_gain_pct is None
+        assert result.accuracy_discount_factor is None
+        assert result.adjusted_solar_gain_pct is None
+        assert result.effective_soc_at_terminal is None
+        assert result.peak_soc_pct is None
+        assert result.dw_entry_soc_pct is None
+
+    def test_diagnostic_fields_set_explicitly(self):
+        """Diagnostic fields can be set via constructor."""
+        from custom_components.localshift.engine.optimizer_dp import OptimizerResult
+
+        result = OptimizerResult(
+            success=True,
+            total_slots=3,
+            forecast_accuracy=0.75,
+            projected_solar_gain_pct=30.0,
+            accuracy_discount_factor=0.75,
+            adjusted_solar_gain_pct=22.5,
+            effective_soc_at_terminal=85.0,
+            peak_soc_pct=92.0,
+            dw_entry_soc_pct=88.0,
+        )
+        assert result.forecast_accuracy == 0.75
+        assert result.projected_solar_gain_pct == 30.0
+        assert result.accuracy_discount_factor == 0.75
+        assert result.adjusted_solar_gain_pct == 22.5
+        assert result.effective_soc_at_terminal == 85.0
+        assert result.peak_soc_pct == 92.0
+        assert result.dw_entry_soc_pct == 88.0

--- a/tests/test_optimizer_runner_integration.py
+++ b/tests/test_optimizer_runner_integration.py
@@ -445,6 +445,41 @@ class TestBuildSummary:
         assert summary["cycle_timestamp_iso"] == "2025-01-15T06:00:00Z"
         assert summary["computed_at"] == "2025-01-15T06:00:00Z"
 
+    def test_includes_terminal_diagnostics(self, mock_coordinator_data):
+        """Verify terminal diagnostic fields included in summary."""
+        from custom_components.localshift.engine.optimizer_dp import OptimizerResult
+
+        result = OptimizerResult(
+            success=True,
+            total_slots=3,
+            forecast_accuracy=0.75,
+            projected_solar_gain_pct=30.0,
+            accuracy_discount_factor=0.75,
+            adjusted_solar_gain_pct=22.5,
+            effective_soc_at_terminal=85.0,
+            peak_soc_pct=92.0,
+            dw_entry_soc_pct=88.0,
+        )
+        summary = _build_summary(result, "cycle123", "2025-01-15T06:00:00Z")
+
+        assert summary["forecast_accuracy"] == 0.75
+        assert summary["projected_solar_gain_pct"] == 30.0
+        assert summary["accuracy_discount_factor"] == 0.75
+        assert summary["adjusted_solar_gain_pct"] == 22.5
+        assert summary["effective_soc_at_terminal"] == 85.0
+        assert summary["peak_soc_pct"] == 92.0
+        assert summary["dw_entry_soc_pct"] == 88.0
+
+    def test_terminal_diagnostics_none_when_not_set(self, mock_coordinator_data):
+        """Verify None diagnostics pass through as None."""
+        from custom_components.localshift.engine.optimizer_dp import OptimizerResult
+
+        result = OptimizerResult(success=True, total_slots=3)
+        summary = _build_summary(result, "cycle123", "2025-01-15T06:00:00Z")
+
+        assert summary["forecast_accuracy"] is None
+        assert summary["peak_soc_pct"] is None
+
 
 class TestNormalizeInitialSoc:
     """Tests for initial SOC normalization and validation guard."""


### PR DESCRIPTION
## Summary

Fixes the data pipeline gap introduced in PR #789 where `_get_terminal_diagnostics()` was defined but never called, causing all 7 diagnostic attributes on the optimizer summary sensor to remain `null`.

## Problem

PR #789 added solar forecast accuracy discount logic and 7 diagnostic attributes to expose internal optimizer calculations:
- `forecast_accuracy` - forecast accuracy (0-1.0)
- `projected_solar_gain_pct` - raw solar projection
- `accuracy_discount_factor` - discount applied (0.5-1.0)
- `adjusted_solar_gain_pct` - solar after discount
- `effective_soc_at_terminal` - effective SOC at terminal
- `peak_soc_pct` - peak SOC across plan
- `dw_entry_soc_pct` - SOC at demand window entry

The accuracy discount **works correctly internally** in `_initialize_dp_tables()` and affects terminal cost calculations. However, the diagnostic values were never propagated to the sensor:

**Data pipeline gap:**
```
_initialize_dp_tables() → computes accuracy_discount (local variable, not returned)
_get_terminal_diagnostics() → DEFINED but NEVER CALLED
_solve() → builds OptimizerResult WITHOUT diagnostic fields
_build_summary() → NO diagnostic keys in summary dict
OptimizerSummarySensor → reads summary.get("forecast_accuracy") → all null
```

## Solution

**3-file fix with TDD:**

1. **types.py**: Add 7 optional `float | None` fields to `OptimizerResult` dataclass
2. **core.py**: In `_solve()` after forward reconstruction, recompute terminal context values and call `_get_terminal_diagnostics()`, populate new `OptimizerResult` fields
3. **optimizer_runner.py**: In `_build_summary()`, read new fields from `result` and add to summary dict

**No changes needed:** `OptimizerSummarySensor` already reads the correct keys via `summary.get()`.

## Changes

### Production Code
- `engine/types.py`: 7 new optional fields on `OptimizerResult`
- `engine/core.py`: Diagnostic computation block in `_solve()` (recomputes terminal context, calls `_get_terminal_diagnostics()`)
- `engine/optimizer_runner.py`: 7 fields added to `_build_summary()`

### Tests
- `tests/engine/test_terminal_cost_accuracy.py`: 
  - `TestOptimizerResultDiagnosticFields` (2 tests) - dataclass field validation
  - `TestSolveDiagnostics` (2 tests) - `_solve()` populates diagnostics with/without demand window
- `tests/test_optimizer_runner_integration.py`:
  - `TestBuildSummary` (2 new tests) - `_build_summary()` propagates diagnostics

## Testing

- All 2773 tests pass
- Coverage: 92% overall (unchanged from baseline)
- Linter: All checks passed
- TDD workflow: RED → GREEN → REFACTOR for each task

## Data Pipeline (After Fix)

```
_get_forecast_accuracy() → accuracy computed
                          ↓
_initialize_dp_tables() → uses accuracy_discount in terminal cost (ALREADY WORKING)
                          ↓
_solve() → calls _get_terminal_diagnostics() → populates OptimizerResult fields ✅ NEW
                          ↓
_build_summary() → reads OptimizerResult fields → adds to summary dict ✅ NEW
                          ↓
OptimizerSummarySensor → reads summary.get("forecast_accuracy") etc. → exposes as HA attributes ✅
```

## Verification

After merge to `test` and deploy, the 7 diagnostic attributes on `sensor.localshift_optimizer_summary` will show actual values instead of `null`:

- `forecast_accuracy`: e.g., 0.17 (17% confidence from Solcast P10/P90 spread)
- `accuracy_discount_factor`: e.g., 0.50 (clamped minimum)
- `projected_solar_gain_pct`: e.g., 30.0 (raw solar projection)
- `adjusted_solar_gain_pct`: e.g., 15.0 (30.0 * 0.50)
- `effective_soc_at_terminal`: e.g., 85.0 (current SOC + adjusted solar)
- `peak_soc_pct`: e.g., 95.8 (max SOC in plan)
- `dw_entry_soc_pct`: e.g., 95.0 (SOC at DW entry slot)

These values will help debug cases like "optimizer says solar will reach target, but forecast is low confidence".