### PR TITLE
docs/tests: codify self-consumption philosophy guardrails

### DIFF
--- a/custom_components/localshift/engine/AGENTS.md
+++ b/custom_components/localshift/engine/AGENTS.md
@@ -42,6 +42,18 @@ terminal_cost()    → What MUST I achieve? (deadline)
 - NEVER modify cost without updating terminal cost
 - NEVER add hard constraint without documenting
 - Keep optimizer pure (deterministic, stateless)
+- NEVER add reserve-holding behavior in self_consumption without explicit request
+
+## Self-Consumption Philosophy
+
+In `self_consumption` mode, the optimizer's goal is to minimize cost, not to keep the battery full.
+
+- **Low overnight SOC is acceptable.** The battery spending hours at minimum SOC is correct if that is the cheapest path.
+- **Grid import is acceptable.** If the battery runs out overnight, importing from the grid is fine. Do not fix this by adding reserve-seeking behavior.
+- **Proactive charging needs strong justification.** Only justified when a real deadline/target demands it. Avoid adding it "just in case."
+- **Anti-goal: do not optimize for overnight reserve.** If a change makes overnight charging easier or adds reserve-holding, it is almost certainly wrong for self_consumption unless explicitly requested.
+
+See `docs/PLANNING_MODEL.md` "Control Philosophy" section for the full policy.
 
 ## See Also
 

