### PR TITLE
Use Solcast confidence to temper solar projections

### DIFF
--- a/.githooks/scripts/check-tdd.sh
+++ b/.githooks/scripts/check-tdd.sh
@@ -50,6 +50,16 @@ for FILE in $STAGED_FILES; do
         if [ -f "$TEST_SUBDIR" ]; then
             TEST_FILE_PATHS+=("$TEST_SUBDIR")
             echo "✅ Test file exists: $TEST_SUBDIR"
+            
+            # Check for additional test files that test the same module
+            # e.g., test_solar_5min.py, test_solar_helpers.py for solar.py
+            ADDITIONAL_TESTS=$(find "tests/${SUBDIR}" -name "test_${MODULE_NAME}_*.py" -type f 2>/dev/null)
+            if [ -n "$ADDITIONAL_TESTS" ]; then
+                for TEST in $ADDITIONAL_TESTS; do
+                    TEST_FILE_PATHS+=("$TEST")
+                    echo "✅ Additional test file: $TEST"
+                done
+            fi
             continue
         fi
     fi

--- a/custom_components/localshift/coordinator/tick_scheduler.py
+++ b/custom_components/localshift/coordinator/tick_scheduler.py
@@ -300,6 +300,9 @@ class TickScheduler:
         if tracker is None:
             return
 
+        if getattr(self._coordinator.data, "boost_charge_active", False) is True:
+            return
+
         from homeassistant.util import dt as dt_util
 
         now = dt_util.now()

--- a/custom_components/localshift/engine/core.py
+++ b/custom_components/localshift/engine/core.py
@@ -374,6 +374,10 @@ class DPPlanner:
             # Recompute terminal context values for diagnostics
             future_solar_gain_pct = 0.0
             if inputs.all_solcast and inputs.slots:
+                from custom_components.localshift.forecast.analysis_resolver import (
+                    ConfidenceResolver,
+                )
+
                 last_slot = inputs.slots[-1]
                 last_slot_start = datetime.fromisoformat(last_slot.timestamp_iso)
                 last_slot_end = last_slot_start + timedelta(
@@ -381,11 +385,16 @@ class DPPlanner:
                 )
                 target_slot = inputs.slots[terminal_penalty_idx]
                 target_time = datetime.fromisoformat(target_slot.timestamp_iso)
+                confidence_resolver = ConfidenceResolver(
+                    inputs.solcast_analysis_today,
+                    inputs.solcast_analysis_tomorrow,
+                )
                 future_solar_gain_pct = DPPlanner._projected_solcast_gain_pct(
                     inputs.all_solcast,
                     start_time=last_slot_end,
                     end_time=target_time,
                     battery_capacity_kwh=config.battery_capacity_kwh,
+                    confidence_resolver=confidence_resolver,
                 )
 
             projected_solar_gain_pct = DPPlanner._projected_solar_soc_gain_pct(
@@ -549,6 +558,10 @@ class DPPlanner:
             # reach the target by the demand window entry.
             future_solar_gain_pct = 0.0
             if inputs.all_solcast and inputs.slots:
+                from custom_components.localshift.forecast.analysis_resolver import (
+                    ConfidenceResolver,
+                )
+
                 last_slot = inputs.slots[-1]
                 last_slot_start = datetime.fromisoformat(last_slot.timestamp_iso)
                 last_slot_end = last_slot_start + timedelta(
@@ -556,6 +569,10 @@ class DPPlanner:
                 )
                 target_slot = inputs.slots[terminal_penalty_idx]
                 target_time = datetime.fromisoformat(target_slot.timestamp_iso)
+                confidence_resolver = ConfidenceResolver(
+                    inputs.solcast_analysis_today,
+                    inputs.solcast_analysis_tomorrow,
+                )
 
                 # Helper computes gain between end of plan and target time
                 future_solar_gain_pct = DPPlanner._projected_solcast_gain_pct(
@@ -563,6 +580,7 @@ class DPPlanner:
                     start_time=last_slot_end,
                     end_time=target_time,
                     battery_capacity_kwh=config.battery_capacity_kwh,
+                    confidence_resolver=confidence_resolver,
                 )
 
             # Issue #624: Hard constraint in self_consumption mode
@@ -1383,6 +1401,10 @@ class DPPlanner:
 
         # 2. Gain from solar beyond horizon (Issue #619)
         if inputs and inputs.all_solcast:
+            from custom_components.localshift.forecast.analysis_resolver import (
+                ConfidenceResolver,
+            )
+
             last_slot = slots[-1]
             last_slot_start = datetime.fromisoformat(last_slot.timestamp_iso)
             last_slot_end = last_slot_start + timedelta(
@@ -1390,12 +1412,17 @@ class DPPlanner:
             )
             target_slot = slots[terminal_penalty_idx]
             target_time = datetime.fromisoformat(target_slot.timestamp_iso)
+            confidence_resolver = ConfidenceResolver(
+                inputs.solcast_analysis_today,
+                inputs.solcast_analysis_tomorrow,
+            )
 
             future_gain = DPPlanner._projected_solcast_gain_pct(
                 inputs.all_solcast,
                 start_time=last_slot_end,
                 end_time=target_time,
                 battery_capacity_kwh=config.battery_capacity_kwh,
+                confidence_resolver=confidence_resolver,
             )
             potential_soc_gain_pct += future_gain
 
@@ -1490,6 +1517,7 @@ class DPPlanner:
         end_time: datetime,
         battery_capacity_kwh: float,
         avg_load_kw: float = 0.5,
+        confidence_resolver: Any | None = None,
     ) -> float:
         """Estimate net SOC gain (%) from solar in Solcast beyond the DP horizon.
 
@@ -1509,7 +1537,23 @@ class DPPlanner:
                 p_start = datetime.fromisoformat(str(p_start_str))
                 # Solcast periods are typically 30 mins
                 if start_time <= p_start < end_time:
-                    solar_kwh += float(period.get("pv_estimate", 0)) * 0.5
+                    # Extract median and P10 estimates separately for blending
+                    raw_estimate = float(period.get("pv_estimate", 0))
+                    raw_p10 = float(period.get("pv_estimate10", 0))
+                    confidence = (
+                        confidence_resolver.get_confidence(p_start)
+                        if confidence_resolver is not None
+                        else 1.0
+                    )
+                    # Blend based on confidence
+                    from custom_components.localshift.forecast.solar import (
+                        _blend_solar_estimate,
+                    )
+
+                    blended_estimate = _blend_solar_estimate(
+                        raw_estimate, raw_p10, confidence
+                    )
+                    solar_kwh += blended_estimate * 0.5
             except (ValueError, TypeError):
                 continue
 

--- a/custom_components/localshift/engine/core.py
+++ b/custom_components/localshift/engine/core.py
@@ -50,6 +50,9 @@ from custom_components.localshift.engine.types import (
     PlannerReasonCode,
     SlotContext,
 )
+from custom_components.localshift.forecast.solar_accuracy import (
+    SolarAccuracyTracker,
+)
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/localshift/engine/optimizer_facade.py
+++ b/custom_components/localshift/engine/optimizer_facade.py
@@ -208,6 +208,10 @@ class OptimizerFacade:
                 slots=slots,
                 config=optimizer_config,
                 all_solcast=slot_metadata.all_solcast,
+                solcast_analysis_today=getattr(data, "solcast_analysis_today", None),
+                solcast_analysis_tomorrow=getattr(
+                    data, "solcast_analysis_tomorrow", None
+                ),
                 solar_accuracy_tracker=self._solar_accuracy_tracker,
             )
             result = self._planner.plan(inputs)
@@ -397,6 +401,10 @@ class OptimizerFacade:
                 slots=shadow_slots,
                 config=optimizer_config,
                 all_solcast=slot_metadata.all_solcast,
+                solcast_analysis_today=getattr(data, "solcast_analysis_today", None),
+                solcast_analysis_tomorrow=getattr(
+                    data, "solcast_analysis_tomorrow", None
+                ),
             )
             result = self._planner.plan(inputs)
 

--- a/custom_components/localshift/engine/optimizer_facade.py
+++ b/custom_components/localshift/engine/optimizer_facade.py
@@ -51,7 +51,7 @@ class OptimizerFacade:
         self._solar_accuracy_tracker = tracker
 
     def _record_forecasts_for_slots(
-        self, slots: list[Any], weather_condition: str
+        self, slots: list[Any], weather_condition: str, is_boost: bool = False
     ) -> None:
         """Record solar forecasts for accuracy tracking.
 
@@ -73,6 +73,7 @@ class OptimizerFacade:
                 period_start=period_start,
                 forecast_kwh=slot.solar_kwh,
                 weather_condition=weather_condition,
+                is_boost=is_boost,
             )
             recorded += 1
 
@@ -184,7 +185,11 @@ class OptimizerFacade:
             )
 
             weather_condition = getattr(data, "weather_condition", None) or "unknown"
-            self._record_forecasts_for_slots(slots, weather_condition)
+            self._record_forecasts_for_slots(
+                slots,
+                weather_condition,
+                is_boost=getattr(data, "boost_charge_active", False),
+            )
             self._apply_bias_correction_to_slots(slots, weather_condition)
             self._apply_cloud_scale_factor_to_slots(slots, data, now_dt)
 

--- a/custom_components/localshift/engine/slots.py
+++ b/custom_components/localshift/engine/slots.py
@@ -183,6 +183,16 @@ class SlotBuilder:
         base_slot = self._compute_base_slot(now_local)
         local_tz = self._get_local_timezone()
 
+        # Create ConfidenceResolver for cross-day confidence lookup
+        from custom_components.localshift.forecast.analysis_resolver import (
+            ConfidenceResolver,
+        )
+
+        resolver = ConfidenceResolver(
+            getattr(data, "solcast_analysis_today", None),
+            getattr(data, "solcast_analysis_tomorrow", None),
+        )
+
         contexts, counts = self._process_all_slots(
             hybrid_slots=hybrid_slots,
             data=data,
@@ -193,6 +203,7 @@ class SlotBuilder:
             dw_start_time=dw_start_time,
             dw_end_time=dw_end_time,
             feed_in_forecast=feed_in_forecast,
+            resolver=resolver,
         )
 
         metadata = SlotBuildMetadata(
@@ -253,6 +264,7 @@ class SlotBuilder:
         dw_start_time: time,
         dw_end_time: time,
         feed_in_forecast: list[dict[str, Any]] | None = None,
+        resolver: Any | None = None,
     ) -> tuple[list[SlotContext], dict[str, int]]:
         """Process all hybrid slots and return contexts with counts."""
         contexts: list[SlotContext] = []
@@ -278,6 +290,7 @@ class SlotBuilder:
                 dw_end_time=dw_end_time,
                 prev_in_demand_window=prev_in_demand_window,
                 feed_in_forecast=feed_in_forecast,
+                resolver=resolver,
             )
             contexts.append(ctx)
             for key in counts:
@@ -299,6 +312,7 @@ class SlotBuilder:
         dw_end_time: time,
         prev_in_demand_window: bool,
         feed_in_forecast: list[dict[str, Any]] | None = None,
+        resolver: Any | None = None,
     ) -> tuple[SlotContext, dict[str, int], bool]:
         """Process a single slot, returning (context, counts, in_demand_window)."""
         slot_start: datetime = slot["start"]
@@ -321,8 +335,14 @@ class SlotBuilder:
             slot_start,
         )
 
+        # Get confidence from resolver (defaults to 1.0 if no resolver)
+        confidence = resolver.get_confidence(slot_start) if resolver else 1.0
         solar_kwh = self._get_solar_kwh(
-            all_solcast, slot_start, interval_minutes, solar_confidence_factor
+            all_solcast,
+            slot_start,
+            interval_minutes,
+            solar_confidence_factor,
+            confidence,
         )
         if solar_kwh < 0.001:
             counts["defaulted_solar"] = 1
@@ -375,6 +395,7 @@ class SlotBuilder:
         slot_start: datetime,
         interval_minutes: int,
         solar_confidence_factor: float,
+        confidence: float = 1.0,
     ) -> float:
         """Get solar kWh for a slot.
 
@@ -383,7 +404,7 @@ class SlotBuilder:
         Otherwise, apply solar_confidence_factor as fallback.
         """
         solar_kwh = get_solar_for_slot_by_interval(
-            all_solcast, slot_start, interval_minutes
+            all_solcast, slot_start, interval_minutes, confidence
         )
 
         # Check if bias correction is ready

--- a/custom_components/localshift/engine/types.py
+++ b/custom_components/localshift/engine/types.py
@@ -514,5 +514,11 @@ class OptimizerInputs:
     all_solcast: list[dict[str, Any]] = field(default_factory=list)
     """Full solar forecast (today + tomorrow) for penalty calculation (Issue #607)."""
 
+    solcast_analysis_today: Any | None = None
+    """Solcast analysis for today with confidence data (Issue #794)."""
+
+    solcast_analysis_tomorrow: Any | None = None
+    """Solcast analysis for tomorrow with confidence data (Issue #794)."""
+
     solar_accuracy_tracker: SolarAccuracyTracker | None = None
     """Tracker for forecast accuracy to apply discount to terminal cost (Issue #785)."""

--- a/custom_components/localshift/forecast/analysis_resolver.py
+++ b/custom_components/localshift/forecast/analysis_resolver.py
@@ -1,0 +1,69 @@
+"""Cross-day confidence resolver for solar forecast analysis.
+
+Provides a single interface to look up per-period confidence from
+today and tomorrow SolcastAnalysis objects.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from custom_components.localshift.forecast.solcast_analysis import (
+    get_confidence_for_period,
+)
+
+
+class ConfidenceResolver:
+    """Resolves per-period confidence across today and tomorrow analyses.
+
+    Uses date-based matching: if the slot date matches the analysis date,
+    use that analysis for confidence lookup. Falls back to day_confidence.
+    """
+
+    def __init__(
+        self,
+        analysis_today: Any | None,
+        analysis_tomorrow: Any | None,
+    ) -> None:
+        self._today = analysis_today
+        self._tomorrow = analysis_tomorrow
+
+    def get_confidence(self, period_start: datetime) -> float:
+        """Get confidence for a specific period, selecting the right analysis by date."""
+        slot_date = period_start.date()
+
+        # Check today's analysis
+        if self._today and self._today.intervals:
+            for interval in self._today.intervals:
+                if interval.period_start.date() == slot_date:
+                    return get_confidence_for_period(self._today, period_start)
+
+        # Check tomorrow's analysis
+        if self._tomorrow and self._tomorrow.intervals:
+            for interval in self._tomorrow.intervals:
+                if interval.period_start.date() == slot_date:
+                    return get_confidence_for_period(self._tomorrow, period_start)
+
+        # Fallback: try today's day_confidence, then tomorrow's, then 1.0
+        if self._today:
+            return get_confidence_for_period(self._today, period_start)
+        if self._tomorrow:
+            return get_confidence_for_period(self._tomorrow, period_start)
+        return 1.0
+
+    def get_analysis_for_period(self, period_start: datetime) -> Any | None:
+        """Return the SolcastAnalysis object that covers the given period."""
+        slot_date = period_start.date()
+
+        if self._today and self._today.intervals:
+            for interval in self._today.intervals:
+                if interval.period_start.date() == slot_date:
+                    return self._today
+
+        if self._tomorrow and self._tomorrow.intervals:
+            for interval in self._tomorrow.intervals:
+                if interval.period_start.date() == slot_date:
+                    return self._tomorrow
+
+        return self._today

--- a/custom_components/localshift/forecast/pipeline.py
+++ b/custom_components/localshift/forecast/pipeline.py
@@ -139,7 +139,17 @@ class ForecastPipeline:
             deficit_kwh = max((target_pct - data.soc) / 100 * BATTERY_CAPACITY_KWH, 0)
 
             all_solcast = [*data.solcast_today, *data.solcast_tomorrow]
-            solar_kwh = sum_solar_before_target(all_solcast, now_dt, target_hour)
+            from custom_components.localshift.forecast.analysis_resolver import (
+                ConfidenceResolver,
+            )
+
+            resolver = ConfidenceResolver(
+                getattr(data, "solcast_analysis_today", None),
+                getattr(data, "solcast_analysis_tomorrow", None),
+            )
+            solar_kwh = sum_solar_before_target(
+                all_solcast, now_dt, target_hour, resolver=resolver
+            )
 
             target_dt = now_dt.replace(
                 hour=target_hour, minute=0, second=0, microsecond=0
@@ -171,7 +181,17 @@ class ForecastPipeline:
             deficit_kwh = max((target_pct - data.soc) / 100 * BATTERY_CAPACITY_KWH, 0)
 
             all_solcast = [*data.solcast_today, *data.solcast_tomorrow]
-            solar_kwh = sum_solar_before_target(all_solcast, now_dt, target_hour)
+            from custom_components.localshift.forecast.analysis_resolver import (
+                ConfidenceResolver,
+            )
+
+            resolver = ConfidenceResolver(
+                getattr(data, "solcast_analysis_today", None),
+                getattr(data, "solcast_analysis_tomorrow", None),
+            )
+            solar_kwh = sum_solar_before_target(
+                all_solcast, now_dt, target_hour, resolver=resolver
+            )
 
             expected_load_kw = self._price_signals.get_expected_load_kw_from_slots(
                 data, hours_to_target

--- a/custom_components/localshift/forecast/solar.py
+++ b/custom_components/localshift/forecast/solar.py
@@ -48,6 +48,23 @@ def _get_period_estimate(entry: dict[str, Any]) -> float:
     )
 
 
+def _blend_solar_estimate(
+    pv_estimate: float,
+    pv_estimate10: float,
+    confidence: float,
+) -> float:
+    """Continuous linear blending between median and P10 based on confidence.
+
+    At high confidence (1.0), returns pv_estimate (median).
+    At low confidence (0.0), returns pv_estimate10 (pessimistic).
+    """
+    if confidence >= 1.0:
+        return pv_estimate
+    if confidence <= 0.0:
+        return pv_estimate10
+    return confidence * pv_estimate + (1.0 - confidence) * pv_estimate10
+
+
 def _process_forecast_entry(
     entry: dict[str, Any] | Any,
     slot_start: datetime,

--- a/custom_components/localshift/forecast/solar.py
+++ b/custom_components/localshift/forecast/solar.py
@@ -411,7 +411,7 @@ def sum_solar_before_target(
     solcast: list[dict[str, Any]],
     now_dt: datetime,
     target_hour: int,
-    confidence: float = 1.0,
+    resolver: Any | None = None,
 ) -> float:
     """Sum expected solar kWh (pv_estimate) from now until target_hour.
 