--- a/custom_components/localshift/engine/constraints.py
+++ b/custom_components/localshift/engine/constraints.py
@@ -97,6 +97,14 @@ def feasible_actions(
     - Slot duration vs transfer limits
     - Negative FIT avoidance (Issue #719)
 
+    PHILOSOPHY NOTE (self_consumption):
+    - Low overnight SOC is acceptable. Do not add reserve-holding behavior
+      that penalizes the battery hitting minimum SOC overnight.
+    - Charging from grid is gated by price AND solar sufficiency —
+      not by a desire to avoid low SOC.
+    - If battery runs out overnight, grid import is the correct outcome.
+      See docs/PLANNING_MODEL.md "Control Philosophy".
+
     Args:
         soc_pct: Current battery SOC percentage.
         slot: Per-slot context (price, solar, consumption, flags).

--- a/custom_components/localshift/engine/cost.py
+++ b/custom_components/localshift/engine/cost.py
@@ -111,6 +111,9 @@ def stage_cost(
     # before reaching a useful period (solar surplus or demand window).
     # Formula: grid_import_kWh × (eff_loss + margin) × buy_price × drain_factor
     # The penalty includes efficiency loss plus a margin to discourage marginal cycling.
+    # PHILOSOPHY NOTE: in self_consumption, overnight charging is generally wasteful
+    # and should stay penalized. Do not reduce these penalties to encourage
+    # reserve-holding behavior. See docs/PLANNING_MODEL.md "Control Philosophy".
     futile_cycling_penalty = 0.0
     if action in (
         PlannerAction.CHARGE_GRID_NORMAL,

--- a/docs/PLANNING_MODEL.md
+++ b/docs/PLANNING_MODEL.md
@@ -303,6 +303,37 @@ When adding a constraint or penalty:
    # Verify behavior change is as expected
    ```
 
+## Control Philosophy
+
+These rules define the intended operating philosophy for `self_consumption` mode.
+They are **not** just preferences — they are part of the system's identity.
+Future changes should not violate them without explicit discussion.
+
+### Principles
+
+1. **Economics over comfort.** The goal is to minimize electricity cost, not to keep the battery full.
+2. **Grid import is acceptable overnight.** If the battery runs down and the house uses the grid, that is often the correct outcome. Overnight charging is generally wasteful and should stay penalized.
+3. **Low overnight SOC is not a bug.** The battery spending hours at 10% SOC is acceptable if that is the cheapest path. Do not interpret this as a problem that needs fixing.
+4. **Proactive charging needs strong justification.** Charging before a deadline is justified only when target-feasibility says so, not just to avoid low SOC or to feel "ready."
+5. **Anti-goal: do not optimize for overnight reserve.** In `self_consumption`, there is no implicit objective to "hold reserve overnight at all costs." If you find yourself adding reserve-holding behavior, stop and check whether it was requested.
+
+### Anti-Goals
+
+These are behaviors that should **not** appear in `self_consumption` unless explicitly requested:
+
+- Holding a meaningful reserve overnight (e.g., 25–35%) without explicit reason
+- Charging from the grid to avoid falling below minimum SOC
+- Reducing anti-cycling penalties to enable more overnight charging
+- Interpreting low overnight SOC as a reason to change the planning model
+
+### Guardrail Questions
+
+Before proposing changes to optimizer behavior, ask:
+
+- "Is this adding reserve-holding behavior?" If yes, it needs explicit approval.
+- "Am I treating low overnight SOC as a bug?" If yes, reconsider the framing.
+- "Does this change make proactive charging easier?" If yes, make sure it is gated by a real deadline, not just comfort.
+
 ## References
 
 - `optimizer_dp.py` - Core DP implementation

--- a/tests/test_cost.py
+++ b/tests/test_cost.py
@@ -1,6 +1,6 @@
-"""Tests for cost.py stage_cost and terminal_cost."""
+"""Tests for ``cost.py`` stage_cost and terminal_cost."""
 
-from custom_components.localshift.engine.cost import stage_cost
+from custom_components.localshift.engine.cost import stage_cost, terminal_cost
 from custom_components.localshift.engine.types import (
     OptimizerConfig,
     PlannerAction,
@@ -53,3 +53,147 @@ def test_stage_cost_positive_fit_positive_revenue():
     assert terms.export_revenue == 2.0 * 0.12
     # Revenue ($0.24) exceeds cycle penalty ($0.16), so net_cost < 0 (profit)
     assert terms.net_cost < 0
+
+
+def test_stage_cost_charge_includes_uncertainty_and_futile_penalties():
+    """Grid charge applies uncertainty and futile-cycling penalties."""
+    config = OptimizerConfig(
+        optimization_mode="self_consumption",
+        forecast_horizon_hours=10.0,  # below 20h threshold -> uncertainty penalty
+    )
+    slot = SlotContext(
+        slot_index=0,
+        timestamp_iso="2026-01-03T10:00:00",
+        slot_interval_minutes=30,
+        buy_price=0.20,
+        sell_price=0.05,
+        solar_kwh=0.0,
+        consumption_kwh=0.4,
+    )
+    terms = stage_cost(
+        action=PlannerAction.CHARGE_GRID_NORMAL,
+        grid_import_kwh=1.0,
+        grid_export_kwh=0.0,
+        slot=slot,
+        config=config,
+        futile_cycling_penalty_factor=1.0,
+    )
+
+    assert terms.import_cost == 0.20
+    assert terms.cycle_penalty == config.cycle_penalty_per_kwh
+    assert terms.uncertainty_penalty > 0.0
+    assert terms.futile_cycling_penalty > 0.0
+
+
+def test_stage_cost_boost_charge_branch_covered():
+    """Boost charge follows the same uncertainty branch."""
+    config = OptimizerConfig(
+        optimization_mode="self_consumption",
+        forecast_horizon_hours=5.0,
+    )
+    slot = SlotContext(
+        slot_index=0,
+        timestamp_iso="2026-01-03T10:00:00",
+        slot_interval_minutes=30,
+        buy_price=0.18,
+        sell_price=0.04,
+        solar_kwh=0.0,
+        consumption_kwh=0.3,
+    )
+    terms = stage_cost(
+        action=PlannerAction.CHARGE_GRID_BOOST,
+        grid_import_kwh=0.8,
+        grid_export_kwh=0.0,
+        slot=slot,
+        config=config,
+    )
+
+    assert terms.uncertainty_penalty > 0.0
+
+
+def test_stage_cost_self_consumption_value_is_soc_capped():
+    """SOC cap limits self-consumption credit when available energy is low."""
+    config = OptimizerConfig(
+        optimization_mode="self_consumption",
+        min_soc_pct=10.0,
+        battery_capacity_kwh=13.5,
+        discharge_rate_kw=5.0,
+    )
+    slot = SlotContext(
+        slot_index=0,
+        timestamp_iso="2026-01-03T10:00:00",
+        slot_interval_minutes=30,
+        buy_price=0.30,
+        sell_price=0.05,
+        solar_kwh=0.0,
+        consumption_kwh=3.0,  # large demand
+    )
+
+    # soc_pct only 11% gives tiny usable battery energy above min SOC.
+    terms = stage_cost(
+        action=PlannerAction.HOLD,
+        grid_import_kwh=0.0,
+        grid_export_kwh=0.0,
+        slot=slot,
+        config=config,
+        soc_pct=11.0,
+    )
+
+    assert terms.self_consumption_value > 0.0
+    # credit must be bounded; not full net-load credit (3.0 * (0.30-0.08)=0.66)
+    assert terms.self_consumption_value < 0.66
+
+
+def test_stage_cost_self_consumption_value_zero_when_no_net_load():
+    """No positive net load means no self-consumption credit."""
+    config = OptimizerConfig(optimization_mode="self_consumption")
+    slot = SlotContext(
+        slot_index=0,
+        timestamp_iso="2026-01-03T10:00:00",
+        slot_interval_minutes=30,
+        buy_price=0.20,
+        sell_price=0.05,
+        solar_kwh=1.0,
+        consumption_kwh=0.2,
+    )
+
+    terms = stage_cost(
+        action=PlannerAction.HOLD,
+        grid_import_kwh=0.0,
+        grid_export_kwh=0.0,
+        slot=slot,
+        config=config,
+        soc_pct=80.0,
+    )
+    assert terms.self_consumption_value == 0.0
+
+
+def test_stage_cost_switching_penalty_applied_on_switch():
+    """Switch flag adds switching penalty."""
+    config = OptimizerConfig(optimization_mode="arbitrage", switching_penalty=0.123)
+    slot = SlotContext(
+        slot_index=0,
+        timestamp_iso="2026-01-03T10:00:00",
+        slot_interval_minutes=30,
+        buy_price=0.10,
+        sell_price=0.10,
+        solar_kwh=0.0,
+        consumption_kwh=0.0,
+    )
+    terms = stage_cost(
+        action=PlannerAction.HOLD,
+        grid_import_kwh=0.0,
+        grid_export_kwh=0.0,
+        slot=slot,
+        config=config,
+        is_switch=True,
+    )
+    assert terms.switching_penalty == 0.123
+
+
+def test_terminal_cost_shortfall_and_no_shortfall():
+    """Terminal penalty is linear in shortfall and zero when target met."""
+    config = OptimizerConfig(target_shortfall_penalty_per_pct=0.015)
+
+    assert terminal_cost(final_soc_pct=92.0, target_soc_pct=90.0, config=config) == 0.0
+    assert terminal_cost(final_soc_pct=80.0, target_soc_pct=90.0, config=config) == 0.15

--- a/tests/test_self_consumption_philosophy.py
+++ b/tests/test_self_consumption_philosophy.py
@@ -1,0 +1,295 @@
+"""Tests encoding the self-consumption operating philosophy.
+
+These tests guard against future changes that drift toward reserve-holding
+or comfort-seeking behavior. In self_consumption mode:
+- Overnight charging is generally wasteful and should stay penalized.
+- Low overnight SOC is acceptable — do not add reserve-holding behavior.
+- Proactive charging needs strong justification (real deadline/target), not
+  just a desire to avoid low SOC.
+- Grid import after battery depletion is the correct outcome.
+
+See docs/PLANNING_MODEL.md "Control Philosophy" and
+custom_components/localshift/engine/AGENTS.md "Self-Consumption Philosophy".
+
+These tests focus on the optimizer's constraint and cost layers directly.
+"""
+
+from __future__ import annotations
+
+from custom_components.localshift.engine.constraints import (
+    feasible_actions,
+)
+from custom_components.localshift.engine.cost import stage_cost
+from custom_components.localshift.engine.types import (
+    OptimizerConfig,
+    PlannerAction,
+    SlotContext,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_slot(
+    buy_price: float = 0.15,
+    solar_kwh: float = 0.0,
+    consumption_kwh: float = 0.2,
+    is_demand_window_slot: bool = False,
+    slot_interval_minutes: int = 30,
+    slot_index: int = 0,
+) -> SlotContext:
+    """Create a minimal SlotContext for testing."""
+    return SlotContext(
+        slot_index=slot_index,
+        timestamp_iso="2026-03-20T02:00:00+11:00",
+        slot_interval_minutes=slot_interval_minutes,
+        buy_price=buy_price,
+        sell_price=0.05,
+        solar_kwh=solar_kwh,
+        consumption_kwh=consumption_kwh,
+        is_demand_window_slot=is_demand_window_slot,
+    )
+
+
+def _make_config(
+    optimization_mode: str = "self_consumption",
+    min_soc_pct: float = 10.0,
+    demand_window_target_soc_pct: float = 80.0,
+    effective_cheap_price: float = 0.13,
+    cycle_penalty_per_kwh: float = 0.08,
+) -> OptimizerConfig:
+    """Create a minimal OptimizerConfig for testing."""
+    return OptimizerConfig(
+        battery_capacity_kwh=13.5,
+        max_soc_pct=100.0,
+        min_soc_pct=min_soc_pct,
+        demand_window_target_soc_pct=demand_window_target_soc_pct,
+        optimization_mode=optimization_mode,
+        effective_cheap_price=effective_cheap_price,
+        cycle_penalty_per_kwh=cycle_penalty_per_kwh,
+        charge_rate_kw=5.0,
+        discharge_rate_kw=5.0,
+        charge_efficiency=0.936,
+        discharge_efficiency=0.96,
+        switching_penalty=0.02,
+        target_shortfall_penalty_per_pct=0.015,
+        export_price_margin=0.10,
+        allow_dw_entry_under_target=False,
+    )
+
+
+def _make_slots_overnight(
+    n_slots: int = 10,
+    buy_price: float = 0.15,
+    solar_kwh: float = 0.0,
+    consumption_kwh: float = 0.15,
+    is_demand_window_slot: bool = False,
+) -> list[SlotContext]:
+    """Create a list of overnight slots with consistent properties."""
+    return [
+        _make_slot(
+            buy_price=buy_price,
+            solar_kwh=solar_kwh,
+            consumption_kwh=consumption_kwh,
+            is_demand_window_slot=is_demand_window_slot,
+        )
+        for _ in range(n_slots)
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Philosophy Tests
+# ---------------------------------------------------------------------------
+
+
+class TestSelfConsumptionPhilosophy:
+    """Tests that encode the self-consumption operating philosophy."""
+
+
+def test_no_reserve_holding_without_deadline():
+    """When SOC is low but there is no target/deadline pressure, the planner
+    should not add reserve-holding behavior.
+
+    In self_consumption, overnight charging is generally wasteful. If the
+    planner finds itself considering charge actions at 12% SOC with no
+    demand window, it should be because the price is very cheap — not
+    because it is trying to keep the battery above some comfort floor.
+    """
+    config = _make_config(
+        optimization_mode="self_consumption",
+        min_soc_pct=10.0,
+        demand_window_target_soc_pct=80.0,
+        effective_cheap_price=0.13,
+    )
+
+    # Overnight slot, moderate price (above cheap threshold), no solar, no DW
+    slot = _make_slot(
+        buy_price=0.18, solar_kwh=0.0, consumption_kwh=0.15, is_demand_window_slot=False
+    )
+
+    actions = feasible_actions(
+        soc_pct=12.0,
+        slot=slot,
+        config=config,
+        slot_idx=0,
+        slots=None,  # no slots → disables solar gate
+        terminal_penalty_idx=None,
+    )
+
+    # At moderate price, charge_grid_normal should NOT be in feasible actions
+    # because buy_price (0.18) > effective_cheap_price (0.13) and there is no target risk
+    assert PlannerAction.CHARGE_GRID_NORMAL not in actions, (
+        "Charge action allowed at moderate overnight price without target — "
+        "this suggests reserve-holding behavior"
+    )
+
+
+def test_grid_import_accepted_at_floor():
+    """When battery is at minimum SOC and solar is insufficient, grid import
+    is the correct outcome. The planner should NOT try to charge proactively
+    to avoid the floor unless the price is actually cheap.
+    """
+    config = _make_config(
+        optimization_mode="self_consumption",
+        min_soc_pct=10.0,
+        demand_window_target_soc_pct=80.0,
+        effective_cheap_price=0.13,
+    )
+
+    # Battery at floor, overnight, moderate price, no solar
+    slot = _make_slot(
+        buy_price=0.18, solar_kwh=0.0, consumption_kwh=0.15, is_demand_window_slot=False
+    )
+
+    actions = feasible_actions(
+        soc_pct=10.0,
+        slot=slot,
+        config=config,
+        slot_idx=0,
+        slots=None,
+        terminal_penalty_idx=None,
+    )
+
+    # HOLD should be feasible (allows draining to floor then importing)
+    # CHARGE_GRID_NORMAL should NOT be feasible at this price
+    assert PlannerAction.HOLD in actions
+    assert PlannerAction.CHARGE_GRID_NORMAL not in actions, (
+        "Charging from grid at SOC floor with moderate price — "
+        "this is reserve-holding behavior, not self-consumption economics"
+    )
+
+
+def test_charge_allowed_at_cheap_price():
+    """Charging should be allowed when the price is genuinely cheap,
+    regardless of SOC level. This is economic optimization, not reserve.
+    """
+    config = _make_config(
+        optimization_mode="self_consumption",
+        min_soc_pct=10.0,
+        demand_window_target_soc_pct=80.0,
+        effective_cheap_price=0.15,
+    )
+
+    # Cheap price, no solar, no DW
+    slot = _make_slot(
+        buy_price=0.10, solar_kwh=0.0, consumption_kwh=0.15, is_demand_window_slot=False
+    )
+
+    actions = feasible_actions(
+        soc_pct=30.0,
+        slot=slot,
+        config=config,
+        slot_idx=0,
+        slots=None,
+        terminal_penalty_idx=None,
+    )
+
+    # At cheap price, charge_grid_normal SHOULD be available — this is economic
+    assert PlannerAction.CHARGE_GRID_NORMAL in actions, (
+        "Charging blocked at genuinely cheap price — "
+        "self-consumption should optimize for economics"
+    )
+
+
+def test_stage_cost_applies_anti_cycling_penalties():
+    """Verify that the cost model penalizes charging with the full anti-cycling stack.
+    This guards against future changes that reduce these penalties to encourage
+    more overnight charging.
+    """
+    config = _make_config(
+        optimization_mode="self_consumption",
+        effective_cheap_price=0.13,
+        cycle_penalty_per_kwh=0.08,
+    )
+
+    slot = _make_slot(
+        buy_price=0.12, solar_kwh=0.0, consumption_kwh=0.15, is_demand_window_slot=False
+    )
+
+    terms = stage_cost(
+        action=PlannerAction.CHARGE_GRID_NORMAL,
+        grid_import_kwh=1.0,
+        grid_export_kwh=0.0,
+        soc_pct=30.0,
+        slot=slot,
+        config=config,
+        is_switch=False,
+        solar_opportunity_penalty_factor=0.0,
+        futile_cycling_penalty_factor=1.0,
+    )
+
+    # The charge should have a meaningful cost that includes:
+    # - import cost (1.0 * 0.12 = 0.12)
+    # - cycle penalty (1.0 * 0.08 = 0.08)
+    # - futile cycling penalty (approx 0.426 * 0.12 * 1.0 = 0.051)
+    assert terms.import_cost > 0, "Import cost should be positive"
+    assert terms.cycle_penalty > 0, "Cycle penalty should be positive"
+    assert terms.futile_cycling_penalty > 0, "Futile cycling penalty should be positive"
+
+    # Net cost should be positive (meaning the charge action is expensive)
+    assert terms.net_cost > 0, "Charge action should have a positive net cost"
+
+    # Overnight, no solar, moderate price, SOC near floor
+    slot = _make_slot(
+        buy_price=0.18, solar_kwh=0.0, consumption_kwh=0.15, is_demand_window_slot=False
+    )
+
+    actions = feasible_actions(
+        soc_pct=10.5,
+        slot=slot,
+        config=config,
+        slot_idx=0,
+        slots=None,
+        terminal_penalty_idx=None,
+    )
+
+    assert PlannerAction.HOLD in actions
+    assert PlannerAction.CHARGE_GRID_NORMAL not in actions
+
+
+def test_penalties_are_not_recently_reduced():
+    """Verify that the penalty defaults have not been softened by
+    well-meaning changes. If someone reduces these defaults to
+    encourage more charging, this test will catch it.
+    """
+    from custom_components.localshift.const import (
+        DEFAULT_CYCLE_PENALTY,
+        DEFAULT_TARGET_PENALTY,
+    )
+
+    # These thresholds reflect the intended anti-cycling stance.
+    # Do not lower them without explicit approval of the policy shift.
+    assert DEFAULT_CYCLE_PENALTY >= 0.08, (
+        f"Default cycle penalty reduced to {DEFAULT_CYCLE_PENALTY} — "
+        "this may enable unwanted overnight charging. "
+        "See docs/PLANNING_MODEL.md 'Control Philosophy'"
+    )
+
+    # Target penalty should stay low — real behavior comes from terminal
+    # constraints, not from soft penalties in self_consumption.
+    assert DEFAULT_TARGET_PENALTY <= 0.030, (
+        f"Default target penalty increased to {DEFAULT_TARGET_PENALTY} — "
+        "self_consumption uses a hard constraint path; raising soft penalties "
+        "is redundant and misleading"
+    )


### PR DESCRIPTION
## Summary
- add an explicit self-consumption control philosophy to planning docs and engine agent guidance
- add guardrail comments in optimizer constraint/cost decision points to prevent reserve-holding regressions
- add scenario tests that lock policy intent (overnight low SOC acceptable, cheap-price charging allowed, anti-cycling penalties preserved)

## Testing
- uv run pytest
- uv run ruff check custom_components/localshift tests/test_self_consumption_philosophy.py
- uv run pytest tests/test_cost.py tests/test_self_consumption_philosophy.py -v

## Related Issue
- Closes #803
- References #800 and #801