@@ -430,6 +430,8 @@ def sum_solar_before_target(
         # Extract median and P10 estimates separately for blending
         raw_estimate = float(period.get("pv_estimate", 0))
         raw_p10 = float(period.get("pv_estimate10", 0))
+        # Get confidence from resolver (defaults to 1.0 if no resolver)
+        confidence = resolver.get_confidence(ps_local) if resolver else 1.0
         # Blend based on confidence
         kwh_per_hour = _blend_solar_estimate(raw_estimate, raw_p10, confidence)
 

--- a/custom_components/localshift/forecast/solar.py
+++ b/custom_components/localshift/forecast/solar.py
@@ -70,6 +70,7 @@ def _process_forecast_entry(
     slot_start: datetime,
     slot_end: datetime,
     period_duration: timedelta,
+    confidence: float = 1.0,
 ) -> dict[str, Any] | None:
     """Process a single forecast entry and return contribution if overlapping.
 
@@ -102,7 +103,11 @@ def _process_forecast_entry(
     if overlap_seconds <= 0:
         return None
 
-    period_kwh = _get_period_estimate(entry)
+    # Extract median and P10 estimates separately for blending
+    raw_estimate = float(entry.get("pv_estimate") or entry.get("estimate") or 0.0)
+    raw_p10 = float(entry.get("pv_estimate10") or entry.get("estimate10") or 0.0)
+    # Blend based on confidence
+    period_kwh = _blend_solar_estimate(raw_estimate, raw_p10, confidence)
     overlap_fraction = overlap_seconds / 3600.0
     contribution = period_kwh * overlap_fraction
 
@@ -172,6 +177,7 @@ def get_solar_for_15min_slot(
     solcast_forecasts: list[dict[str, Any]],
     slot_start: datetime,
     debug_log: bool = False,
+    confidence: float = 1.0,
 ) -> float:
     """Get solar forecast (kWh) for a 15-minute slot from Solcast 30-min periods.
 
@@ -199,7 +205,9 @@ def get_solar_for_15min_slot(
     matched_entries: list[dict[str, Any]] = []
 
     for entry in solcast_forecasts:
-        result = _process_forecast_entry(entry, slot_start, slot_end, period_duration)
+        result = _process_forecast_entry(
+            entry, slot_start, slot_end, period_duration, confidence
+        )
         if result is not None:
             total_solar += result["contribution"]
             matched_entries.append(result)
@@ -213,6 +221,7 @@ def get_solar_for_15min_slot(
 def get_solar_for_5min_slot(
     solcast_forecasts: list[dict[str, Any]],
     slot_start: datetime,
+    confidence: float = 1.0,
 ) -> float:
     """Get solar forecast (kWh) for a 5-minute slot from Solcast 30-min periods.
 
@@ -228,6 +237,7 @@ def get_solar_for_5min_slot(
     Args:
         solcast_forecasts: List of Solcast forecast dicts (today + tomorrow).
         slot_start: Start of the 5-minute slot (timezone-aware or naive local).
+        confidence: Confidence score (0.0-1.0) for blending median and P10 estimates.
 
     Returns:
         Solar energy in kWh for the 5-minute slot, or 0.0 if no data found.
@@ -267,14 +277,15 @@ def get_solar_for_5min_slot(
         overlap_seconds = (overlap_end - overlap_start).total_seconds()
 
         if overlap_seconds > 0:
-            # Use pv_estimate (expected) as primary, fallback to pv_estimate10 (pessimistic)
-            period_kwh = float(
-                entry.get("pv_estimate")
-                or entry.get("estimate")
-                or entry.get("pv_estimate10")
-                or entry.get("estimate10")
-                or 0.0
+            # Extract median and P10 estimates separately for blending
+            raw_estimate = float(
+                entry.get("pv_estimate") or entry.get("estimate") or 0.0
             )
+            raw_p10 = float(
+                entry.get("pv_estimate10") or entry.get("estimate10") or 0.0
+            )
+            # Blend based on confidence
+            period_kwh = _blend_solar_estimate(raw_estimate, raw_p10, confidence)
             # pv_estimate is kWh per HOUR, so divide by 3600 seconds
             overlap_fraction = overlap_seconds / 3600.0
             total_solar += period_kwh * overlap_fraction
@@ -285,6 +296,7 @@ def get_solar_for_5min_slot(
 def get_solar_for_30min_slot(
     solcast_forecasts: list[dict[str, Any]],
     slot_start: datetime,
+    confidence: float = 1.0,
 ) -> float:
     """Get solar forecast (kWh) for a 30-minute slot from Solcast 30-min periods.
 
@@ -300,6 +312,7 @@ def get_solar_for_30min_slot(
     Args:
         solcast_forecasts: List of Solcast forecast dicts (today + tomorrow).
         slot_start: Start of the 30-minute slot (timezone-aware or naive local).
+        confidence: Confidence score (0.0-1.0) for blending median and P10 estimates.
 
     Returns:
         Solar energy in kWh for the 30-minute slot, or 0.0 if no data found.
@@ -339,14 +352,15 @@ def get_solar_for_30min_slot(
         overlap_seconds = (overlap_end - overlap_start).total_seconds()
 
         if overlap_seconds > 0:
-            # Use pv_estimate (expected) as primary, fallback to pv_estimate10 (pessimistic)
-            period_kwh = float(
-                entry.get("pv_estimate")
-                or entry.get("estimate")
-                or entry.get("pv_estimate10")
-                or entry.get("estimate10")
-                or 0.0
+            # Extract median and P10 estimates separately for blending
+            raw_estimate = float(
+                entry.get("pv_estimate") or entry.get("estimate") or 0.0
             )
+            raw_p10 = float(
+                entry.get("pv_estimate10") or entry.get("estimate10") or 0.0
+            )
+            # Blend based on confidence
+            period_kwh = _blend_solar_estimate(raw_estimate, raw_p10, confidence)
             # pv_estimate is kWh per HOUR, so divide by 3600 seconds
             overlap_fraction = overlap_seconds / 3600.0
             total_solar += period_kwh * overlap_fraction
@@ -358,6 +372,7 @@ def get_solar_for_slot_by_interval(
     solcast_forecasts: list[dict[str, Any]],
     slot_start: datetime,
     interval_minutes: int,
+    confidence: float = 1.0,
 ) -> float:
     """Get solar forecast (kWh) for a slot with variable duration.
 
@@ -368,29 +383,35 @@ def get_solar_for_slot_by_interval(
         solcast_forecasts: List of Solcast forecast dicts (today + tomorrow).
         slot_start: Start of the slot (timezone-aware or naive local).
         interval_minutes: Slot duration in minutes (5, 15, or 30).
+        confidence: Confidence score (0.0-1.0) for blending median and P10 estimates.
 
     Returns:
         Solar energy in kWh for the slot, or 0.0 if no data found.
 
     """
     if interval_minutes == 5:
-        return get_solar_for_5min_slot(solcast_forecasts, slot_start)
+        return get_solar_for_5min_slot(solcast_forecasts, slot_start, confidence)
     elif interval_minutes == 15:
-        return get_solar_for_15min_slot(solcast_forecasts, slot_start)
+        return get_solar_for_15min_slot(
+            solcast_forecasts, slot_start, confidence=confidence
+        )
     elif interval_minutes == 30:
-        return get_solar_for_30min_slot(solcast_forecasts, slot_start)
+        return get_solar_for_30min_slot(solcast_forecasts, slot_start, confidence)
     else:
         _LOGGER.warning(
             "Unsupported slot interval %d minutes, defaulting to 15-min",
             interval_minutes,
         )
-        return get_solar_for_15min_slot(solcast_forecasts, slot_start)
+        return get_solar_for_15min_slot(
+            solcast_forecasts, slot_start, confidence=confidence
+        )
 
 
 def sum_solar_before_target(
     solcast: list[dict[str, Any]],
     now_dt: datetime,
     target_hour: int,
+    confidence: float = 1.0,
 ) -> float:
     """Sum expected solar kWh (pv_estimate) from now until target_hour.
 
@@ -406,8 +427,11 @@ def sum_solar_before_target(
             continue
         ps_local = dt_util.as_local(period_start)
         period_end = ps_local + period_duration
-        # pv_estimate is kWh per HOUR (average power)
-        kwh_per_hour = float(period.get("pv_estimate", 0))
+        # Extract median and P10 estimates separately for blending
+        raw_estimate = float(period.get("pv_estimate", 0))
+        raw_p10 = float(period.get("pv_estimate10", 0))
+        # Blend based on confidence
+        kwh_per_hour = _blend_solar_estimate(raw_estimate, raw_p10, confidence)
 
         if ps_local >= target_dt:
             # Period starts at or after target — skip

--- a/custom_components/localshift/forecast/solar_accuracy.py
+++ b/custom_components/localshift/forecast/solar_accuracy.py
@@ -51,6 +51,7 @@ class SolarPeriodRecord:
     season: str
     bias: float = 0.0
     additive_bias: float = 0.0
+    is_boost_period: bool = False
 
     def __post_init__(self) -> None:
         """Calculate bias after initialization."""
@@ -76,6 +77,7 @@ class SolarPeriodRecord:
             "season": self.season,
             "bias": self.bias,
             "additive_bias": self.additive_bias,
+            "is_boost_period": self.is_boost_period,
         }
 
     @classmethod
@@ -99,6 +101,7 @@ class SolarPeriodRecord:
             season=data.get("season", "unknown"),
             bias=data.get("bias", 0.0),
             additive_bias=data.get("additive_bias", 0.0),
+            is_boost_period=data.get("is_boost_period", False),
         )
 
 
@@ -260,6 +263,7 @@ class SolarAccuracyTracker:
         period_start: datetime,
         forecast_kwh: float,
         weather_condition: str,
+        is_boost: bool = False,
     ) -> None:
         """Record a solar forecast for a 30-min period.
 
@@ -277,6 +281,7 @@ class SolarAccuracyTracker:
             weather_condition=self._normalize_weather(weather_condition),
             time_of_day=time_of_day,
             season=season,
+            is_boost_period=is_boost,
         )
         self._pending_forecasts[key] = record
         _LOGGER.debug(
@@ -329,7 +334,10 @@ class SolarAccuracyTracker:
         if not self._period_records:
             return
 
-        records = list(self._period_records)
+        records = [r for r in self._period_records if not r.is_boost_period]
+        if not records:
+            self._metrics = SolarBiasMetrics()
+            return
 
         self._metrics.sample_count = len(records)
         self._metrics.overall_bias = sum(r.bias for r in records) / len(records)

--- a/custom_components/localshift/forecast/solcast_analysis.py
+++ b/custom_components/localshift/forecast/solcast_analysis.py
@@ -182,8 +182,12 @@ def get_confidence_for_period(
         Confidence score (0-1), defaults to 1.0 if no data available
 
     """
-    if analysis is None or not analysis.intervals:
+    if analysis is None:
         return 1.0
+
+    if not analysis.intervals:
+        # No intervals available, return day-level confidence
+        return analysis.day_confidence
 
     # Find matching interval (allow 5-minute tolerance for rounding)
     period_start_local = dt_util.as_local(period_start)

--- a/custom_components/localshift/sensors/forecast.py
+++ b/custom_components/localshift/sensors/forecast.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.components.sensor import SensorStateClass
+from homeassistant.util import dt as dt_util
 
 from ..pricing.types import ForecastSlot
 from .base import LocalShiftSensorBase
@@ -38,7 +39,19 @@ class SolarBatteryForecastSensor(LocalShiftSensorBase):
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
-        return self.coordinator.data.solar_battery_forecast
+        attrs = dict(self.coordinator.data.solar_battery_forecast)
+        from custom_components.localshift.forecast.analysis_resolver import (
+            ConfidenceResolver,
+        )
+
+        resolver = ConfidenceResolver(
+            getattr(self.coordinator.data, "solcast_analysis_today", None),
+            getattr(self.coordinator.data, "solcast_analysis_tomorrow", None),
+        )
+        confidence = resolver.get_confidence(dt_util.now())
+        attrs["solar_confidence_used"] = confidence
+        attrs["solar_blend_applied"] = confidence < 1.0
+        return attrs
 
 
 class NetElectricityCostSensor(LocalShiftSensorBase):

--- a/custom_components/localshift/sensors/optimizer.py
+++ b/custom_components/localshift/sensors/optimizer.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+from datetime import timedelta
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.components.sensor import SensorStateClass
+from homeassistant.util import dt as dt_util
 
 from .base import LocalShiftSensorBase
 
@@ -30,6 +32,19 @@ class OptimizerPlanDetailedSensor(LocalShiftSensorBase):
         d = self.coordinator.data
         decisions = d.optimizer_decisions or []
         summary = d.optimizer_summary or {}
+        from custom_components.localshift.forecast.analysis_resolver import (
+            ConfidenceResolver,
+        )
+
+        resolver = ConfidenceResolver(
+            getattr(d, "solcast_analysis_today", None),
+            getattr(d, "solcast_analysis_tomorrow", None),
+        )
+        now = dt_util.now()
+        confidences = [
+            resolver.get_confidence(now + timedelta(hours=i)) for i in range(24)
+        ]
+        avg_confidence = sum(confidences) / len(confidences) if confidences else 1.0
 
         return {
             "enabled": summary.get("enabled", False),
@@ -40,6 +55,15 @@ class OptimizerPlanDetailedSensor(LocalShiftSensorBase):
             "forecast_horizon_hours": d.forecast_horizon_hours,
             "computed_at": summary.get("cycle_timestamp_iso")
             or summary.get("computed_at"),
+            "solar_confidence_avg": avg_confidence,
+            "solar_confidence_regime": (
+                "high"
+                if avg_confidence >= 0.7
+                else "medium"
+                if avg_confidence >= 0.4
+                else "low"
+            ),
+            "solar_blend_applied": avg_confidence < 1.0,
         }
 
     @property
@@ -70,6 +94,21 @@ class OptimizerSummarySensor(LocalShiftSensorBase):
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         summary = self.coordinator.data.optimizer_summary or {}
+        d = self.coordinator.data
+        from custom_components.localshift.forecast.analysis_resolver import (
+            ConfidenceResolver,
+        )
+
+        resolver = ConfidenceResolver(
+            getattr(d, "solcast_analysis_today", None),
+            getattr(d, "solcast_analysis_tomorrow", None),
+        )
+        now = dt_util.now()
+        confidences = [
+            resolver.get_confidence(now + timedelta(hours=i)) for i in range(24)
+        ]
+        avg_confidence = sum(confidences) / len(confidences) if confidences else 1.0
+
         return {
             "enabled": summary.get("enabled", False),
             "success": summary.get("success", False),
@@ -95,6 +134,15 @@ class OptimizerSummarySensor(LocalShiftSensorBase):
             "accuracy_discount_factor": summary.get("accuracy_discount_factor"),
             "adjusted_solar_gain_pct": summary.get("adjusted_solar_gain_pct"),
             "effective_soc_at_terminal": summary.get("effective_soc_at_terminal"),
+            "solar_confidence_avg": avg_confidence,
+            "solar_confidence_regime": (
+                "high"
+                if avg_confidence >= 0.7
+                else "medium"
+                if avg_confidence >= 0.4
+                else "low"
+            ),
+            "solar_blend_applied": avg_confidence < 1.0,
         }
 
     @property

--- a/docs/superpowers/plans/2026-03-19-solar-confidence-boost-protection.md
+++ b/docs/superpowers/plans/2026-03-19-solar-confidence-boost-protection.md
@@ -10,14 +10,25 @@
 
 ---
 
+## Design Note: Interaction with `solar_confidence_factor`
+
+The existing adaptive `solar_confidence_factor` (in `engine/slots.py`, default 1.0, range [0.5, 1.5]) is applied when solar accuracy tracking has insufficient samples (<20). When confidence blending is active AND `solar_confidence_factor` is in play, both adjustments apply multiplicatively. This is acceptable because:
+- `solar_confidence_factor` adjusts for **systemic** forecast bias (learned over time)
+- Confidence blending adjusts for **specific forecast uncertainty** (from Solcast data)
+- They address different concerns and the combined effect is bounded
+- As accuracy tracking matures (≥20 samples), `solar_confidence_factor` falls out and only confidence blending remains
+
+No change to the `solar_confidence_factor` mechanism is needed.
+
 ## File Structure
 
 | File | Change | Responsibility |
 |------|--------|---------------|
 | `forecast/solar.py` | Add `_blend_solar_estimate()`, add `confidence` param to getters and `sum_solar_before_target` | Core blending algorithm |
-| `engine/slots.py` | Thread confidence from `data.solcast_analysis_*` into `_get_solar_kwh()` | Slot builder confidence |
-| `forecast/pipeline.py` | Pass analysis to `sum_solar_before_target()` at both call sites | Forecast battery confidence |
-| `engine/types.py` | Add `solcast_analysis_today` field to `OptimizerInputs` | Data threading |
+| `engine/slots.py` | Thread confidence via resolver into `_get_solar_kwh()` | Slot builder confidence |
+| `forecast/pipeline.py` | Pass both today/tomorrow analyses to `sum_solar_before_target()` | Forecast battery confidence |
+| `forecast/analysis_resolver.py` | New: `ConfidenceResolver` to unify today+tomorrow lookup | Cross-day confidence |
+| `engine/types.py` | Add `solcast_analysis_today` and `solcast_analysis_tomorrow` to `OptimizerInputs` | Data threading |
 | `engine/core.py` | Use blended solar in `_projected_solcast_gain_pct()` | Terminal cost projection |
 | `forecast/solar_accuracy.py` | Add `is_boost_period` to `SolarPeriodRecord`, add `is_boost` param to `record_forecast()`, filter in `_recompute_metrics()` | Boost tagging |
 | `engine/optimizer_facade.py` | Pass `is_boost` flag to `record_forecast()` | Boost detection |
@@ -25,7 +36,7 @@
 | `sensors/optimizer.py` | Add confidence diagnostic attributes | Observability |
 | `sensors/forecast.py` | Add confidence diagnostic attributes | Observability |
 | `tests/forecast/test_solar_confidence.py` | New: confidence blending unit tests | Test coverage |
-| `tests/test_solar_confidence_scenarios.py` | New: integration scenarios | Test coverage |
+| `tests/forecast/test_solar_confidence_scenarios.py` | New: integration scenarios | Test coverage |
 | `tests/forecast/test_solar_accuracy.py` | Extend: boost contamination tests | Test coverage |
 
 ---
@@ -478,59 +489,235 @@ git commit -m "feat(solar): add analysis-based confidence to sum_solar_before_ta
 
 ---
 
-## Chunk 2: Confidence Threading to Slot Builder
+## Chunk 2: Cross-Day Confidence Resolver
 
-### Task 2.1: Thread confidence through `slots.py`
+### Task 2.1: Create `forecast/analysis_resolver.py`
+
+**Problem:** Slots and forecasts can span today and tomorrow. Threading `solcast_analysis_today` alone gives wrong confidence for tomorrow's slots. A resolver unifies both analyses.
+
+**Files:**
+- Create: `custom_components/localshift/forecast/analysis_resolver.py`
+- Test: `tests/forecast/test_solar_confidence.py`
+
+- [ ] **Step 1: Write failing test**
+
+```python
+class TestConfidenceResolver:
+    """Tests for ConfidenceResolver cross-day lookup."""
+
+    def test_returns_today_confidence_for_today_slot(self):
+        from custom_components.localshift.forecast.analysis_resolver import ConfidenceResolver
+        from custom_components.localshift.forecast.solcast_analysis import (
+            SolcastAnalysis, ConfidenceInterval,
+        )
+        from datetime import datetime, timezone, timedelta
+
+        today_analysis = SolcastAnalysis(
+            entity_id="today", last_updated=datetime.now(timezone.utc),
+            day_confidence=0.8, day_spread_kwh=0,
+            estimate10_kwh=0, estimate90_kwh=0,
+            intervals=[
+                ConfidenceInterval(
+                    period_start=datetime(2026, 3, 19, 10, 0, tzinfo=timezone.utc),
+                    spread_kwh=0, confidence=0.9,
+                ),
+            ],
+        )
+        tomorrow_analysis = SolcastAnalysis(
+            entity_id="tomorrow", last_updated=datetime.now(timezone.utc),
+            day_confidence=0.3, day_spread_kwh=0,
+            estimate10_kwh=0, estimate90_kwh=0,
+            intervals=[
+                ConfidenceInterval(
+                    period_start=datetime(2026, 3, 20, 10, 0, tzinfo=timezone.utc),
+                    spread_kwh=0, confidence=0.4,
+                ),
+            ],
+        )
+
+        resolver = ConfidenceResolver(today_analysis, tomorrow_analysis)
+        # Today slot should get today's interval confidence
+        conf = resolver.get_confidence(datetime(2026, 3, 19, 10, 0, tzinfo=timezone.utc))
+        assert conf == pytest.approx(0.9)
+
+    def test_returns_tomorrow_confidence_for_tomorrow_slot(self):
+        from custom_components.localshift.forecast.analysis_resolver import ConfidenceResolver
+        from custom_components.localshift.forecast.solcast_analysis import (
+            SolcastAnalysis, ConfidenceInterval,
+        )
+        from datetime import datetime, timezone
+
+        today_analysis = SolcastAnalysis(
+            entity_id="today", last_updated=datetime.now(timezone.utc),
+            day_confidence=0.8, day_spread_kwh=0,
+            estimate10_kwh=0, estimate90_kwh=0,
+            intervals=[],
+        )
+        tomorrow_analysis = SolcastAnalysis(
+            entity_id="tomorrow", last_updated=datetime.now(timezone.utc),
+            day_confidence=0.3, day_spread_kwh=0,
+            estimate10_kwh=0, estimate90_kwh=0,
+            intervals=[
+                ConfidenceInterval(
+                    period_start=datetime(2026, 3, 20, 10, 0, tzinfo=timezone.utc),
+                    spread_kwh=0, confidence=0.4,
+                ),
+            ],
+        )
+
+        resolver = ConfidenceResolver(today_analysis, tomorrow_analysis)
+        conf = resolver.get_confidence(datetime(2026, 3, 20, 10, 0, tzinfo=timezone.utc))
+        assert conf == pytest.approx(0.4)
+
+    def test_fallback_to_day_confidence_when_no_match(self):
+        from custom_components.localshift.forecast.analysis_resolver import ConfidenceResolver
+        from custom_components.localshift.forecast.solcast_analysis import SolcastAnalysis
+        from datetime import datetime, timezone
+
+        analysis = SolcastAnalysis(
+            entity_id="today", last_updated=datetime.now(timezone.utc),
+            day_confidence=0.6, day_spread_kwh=0,
+            estimate10_kwh=0, estimate90_kwh=0,
+            intervals=[],
+        )
+        resolver = ConfidenceResolver(analysis, None)
+        conf = resolver.get_confidence(datetime(2026, 3, 19, 15, 0, tzinfo=timezone.utc))
+        assert conf == pytest.approx(0.6)  # Falls back to day_confidence
+
+    def test_no_analysis_returns_1(self):
+        from custom_components.localshift.forecast.analysis_resolver import ConfidenceResolver
+        from datetime import datetime, timezone
+
+        resolver = ConfidenceResolver(None, None)
+        conf = resolver.get_confidence(datetime(2026, 3, 19, 10, 0, tzinfo=timezone.utc))
+        assert conf == 1.0
+```
+
+- [ ] **Step 2: Create `ConfidenceResolver` class**
+
+```python
+"""Cross-day confidence resolver for solar forecast analysis.
+
+Provides a single interface to look up per-period confidence from
+today and tomorrow SolcastAnalysis objects.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from custom_components.localshift.forecast.solcast_analysis import (
+    get_confidence_for_period,
+)
+
+
+class ConfidenceResolver:
+    """Resolves per-period confidence across today and tomorrow analyses.
+
+    Uses date-based matching: if the slot date matches the analysis date,
+    use that analysis for confidence lookup. Falls back to day_confidence.
+    """
+
+    def __init__(
+        self,
+        analysis_today: Any | None,
+        analysis_tomorrow: Any | None,
+    ) -> None:
+        self._today = analysis_today
+        self._tomorrow = analysis_tomorrow
+
+    def get_confidence(self, period_start: datetime) -> float:
+        """Get confidence for a specific period, selecting the right analysis by date."""
+        slot_date = period_start.date()
+
+        # Check today's analysis
+        if self._today and self._today.intervals:
+            for interval in self._today.intervals:
+                if interval.period_start.date() == slot_date:
+                    return get_confidence_for_period(self._today, period_start)
+
+        # Check tomorrow's analysis
+        if self._tomorrow and self._tomorrow.intervals:
+            for interval in self._tomorrow.intervals:
+                if interval.period_start.date() == slot_date:
+                    return get_confidence_for_period(self._tomorrow, period_start)
+
+        # Fallback: try today's day_confidence, then tomorrow's, then 1.0
+        if self._today:
+            return get_confidence_for_period(self._today, period_start)
+        if self._tomorrow:
+            return get_confidence_for_period(self._tomorrow, period_start)
+        return 1.0
+
+    def get_analysis_for_period(self, period_start: datetime) -> Any | None:
+        """Return the SolcastAnalysis object that covers the given period."""
+        slot_date = period_start.date()
+
+        if self._today and self._today.intervals:
+            for interval in self._today.intervals:
+                if interval.period_start.date() == slot_date:
+                    return self._today
+
+        if self._tomorrow and self._tomorrow.intervals:
+            for interval in self._tomorrow.intervals:
+                if interval.period_start.date() == slot_date:
+                    return self._tomorrow
+
+        return self._today
+```
+
+- [ ] **Step 3: Run test to verify it passes**
+
+Run: `uv run pytest tests/forecast/test_solar_confidence.py::TestConfidenceResolver -v`
+Expected: All 4 tests PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add custom_components/localshift/forecast/analysis_resolver.py tests/forecast/test_solar_confidence.py
+git commit -m "feat(forecast): add cross-day ConfidenceResolver for today+tomorrow analysis (#794)"
+```
+
+---
+
+## Chunk 3: Confidence Threading to Slot Builder
+
+### Task 3.1: Thread confidence through `slots.py`
 
 **Files:**
 - Modify: `custom_components/localshift/engine/slots.py`
 
-- [ ] **Step 1: Add helper method to SlotBuilder**
+- [ ] **Step 1: Create ConfidenceResolver in SlotBuilder**
 
-Add `_get_analysis_for_slot()` method to pick the right `SolcastAnalysis` based on slot date:
+In `SlotBuilder.build_slots()`, create a resolver from `data`:
 
 ```python
-def _get_analysis_for_slot(self, data: Any, slot_start: datetime) -> Any:
-    """Get the SolcastAnalysis for a slot based on its date."""
-    analysis_today = getattr(data, "solcast_analysis_today", None)
-    analysis_tomorrow = getattr(data, "solcast_analysis_tomorrow", None)
+from custom_components.localshift.forecast.analysis_resolver import ConfidenceResolver
 
-    # Check if slot matches today's analysis intervals
-    if analysis_today and analysis_today.intervals:
-        for interval in analysis_today.intervals:
-            if abs((slot_start - interval.period_start).total_seconds()) <= 1800:
-                return analysis_today
-
-    # Check tomorrow
-    if analysis_tomorrow and analysis_tomorrow.intervals:
-        for interval in analysis_tomorrow.intervals:
-            if abs((slot_start - interval.period_start).total_seconds()) <= 1800:
-                return analysis_tomorrow
-
-    # Fallback to today (has day_confidence fallback)
-    return analysis_today
+# In build_slots(), after data is received:
+resolver = ConfidenceResolver(
+    getattr(data, "solcast_analysis_today", None),
+    getattr(data, "solcast_analysis_tomorrow", None),
+)
 ```
+
+Pass `resolver` through to `_process_all_slots()` and `_process_single_slot()`.
 
 - [ ] **Step 2: Modify `_process_single_slot()` to extract confidence**
 
-Add import at top of file:
+In `_process_single_slot()`, before the `_get_solar_kwh()` call, get confidence from the resolver:
+
 ```python
-from custom_components.localshift.forecast.solcast_analysis import get_confidence_for_period
+        confidence = resolver.get_confidence(slot_start)
 ```
 
-Before the `_get_solar_kwh()` call at line 324, add:
-```python
-        analysis = self._get_analysis_for_slot(data, slot_start)
-        confidence = get_confidence_for_period(analysis, slot_start)
-```
-
-Change the call at line 324 to pass `confidence=confidence`.
+Pass `confidence=confidence` to `_get_solar_kwh()`.
 
 - [ ] **Step 3: Modify `_get_solar_kwh()` to accept confidence**
 
 Add `confidence: float = 1.0` parameter to signature.
 
-Change line 385 to pass `confidence=confidence` to `get_solar_for_slot_by_interval()`.
+Pass `confidence=confidence` to `get_solar_for_slot_by_interval()`.
 
 - [ ] **Step 4: Run existing tests**
 
@@ -541,61 +728,75 @@ Expected: All PASS (backward compat via default `confidence=1.0`)
 
 ```bash
 git add custom_components/localshift/engine/slots.py
-git commit -m "feat(solar): thread confidence through slot builder to getter functions (#794)"
+git commit -m "feat(solar): thread confidence via resolver through slot builder (#794)"
 ```
 
 ---
 
-## Chunk 3: Confidence Threading to Forecast Battery + Terminal Cost
+## Chunk 4: Confidence Threading to Forecast Battery + Terminal Cost
 
-### Task 3.1: Pass analysis to `sum_solar_before_target()` in pipeline.py
+### Task 4.1: Pass both analyses to `sum_solar_before_target()` in pipeline.py
 
 **Files:**
-- Modify: `custom_components/localshift/forecast/pipeline.py:141-142, 173-174`
+- Modify: `custom_components/localshift/forecast/pipeline.py`
 
 - [ ] **Step 1: Modify both call sites**
 
-Change both call sites (line 142 and 174) from:
+At both call sites (forecast battery solar sum), use `ConfidenceResolver` instead of just today's analysis:
 ```python
-            solar_kwh = sum_solar_before_target(all_solcast, now_dt, target_hour)
-```
-to:
-```python
-            analysis = getattr(data, "solcast_analysis_today", None)
-            solar_kwh = sum_solar_before_target(all_solcast, now_dt, target_hour, analysis=analysis)
+            from custom_components.localshift.forecast.analysis_resolver import ConfidenceResolver
+            resolver = ConfidenceResolver(
+                getattr(data, "solcast_analysis_today", None),
+                getattr(data, "solcast_analysis_tomorrow", None),
+            )
+            solar_kwh = sum_solar_before_target(all_solcast, now_dt, target_hour, resolver=resolver)
 ```
 
-- [ ] **Step 2: Commit**
+- [ ] **Step 2: Update `sum_solar_before_target()` to accept resolver**
+
+Change signature: add `resolver: Any | None = None` parameter.
+
+In the loop body, replace per-period confidence lookup with:
+```python
+        if resolver is not None:
+            confidence = resolver.get_confidence(ps_local)
+        else:
+            confidence = 1.0
+```
+
+- [ ] **Step 3: Commit**
 
 ```bash
-git add custom_components/localshift/forecast/pipeline.py
-git commit -m "feat(solar): pass Solcast analysis to forecast battery solar sum (#794)"
+git add custom_components/localshift/forecast/pipeline.py custom_components/localshift/forecast/solar.py
+git commit -m "feat(solar): pass cross-day ConfidenceResolver to forecast battery solar sum (#794)"
 ```
 
-### Task 3.2: Add SolcastAnalysis to OptimizerInputs
+### Task 4.2: Add both analyses to OptimizerInputs
 
 **Files:**
-- Modify: `custom_components/localshift/engine/types.py:468-496`
+- Modify: `custom_components/localshift/engine/types.py`
 
-- [ ] **Step 1: Add field to `OptimizerInputs`**
+- [ ] **Step 1: Add both fields to `OptimizerInputs`**
 
-After `solar_accuracy_tracker` field (line 496), add:
 ```python
     solcast_analysis_today: Any | None = None
-    """Solcast analysis with confidence data for solar blending (Issue #794)."""
+    """Solcast analysis for today with confidence data (Issue #794)."""
+
+    solcast_analysis_tomorrow: Any | None = None
+    """Solcast analysis for tomorrow with confidence data (Issue #794)."""
 ```
 
 - [ ] **Step 2: Commit**
 
 ```bash
 git add custom_components/localshift/engine/types.py
-git commit -m "feat(optimizer): add solcast_analysis_today to OptimizerInputs (#794)"
+git commit -m "feat(optimizer): add both today/tomorrow solcast analysis to OptimizerInputs (#794)"
 ```
 
-### Task 3.3: Use blended solar in terminal cost projection
+### Task 4.3: Use blended solar in terminal cost projection
 
 **Files:**
-- Modify: `custom_components/localshift/engine/core.py:1435-1463`
+- Modify: `custom_components/localshift/engine/core.py`
 
 - [ ] **Step 1: Write failing test**
 
@@ -617,10 +818,12 @@ class TestProjectedSolcastGainWithConfidence:
     """Tests for _projected_solcast_gain_pct() with confidence."""
 
     def test_low_confidence_reduces_projected_gain(self):
+        """Low confidence should reduce the projected solar gain."""
         solcast = [{"period_start": "2026-03-19T12:00:00", "pv_estimate": 6.0, "pv_estimate10": 1.0}]
         start = datetime(2026, 3, 19, 12, 0, tzinfo=timezone.utc)
         end = datetime(2026, 3, 19, 12, 30, tzinfo=timezone.utc)
 
+        # No analysis = full median
         gain_high = DPPlanner._projected_solcast_gain_pct(solcast, start, end, 13.5)
 
         analysis_low = SolcastAnalysis(
@@ -633,10 +836,19 @@ class TestProjectedSolcastGainWithConfidence:
         )
 
         assert gain_low < gain_high
-        assert gain_low == pytest.approx(gain_high * 0.2 / 1.0 + (1 - 0.2) * (1.0 / 6.0) * gain_high, rel=0.1)
+        assert gain_low > 0
+
+    def test_no_analysis_backward_compatible(self):
+        """Without analysis, behavior is identical to current."""
+        solcast = [{"period_start": "2026-03-19T12:00:00", "pv_estimate": 6.0, "pv_estimate10": 1.0}]
+        start = datetime(2026, 3, 19, 12, 0, tzinfo=timezone.utc)
+        end = datetime(2026, 3, 19, 12, 30, tzinfo=timezone.utc)
+
+        gain = DPPlanner._projected_solcast_gain_pct(solcast, start, end, 13.5)
+        assert gain > 0.2  # Uses pv_estimate=6.0
 ```
 
-- [ ] **Step 2: Modify `_projected_solcast_gain_pct()` signature**
+- [ ] **Step 2: Modify `_projected_solcast_gain_pct()`**
 
 Add `solcast_analysis: Any | None = None` parameter.
 
@@ -646,53 +858,44 @@ from custom_components.localshift.forecast.solar import _blend_solar_estimate
 from custom_components.localshift.forecast.solcast_analysis import get_confidence_for_period
 ```
 
-Change the solar accumulation loop (lines 1452-1463) to use `_blend_solar_estimate()` with per-period confidence from `get_confidence_for_period(solcast_analysis, p_start)`.
+Change the solar accumulation loop to use `_blend_solar_estimate()` with per-period confidence.
 
 - [ ] **Step 3: Update caller in `_initialize_dp_tables()`**
 
-Pass `solcast_analysis=inputs.solcast_analysis_today` when calling `_projected_solcast_gain_pct()`.
+Create a `ConfidenceResolver` from `inputs.solcast_analysis_today` and `inputs.solcast_analysis_tomorrow`. Use it to get the appropriate analysis for the terminal cost projection time range, then pass to `_projected_solcast_gain_pct()`.
 
-- [ ] **Step 4: Run tests**
-
-Run: `uv run pytest tests/engine/test_terminal_cost_confidence.py -v`
-Expected: All PASS
-
-- [ ] **Step 5: Run existing optimizer tests**
-
-Run: `uv run pytest tests/engine/ -v`
-Expected: All PASS
-
-- [ ] **Step 6: Commit**
+- [ ] **Step 4: Run tests and commit**
 
 ```bash
+uv run pytest tests/engine/test_terminal_cost_confidence.py tests/engine/ -v
 git add custom_components/localshift/engine/core.py custom_components/localshift/engine/types.py tests/engine/test_terminal_cost_confidence.py
 git commit -m "feat(optimizer): apply confidence blending in terminal cost projection (#794)"
 ```
 
-### Task 3.4: Thread analysis through OptimizerFacade to OptimizerInputs
+### Task 4.4: Thread both analyses through OptimizerFacade
 
 **Files:**
-- Modify: `custom_components/localshift/engine/optimizer_facade.py:205-212`
+- Modify: `custom_components/localshift/engine/optimizer_facade.py`
 
-- [ ] **Step 1: Pass analysis when constructing OptimizerInputs**
+- [ ] **Step 1: Pass both analyses when constructing OptimizerInputs**
 
-Change `OptimizerInputs` construction to add:
 ```python
                 solcast_analysis_today=getattr(data, "solcast_analysis_today", None),
+                solcast_analysis_tomorrow=getattr(data, "solcast_analysis_tomorrow", None),
 ```
 
 - [ ] **Step 2: Commit**
 
 ```bash
 git add custom_components/localshift/engine/optimizer_facade.py
-git commit -m "feat(optimizer): thread SolcastAnalysis from coordinator data to DP planner (#794)"
+git commit -m "feat(optimizer): thread both SolcastAnalysis objects from coordinator to DP planner (#794)"
 ```
 
 ---
 
-## Chunk 4: Boost Contamination Protection
+## Chunk 5: Boost Contamination Protection
 
-### Task 4.1: Add boost period tagging to SolarPeriodRecord
+### Task 5.1: Add boost period tagging to SolarPeriodRecord
 
 **Files:**
 - Modify: `custom_components/localshift/forecast/solar_accuracy.py:31-61`
@@ -746,7 +949,7 @@ git add custom_components/localshift/forecast/solar_accuracy.py tests/forecast/t
 git commit -m "feat(accuracy): add is_boost_period field to SolarPeriodRecord (#794)"
 ```
 
-### Task 4.2: Add `is_boost` param to `record_forecast()`
+### Task 5.2: Add `is_boost` param to `record_forecast()`
 
 **Files:**
 - Modify: `custom_components/localshift/forecast/solar_accuracy.py:258-289`
@@ -790,7 +993,7 @@ git add custom_components/localshift/forecast/solar_accuracy.py tests/forecast/t
 git commit -m "feat(accuracy): add is_boost parameter to record_forecast() (#794)"
 ```
 
-### Task 4.3: Filter boost records in `_recompute_metrics()`
+### Task 5.3: Filter boost records in `_recompute_metrics()`
 
 **Files:**
 - Modify: `custom_components/localshift/forecast/solar_accuracy.py:327-381`
@@ -859,7 +1062,7 @@ git add custom_components/localshift/forecast/solar_accuracy.py tests/forecast/t
 git commit -m "feat(accuracy): exclude boost-tagged records from MAPE and bias computation (#794)"
 ```
 
-### Task 4.4: Pass boost flag from OptimizerFacade
+### Task 5.4: Pass boost flag from OptimizerFacade
 
 **Files:**
 - Modify: `custom_components/localshift/engine/optimizer_facade.py:53-80, 187`
@@ -913,7 +1116,7 @@ git add custom_components/localshift/engine/optimizer_facade.py tests/test_boost
 git commit -m "feat(accuracy): pass boost flag from OptimizerFacade to record_forecast() (#794)"
 ```
 
-### Task 4.5: Skip SOC accuracy recording during boost
+### Task 5.5: Skip SOC accuracy recording during boost
 
 **Files:**
 - Modify: `custom_components/localshift/coordinator/tick_scheduler.py`
@@ -938,12 +1141,12 @@ git commit -m "feat(accuracy): skip SOC accuracy recording during boost charge (
 
 ## Chunk 5: Integration Tests & Diagnostics
 
-### Task 5.1: Integration tests for low-confidence scenarios
+### Task 6.1: Integration tests for low-confidence scenarios
 
 **Files:**
-- Create: `tests/test_solar_confidence_scenarios.py`
+- Create: `tests/forecast/test_solar_confidence_scenarios.py`
 
-- [ ] **Step 1: Write scenario tests**
+- [ ] **Step 1: Write scenario tests with timezone-aware timestamps**
 
 ```python
 """Integration tests for solar confidence blending scenarios (Issue #794)."""
@@ -959,6 +1162,7 @@ from custom_components.localshift.forecast.solar import (
 from custom_components.localshift.forecast.solcast_analysis import (
     SolcastAnalysis, ConfidenceInterval,
 )
+from custom_components.localshift.forecast.analysis_resolver import ConfidenceResolver
 
 
 class TestLowConfidenceScenarios:
@@ -972,7 +1176,7 @@ class TestLowConfidenceScenarios:
 
     def test_high_confidence_no_regression(self):
         """High confidence (>=0.9) should behave like current system."""
-        forecasts = [{"period_start": "2026-03-19T10:00:00", "pv_estimate": 4.0, "pv_estimate10": 1.0}]
+        forecasts = [{"period_start": "2026-03-19T10:00:00+00:00", "pv_estimate": 4.0, "pv_estimate10": 1.0}]
         slot_start = datetime(2026, 3, 19, 10, 0, tzinfo=timezone.utc)
         result_high = get_solar_for_slot_by_interval(forecasts, slot_start, 30, confidence=0.95)
         result_legacy = get_solar_for_slot_by_interval(forecasts, slot_start, 30, confidence=1.0)
@@ -982,9 +1186,9 @@ class TestLowConfidenceScenarios:
         """Low confidence sum should be much less than optimistic sum."""
         now = datetime(2026, 3, 19, 9, 0, tzinfo=timezone.utc)
         forecasts = [
-            {"period_start": "2026-03-19T09:00:00", "pv_estimate": 6.0, "pv_estimate10": 1.0},
-            {"period_start": "2026-03-19T09:30:00", "pv_estimate": 6.0, "pv_estimate10": 1.0},
-            {"period_start": "2026-03-19T10:00:00", "pv_estimate": 6.0, "pv_estimate10": 1.0},
+            {"period_start": "2026-03-19T09:00:00+00:00", "pv_estimate": 6.0, "pv_estimate10": 1.0},
+            {"period_start": "2026-03-19T09:30:00+00:00", "pv_estimate": 6.0, "pv_estimate10": 1.0},
+            {"period_start": "2026-03-19T10:00:00+00:00", "pv_estimate": 6.0, "pv_estimate10": 1.0},
         ]
         analysis = SolcastAnalysis(
             entity_id="test", last_updated=now, day_confidence=0.2,
@@ -996,15 +1200,16 @@ class TestLowConfidenceScenarios:
                 ) for h, m in [(9, 0), (9, 30), (10, 0)]
             ],
         )
+        resolver = ConfidenceResolver(analysis, None)
         solar_optimistic = sum_solar_before_target(forecasts, now, 11)
-        solar_conservative = sum_solar_before_target(forecasts, now, 11, analysis=analysis)
+        solar_conservative = sum_solar_before_target(forecasts, now, 11, resolver=resolver)
         assert solar_conservative < solar_optimistic * 0.5
         assert solar_optimistic == pytest.approx(9.0)  # 3 * 6.0 * 0.5
         assert solar_conservative == pytest.approx(3.0, abs=0.1)  # 3 * 2.0 * 0.5
 
     def test_no_analysis_backward_compatible(self):
         """Without SolcastAnalysis, behavior identical to current system."""
-        forecasts = [{"period_start": "2026-03-19T10:00:00", "pv_estimate": 4.0, "pv_estimate10": 1.0}]
+        forecasts = [{"period_start": "2026-03-19T10:00:00+00:00", "pv_estimate": 4.0, "pv_estimate10": 1.0}]
         slot_start = datetime(2026, 3, 19, 10, 0, tzinfo=timezone.utc)
         result = get_solar_for_slot_by_interval(forecasts, slot_start, 30)
         assert result == pytest.approx(4.0 * 0.5)  # 2.0 kWh
@@ -1012,17 +1217,17 @@ class TestLowConfidenceScenarios:
 
 - [ ] **Step 2: Run all new tests**
 
-Run: `uv run pytest tests/forecast/test_solar_confidence.py tests/test_solar_confidence_scenarios.py tests/test_boost_contamination.py -v`
+Run: `uv run pytest tests/forecast/test_solar_confidence.py tests/forecast/test_solar_confidence_scenarios.py tests/forecast/test_boost_contamination.py -v`
 Expected: All PASS
 
 - [ ] **Step 3: Commit**
 
 ```bash
-git add tests/test_solar_confidence_scenarios.py
+git add tests/forecast/test_solar_confidence_scenarios.py
 git commit -m "test(solar): add integration tests for confidence blending scenarios (#794)"
 ```
 
-### Task 5.2: Add diagnostic attributes to sensors
+### Task 6.2: Add diagnostic attributes to sensors
 
 **Files:**
 - Modify: `custom_components/localshift/sensors/forecast.py`
@@ -1030,23 +1235,52 @@ git commit -m "test(solar): add integration tests for confidence blending scenar
 
 - [ ] **Step 1: Add confidence attributes to forecast battery sensor**
 
-In `sensors/forecast.py`, where `ForecastBatterySensor` builds attributes, add:
+In `sensors/forecast.py`, `SolarBatteryForecastSensor.extra_state_attributes`, add:
 ```python
-"solar_confidence_used": getattr(data, "avg_confidence_today", 1.0),
-"solar_blend_applied": getattr(data, "avg_confidence_today", 1.0) < 1.0,
+        # Add confidence diagnostics
+        analysis_today = self.coordinator.data.solcast_analysis_today
+        analysis_tomorrow = self.coordinator.data.solcast_analysis_tomorrow
+        resolver = ConfidenceResolver(analysis_today, analysis_tomorrow)
+        
+        # Get confidence for the current time
+        from homeassistant.util import dt as dt_util
+        now = dt_util.now()
+        confidence = resolver.get_confidence(now)
+        
+        return {
+            **self.coordinator.data.solar_battery_forecast,
+            "solar_confidence_used": confidence,
+            "solar_blend_applied": confidence < 1.0,
+        }
 ```
 
 - [ ] **Step 2: Add confidence attributes to optimizer summary sensor**
 
-In `sensors/optimizer.py`, add to optimizer plan detailed attributes:
+In `sensors/optimizer.py`, `OptimizerPlanDetailedSensor.extra_state_attributes`, add:
 ```python
-"solar_confidence_avg": getattr(data, "avg_confidence_today", 1.0),
-"solar_confidence_regime": (
-    "high" if getattr(data, "avg_confidence_today", 1.0) >= 0.7
-    else "medium" if getattr(data, "avg_confidence_today", 1.0) >= 0.4
-    else "low"
-),
-"solar_blend_applied": getattr(data, "avg_confidence_today", 1.0) < 1.0,
+        # Add confidence diagnostics
+        analysis_today = d.solcast_analysis_today
+        analysis_tomorrow = d.solcast_analysis_tomorrow
+        from custom_components.localshift.forecast.analysis_resolver import ConfidenceResolver
+        resolver = ConfidenceResolver(analysis_today, analysis_tomorrow)
+        
+        # Get average confidence across next 24 hours
+        from homeassistant.util import dt as dt_util
+        from datetime import timedelta
+        now = dt_util.now()
+        confidences = [resolver.get_confidence(now + timedelta(hours=i)) for i in range(24)]
+        avg_confidence = sum(confidences) / len(confidences) if confidences else 1.0
+        
+        return {
+            **existing_attrs,
+            "solar_confidence_avg": avg_confidence,
+            "solar_confidence_regime": (
+                "high" if avg_confidence >= 0.7
+                else "medium" if avg_confidence >= 0.4
+                else "low"
+            ),
+            "solar_blend_applied": avg_confidence < 1.0,
+        }
 ```
 
 - [ ] **Step 3: Commit**
@@ -1056,7 +1290,7 @@ git add custom_components/localshift/sensors/forecast.py custom_components/local
 git commit -m "feat(sensors): add confidence diagnostic attributes (#794)"
 ```
 
-### Task 5.3: Final verification
+### Task 6.3: Final verification
 
 - [ ] **Step 1: Run full test suite with coverage**
 
@@ -1077,10 +1311,10 @@ Expected: No new errors
 
 ## Summary
 
-**Total tasks:** 19 across 5 chunks
-**Estimated commits:** 15-19
-**Files modified:** 8 production files
-**Files created:** 3 test files
+**Total tasks:** 20 across 6 chunks
+**Estimated commits:** 16-20
+**Files modified:** 9 production files
+**Files created:** 4 test files
 
 **Key behavioral changes:**
 1. Solar getter functions blend median and P10 based on per-period Solcast confidence
@@ -1091,3 +1325,5 @@ Expected: No new errors
 6. Diagnostic attributes expose confidence regime and blending status
 
 **Backward compatibility:** When `SolcastAnalysis` is None (older Solcast, parsing failure), all functions default to `confidence=1.0` — identical to current behavior.
+
+**Cross-day handling:** The new `ConfidenceResolver` class correctly selects today's or tomorrow's analysis based on the slot date, ensuring overnight and next-day forecasts use the correct confidence data.

--- a/docs/superpowers/plans/2026-03-19-solar-confidence-boost-protection.md
+++ b/docs/superpowers/plans/2026-03-19-solar-confidence-boost-protection.md
@@ -1,0 +1,1093 @@
+# Solar Confidence Blending + Boost Contamination Protection — Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix false 100% SOC projections under low-confidence solar forecasts by blending median and P10 estimates based on Solcast confidence, and protect forecast accuracy learning from manual boost charge contamination.
+
+**Architecture:** Two subsystems sharing Solcast confidence infrastructure. Solar confidence blending applies continuous linear interpolation between `pv_estimate` and `pv_estimate10` inside the solar getter functions, so all consumers (optimizer slots, forecast battery, terminal cost) get consistent values. Boost contamination protection tags period records during boost and excludes them from accuracy computation.
+
+**Tech Stack:** Python 3.13+, Home Assistant integration, Dynamic Programming optimizer, Solcast solar forecast API.
+
+---
+
+## File Structure
+
+| File | Change | Responsibility |
+|------|--------|---------------|
+| `forecast/solar.py` | Add `_blend_solar_estimate()`, add `confidence` param to getters and `sum_solar_before_target` | Core blending algorithm |
+| `engine/slots.py` | Thread confidence from `data.solcast_analysis_*` into `_get_solar_kwh()` | Slot builder confidence |
+| `forecast/pipeline.py` | Pass analysis to `sum_solar_before_target()` at both call sites | Forecast battery confidence |
+| `engine/types.py` | Add `solcast_analysis_today` field to `OptimizerInputs` | Data threading |
+| `engine/core.py` | Use blended solar in `_projected_solcast_gain_pct()` | Terminal cost projection |
+| `forecast/solar_accuracy.py` | Add `is_boost_period` to `SolarPeriodRecord`, add `is_boost` param to `record_forecast()`, filter in `_recompute_metrics()` | Boost tagging |
+| `engine/optimizer_facade.py` | Pass `is_boost` flag to `record_forecast()` | Boost detection |
+| `coordinator/tick_scheduler.py` | Skip SOC accuracy recording during boost | SOC accuracy protection |
+| `sensors/optimizer.py` | Add confidence diagnostic attributes | Observability |
+| `sensors/forecast.py` | Add confidence diagnostic attributes | Observability |
+| `tests/forecast/test_solar_confidence.py` | New: confidence blending unit tests | Test coverage |
+| `tests/test_solar_confidence_scenarios.py` | New: integration scenarios | Test coverage |
+| `tests/forecast/test_solar_accuracy.py` | Extend: boost contamination tests | Test coverage |
+
+---
+
+## Chunk 1: Solar Confidence Blending Core
+
+### Task 1.1: Add blending function to `forecast/solar.py`
+
+**Files:**
+- Modify: `custom_components/localshift/forecast/solar.py`
+
+- [ ] **Step 1: Add `_blend_solar_estimate()` function** (after `_get_period_estimate()` at line 48)
+
+```python
+def _blend_solar_estimate(
+    pv_estimate: float,
+    pv_estimate10: float,
+    confidence: float,
+) -> float:
+    """Continuous linear blending between median and P10 based on confidence.
+
+    At high confidence (1.0), returns pv_estimate (median).
+    At low confidence (0.0), returns pv_estimate10 (pessimistic).
+    """
+    if confidence >= 1.0:
+        return pv_estimate
+    if confidence <= 0.0:
+        return pv_estimate10
+    return confidence * pv_estimate + (1.0 - confidence) * pv_estimate10
+```
+
+- [ ] **Step 2: Write failing test**
+
+Create `tests/forecast/test_solar_confidence.py`:
+
+```python
+"""Tests for solar confidence blending (Issue #794)."""
+from __future__ import annotations
+
+import pytest
+from custom_components.localshift.forecast.solar import _blend_solar_estimate
+
+
+class TestBlendSolarEstimate:
+    """Tests for _blend_solar_estimate()."""
+
+    def test_full_confidence_returns_median(self):
+        assert _blend_solar_estimate(29.56, 7.99, 1.0) == 29.56
+
+    def test_zero_confidence_returns_p10(self):
+        assert _blend_solar_estimate(29.56, 7.99, 0.0) == 7.99
+
+    def test_mid_confidence_returns_average(self):
+        result = _blend_solar_estimate(20.0, 10.0, 0.5)
+        assert result == pytest.approx(15.0)
+
+    def test_low_confidence_realistic(self):
+        # Issue #794 reported case: confidence 17%, median 29.56, P10 7.99
+        result = _blend_solar_estimate(29.56, 7.99, 0.17)
+        expected = 0.17 * 29.56 + 0.83 * 7.99  # ~11.65
+        assert result == pytest.approx(expected, abs=0.01)
+
+    def test_confidence_above_one_clamps_to_median(self):
+        assert _blend_solar_estimate(29.56, 7.99, 1.5) == 29.56
+
+    def test_confidence_below_zero_clamps_to_p10(self):
+        assert _blend_solar_estimate(29.56, 7.99, -0.5) == 7.99
+
+    def test_zero_values(self):
+        assert _blend_solar_estimate(0.0, 0.0, 0.5) == 0.0
+
+    def test_p10_larger_than_median(self):
+        # Edge case: inverted spread
+        result = _blend_solar_estimate(5.0, 10.0, 0.5)
+        assert result == pytest.approx(7.5)
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `uv run pytest tests/forecast/test_solar_confidence.py::TestBlendSolarEstimate -v`
+Expected: FAIL with "cannot import name '_blend_solar_estimate'"
+
+- [ ] **Step 4: Implementation already done in Step 1**
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `uv run pytest tests/forecast/test_solar_confidence.py::TestBlendSolarEstimate -v`
+Expected: All 8 tests PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add custom_components/localshift/forecast/solar.py tests/forecast/test_solar_confidence.py
+git commit -m "feat(solar): add confidence-based percentile blending function (#794)"
+```
+
+### Task 1.2: Add confidence param to `get_solar_for_5min_slot()`
+
+**Files:**
+- Modify: `custom_components/localshift/forecast/solar.py:196-265`
+
+- [ ] **Step 1: Write failing test**
+
+Add to `tests/forecast/test_solar_confidence.py`:
+
+```python
+class TestGetSolarFor5MinSlotWithConfidence:
+    """Tests for get_solar_for_5min_slot() with confidence blending."""
+
+    def _make_forecast(self, period_start, pv_estimate, pv_estimate10):
+        return {
+            "period_start": period_start,
+            "pv_estimate": pv_estimate,
+            "pv_estimate10": pv_estimate10,
+        }
+
+    def test_high_confidence_uses_median(self):
+        from custom_components.localshift.forecast.solar import get_solar_for_5min_slot
+        from datetime import datetime, timezone
+
+        slot_start = datetime(2026, 3, 19, 10, 0, tzinfo=timezone.utc)
+        forecasts = [self._make_forecast("2026-03-19T10:00:00", 4.0, 1.0)]
+        result = get_solar_for_5min_slot(forecasts, slot_start, confidence=1.0)
+        assert result > 0.3  # median-based (4.0 * 5/60)
+
+    def test_zero_confidence_uses_p10(self):
+        from custom_components.localshift.forecast.solar import get_solar_for_5min_slot
+        from datetime import datetime, timezone
+
+        slot_start = datetime(2026, 3, 19, 10, 0, tzinfo=timezone.utc)
+        forecasts = [self._make_forecast("2026-03-19T10:00:00", 4.0, 1.0)]
+        result = get_solar_for_5min_slot(forecasts, slot_start, confidence=0.0)
+        assert result < 0.1  # P10-based (1.0 * 5/60)
+
+    def test_default_confidence_preserves_behavior(self):
+        from custom_components.localshift.forecast.solar import get_solar_for_5min_slot
+        from datetime import datetime, timezone
+
+        slot_start = datetime(2026, 3, 19, 10, 0, tzinfo=timezone.utc)
+        forecasts = [self._make_forecast("2026-03-19T10:00:00", 4.0, 1.0)]
+        result_default = get_solar_for_5min_slot(forecasts, slot_start)
+        result_explicit = get_solar_for_5min_slot(forecasts, slot_start, confidence=1.0)
+        assert result_default == result_explicit
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/forecast/test_solar_confidence.py::TestGetSolarFor5MinSlotWithConfidence -v`
+Expected: FAIL (unexpected keyword argument 'confidence')
+
+- [ ] **Step 3: Modify `get_solar_for_5min_slot()`**
+
+Change signature to add `confidence: float = 1.0` parameter.
+
+Change value selection block (lines 253-260) from inline cascade to:
+```python
+            raw_estimate = float(
+                entry.get("pv_estimate")
+                or entry.get("estimate")
+                or 0.0
+            )
+            raw_p10 = float(
+                entry.get("pv_estimate10")
+                or entry.get("estimate10")
+                or 0.0
+            )
+            period_kwh = _blend_solar_estimate(raw_estimate, raw_p10, confidence)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/forecast/test_solar_confidence.py::TestGetSolarFor5MinSlotWithConfidence -v`
+Expected: All 3 tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add custom_components/localshift/forecast/solar.py tests/forecast/test_solar_confidence.py
+git commit -m "feat(solar): add confidence blending to 5-min slot getter (#794)"
+```
+
+### Task 1.3: Add confidence param to `get_solar_for_15min_slot()` via `_process_forecast_entry()`
+
+**Files:**
+- Modify: `custom_components/localshift/forecast/solar.py:51-99` (`_process_forecast_entry`)
+- Modify: `custom_components/localshift/forecast/solar.py:154-193` (`get_solar_for_15min_slot`)
+
+- [ ] **Step 1: Write failing test**
+
+```python
+class TestGetSolarFor15MinSlotWithConfidence:
+    """Tests for get_solar_for_15min_slot() with confidence blending."""
+
+    def _make_forecast(self, period_start, pv_estimate, pv_estimate10):
+        return {
+            "period_start": period_start,
+            "pv_estimate": pv_estimate,
+            "pv_estimate10": pv_estimate10,
+        }
+
+    def test_high_confidence_uses_median(self):
+        from custom_components.localshift.forecast.solar import get_solar_for_15min_slot
+        from datetime import datetime, timezone
+
+        slot_start = datetime(2026, 3, 19, 10, 0, tzinfo=timezone.utc)
+        forecasts = [self._make_forecast("2026-03-19T10:00:00", 4.0, 1.0)]
+        result_high = get_solar_for_15min_slot(forecasts, slot_start, confidence=1.0)
+        result_low = get_solar_for_15min_slot(forecasts, slot_start, confidence=0.0)
+        assert result_high > result_low
+
+    def test_zero_confidence_uses_p10(self):
+        from custom_components.localshift.forecast.solar import get_solar_for_15min_slot
+        from datetime import datetime, timezone
+
+        slot_start = datetime(2026, 3, 19, 10, 0, tzinfo=timezone.utc)
+        forecasts = [self._make_forecast("2026-03-19T10:00:00", 4.0, 1.0)]
+        result = get_solar_for_15min_slot(forecasts, slot_start, confidence=0.0)
+        # P10=1.0, 15 min = 15/60 = 0.25 kWh
+        assert result == pytest.approx(0.25)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/forecast/test_solar_confidence.py::TestGetSolarFor15MinSlotWithConfidence -v`
+Expected: FAIL
+
+- [ ] **Step 3: Modify `_process_forecast_entry()` to accept confidence**
+
+Add `confidence: float = 1.0` parameter to signature.
+
+Change line 88 from `period_kwh = _get_period_estimate(entry)` to:
+```python
+    raw_estimate = float(entry.get("pv_estimate") or entry.get("estimate") or 0.0)
+    raw_p10 = float(entry.get("pv_estimate10") or entry.get("estimate10") or 0.0)
+    period_kwh = _blend_solar_estimate(raw_estimate, raw_p10, confidence)
+```
+
+- [ ] **Step 4: Modify `get_solar_for_15min_slot()` to pass confidence through**
+
+Add `confidence: float = 1.0` parameter to signature.
+
+Change line 185 to pass `confidence` to `_process_forecast_entry()`.
+
+- [ ] **Step 5: Run tests**
+
+Run: `uv run pytest tests/forecast/test_solar_confidence.py -v`
+Expected: All tests PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add custom_components/localshift/forecast/solar.py tests/forecast/test_solar_confidence.py
+git commit -m "feat(solar): add confidence blending to 15-min slot getter (#794)"
+```
+
+### Task 1.4: Add confidence param to `get_solar_for_30min_slot()`
+
+**Files:**
+- Modify: `custom_components/localshift/forecast/solar.py:268-337`
+
+- [ ] **Step 1: Write failing test**
+
+```python
+class TestGetSolarFor30MinSlotWithConfidence:
+    """Tests for get_solar_for_30min_slot() with confidence blending."""
+
+    def _make_forecast(self, period_start, pv_estimate, pv_estimate10):
+        return {
+            "period_start": period_start,
+            "pv_estimate": pv_estimate,
+            "pv_estimate10": pv_estimate10,
+        }
+
+    def test_blending_applied(self):
+        from custom_components.localshift.forecast.solar import get_solar_for_30min_slot
+        from datetime import datetime, timezone
+
+        slot_start = datetime(2026, 3, 19, 10, 0, tzinfo=timezone.utc)
+        forecasts = [self._make_forecast("2026-03-19T10:00:00", 4.0, 1.0)]
+
+        result_high = get_solar_for_30min_slot(forecasts, slot_start, confidence=1.0)
+        result_low = get_solar_for_30min_slot(forecasts, slot_start, confidence=0.0)
+        result_mid = get_solar_for_30min_slot(forecasts, slot_start, confidence=0.5)
+
+        # 30 min = 0.5 hours
+        assert result_high == pytest.approx(4.0 * 0.5)  # 2.0
+        assert result_low == pytest.approx(1.0 * 0.5)    # 0.5
+        assert result_mid == pytest.approx(2.5 * 0.5)    # 1.25
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/forecast/test_solar_confidence.py::TestGetSolarFor30MinSlotWithConfidence -v`
+Expected: FAIL
+
+- [ ] **Step 3: Modify `get_solar_for_30min_slot()`**
+
+Add `confidence: float = 1.0` parameter to signature.
+
+Change value selection block (lines 326-331) to use `_blend_solar_estimate()` with `raw_estimate` and `raw_p10`.
+
+- [ ] **Step 4: Run tests**
+
+Run: `uv run pytest tests/forecast/test_solar_confidence.py -v`
+Expected: All tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add custom_components/localshift/forecast/solar.py tests/forecast/test_solar_confidence.py
+git commit -m "feat(solar): add confidence blending to 30-min slot getter (#794)"
+```
+
+### Task 1.5: Thread confidence through `get_solar_for_slot_by_interval()`
+
+**Files:**
+- Modify: `custom_components/localshift/forecast/solar.py:340-370`
+
+- [ ] **Step 1: Write failing test**
+
+```python
+class TestGetSolarForSlotByIntervalWithConfidence:
+    """Tests for get_solar_for_slot_by_interval() confidence threading."""
+
+    def test_confidence_passed_through_to_5min(self):
+        from custom_components.localshift.forecast.solar import get_solar_for_slot_by_interval
+        from datetime import datetime, timezone
+
+        slot_start = datetime(2026, 3, 19, 10, 0, tzinfo=timezone.utc)
+        forecasts = [{"period_start": "2026-03-19T10:00:00", "pv_estimate": 4.0, "pv_estimate10": 1.0}]
+        result_high = get_solar_for_slot_by_interval(forecasts, slot_start, 5, confidence=1.0)
+        result_low = get_solar_for_slot_by_interval(forecasts, slot_start, 5, confidence=0.0)
+        assert result_high > result_low
+
+    def test_confidence_passed_through_to_30min(self):
+        from custom_components.localshift.forecast.solar import get_solar_for_slot_by_interval
+        from datetime import datetime, timezone
+
+        slot_start = datetime(2026, 3, 19, 10, 0, tzinfo=timezone.utc)
+        forecasts = [{"period_start": "2026-03-19T10:00:00", "pv_estimate": 4.0, "pv_estimate10": 1.0}]
+        result_high = get_solar_for_slot_by_interval(forecasts, slot_start, 30, confidence=1.0)
+        result_low = get_solar_for_slot_by_interval(forecasts, slot_start, 30, confidence=0.0)
+        assert result_high > result_low
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/forecast/test_solar_confidence.py::TestGetSolarForSlotByIntervalWithConfidence -v`
+Expected: FAIL
+
+- [ ] **Step 3: Modify `get_solar_for_slot_by_interval()`**
+
+Add `confidence: float = 1.0` parameter to signature.
+
+Update all dispatch calls to pass `confidence=confidence` to the sub-functions.
+
+- [ ] **Step 4: Run tests**
+
+Run: `uv run pytest tests/forecast/test_solar_confidence.py -v`
+Expected: All tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add custom_components/localshift/forecast/solar.py tests/forecast/test_solar_confidence.py
+git commit -m "feat(solar): thread confidence through slot interval dispatcher (#794)"
+```
+
+### Task 1.6: Add analysis param to `sum_solar_before_target()`
+
+**Files:**
+- Modify: `custom_components/localshift/forecast/solar.py:373-410`
+
+- [ ] **Step 1: Write failing test**
+
+```python
+class TestSumSolarBeforeTargetWithConfidence:
+    """Tests for sum_solar_before_target() with analysis-based confidence."""
+
+    def test_sum_uses_per_period_confidence(self):
+        from custom_components.localshift.forecast.solar import sum_solar_before_target
+        from custom_components.localshift.forecast.solcast_analysis import (
+            SolcastAnalysis, ConfidenceInterval,
+        )
+        from datetime import datetime, timezone
+
+        now = datetime(2026, 3, 19, 9, 0, tzinfo=timezone.utc)
+        forecasts = [
+            {"period_start": "2026-03-19T09:00:00", "pv_estimate": 4.0, "pv_estimate10": 1.0},
+            {"period_start": "2026-03-19T09:30:00", "pv_estimate": 4.0, "pv_estimate10": 1.0},
+        ]
+        analysis = SolcastAnalysis(
+            entity_id="test", last_updated=now, day_confidence=0.5,
+            day_spread_kwh=0, estimate10_kwh=0, estimate90_kwh=0,
+            intervals=[
+                ConfidenceInterval(period_start=datetime(2026, 3, 19, 9, 0, tzinfo=timezone.utc), spread_kwh=0, confidence=1.0),
+                ConfidenceInterval(period_start=datetime(2026, 3, 19, 9, 30, tzinfo=timezone.utc), spread_kwh=0, confidence=0.2),
+            ],
+        )
+        result = sum_solar_before_target(forecasts, now, 12, analysis=analysis)
+        # Period 1: conf=1.0, blended=4.0, 0.5h = 2.0 kWh
+        # Period 2: conf=0.2, blended=0.2*4.0+0.8*1.0=1.4, 0.5h = 0.7 kWh
+        assert result == pytest.approx(2.7, abs=0.01)
+
+    def test_no_analysis_uses_full_confidence(self):
+        from custom_components.localshift.forecast.solar import sum_solar_before_target
+        from datetime import datetime, timezone
+
+        now = datetime(2026, 3, 19, 9, 0, tzinfo=timezone.utc)
+        forecasts = [{"period_start": "2026-03-19T09:00:00", "pv_estimate": 4.0, "pv_estimate10": 1.0}]
+        result = sum_solar_before_target(forecasts, now, 10)
+        assert result == pytest.approx(4.0 * 0.5)  # 2.0 kWh
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/forecast/test_solar_confidence.py::TestSumSolarBeforeTargetWithConfidence -v`
+Expected: FAIL
+
+- [ ] **Step 3: Modify `sum_solar_before_target()`**
+
+Add `analysis: Any | None = None` parameter to signature.
+
+Add import: `from custom_components.localshift.forecast.solcast_analysis import get_confidence_for_period`
+
+Change line 393 from `kwh_per_hour = float(period.get("pv_estimate", 0))` to:
+```python
+        raw_estimate = float(period.get("pv_estimate", 0))
+        raw_p10 = float(period.get("pv_estimate10", 0))
+        confidence = get_confidence_for_period(analysis, ps_local)
+        kwh_per_hour = _blend_solar_estimate(raw_estimate, raw_p10, confidence)
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `uv run pytest tests/forecast/test_solar_confidence.py -v`
+Expected: All tests PASS
+
+- [ ] **Step 5: Run existing solar tests for regression**
+
+Run: `uv run pytest tests/forecast/ -v`
+Expected: All PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add custom_components/localshift/forecast/solar.py tests/forecast/test_solar_confidence.py
+git commit -m "feat(solar): add analysis-based confidence to sum_solar_before_target (#794)"
+```
+
+---
+
+## Chunk 2: Confidence Threading to Slot Builder
+
+### Task 2.1: Thread confidence through `slots.py`
+
+**Files:**
+- Modify: `custom_components/localshift/engine/slots.py`
+
+- [ ] **Step 1: Add helper method to SlotBuilder**
+
+Add `_get_analysis_for_slot()` method to pick the right `SolcastAnalysis` based on slot date:
+
+```python
+def _get_analysis_for_slot(self, data: Any, slot_start: datetime) -> Any:
+    """Get the SolcastAnalysis for a slot based on its date."""
+    analysis_today = getattr(data, "solcast_analysis_today", None)
+    analysis_tomorrow = getattr(data, "solcast_analysis_tomorrow", None)
+
+    # Check if slot matches today's analysis intervals
+    if analysis_today and analysis_today.intervals:
+        for interval in analysis_today.intervals:
+            if abs((slot_start - interval.period_start).total_seconds()) <= 1800:
+                return analysis_today
+
+    # Check tomorrow
+    if analysis_tomorrow and analysis_tomorrow.intervals:
+        for interval in analysis_tomorrow.intervals:
+            if abs((slot_start - interval.period_start).total_seconds()) <= 1800:
+                return analysis_tomorrow
+
+    # Fallback to today (has day_confidence fallback)
+    return analysis_today
+```
+
+- [ ] **Step 2: Modify `_process_single_slot()` to extract confidence**
+
+Add import at top of file:
+```python
+from custom_components.localshift.forecast.solcast_analysis import get_confidence_for_period
+```
+
+Before the `_get_solar_kwh()` call at line 324, add:
+```python
+        analysis = self._get_analysis_for_slot(data, slot_start)
+        confidence = get_confidence_for_period(analysis, slot_start)
+```
+
+Change the call at line 324 to pass `confidence=confidence`.
+
+- [ ] **Step 3: Modify `_get_solar_kwh()` to accept confidence**
+
+Add `confidence: float = 1.0` parameter to signature.
+
+Change line 385 to pass `confidence=confidence` to `get_solar_for_slot_by_interval()`.
+
+- [ ] **Step 4: Run existing tests**
+
+Run: `uv run pytest tests/engine/ -v`
+Expected: All PASS (backward compat via default `confidence=1.0`)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add custom_components/localshift/engine/slots.py
+git commit -m "feat(solar): thread confidence through slot builder to getter functions (#794)"
+```
+
+---
+
+## Chunk 3: Confidence Threading to Forecast Battery + Terminal Cost
+
+### Task 3.1: Pass analysis to `sum_solar_before_target()` in pipeline.py
+
+**Files:**
+- Modify: `custom_components/localshift/forecast/pipeline.py:141-142, 173-174`
+
+- [ ] **Step 1: Modify both call sites**
+
+Change both call sites (line 142 and 174) from:
+```python
+            solar_kwh = sum_solar_before_target(all_solcast, now_dt, target_hour)
+```
+to:
+```python
+            analysis = getattr(data, "solcast_analysis_today", None)
+            solar_kwh = sum_solar_before_target(all_solcast, now_dt, target_hour, analysis=analysis)
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add custom_components/localshift/forecast/pipeline.py
+git commit -m "feat(solar): pass Solcast analysis to forecast battery solar sum (#794)"
+```
+
+### Task 3.2: Add SolcastAnalysis to OptimizerInputs
+
+**Files:**
+- Modify: `custom_components/localshift/engine/types.py:468-496`
+
+- [ ] **Step 1: Add field to `OptimizerInputs`**
+
+After `solar_accuracy_tracker` field (line 496), add:
+```python
+    solcast_analysis_today: Any | None = None
+    """Solcast analysis with confidence data for solar blending (Issue #794)."""
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add custom_components/localshift/engine/types.py
+git commit -m "feat(optimizer): add solcast_analysis_today to OptimizerInputs (#794)"
+```
+
+### Task 3.3: Use blended solar in terminal cost projection
+
+**Files:**
+- Modify: `custom_components/localshift/engine/core.py:1435-1463`
+
+- [ ] **Step 1: Write failing test**
+
+Create `tests/engine/test_terminal_cost_confidence.py`:
+
+```python
+"""Tests for terminal cost projection with confidence blending (Issue #794)."""
+from __future__ import annotations
+
+import pytest
+from datetime import datetime, timezone
+from custom_components.localshift.engine.core import DPPlanner
+from custom_components.localshift.forecast.solcast_analysis import (
+    SolcastAnalysis, ConfidenceInterval,
+)
+
+
+class TestProjectedSolcastGainWithConfidence:
+    """Tests for _projected_solcast_gain_pct() with confidence."""
+
+    def test_low_confidence_reduces_projected_gain(self):
+        solcast = [{"period_start": "2026-03-19T12:00:00", "pv_estimate": 6.0, "pv_estimate10": 1.0}]
+        start = datetime(2026, 3, 19, 12, 0, tzinfo=timezone.utc)
+        end = datetime(2026, 3, 19, 12, 30, tzinfo=timezone.utc)
+
+        gain_high = DPPlanner._projected_solcast_gain_pct(solcast, start, end, 13.5)
+
+        analysis_low = SolcastAnalysis(
+            entity_id="test", last_updated=start, day_confidence=0.2,
+            day_spread_kwh=0, estimate10_kwh=0, estimate90_kwh=0,
+            intervals=[ConfidenceInterval(period_start=start, spread_kwh=0, confidence=0.2)],
+        )
+        gain_low = DPPlanner._projected_solcast_gain_pct(
+            solcast, start, end, 13.5, solcast_analysis=analysis_low,
+        )
+
+        assert gain_low < gain_high
+        assert gain_low == pytest.approx(gain_high * 0.2 / 1.0 + (1 - 0.2) * (1.0 / 6.0) * gain_high, rel=0.1)
+```
+
+- [ ] **Step 2: Modify `_projected_solcast_gain_pct()` signature**
+
+Add `solcast_analysis: Any | None = None` parameter.
+
+Add imports at top of `core.py`:
+```python
+from custom_components.localshift.forecast.solar import _blend_solar_estimate
+from custom_components.localshift.forecast.solcast_analysis import get_confidence_for_period
+```
+
+Change the solar accumulation loop (lines 1452-1463) to use `_blend_solar_estimate()` with per-period confidence from `get_confidence_for_period(solcast_analysis, p_start)`.
+
+- [ ] **Step 3: Update caller in `_initialize_dp_tables()`**
+
+Pass `solcast_analysis=inputs.solcast_analysis_today` when calling `_projected_solcast_gain_pct()`.
+
+- [ ] **Step 4: Run tests**
+
+Run: `uv run pytest tests/engine/test_terminal_cost_confidence.py -v`
+Expected: All PASS
+
+- [ ] **Step 5: Run existing optimizer tests**
+
+Run: `uv run pytest tests/engine/ -v`
+Expected: All PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add custom_components/localshift/engine/core.py custom_components/localshift/engine/types.py tests/engine/test_terminal_cost_confidence.py
+git commit -m "feat(optimizer): apply confidence blending in terminal cost projection (#794)"
+```
+
+### Task 3.4: Thread analysis through OptimizerFacade to OptimizerInputs
+
+**Files:**
+- Modify: `custom_components/localshift/engine/optimizer_facade.py:205-212`
+
+- [ ] **Step 1: Pass analysis when constructing OptimizerInputs**
+
+Change `OptimizerInputs` construction to add:
+```python
+                solcast_analysis_today=getattr(data, "solcast_analysis_today", None),
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add custom_components/localshift/engine/optimizer_facade.py
+git commit -m "feat(optimizer): thread SolcastAnalysis from coordinator data to DP planner (#794)"
+```
+
+---
+
+## Chunk 4: Boost Contamination Protection
+
+### Task 4.1: Add boost period tagging to SolarPeriodRecord
+
+**Files:**
+- Modify: `custom_components/localshift/forecast/solar_accuracy.py:31-61`
+
+- [ ] **Step 1: Write failing test**
+
+Add to `tests/forecast/test_solar_accuracy.py`:
+
+```python
+class TestBoostPeriodTagging:
+    """Tests for boost period tagging (Issue #794)."""
+
+    def test_boost_record_has_flag(self):
+        from custom_components.localshift.forecast.solar_accuracy import SolarPeriodRecord
+        from datetime import datetime, timezone
+
+        record = SolarPeriodRecord(
+            period_start=datetime(2026, 3, 19, 10, 0, tzinfo=timezone.utc),
+            forecast_kwh=4.0, actual_kwh=0.5,
+            weather_condition="sunny", time_of_day="morning", season="autumn",
+            is_boost_period=True,
+        )
+        assert record.is_boost_period is True
+
+    def test_default_is_not_boost(self):
+        from custom_components.localshift.forecast.solar_accuracy import SolarPeriodRecord
+        from datetime import datetime, timezone
+
+        record = SolarPeriodRecord(
+            period_start=datetime(2026, 3, 19, 10, 0, tzinfo=timezone.utc),
+            forecast_kwh=4.0, actual_kwh=0.5,
+            weather_condition="sunny", time_of_day="morning", season="autumn",
+        )
+        assert record.is_boost_period is False
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/forecast/test_solar_accuracy.py::TestBoostPeriodTagging -v`
+Expected: FAIL
+
+- [ ] **Step 3: Add `is_boost_period` field**
+
+After `additive_bias` field (line 53), add: `is_boost_period: bool = False`
+
+- [ ] **Step 4: Run tests and commit**
+
+```bash
+uv run pytest tests/forecast/test_solar_accuracy.py::TestBoostPeriodTagging -v
+git add custom_components/localshift/forecast/solar_accuracy.py tests/forecast/test_solar_accuracy.py
+git commit -m "feat(accuracy): add is_boost_period field to SolarPeriodRecord (#794)"
+```
+
+### Task 4.2: Add `is_boost` param to `record_forecast()`
+
+**Files:**
+- Modify: `custom_components/localshift/forecast/solar_accuracy.py:258-289`
+
+- [ ] **Step 1: Write failing test**
+
+```python
+class TestRecordForecastWithBoost:
+    """Tests for record_forecast() with boost flag."""
+
+    def test_record_forecast_sets_boost_flag(self, tracker):
+        from datetime import datetime, timezone
+        tracker.record_forecast(
+            period_start=datetime(2026, 3, 19, 10, 0, tzinfo=timezone.utc),
+            forecast_kwh=4.0, weather_condition="sunny", is_boost=True,
+        )
+        key = datetime(2026, 3, 19, 10, 0, tzinfo=timezone.utc).isoformat()
+        assert tracker._pending_forecasts[key].is_boost_period is True
+
+    def test_record_forecast_default_no_boost(self, tracker):
+        from datetime import datetime, timezone
+        tracker.record_forecast(
+            period_start=datetime(2026, 3, 19, 10, 0, tzinfo=timezone.utc),
+            forecast_kwh=4.0, weather_condition="sunny",
+        )
+        key = datetime(2026, 3, 19, 10, 0, tzinfo=timezone.utc).isoformat()
+        assert tracker._pending_forecasts[key].is_boost_period is False
+```
+
+- [ ] **Step 2: Modify `record_forecast()`**
+
+Add `is_boost: bool = False` parameter to signature.
+
+Pass `is_boost_period=is_boost` to `SolarPeriodRecord` constructor.
+
+- [ ] **Step 3: Run tests and commit**
+
+```bash
+uv run pytest tests/forecast/test_solar_accuracy.py::TestRecordForecastWithBoost -v
+git add custom_components/localshift/forecast/solar_accuracy.py tests/forecast/test_solar_accuracy.py
+git commit -m "feat(accuracy): add is_boost parameter to record_forecast() (#794)"
+```
+
+### Task 4.3: Filter boost records in `_recompute_metrics()`
+
+**Files:**
+- Modify: `custom_components/localshift/forecast/solar_accuracy.py:327-381`
+
+- [ ] **Step 1: Write failing test**
+
+```python
+class TestBoostExcludedFromMetrics:
+    """Tests for boost period exclusion from accuracy metrics."""
+
+    def test_boost_excluded_from_mape(self, tracker):
+        from datetime import datetime, timezone
+
+        # Normal period with high error
+        tracker.record_forecast(
+            period_start=datetime(2026, 3, 19, 10, 0, tzinfo=timezone.utc),
+            forecast_kwh=5.0, weather_condition="sunny",
+        )
+        tracker.backfill_actual(datetime(2026, 3, 19, 10, 0, tzinfo=timezone.utc), 2.0)
+
+        # Boost period with high error (should be excluded)
+        tracker.record_forecast(
+            period_start=datetime(2026, 3, 19, 10, 30, tzinfo=timezone.utc),
+            forecast_kwh=5.0, weather_condition="sunny", is_boost=True,
+        )
+        tracker.backfill_actual(datetime(2026, 3, 19, 10, 30, tzinfo=timezone.utc), 1.0)
+
+        assert tracker.metrics.sample_count == 1  # Only non-boost record
+
+    def test_boost_still_in_history(self, tracker):
+        from datetime import datetime, timezone
+
+        tracker.record_forecast(
+            period_start=datetime(2026, 3, 19, 10, 0, tzinfo=timezone.utc),
+            forecast_kwh=4.0, weather_condition="sunny", is_boost=True,
+        )
+        tracker.backfill_actual(datetime(2026, 3, 19, 10, 0, tzinfo=timezone.utc), 1.0)
+
+        assert len(tracker._period_records) == 1  # Still in deque
+        assert tracker.metrics.sample_count == 0   # But excluded from metrics
+```
+
+- [ ] **Step 2: Modify `_recompute_metrics()`**
+
+After line 329 (`if not self._period_records: return`), change:
+```python
+        records = list(self._period_records)
+```
+to:
+```python
+        records = [r for r in self._period_records if not r.is_boost_period]
+        if not records:
+            self._metrics = SolarBiasMetrics()
+            return
+```
+
+- [ ] **Step 3: Run all solar accuracy tests**
+
+Run: `uv run pytest tests/forecast/test_solar_accuracy.py -v`
+Expected: All PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add custom_components/localshift/forecast/solar_accuracy.py tests/forecast/test_solar_accuracy.py
+git commit -m "feat(accuracy): exclude boost-tagged records from MAPE and bias computation (#794)"
+```
+
+### Task 4.4: Pass boost flag from OptimizerFacade
+
+**Files:**
+- Modify: `custom_components/localshift/engine/optimizer_facade.py:53-80, 187`
+
+- [ ] **Step 1: Modify `_record_forecasts_for_slots()`**
+
+Add `is_boost: bool = False` parameter to signature.
+
+Pass `is_boost=is_boost` to `record_forecast()` call at line 72.
+
+- [ ] **Step 2: Pass boost flag from `run_inline()`**
+
+Change line 187 from:
+```python
+            self._record_forecasts_for_slots(slots, weather_condition)
+```
+to:
+```python
+            is_boost = getattr(data, "boost_charge_active", False)
+            self._record_forecasts_for_slots(slots, weather_condition, is_boost=is_boost)
+```
+
+- [ ] **Step 3: Write test**
+
+Create `tests/test_boost_contamination.py`:
+
+```python
+"""Tests for boost contamination protection (Issue #794)."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+
+class TestBoostDetectionInFacade:
+    """Tests for boost flag passing in OptimizerFacade."""
+
+    def test_boost_active_detected(self):
+        data = MagicMock()
+        data.boost_charge_active = True
+        assert getattr(data, "boost_charge_active", False) is True
+
+    def test_boost_inactive_default(self):
+        data = MagicMock(spec=[])
+        assert getattr(data, "boost_charge_active", False) is False
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add custom_components/localshift/engine/optimizer_facade.py tests/test_boost_contamination.py
+git commit -m "feat(accuracy): pass boost flag from OptimizerFacade to record_forecast() (#794)"
+```
+
+### Task 4.5: Skip SOC accuracy recording during boost
+
+**Files:**
+- Modify: `custom_components/localshift/coordinator/tick_scheduler.py`
+
+- [ ] **Step 1: Add boost guard**
+
+In `handle_slow_tick()`, find where `ForecastAccuracyEngine` recording happens and add guard:
+```python
+if not getattr(data, "boost_charge_active", False):
+    # Record SOC forecast accuracy (existing code)
+    ...
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add custom_components/localshift/coordinator/tick_scheduler.py
+git commit -m "feat(accuracy): skip SOC accuracy recording during boost charge (#794)"
+```
+
+---
+
+## Chunk 5: Integration Tests & Diagnostics
+
+### Task 5.1: Integration tests for low-confidence scenarios
+
+**Files:**
+- Create: `tests/test_solar_confidence_scenarios.py`
+
+- [ ] **Step 1: Write scenario tests**
+
+```python
+"""Integration tests for solar confidence blending scenarios (Issue #794)."""
+from __future__ import annotations
+
+import pytest
+from datetime import datetime, timezone
+from custom_components.localshift.forecast.solar import (
+    _blend_solar_estimate,
+    get_solar_for_slot_by_interval,
+    sum_solar_before_target,
+)
+from custom_components.localshift.forecast.solcast_analysis import (
+    SolcastAnalysis, ConfidenceInterval,
+)
+
+
+class TestLowConfidenceScenarios:
+    """End-to-end scenarios matching reported issue #794."""
+
+    def test_issue_794_reported_case(self):
+        """Median 29.56 kWh, P10 7.99 kWh, confidence 17% -> ~11.65 kWh."""
+        blended = _blend_solar_estimate(29.56, 7.99, 0.17)
+        assert blended == pytest.approx(11.65, abs=0.1)
+        assert blended < 29.56 * 0.5
+
+    def test_high_confidence_no_regression(self):
+        """High confidence (>=0.9) should behave like current system."""
+        forecasts = [{"period_start": "2026-03-19T10:00:00", "pv_estimate": 4.0, "pv_estimate10": 1.0}]
+        slot_start = datetime(2026, 3, 19, 10, 0, tzinfo=timezone.utc)
+        result_high = get_solar_for_slot_by_interval(forecasts, slot_start, 30, confidence=0.95)
+        result_legacy = get_solar_for_slot_by_interval(forecasts, slot_start, 30, confidence=1.0)
+        assert abs(result_high - result_legacy) / result_legacy < 0.05
+
+    def test_forecast_battery_conservative_sum(self):
+        """Low confidence sum should be much less than optimistic sum."""
+        now = datetime(2026, 3, 19, 9, 0, tzinfo=timezone.utc)
+        forecasts = [
+            {"period_start": "2026-03-19T09:00:00", "pv_estimate": 6.0, "pv_estimate10": 1.0},
+            {"period_start": "2026-03-19T09:30:00", "pv_estimate": 6.0, "pv_estimate10": 1.0},
+            {"period_start": "2026-03-19T10:00:00", "pv_estimate": 6.0, "pv_estimate10": 1.0},
+        ]
+        analysis = SolcastAnalysis(
+            entity_id="test", last_updated=now, day_confidence=0.2,
+            day_spread_kwh=0, estimate10_kwh=0, estimate90_kwh=0,
+            intervals=[
+                ConfidenceInterval(
+                    period_start=datetime(2026, 3, 19, h, m, tzinfo=timezone.utc),
+                    spread_kwh=0, confidence=0.2,
+                ) for h, m in [(9, 0), (9, 30), (10, 0)]
+            ],
+        )
+        solar_optimistic = sum_solar_before_target(forecasts, now, 11)
+        solar_conservative = sum_solar_before_target(forecasts, now, 11, analysis=analysis)
+        assert solar_conservative < solar_optimistic * 0.5
+        assert solar_optimistic == pytest.approx(9.0)  # 3 * 6.0 * 0.5
+        assert solar_conservative == pytest.approx(3.0, abs=0.1)  # 3 * 2.0 * 0.5
+
+    def test_no_analysis_backward_compatible(self):
+        """Without SolcastAnalysis, behavior identical to current system."""
+        forecasts = [{"period_start": "2026-03-19T10:00:00", "pv_estimate": 4.0, "pv_estimate10": 1.0}]
+        slot_start = datetime(2026, 3, 19, 10, 0, tzinfo=timezone.utc)
+        result = get_solar_for_slot_by_interval(forecasts, slot_start, 30)
+        assert result == pytest.approx(4.0 * 0.5)  # 2.0 kWh
+```
+
+- [ ] **Step 2: Run all new tests**
+
+Run: `uv run pytest tests/forecast/test_solar_confidence.py tests/test_solar_confidence_scenarios.py tests/test_boost_contamination.py -v`
+Expected: All PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_solar_confidence_scenarios.py
+git commit -m "test(solar): add integration tests for confidence blending scenarios (#794)"
+```
+
+### Task 5.2: Add diagnostic attributes to sensors
+
+**Files:**
+- Modify: `custom_components/localshift/sensors/forecast.py`
+- Modify: `custom_components/localshift/sensors/optimizer.py`
+
+- [ ] **Step 1: Add confidence attributes to forecast battery sensor**
+
+In `sensors/forecast.py`, where `ForecastBatterySensor` builds attributes, add:
+```python
+"solar_confidence_used": getattr(data, "avg_confidence_today", 1.0),
+"solar_blend_applied": getattr(data, "avg_confidence_today", 1.0) < 1.0,
+```
+
+- [ ] **Step 2: Add confidence attributes to optimizer summary sensor**
+
+In `sensors/optimizer.py`, add to optimizer plan detailed attributes:
+```python
+"solar_confidence_avg": getattr(data, "avg_confidence_today", 1.0),
+"solar_confidence_regime": (
+    "high" if getattr(data, "avg_confidence_today", 1.0) >= 0.7
+    else "medium" if getattr(data, "avg_confidence_today", 1.0) >= 0.4
+    else "low"
+),
+"solar_blend_applied": getattr(data, "avg_confidence_today", 1.0) < 1.0,
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add custom_components/localshift/sensors/forecast.py custom_components/localshift/sensors/optimizer.py
+git commit -m "feat(sensors): add confidence diagnostic attributes (#794)"
+```
+
+### Task 5.3: Final verification
+
+- [ ] **Step 1: Run full test suite with coverage**
+
+Run: `uv run pytest --cov=custom_components/localshift --cov-report=term-missing`
+Expected: All PASS, coverage >=95%
+
+- [ ] **Step 2: Run linting**
+
+Run: `uv run ruff check custom_components/localshift`
+Expected: No errors
+
+- [ ] **Step 3: Run type checking**
+
+Run: `uv run pyright custom_components/localshift` (if configured)
+Expected: No new errors
+
+---
+
+## Summary
+
+**Total tasks:** 19 across 5 chunks
+**Estimated commits:** 15-19
+**Files modified:** 8 production files
+**Files created:** 3 test files
+
+**Key behavioral changes:**
+1. Solar getter functions blend median and P10 based on per-period Solcast confidence
+2. Forecast battery uses confidence-adjusted solar sums (no more false 100% SOC)
+3. Terminal cost projection uses confidence-blended solar (complementary to accuracy discount)
+4. Boost periods tagged and excluded from accuracy learning
+5. SOC accuracy recording skipped during boost
+6. Diagnostic attributes expose confidence regime and blending status
+
+**Backward compatibility:** When `SolcastAnalysis` is None (older Solcast, parsing failure), all functions default to `confidence=1.0` — identical to current behavior.

--- a/tests/coordinator/test_tick_scheduler.py
+++ b/tests/coordinator/test_tick_scheduler.py
@@ -499,6 +499,28 @@ async def test_backfill_solar_actual_success(coordinator):
 
 
 @pytest.mark.asyncio
+async def test_backfill_solar_actual_skips_during_boost(coordinator):
+    """Boost charging periods should not contaminate solar accuracy backfill."""
+    from homeassistant.util import dt as dt_util
+
+    scheduler = TickScheduler(coordinator)
+
+    coordinator.solar_accuracy_tracker = MagicMock()
+    coordinator.solar_accuracy_tracker.backfill_actual = MagicMock()
+
+    now = dt_util.now()
+    coordinator._last_solar_power_timestamp = now - timedelta(minutes=30)
+    coordinator._last_solar_power_kw = 4.0
+    coordinator.data = MagicMock()
+    coordinator.data.solar_power_kw = 6.0
+    coordinator.data.boost_charge_active = True
+
+    scheduler._backfill_solar_actual()
+
+    coordinator.solar_accuracy_tracker.backfill_actual.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_handle_medium_tick_with_solar_tracker(coordinator):
     """Test handle_medium_tick updates solar bias metrics."""
     scheduler = TickScheduler(coordinator)

--- a/tests/engine/test_terminal_cost_accuracy.py
+++ b/tests/engine/test_terminal_cost_accuracy.py
@@ -9,6 +9,11 @@ from custom_components.localshift.engine.types import (
     OptimizerInputs,
     SlotContext,
 )
+from custom_components.localshift.forecast.analysis_resolver import ConfidenceResolver
+from custom_components.localshift.forecast.solcast_analysis import (
+    ConfidenceInterval,
+    SolcastAnalysis,
+)
 
 
 class TestGetForecastAccuracy:
@@ -199,6 +204,95 @@ class TestOptimizerResultDiagnosticFields:
         assert result.peak_soc_pct is None
         assert result.dw_entry_soc_pct is None
 
+
+class TestProjectedSolcastGainWithConfidence:
+    """Tests for confidence-aware terminal solar projection."""
+
+    def test_low_confidence_reduces_projected_gain(self):
+        start = datetime(2026, 3, 19, 12, 0, tzinfo=timezone.utc)
+        end = datetime(2026, 3, 19, 12, 30, tzinfo=timezone.utc)
+        solcast = [
+            {
+                "period_start": start.isoformat(),
+                "pv_estimate": 6.0,
+                "pv_estimate10": 1.0,
+            }
+        ]
+
+        optimistic_gain = DPPlanner._projected_solcast_gain_pct(
+            solcast,
+            start,
+            end,
+            13.5,
+        )
+
+        analysis = SolcastAnalysis(
+            entity_id="sensor.test",
+            last_updated=start,
+            day_confidence=0.2,
+            day_spread_kwh=0.0,
+            estimate10_kwh=0.0,
+            estimate90_kwh=0.0,
+            intervals=[
+                ConfidenceInterval(
+                    period_start=start,
+                    spread_kwh=0.0,
+                    confidence=0.2,
+                )
+            ],
+        )
+        resolver = ConfidenceResolver(analysis, None)
+
+        conservative_gain = DPPlanner._projected_solcast_gain_pct(
+            solcast,
+            start,
+            end,
+            13.5,
+            confidence_resolver=resolver,
+        )
+
+        assert conservative_gain < optimistic_gain
+        assert conservative_gain > 0.0
+
+    def test_tomorrow_analysis_is_used_for_cross_day_projection(self):
+        start = datetime(2026, 3, 20, 8, 0, tzinfo=timezone.utc)
+        end = datetime(2026, 3, 20, 8, 30, tzinfo=timezone.utc)
+        solcast = [
+            {
+                "period_start": start.isoformat(),
+                "pv_estimate": 4.0,
+                "pv_estimate10": 0.5,
+            }
+        ]
+        tomorrow_analysis = SolcastAnalysis(
+            entity_id="sensor.tomorrow",
+            last_updated=start,
+            day_confidence=0.1,
+            day_spread_kwh=0.0,
+            estimate10_kwh=0.0,
+            estimate90_kwh=0.0,
+            intervals=[
+                ConfidenceInterval(
+                    period_start=start,
+                    spread_kwh=0.0,
+                    confidence=0.1,
+                )
+            ],
+        )
+
+        optimistic_gain = DPPlanner._projected_solcast_gain_pct(
+            solcast, start, end, 13.5
+        )
+        conservative_gain = DPPlanner._projected_solcast_gain_pct(
+            solcast,
+            start,
+            end,
+            13.5,
+            confidence_resolver=ConfidenceResolver(None, tomorrow_analysis),
+        )
+
+        assert conservative_gain < optimistic_gain
+
     def test_diagnostic_fields_set_explicitly(self):
         """Diagnostic fields can be set via constructor."""
         from custom_components.localshift.engine.optimizer_dp import OptimizerResult
@@ -324,3 +418,40 @@ class TestSolveDiagnostics:
         assert result.success is True
         assert result.forecast_accuracy is None
         assert result.projected_solar_gain_pct is None
+
+    def test_future_solcast_projection_uses_confidence_resolver(self):
+        """Future solar beyond the slot horizon uses confidence-aware projection."""
+        inputs = self._make_inputs(accuracy=75.0)
+        inputs.initial_soc_pct = 20.0
+        future_start = datetime(2026, 3, 20, 16, 0, tzinfo=timezone.utc)
+        inputs.all_solcast = [
+            {
+                "period_start": future_start.isoformat(),
+                "pv_estimate": 6.0,
+                "pv_estimate10": 1.0,
+            }
+        ]
+        inputs.solcast_analysis_today = SolcastAnalysis(
+            entity_id="sensor.today",
+            last_updated=future_start,
+            day_confidence=0.2,
+            day_spread_kwh=0.0,
+            estimate10_kwh=0.0,
+            estimate90_kwh=0.0,
+            intervals=[
+                ConfidenceInterval(
+                    period_start=future_start,
+                    spread_kwh=0.0,
+                    confidence=0.2,
+                )
+            ],
+        )
+
+        planner = DPPlanner()
+        result = planner._solve(inputs)
+
+        assert result.success is True
+        assert result.projected_solar_gain_pct is not None
+        assert result.adjusted_solar_gain_pct is not None
+        assert result.projected_solar_gain_pct > 0.0
+        assert result.adjusted_solar_gain_pct < result.projected_solar_gain_pct

--- a/tests/forecast/test_analysis_resolver.py
+++ b/tests/forecast/test_analysis_resolver.py
@@ -1,0 +1,190 @@
+"""Tests for cross-day confidence resolver (Issue #794)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+from custom_components.localshift.forecast.analysis_resolver import ConfidenceResolver
+from custom_components.localshift.forecast.solcast_analysis import (
+    SolcastAnalysis,
+    ConfidenceInterval,
+)
+
+
+class TestConfidenceResolver:
+    """Tests for ConfidenceResolver cross-day lookup."""
+
+    def test_returns_today_confidence_for_today_slot(self):
+        today_analysis = SolcastAnalysis(
+            entity_id="today",
+            last_updated=datetime.now(timezone.utc),
+            day_confidence=0.8,
+            day_spread_kwh=0,
+            estimate10_kwh=0,
+            estimate90_kwh=0,
+            intervals=[
+                ConfidenceInterval(
+                    period_start=datetime(2026, 3, 19, 10, 0, tzinfo=timezone.utc),
+                    spread_kwh=0,
+                    confidence=0.9,
+                ),
+            ],
+        )
+        tomorrow_analysis = SolcastAnalysis(
+            entity_id="tomorrow",
+            last_updated=datetime.now(timezone.utc),
+            day_confidence=0.3,
+            day_spread_kwh=0,
+            estimate10_kwh=0,
+            estimate90_kwh=0,
+            intervals=[
+                ConfidenceInterval(
+                    period_start=datetime(2026, 3, 20, 10, 0, tzinfo=timezone.utc),
+                    spread_kwh=0,
+                    confidence=0.4,
+                ),
+            ],
+        )
+
+        resolver = ConfidenceResolver(today_analysis, tomorrow_analysis)
+        # Today slot should get today's interval confidence
+        conf = resolver.get_confidence(
+            datetime(2026, 3, 19, 10, 0, tzinfo=timezone.utc)
+        )
+        assert conf == pytest.approx(0.9)
+
+    def test_returns_tomorrow_confidence_for_tomorrow_slot(self):
+        today_analysis = SolcastAnalysis(
+            entity_id="today",
+            last_updated=datetime.now(timezone.utc),
+            day_confidence=0.8,
+            day_spread_kwh=0,
+            estimate10_kwh=0,
+            estimate90_kwh=0,
+            intervals=[],
+        )
+        tomorrow_analysis = SolcastAnalysis(
+            entity_id="tomorrow",
+            last_updated=datetime.now(timezone.utc),
+            day_confidence=0.3,
+            day_spread_kwh=0,
+            estimate10_kwh=0,
+            estimate90_kwh=0,
+            intervals=[
+                ConfidenceInterval(
+                    period_start=datetime(2026, 3, 20, 10, 0, tzinfo=timezone.utc),
+                    spread_kwh=0,
+                    confidence=0.4,
+                ),
+            ],
+        )
+
+        resolver = ConfidenceResolver(today_analysis, tomorrow_analysis)
+        conf = resolver.get_confidence(
+            datetime(2026, 3, 20, 10, 0, tzinfo=timezone.utc)
+        )
+        assert conf == pytest.approx(0.4)
+
+    def test_fallback_to_day_confidence_when_no_match(self):
+        analysis = SolcastAnalysis(
+            entity_id="today",
+            last_updated=datetime.now(timezone.utc),
+            day_confidence=0.6,
+            day_spread_kwh=0,
+            estimate10_kwh=0,
+            estimate90_kwh=0,
+            intervals=[],
+        )
+        resolver = ConfidenceResolver(analysis, None)
+        conf = resolver.get_confidence(
+            datetime(2026, 3, 19, 15, 0, tzinfo=timezone.utc)
+        )
+        assert conf == pytest.approx(0.6)  # Falls back to day_confidence
+
+    def test_no_analysis_returns_1(self):
+        resolver = ConfidenceResolver(None, None)
+        conf = resolver.get_confidence(
+            datetime(2026, 3, 19, 10, 0, tzinfo=timezone.utc)
+        )
+        assert conf == 1.0
+
+    def test_tomorrow_only_when_today_is_none(self):
+        """Test fallback to tomorrow when today is None."""
+        tomorrow_analysis = SolcastAnalysis(
+            entity_id="tomorrow",
+            last_updated=datetime.now(timezone.utc),
+            day_confidence=0.5,
+            day_spread_kwh=0,
+            estimate10_kwh=0,
+            estimate90_kwh=0,
+            intervals=[],
+        )
+        resolver = ConfidenceResolver(None, tomorrow_analysis)
+        conf = resolver.get_confidence(
+            datetime(2026, 3, 20, 10, 0, tzinfo=timezone.utc)
+        )
+        assert conf == pytest.approx(0.5)
+
+    def test_get_analysis_for_period_today(self):
+        """Test get_analysis_for_period returns today's analysis."""
+        today_analysis = SolcastAnalysis(
+            entity_id="today",
+            last_updated=datetime.now(timezone.utc),
+            day_confidence=0.8,
+            day_spread_kwh=0,
+            estimate10_kwh=0,
+            estimate90_kwh=0,
+            intervals=[
+                ConfidenceInterval(
+                    period_start=datetime(2026, 3, 19, 10, 0, tzinfo=timezone.utc),
+                    spread_kwh=0,
+                    confidence=0.9,
+                ),
+            ],
+        )
+        resolver = ConfidenceResolver(today_analysis, None)
+        analysis = resolver.get_analysis_for_period(
+            datetime(2026, 3, 19, 10, 0, tzinfo=timezone.utc)
+        )
+        assert analysis == today_analysis
+
+    def test_get_analysis_for_period_tomorrow(self):
+        """Test get_analysis_for_period returns tomorrow's analysis."""
+        tomorrow_analysis = SolcastAnalysis(
+            entity_id="tomorrow",
+            last_updated=datetime.now(timezone.utc),
+            day_confidence=0.3,
+            day_spread_kwh=0,
+            estimate10_kwh=0,
+            estimate90_kwh=0,
+            intervals=[
+                ConfidenceInterval(
+                    period_start=datetime(2026, 3, 20, 10, 0, tzinfo=timezone.utc),
+                    spread_kwh=0,
+                    confidence=0.4,
+                ),
+            ],
+        )
+        resolver = ConfidenceResolver(None, tomorrow_analysis)
+        analysis = resolver.get_analysis_for_period(
+            datetime(2026, 3, 20, 10, 0, tzinfo=timezone.utc)
+        )
+        assert analysis == tomorrow_analysis
+
+    def test_get_analysis_for_period_no_match(self):
+        """Test get_analysis_for_period returns today when no match."""
+        today_analysis = SolcastAnalysis(
+            entity_id="today",
+            last_updated=datetime.now(timezone.utc),
+            day_confidence=0.6,
+            day_spread_kwh=0,
+            estimate10_kwh=0,
+            estimate90_kwh=0,
+            intervals=[],
+        )
+        resolver = ConfidenceResolver(today_analysis, None)
+        analysis = resolver.get_analysis_for_period(
+            datetime(2026, 3, 19, 15, 0, tzinfo=timezone.utc)
+        )
+        assert analysis == today_analysis

--- a/tests/forecast/test_solar.py
+++ b/tests/forecast/test_solar.py
@@ -1,0 +1,62 @@
+"""Tests for solar confidence blending (Issue #794)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+from custom_components.localshift.forecast.solar import (
+    _blend_solar_estimate,
+    get_solar_for_5min_slot,
+)
+
+
+class TestBlendSolarEstimate:
+    """Tests for _blend_solar_estimate()."""
+
+    def test_full_confidence_returns_median(self):
+        assert _blend_solar_estimate(29.56, 7.99, 1.0) == 29.56
+
+    def test_zero_confidence_returns_p10(self):
+        assert _blend_solar_estimate(29.56, 7.99, 0.0) == 7.99
+
+    def test_mid_confidence_returns_average(self):
+        result = _blend_solar_estimate(20.0, 10.0, 0.5)
+        assert result == pytest.approx(15.0)
+
+    def test_low_confidence_realistic(self):
+        # Issue #794 reported case: confidence 17%, median 29.56, P10 7.99
+        result = _blend_solar_estimate(29.56, 7.99, 0.17)
+        expected = 0.17 * 29.56 + 0.83 * 7.99  # ~11.65
+        assert result == pytest.approx(expected, abs=0.01)
+
+    def test_confidence_above_one_clamps_to_median(self):
+        assert _blend_solar_estimate(29.56, 7.99, 1.5) == 29.56
+
+    def test_confidence_below_zero_clamps_to_p10(self):
+        assert _blend_solar_estimate(29.56, 7.99, -0.5) == 7.99
+
+    def test_zero_values(self):
+        assert _blend_solar_estimate(0.0, 0.0, 0.5) == 0.0
+
+    def test_p10_larger_than_median(self):
+        # Edge case: inverted spread
+        result = _blend_solar_estimate(5.0, 10.0, 0.5)
+        assert result == pytest.approx(7.5)
+
+
+class TestGetSolarFor5minSlotCoverage:
+    """Additional tests to ensure coverage for get_solar_for_5min_slot()."""
+
+    def test_naive_datetime_with_forecast(self):
+        """Test that naive datetime is converted to local (line 241 coverage)."""
+        forecasts = [
+            {
+                "period_start": "2026-03-19T10:00:00+00:00",
+                "pv_estimate": 4.0,
+                "pv_estimate10": 1.0,
+            }
+        ]
+        slot_start = datetime(2026, 3, 19, 10, 0)  # Naive datetime
+        result = get_solar_for_5min_slot(forecasts, slot_start)
+        assert result > 0.0

--- a/tests/forecast/test_solar_accuracy.py
+++ b/tests/forecast/test_solar_accuracy.py
@@ -59,6 +59,19 @@ class TestSolarPeriodRecord:
         assert record.bias == 0.0
         assert record.additive_bias == pytest.approx(0.001)
 
+    def test_initialization_with_boost_flag(self):
+        """Boost-tagged records preserve the boost marker."""
+        record = SolarPeriodRecord(
+            period_start=datetime(2026, 1, 15, 10, 0, tzinfo=UTC),
+            forecast_kwh=2.0,
+            actual_kwh=1.0,
+            weather_condition="sunny",
+            time_of_day="morning",
+            season="summer",
+            is_boost_period=True,
+        )
+        assert record.is_boost_period is True
+
     def test_to_dict(self):
         """Test serialization to dictionary."""
         record = SolarPeriodRecord(
@@ -214,6 +227,14 @@ class TestSolarAccuracyTracker:
         assert record.time_of_day == "morning"
         assert record.season == "summer"
 
+    def test_record_forecast_sets_boost_flag(self, tracker):
+        """Boost periods are tagged when forecasts are recorded."""
+        period_start = datetime(2026, 1, 15, 10, 0, tzinfo=UTC)
+        tracker.record_forecast(period_start, 2.5, "sunny", is_boost=True)
+
+        record = tracker._pending_forecasts[period_start.isoformat()]
+        assert record.is_boost_period is True
+
     def test_record_forecast_normalizes_weather(self, tracker):
         """Test weather normalization when recording forecast."""
         period_start = datetime(2026, 1, 15, 10, 0, tzinfo=UTC)
@@ -341,6 +362,21 @@ class TestSolarAccuracyTracker:
 
         # With perfect forecasts, accuracy should be high
         assert tracker._metrics.accuracy > 90
+
+    def test_boost_periods_are_excluded_from_metrics(self, tracker):
+        """Boost-tagged periods remain in history but not in learning metrics."""
+        normal_period = datetime(2026, 1, 15, 10, 0, tzinfo=UTC)
+        boost_period = datetime(2026, 1, 15, 10, 30, tzinfo=UTC)
+
+        tracker.record_forecast(normal_period, 5.0, "sunny")
+        tracker.backfill_actual(normal_period, 2.0)
+
+        tracker.record_forecast(boost_period, 5.0, "sunny", is_boost=True)
+        tracker.backfill_actual(boost_period, 1.0)
+
+        assert len(tracker._period_records) == 2
+        assert tracker._metrics.sample_count == 1
+        assert tracker._period_records[-1].is_boost_period is True
 
     def test_get_bias_correction_no_data(self, tracker):
         """Test get_bias_correction with no historical data returns 1.0."""

--- a/tests/forecast/test_solar_confidence_scenarios.py
+++ b/tests/forecast/test_solar_confidence_scenarios.py
@@ -1,0 +1,62 @@
+"""Scenario tests for solar confidence blending (Issue #794)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from custom_components.localshift.forecast.analysis_resolver import ConfidenceResolver
+from custom_components.localshift.forecast.solcast_analysis import (
+    ConfidenceInterval,
+    SolcastAnalysis,
+)
+from custom_components.localshift.forecast.solar import (
+    _blend_solar_estimate,
+    sum_solar_before_target,
+)
+
+
+def test_reported_issue_794_blends_to_conservative_value():
+    blended = _blend_solar_estimate(29.56, 7.99, 0.17)
+
+    assert blended == pytest.approx(11.66, abs=0.02)
+    assert blended < 29.56 * 0.5
+
+
+def test_low_confidence_sum_uses_cross_day_resolver():
+    now = datetime(2026, 3, 20, 0, 0, tzinfo=timezone.utc)
+    forecasts = [
+        {
+            "period_start": "2026-03-20T00:00:00+00:00",
+            "pv_estimate": 6.0,
+            "pv_estimate10": 1.0,
+        },
+    ]
+    tomorrow_analysis = SolcastAnalysis(
+        entity_id="sensor.tomorrow",
+        last_updated=now,
+        day_confidence=0.2,
+        day_spread_kwh=0.0,
+        estimate10_kwh=0.0,
+        estimate90_kwh=0.0,
+        intervals=[
+            ConfidenceInterval(
+                period_start=datetime(2026, 3, 20, 0, 0, tzinfo=timezone.utc),
+                spread_kwh=0.0,
+                confidence=0.2,
+            )
+        ],
+    )
+
+    optimistic = sum_solar_before_target(forecasts, now, 1)
+    conservative = sum_solar_before_target(
+        forecasts,
+        now,
+        1,
+        resolver=ConfidenceResolver(None, tomorrow_analysis),
+    )
+
+    assert optimistic == pytest.approx(3.0)
+    assert conservative == pytest.approx(1.0, abs=0.01)
+    assert conservative < optimistic

--- a/tests/forecast/test_solcast_analysis.py
+++ b/tests/forecast/test_solcast_analysis.py
@@ -258,7 +258,7 @@ def test_get_confidence_for_period_no_intervals():
 
     confidence = get_confidence_for_period(analysis, now)
 
-    assert confidence == 1.0  # Default when no intervals
+    assert confidence == 0.75  # Falls back to day_confidence when no intervals
 
 
 def test_get_confidence_for_period_exact_match():

--- a/tests/sensors/test_forecast.py
+++ b/tests/sensors/test_forecast.py
@@ -12,11 +12,16 @@ Tests cover:
 - MinimumTargetSOCSensor: native_value
 """
 
-from unittest.mock import MagicMock
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
 
 from custom_components.localshift.coordinator.data import (
     AdaptiveParameters,
     CoordinatorData,
+)
+from custom_components.localshift.forecast.solcast_analysis import (
+    ConfidenceInterval,
+    SolcastAnalysis,
 )
 from custom_components.localshift.sensors.forecast import (
     DecisionLogSensor,
@@ -90,7 +95,44 @@ class TestSolarBatteryForecastSensor:
 
         sensor = SolarBatteryForecastSensor(mock_coordinator, mock_entry)
 
-        assert sensor.extra_state_attributes == forecast
+        attrs = sensor.extra_state_attributes
+        assert attrs["predicted_soc"] == 75.5
+        assert attrs["hours_to_target"] == 4
+        assert attrs["solar_kwh"] == 12.5
+        assert attrs["solar_confidence_used"] == 1.0
+        assert attrs["solar_blend_applied"] is False
+
+    def test_extra_state_attributes_adds_confidence_diagnostics(self):
+        forecast = {"predicted_soc": 75.5}
+        analysis = SolcastAnalysis(
+            entity_id="sensor.today",
+            last_updated=datetime(2026, 3, 19, 10, 0, tzinfo=timezone.utc),
+            day_confidence=0.2,
+            day_spread_kwh=0.0,
+            estimate10_kwh=0.0,
+            estimate90_kwh=0.0,
+            intervals=[
+                ConfidenceInterval(
+                    period_start=datetime(2026, 3, 19, 10, 0, tzinfo=timezone.utc),
+                    spread_kwh=0.0,
+                    confidence=0.2,
+                )
+            ],
+        )
+        mock_coordinator, _ = create_mock_coordinator_with_data(
+            solar_battery_forecast=forecast,
+            solcast_analysis_today=analysis,
+        )
+        sensor = SolarBatteryForecastSensor(mock_coordinator, MagicMock())
+
+        with patch(
+            "custom_components.localshift.sensors.forecast.dt_util.now",
+            return_value=datetime(2026, 3, 19, 10, 0, tzinfo=timezone.utc),
+        ):
+            attrs = sensor.extra_state_attributes
+
+        assert attrs["solar_confidence_used"] == 0.2
+        assert attrs["solar_blend_applied"] is True
 
 
 class TestNetElectricityCostSensor:

--- a/tests/sensors/test_optimizer.py
+++ b/tests/sensors/test_optimizer.py
@@ -6,9 +6,14 @@ Tests cover:
 - SolarForecastAccuracySensor: native_value, extra_state_attributes
 """
 
-from unittest.mock import MagicMock
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
 
 from custom_components.localshift.coordinator.data import CoordinatorData
+from custom_components.localshift.forecast.solcast_analysis import (
+    ConfidenceInterval,
+    SolcastAnalysis,
+)
 from custom_components.localshift.sensors.optimizer import (
     OptimizerPlanDetailedSensor,
     OptimizerSummarySensor,
@@ -104,6 +109,43 @@ class TestOptimizerPlanDetailedSensor:
         assert attrs["total_slots"] == 2
         assert attrs["forecast_horizon_hours"] == 24
         assert attrs["computed_at"] == "2026-03-13T10:00:00"
+        assert attrs["solar_confidence_avg"] == 1.0
+        assert attrs["solar_confidence_regime"] == "high"
+        assert attrs["solar_blend_applied"] is False
+
+    def test_extra_state_attributes_with_confidence_diagnostics(self):
+        analysis = SolcastAnalysis(
+            entity_id="sensor.today",
+            last_updated=datetime(2026, 3, 19, 10, 0, tzinfo=timezone.utc),
+            day_confidence=0.3,
+            day_spread_kwh=0.0,
+            estimate10_kwh=0.0,
+            estimate90_kwh=0.0,
+            intervals=[
+                ConfidenceInterval(
+                    period_start=datetime(2026, 3, 19, 10, 0, tzinfo=timezone.utc),
+                    spread_kwh=0.0,
+                    confidence=0.3,
+                )
+            ],
+        )
+        mock_coordinator, _ = create_mock_coordinator_with_data(
+            optimizer_decisions=[],
+            optimizer_summary={"enabled": True, "success": True},
+            forecast_horizon_hours=24,
+            solcast_analysis_today=analysis,
+        )
+        sensor = OptimizerPlanDetailedSensor(mock_coordinator, MagicMock())
+
+        with patch(
+            "custom_components.localshift.sensors.optimizer.dt_util.now",
+            return_value=datetime(2026, 3, 19, 10, 0, tzinfo=timezone.utc),
+        ):
+            attrs = sensor.extra_state_attributes
+
+        assert attrs["solar_confidence_avg"] == 0.3
+        assert attrs["solar_confidence_regime"] == "low"
+        assert attrs["solar_blend_applied"] is True
 
     def test_icon_computed(self):
         """Test icon for computed state."""
@@ -200,6 +242,38 @@ class TestOptimizerSummarySensor:
         sensor._update_from_coordinator()
 
         assert sensor._attr_native_value == "failed"
+
+    def test_extra_state_attributes_add_confidence_diagnostics(self):
+        analysis = SolcastAnalysis(
+            entity_id="sensor.today",
+            last_updated=datetime(2026, 3, 19, 10, 0, tzinfo=timezone.utc),
+            day_confidence=0.5,
+            day_spread_kwh=0.0,
+            estimate10_kwh=0.0,
+            estimate90_kwh=0.0,
+            intervals=[
+                ConfidenceInterval(
+                    period_start=datetime(2026, 3, 19, 10, 0, tzinfo=timezone.utc),
+                    spread_kwh=0.0,
+                    confidence=0.5,
+                )
+            ],
+        )
+        mock_coordinator, _ = create_mock_coordinator_with_data(
+            optimizer_summary={"enabled": True, "success": True},
+            solcast_analysis_today=analysis,
+        )
+        sensor = OptimizerSummarySensor(mock_coordinator, MagicMock())
+
+        with patch(
+            "custom_components.localshift.sensors.optimizer.dt_util.now",
+            return_value=datetime(2026, 3, 19, 10, 0, tzinfo=timezone.utc),
+        ):
+            attrs = sensor.extra_state_attributes
+
+        assert attrs["solar_confidence_avg"] == 0.5
+        assert attrs["solar_confidence_regime"] == "medium"
+        assert attrs["solar_blend_applied"] is True
 
     def test_native_value_no_summary(self):
         """Test native_value returns 'disabled' when no summary."""

--- a/tests/test_optimizer_facade.py
+++ b/tests/test_optimizer_facade.py
@@ -231,11 +231,31 @@ def test_record_forecasts_for_slots_records_only_backfillable_timestamps():
         period_start=datetime(2026, 1, 15, 10, 0, tzinfo=UTC),
         forecast_kwh=0.0,
         weather_condition="sunny",
+        is_boost=False,
     )
     tracker.record_forecast.assert_any_call(
         period_start=datetime(2026, 1, 15, 10, 30, tzinfo=UTC),
         forecast_kwh=0.2,
         weather_condition="sunny",
+        is_boost=False,
+    )
+
+
+def test_record_forecasts_for_slots_passes_boost_flag():
+    tracker = MagicMock()
+    slots = [
+        SimpleNamespace(solar_kwh=0.2, timestamp_iso="2026-01-15T10:30:00+00:00"),
+    ]
+
+    facade = OptimizerFacade(slot_builder_cls=_StubSlotBuilder)
+    facade.set_solar_accuracy_tracker(tracker)
+    facade._record_forecasts_for_slots(slots, "sunny", is_boost=True)
+
+    tracker.record_forecast.assert_called_once_with(
+        period_start=datetime(2026, 1, 15, 10, 30, tzinfo=UTC),
+        forecast_kwh=0.2,
+        weather_condition="sunny",
+        is_boost=True,
     )
 
 

--- a/tests/test_optimizer_facade.py
+++ b/tests/test_optimizer_facade.py
@@ -2,6 +2,7 @@
 
 from datetime import UTC, datetime
 from types import SimpleNamespace
+from typing import Any, cast
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -378,3 +379,186 @@ def test_assign_active_mode_falls_back_on_invalid_battery_mode():
 
     assert data.active_mode == BatteryMode.SELF_CONSUMPTION
     assert data.optimizer_last_apply_status == "fallback"
+
+
+class _ShadowSlotBuilderWithOneSlot:
+    def __init__(self, **_kwargs) -> None:
+        pass
+
+    def build_slots(
+        self,
+        _data,
+        _adaptive_params,
+        now_dt=None,
+        override_general_forecast=None,
+        override_feed_in_forecast=None,
+    ):
+        assert now_dt is not None
+        assert override_general_forecast is not None
+        assert override_feed_in_forecast is not None
+        return [SimpleNamespace(timestamp_iso="2026-01-15T10:00:00+00:00")], MagicMock()
+
+
+class _ShadowSlotBuilderEmpty:
+    def __init__(self, **_kwargs) -> None:
+        pass
+
+    def build_slots(self, *_args, **_kwargs):
+        return [], MagicMock()
+
+
+class _ShadowSlotBuilderBoom:
+    def __init__(self, **_kwargs) -> None:
+        pass
+
+    def build_slots(self, *_args, **_kwargs):
+        raise RuntimeError("shadow boom")
+
+
+def test_run_shadow_comparison_disabled_returns_early():
+    facade = OptimizerFacade(slot_builder_cls=_StubSlotBuilder)
+    data = CoordinatorData()
+    data.general_price_shadow = 0.25
+
+    facade._run_shadow_comparison(
+        data,
+        datetime(2026, 1, 15, 10, 0, tzinfo=UTC),
+        {"comparison_mode": "disabled"},
+        MagicMock(all_solcast=[]),
+    )
+
+    assert data.primary_decision == ""
+    assert data.shadow_decision == ""
+
+
+def test_run_shadow_comparison_resets_when_shadow_price_unavailable():
+    facade = OptimizerFacade(slot_builder_cls=_StubSlotBuilder)
+    data = CoordinatorData()
+    data.general_price_shadow = 0.0
+    data.comparison_match = False
+    data.primary_decision = "old"
+    data.shadow_decision = "other"
+    data.price_delta = 99.0
+
+    facade._run_shadow_comparison(
+        data,
+        datetime(2026, 1, 15, 10, 0, tzinfo=UTC),
+        {"comparison_mode": "enabled"},
+        MagicMock(all_solcast=[]),
+    )
+
+    assert data.comparison_match is True
+    assert data.primary_decision == ""
+    assert data.shadow_decision == ""
+    assert data.price_delta == 0.0
+
+
+def test_run_shadow_comparison_threads_solcast_analysis_and_logs_mismatch():
+    facade = OptimizerFacade(slot_builder_cls=_ShadowSlotBuilderWithOneSlot)
+    facade._planner = MagicMock(
+        plan=MagicMock(return_value=SimpleNamespace(decisions=[SimpleNamespace()]))
+    )
+    data = CoordinatorData()
+    data.general_price_shadow = 0.15
+    data.general_price = 0.25
+    data.general_forecast_shadow = cast(Any, [{"start": "shadow"}])
+    data.feed_in_forecast_shadow = cast(Any, [{"start": "shadow-fit"}])
+    data.adaptive_params = cast(Any, None)
+    data.soc = 55.0
+    data.active_mode = BatteryMode.SELF_CONSUMPTION
+    data.solcast_analysis_today = cast(Any, object())
+    data.solcast_analysis_tomorrow = cast(Any, object())
+    data.decision_log = []
+
+    with (
+        patch(
+            "custom_components.localshift.engine.optimizer_facade._build_optimizer_config",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "custom_components.localshift.engine.optimizer_facade._normalize_initial_soc",
+            return_value=(55.0, {}),
+        ),
+        patch(
+            "custom_components.localshift.engine.optimizer_facade._serialize_decision",
+            return_value={"action": "hold"},
+        ),
+        patch(
+            "custom_components.localshift.engine.optimizer_facade._find_current_slot_index",
+            return_value=0,
+        ),
+        patch(
+            "custom_components.localshift.engine.optimizer_facade._derive_runtime_apply_plan",
+            return_value={"battery_mode": BatteryMode.GRID_CHARGING.value},
+        ),
+    ):
+        facade._run_shadow_comparison(
+            data,
+            datetime(2026, 1, 15, 10, 0, tzinfo=UTC),
+            {"comparison_mode": "enabled"},
+            MagicMock(all_solcast=[{"period_start": "2026-01-15T10:00:00+00:00"}]),
+        )
+
+    inputs = facade._planner.plan.call_args.args[0]
+    assert inputs.solcast_analysis_today is data.solcast_analysis_today
+    assert inputs.solcast_analysis_tomorrow is data.solcast_analysis_tomorrow
+    assert data.primary_decision == BatteryMode.SELF_CONSUMPTION.value
+    assert data.shadow_decision == BatteryMode.GRID_CHARGING.value
+    assert data.comparison_match is False
+    assert data.price_delta == pytest.approx(0.10)
+    assert len(data.decision_log) == 1
+
+
+def test_run_shadow_comparison_handles_empty_slots_invalid_soc_and_exceptions(caplog):
+    data = CoordinatorData()
+    data.general_price_shadow = 0.15
+    data.general_forecast_shadow = cast(Any, [{"start": "shadow"}])
+    data.feed_in_forecast_shadow = cast(Any, [{"start": "shadow-fit"}])
+    data.adaptive_params = cast(Any, None)
+    data.soc = 55.0
+
+    empty_facade = OptimizerFacade(slot_builder_cls=_ShadowSlotBuilderEmpty)
+    with caplog.at_level("WARNING"):
+        empty_facade._run_shadow_comparison(
+            data,
+            datetime(2026, 1, 15, 10, 0, tzinfo=UTC),
+            {"comparison_mode": "enabled"},
+            MagicMock(all_solcast=[]),
+        )
+    assert "Shadow optimizer: no slots available" in caplog.text
+
+    invalid_soc_facade = OptimizerFacade(slot_builder_cls=_ShadowSlotBuilderWithOneSlot)
+    with patch(
+        "custom_components.localshift.engine.optimizer_facade._normalize_initial_soc",
+        return_value=(None, {"error": "invalid"}),
+    ):
+        with caplog.at_level("WARNING"):
+            invalid_soc_facade._run_shadow_comparison(
+                data,
+                datetime(2026, 1, 15, 10, 0, tzinfo=UTC),
+                {"comparison_mode": "enabled"},
+                MagicMock(all_solcast=[]),
+            )
+    assert "Shadow optimizer: invalid SOC" in caplog.text
+
+    exploding_facade = OptimizerFacade(slot_builder_cls=_ShadowSlotBuilderBoom)
+    with caplog.at_level("WARNING"):
+        exploding_facade._run_shadow_comparison(
+            data,
+            datetime(2026, 1, 15, 10, 0, tzinfo=UTC),
+            {"comparison_mode": "enabled"},
+            MagicMock(all_solcast=[]),
+        )
+    assert "Shadow optimizer failed: shadow boom" in caplog.text
+
+
+def test_log_comparison_mismatch_trims_decision_log_to_50_entries():
+    facade = OptimizerFacade(slot_builder_cls=_StubSlotBuilder)
+    data = CoordinatorData()
+    data.decision_log = [{"idx": i} for i in range(50)]
+
+    facade._log_comparison_mismatch(data, "self_consumption", "grid_charging", 0.12)
+
+    assert len(data.decision_log) == 50
+    assert data.decision_log[-1]["old_mode"] == "self_consumption"
+    assert data.decision_log[-1]["new_mode"] == "grid_charging"


### PR DESCRIPTION
## Summary
- blend Solcast median and P10 solar estimates using per-period confidence, including cross-day resolver support for slot building, forecast battery, and terminal-cost projection
- exclude boost-charging periods from solar accuracy learning so manual reserve changes do not poison forecast bias metrics
- expose solar confidence diagnostics on forecast and optimizer sensors, and add scenario/regression coverage for issue #794

## Related Issue
Closes #794

## Testing
- `uv run ruff check custom_components/localshift`
- `uv run pytest --cov=custom_components/localshift --cov-report=term-missing`