### PR TITLE
refactor: reduce TickScheduler coupling to coordinator internals (#775)

### DIFF
--- a/custom_components/localshift/coordinator/coordinator.py
+++ b/custom_components/localshift/coordinator/coordinator.py
@@ -120,10 +120,6 @@ class LocalShiftCoordinator:
         self._subscription_manager: SubscriptionManager | None = None
         self._tick_scheduler: TickScheduler | None = None
 
-        # Solar energy tracking for backfill (Issue #513)
-        self._last_solar_power_kw: float = 0.0
-        self._last_solar_power_timestamp: datetime | None = None
-
     # ------------------------------------------------------------------
     # Entity ID helpers (read from config entry data)
     # ------------------------------------------------------------------

--- a/custom_components/localshift/coordinator/coordinator.py
+++ b/custom_components/localshift/coordinator/coordinator.py
@@ -133,7 +133,7 @@ class LocalShiftCoordinator:
         """Return the configured external entity IDs."""
         return self.entry.data
 
-    def _get_entity_id(self, key: str) -> str:
+    def get_entity_id(self, key: str) -> str:
         """Get a configured external entity ID by config key.
 
         For notify_service, checks options first (new location) then data
@@ -166,7 +166,46 @@ class LocalShiftCoordinator:
         """
         if self._state_machine is None:
             return True
-        return self._state_machine._startup_grace_until is not None
+        return self._state_machine.startup_grace_until is not None
+
+    # ------------------------------------------------------------------
+    # Sub-object accessors (public API for TickScheduler)
+    # ------------------------------------------------------------------
+
+    @property
+    def evaluation_dispatcher(self) -> EvaluationDispatcher | None:
+        """Return the evaluation dispatcher, if initialized."""
+        return self._evaluation_dispatcher
+
+    @property
+    def entity_monitor(self) -> EntityMonitor | None:
+        """Return the entity monitor, if initialized."""
+        return self._entity_monitor
+
+    @property
+    def computation_engine(self) -> ComputationEngine | None:
+        """Return the computation engine, if initialized."""
+        return self._computation_engine
+
+    @property
+    def learning_orchestrator(self) -> LearningOrchestrator | None:
+        """Return the learning orchestrator, if initialized."""
+        return self._learning_orchestrator
+
+    @property
+    def state_machine(self) -> StateMachine | None:
+        """Return the state machine, if initialized."""
+        return self._state_machine
+
+    @property
+    def cost_tracker(self) -> CostTracker | None:
+        """Return the cost tracker, if initialized."""
+        return self._cost_tracker
+
+    @property
+    def notification_service(self) -> NotificationService | None:
+        """Return the notification service, if initialized."""
+        return self._notification_service
 
     # ------------------------------------------------------------------
     # Options helpers (read from config entry options)
@@ -203,7 +242,7 @@ class LocalShiftCoordinator:
         from ..utils.costs import CostTracker
         from ..utils.validation import EntityValidator
 
-        self._entity_validator = EntityValidator(self.hass, self._get_entity_id)
+        self._entity_validator = EntityValidator(self.hass, self.get_entity_id)
 
         # Import EntityMonitor
         from .entity_monitor import EntityMonitor
@@ -228,12 +267,12 @@ class LocalShiftCoordinator:
             self.hass, self.entry, self._entity_validator, _pricing_provider
         )
         self._cost_tracker = CostTracker(self.hass)
-        self._battery_controller = BatteryController(self.hass, self._get_entity_id)
+        self._battery_controller = BatteryController(self.hass, self.get_entity_id)
         self._notification_service = NotificationService(
-            self.hass, self.entry, self._get_entity_id, self.get_switch_state
+            self.hass, self.entry, self.get_entity_id, self.get_switch_state
         )
         self._computation_engine = ComputationEngine(
-            self.hass, self.entry, self._get_entity_id, self.get_switch_state
+            self.hass, self.entry, self.get_entity_id, self.get_switch_state
         )
         self._state_machine = StateMachine(
             self._battery_controller,
@@ -299,23 +338,23 @@ class LocalShiftCoordinator:
         # - OPERATION_MODE/BACKUP_RESERVE: outputs, health-checked in 1-min tick
         monitored_entities = [
             # Price entities - trigger mode decisions on price changes
-            self._get_entity_id(CONF_PRICING_GENERAL_PRICE),
-            self._get_entity_id(CONF_PRICING_FEED_IN_PRICE),
-            self._get_entity_id(CONF_PRICING_GENERAL_FORECAST),
-            self._get_entity_id(CONF_PRICING_FEED_IN_FORECAST),
-            self._get_entity_id(CONF_PRICING_PRICE_SPIKE),
+            self.get_entity_id(CONF_PRICING_GENERAL_PRICE),
+            self.get_entity_id(CONF_PRICING_FEED_IN_PRICE),
+            self.get_entity_id(CONF_PRICING_GENERAL_FORECAST),
+            self.get_entity_id(CONF_PRICING_FEED_IN_FORECAST),
+            self.get_entity_id(CONF_PRICING_PRICE_SPIKE),
             # Solcast entities - trigger forecast recomputation
-            self._get_entity_id(CONF_SOLCAST_FORECAST_TODAY),
-            self._get_entity_id(CONF_SOLCAST_FORECAST_TOMORROW),
+            self.get_entity_id(CONF_SOLCAST_FORECAST_TODAY),
+            self.get_entity_id(CONF_SOLCAST_FORECAST_TOMORROW),
             # SOC - trigger target stop when battery reaches target
-            # self._get_entity_id(CONF_TESLEMETRY_SOC),  # REMOVED (Issue #524) - handled by 1-min periodic tick instead
+            # self.get_entity_id(CONF_TESLEMETRY_SOC),  # REMOVED (Issue #524) - handled by 1-min periodic tick instead
         ]
 
         self._evaluation_dispatcher = EvaluationDispatcher(
             self.hass,
-            self._get_entity_id,
+            self.get_entity_id,
             self._read_all_external_state,
-            self._notify_listeners,
+            self.notify_listeners,
             self._evaluate_state_machine,
             self._state_machine,
             STALE_PRICE_THRESHOLD,
@@ -358,7 +397,7 @@ class LocalShiftCoordinator:
             )
 
         # Fetch historical load data in background (runs in thread pool, won't block)
-        load_entity_id = self._get_entity_id(CONF_TESLEMETRY_LOAD_POWER)
+        load_entity_id = self.get_entity_id(CONF_TESLEMETRY_LOAD_POWER)
         await self._computation_engine.async_get_historical_hourly_averages(
             load_entity_id
         )
@@ -380,10 +419,10 @@ class LocalShiftCoordinator:
         self._forecast_bootstrapper = ForecastBootstrapper(
             self.hass,
             self.data,
-            self._get_entity_id,
+            self.get_entity_id,
             self._read_all_external_state,
             self._compute_derived_values,
-            self._notify_listeners,
+            self.notify_listeners,
             self._evaluate_state_machine,
             SOLCAST_STARTUP_RETRY_DELAY,
             SOLCAST_MAX_STARTUP_RETRIES,
@@ -471,7 +510,7 @@ class LocalShiftCoordinator:
         return remove_listener
 
     @callback
-    def _notify_listeners(self) -> None:
+    def notify_listeners(self) -> None:
         """Notify all registered entity listeners of new data."""
         for cb in self._update_callbacks:
             cb()
@@ -542,7 +581,7 @@ class LocalShiftCoordinator:
 
         # Refresh load data (historical and recent)
         if self._computation_engine is not None:
-            load_entity_id = self._get_entity_id(CONF_TESLEMETRY_LOAD_POWER)
+            load_entity_id = self.get_entity_id(CONF_TESLEMETRY_LOAD_POWER)
             self.hass.async_create_task(
                 self._computation_engine.async_get_recent_load_1hr(load_entity_id),
                 "localshift_fetch_recent_load",
@@ -692,7 +731,7 @@ class LocalShiftCoordinator:
         Encapsulates the pattern: compute derived values → notify listeners → evaluate state machine.
         """
         self._compute_derived_values()
-        self._notify_listeners()
+        self.notify_listeners()
         await self.async_evaluate_state_machine()
 
     def reset_entity_tracking_on_options_change(self) -> None:
@@ -722,7 +761,7 @@ class LocalShiftCoordinator:
                 self.data,
                 self._computation_engine,
                 read_state_func=self._read_all_external_state,
-                notify_func=self._notify_listeners,
+                notify_func=self.notify_listeners,
                 check_automation_ready_func=self._state_reader.check_automation_ready
                 if self._state_reader is not None
                 else None,

--- a/custom_components/localshift/coordinator/tick_scheduler.py
+++ b/custom_components/localshift/coordinator/tick_scheduler.py
@@ -316,6 +316,8 @@ class TickScheduler:
             self._last_solar_power_kw = current_power
             return
 
+        assert self._last_solar_power_kw is not None  # nosec B101 — type narrowing, not assertion
+
         time_delta_hours = (
             now - self._last_solar_power_timestamp
         ).total_seconds() / 3600.0

--- a/custom_components/localshift/coordinator/tick_scheduler.py
+++ b/custom_components/localshift/coordinator/tick_scheduler.py
@@ -240,7 +240,7 @@ class TickScheduler:
                 self._coordinator.data
             )
 
-        self._coordinator._notify_listeners()
+        self._coordinator.notify_listeners()
         _LOGGER.info("Midnight reset: cost accumulators and target flag")
 
     @callback

--- a/custom_components/localshift/coordinator/tick_scheduler.py
+++ b/custom_components/localshift/coordinator/tick_scheduler.py
@@ -37,13 +37,18 @@ class TickScheduler:
         """
         self._coordinator = coordinator
 
+        # Solar energy tracking for backfill (Issue #513)
+        # Moved from coordinator — only TickScheduler reads/writes these
+        self._last_solar_power_kw: float | None = None
+        self._last_solar_power_timestamp: datetime | None = None
+
     @callback
     def handle_state_change(self, _event: Event) -> None:
         """Handle a state change from a monitored entity."""
-        if self._coordinator._evaluation_dispatcher is None:
+        if self._coordinator.evaluation_dispatcher is None:
             return
 
-        self._coordinator._evaluation_dispatcher.on_state_change(_event)
+        self._coordinator.evaluation_dispatcher.on_state_change(_event)
 
     @callback
     def handle_periodic_tick(self, now: datetime) -> None:
@@ -66,8 +71,8 @@ class TickScheduler:
         price changes (Issue #622 - legacy price gate removed).
         """
         # Read raw entity values now — needed for cost accumulation
-        if self._coordinator._entity_monitor is not None:
-            self._coordinator._entity_monitor.read_all_external_state()
+        if self._coordinator.entity_monitor is not None:
+            self._coordinator.entity_monitor.read_all_external_state()
 
         # Cost accumulation uses the raw state we just read (sync, no lock needed)
         self._accumulate_costs()
@@ -81,8 +86,8 @@ class TickScheduler:
 
         # Issue #478: Check if automation just became ready during startup
         # Triggers immediate evaluation when transitioning from not-ready to ready
-        if self._coordinator._evaluation_dispatcher is not None:
-            self._coordinator._evaluation_dispatcher.maybe_trigger_on_startup_ready(
+        if self._coordinator.evaluation_dispatcher is not None:
+            self._coordinator.evaluation_dispatcher.maybe_trigger_on_startup_ready(
                 lambda: (
                     self._coordinator.data.automation_ready
                     if self._coordinator.data
@@ -93,8 +98,8 @@ class TickScheduler:
         # Issue #622: Always dispatch to StateMachine
         # StateMachine gates mode transitions based on price fingerprint
         # This ensures optimizer runs every minute for plan updates
-        if self._coordinator._evaluation_dispatcher is not None:
-            self._coordinator._evaluation_dispatcher.on_fast_tick(now)
+        if self._coordinator.evaluation_dispatcher is not None:
+            self._coordinator.evaluation_dispatcher.on_fast_tick(now)
 
     @callback
     def handle_medium_tick(self, now: datetime) -> None:
@@ -108,8 +113,8 @@ class TickScheduler:
         - Baseline calculation
         """
         # Read raw entity values
-        if self._coordinator._entity_monitor is not None:
-            self._coordinator._entity_monitor.read_all_external_state()
+        if self._coordinator.entity_monitor is not None:
+            self._coordinator.entity_monitor.read_all_external_state()
 
         # Skip expensive operations during startup grace period
         if self._is_in_startup_grace():
@@ -117,31 +122,29 @@ class TickScheduler:
             return
 
         # Check entity health
-        if self._coordinator._entity_monitor is not None:
-            self._coordinator._entity_monitor.check_entity_health()
+        if self._coordinator.entity_monitor is not None:
+            self._coordinator.entity_monitor.check_entity_health()
 
         # Refresh load data (historical and recent)
-        if self._coordinator._computation_engine is not None:
+        if self._coordinator.computation_engine is not None:
             from ..const import CONF_TESLEMETRY_LOAD_POWER
 
-            load_entity_id = self._coordinator._get_entity_id(
-                CONF_TESLEMETRY_LOAD_POWER
-            )
+            load_entity_id = self._coordinator.get_entity_id(CONF_TESLEMETRY_LOAD_POWER)
             self._coordinator.hass.async_create_task(
-                self._coordinator._computation_engine.async_get_recent_load_1hr(
+                self._coordinator.computation_engine.async_get_recent_load_1hr(
                     load_entity_id
                 ),
                 "localshift_fetch_recent_load",
             )
             self._coordinator.hass.async_create_task(
-                self._coordinator._computation_engine.async_get_historical_hourly_averages(
+                self._coordinator.computation_engine.async_get_historical_hourly_averages(
                     load_entity_id
                 ),
                 "localshift_fetch_historical_load",
             )
 
-        if self._coordinator._learning_orchestrator is not None:
-            self._coordinator._learning_orchestrator.update_medium_tick(
+        if self._coordinator.learning_orchestrator is not None:
+            self._coordinator.learning_orchestrator.update_medium_tick(
                 self._coordinator.data
             )
 
@@ -165,9 +168,9 @@ class TickScheduler:
             )
 
         # Learn from current temperature/load for weather correlation
-        if self._coordinator._computation_engine is not None:
+        if self._coordinator.computation_engine is not None:
             self._coordinator.hass.async_create_task(
-                self._coordinator._computation_engine.async_learn_weather_sample(
+                self._coordinator.computation_engine.async_learn_weather_sample(
                     self._coordinator.data
                 ),
                 "localshift_weather_learning",
@@ -185,30 +188,30 @@ class TickScheduler:
         - Forecast history save
         """
         # Refresh temperature forecast from weather entity (Issue #135)
-        if self._coordinator._entity_monitor is not None:
+        if self._coordinator.entity_monitor is not None:
             self._coordinator.hass.async_create_task(
-                self._coordinator._entity_monitor.refresh_weather_forecast(),
+                self._coordinator.entity_monitor.refresh_weather_forecast(),
                 "localshift_weather_forecast",
             )
 
         # Refresh weather forecast
-        if self._coordinator._computation_engine is not None:
+        if self._coordinator.computation_engine is not None:
             self._coordinator.hass.async_create_task(
-                self._coordinator._computation_engine.async_compute_forecast_accuracy(
+                self._coordinator.computation_engine.async_compute_forecast_accuracy(
                     self._coordinator.data
                 ),
                 "localshift_forecast_accuracy",
             )
             # Save forecast history periodically (Issue #131)
             self._coordinator.hass.async_create_task(
-                self._coordinator._computation_engine.async_save_forecast_history(
+                self._coordinator.computation_engine.async_save_forecast_history(
                     self._coordinator.data
                 ),
                 "localshift_save_forecast_history",
             )
             # Save accuracy metrics periodically (Issue #706)
             self._coordinator.hass.async_create_task(
-                self._coordinator._computation_engine.async_save_accuracy_metrics(
+                self._coordinator.computation_engine.async_save_accuracy_metrics(
                     self._coordinator.data
                 ),
                 "localshift_save_accuracy_metrics",
@@ -235,8 +238,8 @@ class TickScheduler:
         self._coordinator.data.battery_charge_cost = 0.0
         self._coordinator.data.target_reached_today = False
 
-        if self._coordinator._learning_orchestrator is not None:
-            self._coordinator._learning_orchestrator.handle_midnight_reset(
+        if self._coordinator.learning_orchestrator is not None:
+            self._coordinator.learning_orchestrator.handle_midnight_reset(
                 self._coordinator.data
             )
 
@@ -264,10 +267,10 @@ class TickScheduler:
 
         Called by handle_daily_summary to send end-of-day notification.
         """
-        if self._coordinator._notification_service is None:
+        if self._coordinator.notification_service is None:
             return
 
-        await self._coordinator._notification_service.send_daily_summary(
+        await self._coordinator.notification_service.send_daily_summary(
             self._coordinator.data
         )
 
@@ -278,14 +281,14 @@ class TickScheduler:
         False otherwise. Used to skip expensive operations during initialization
         when entities may not be populated yet (Issue #551).
         """
-        if self._coordinator._state_machine is None:
+        if self._coordinator.state_machine is None:
             return True
-        return self._coordinator._state_machine._startup_grace_until is not None
+        return self._coordinator.state_machine.startup_grace_until is not None
 
     def _accumulate_costs(self) -> None:
         """Accumulate per-minute energy costs from current power and price."""
-        if self._coordinator._cost_tracker is not None:
-            self._coordinator._cost_tracker.accumulate_costs(self._coordinator.data)
+        if self._coordinator.cost_tracker is not None:
+            self._coordinator.cost_tracker.accumulate_costs(self._coordinator.data)
 
     def _backfill_solar_actual(self) -> None:
         """Backfill actual solar energy for completed 30-min periods.
@@ -308,18 +311,18 @@ class TickScheduler:
         now = dt_util.now()
         current_power = self._coordinator.data.solar_power_kw
 
-        if self._coordinator._last_solar_power_timestamp is None:
-            self._coordinator._last_solar_power_timestamp = now
-            self._coordinator._last_solar_power_kw = current_power
+        if self._last_solar_power_timestamp is None:
+            self._last_solar_power_timestamp = now
+            self._last_solar_power_kw = current_power
             return
 
         time_delta_hours = (
-            now - self._coordinator._last_solar_power_timestamp
+            now - self._last_solar_power_timestamp
         ).total_seconds() / 3600.0
         if time_delta_hours < 0.01:
             return
 
-        avg_power_kw = (self._coordinator._last_solar_power_kw + current_power) / 2.0
+        avg_power_kw = (self._last_solar_power_kw + current_power) / 2.0
         energy_kwh = avg_power_kw * time_delta_hours
 
         if energy_kwh > 0.001 and current_power > 0.01:
@@ -329,5 +332,5 @@ class TickScheduler:
             )
             tracker.backfill_actual(period_start, energy_kwh)
 
-        self._coordinator._last_solar_power_timestamp = now
-        self._coordinator._last_solar_power_kw = current_power
+        self._last_solar_power_timestamp = now
+        self._last_solar_power_kw = current_power

--- a/custom_components/localshift/state/machine.py
+++ b/custom_components/localshift/state/machine.py
@@ -1146,6 +1146,11 @@ class StateMachine:
                 self._commanded_mode, data, mismatch_details
             )
 
+    @property
+    def startup_grace_until(self) -> datetime | None:
+        """Return the startup grace period deadline, if active."""
+        return self._startup_grace_until
+
     def set_startup_grace(self, grace_seconds: int = 30) -> None:
         """Set startup grace period to wait for entities to populate."""
         self._startup_grace_until = dt_util.now() + timedelta(seconds=grace_seconds)

--- a/tests/coordinator/test_coordinator.py
+++ b/tests/coordinator/test_coordinator.py
@@ -382,7 +382,7 @@ class TestHandleMidnightReset:
         coordinator.data.target_reached_today = True
 
         # Mock listeners
-        coordinator._notify_listeners = MagicMock()
+        coordinator.notify_listeners = MagicMock()
 
         now = datetime(2026, 2, 17, 0, 0, 0)
         coordinator._handle_midnight_reset(now)
@@ -401,12 +401,12 @@ class TestHandleMidnightReset:
         coordinator.data = coordinator_data
 
         # Mock listeners
-        coordinator._notify_listeners = MagicMock()
+        coordinator.notify_listeners = MagicMock()
 
         now = datetime(2026, 2, 17, 0, 0, 0)
         coordinator._handle_midnight_reset(now)
 
-        coordinator._notify_listeners.assert_called_once()
+        coordinator.notify_listeners.assert_called_once()
 
 
 # =============================================================================
@@ -432,7 +432,7 @@ class TestEvaluateStateMachine:
         coordinator._state_reader.read_all_external_state = MagicMock()
 
         # Mock notify
-        coordinator._notify_listeners = MagicMock()
+        coordinator.notify_listeners = MagicMock()
 
         await coordinator._evaluate_state_machine()
 
@@ -462,7 +462,7 @@ class TestEvaluateStateMachine:
         coordinator._state_reader.read_all_external_state = MagicMock()
 
         # Mock notify
-        coordinator._notify_listeners = MagicMock()
+        coordinator.notify_listeners = MagicMock()
 
         await coordinator.async_evaluate_state_machine()
 
@@ -582,7 +582,7 @@ class TestListeners:
         coordinator.async_add_listener(callback1)
         coordinator.async_add_listener(callback2)
 
-        coordinator._notify_listeners()
+        coordinator.notify_listeners()
 
         callback1.assert_called_once()
         callback2.assert_called_once()
@@ -919,7 +919,7 @@ class TestFastTickPriceGate:
 
 
 class TestCoordinatorEntityIds:
-    """Tests for entity_ids property and _get_entity_id method."""
+    """Tests for entity_ids property and get_entity_id method."""
 
     def test_entity_ids_property_returns_entry_data(self, mock_hass, mock_entry):
         """Test that entity_ids property returns entry.data."""
@@ -935,31 +935,31 @@ class TestCoordinatorEntityIds:
         assert coordinator.entity_ids["teslemetry_soc"] == "sensor.tesla_soc"
 
     def test_get_entity_id_from_entry_data(self, mock_hass, mock_entry):
-        """Test _get_entity_id retrieves from entry.data."""
+        """Test get_entity_id retrieves from entry.data."""
         coordinator = LocalShiftCoordinator(mock_hass, mock_entry)
 
         # Mock entry data with a key
         mock_entry.data = {"teslemetry_soc": "sensor.tesla_soc"}
 
-        entity_id = coordinator._get_entity_id("teslemetry_soc")
+        entity_id = coordinator.get_entity_id("teslemetry_soc")
         assert entity_id == "sensor.tesla_soc"
 
     def test_get_entity_id_returns_default_when_not_found(self, mock_hass, mock_entry):
-        """Test _get_entity_id returns default when key not found."""
+        """Test get_entity_id returns default when key not found."""
         coordinator = LocalShiftCoordinator(mock_hass, mock_entry)
 
         # Mock entry with no matching key
         mock_entry.data = {}
 
         # Should return default from DEFAULT_ENTITY_IDS
-        entity_id = coordinator._get_entity_id("unknown_key")
+        entity_id = coordinator.get_entity_id("unknown_key")
         # The default might be from DEFAULT_ENTITY_IDS, or empty string
         assert isinstance(entity_id, str)
 
     def test_get_entity_id_notify_service_checks_options_first(
         self, mock_hass, mock_entry
     ):
-        """Test _get_entity_id for notify_service checks options first."""
+        """Test get_entity_id for notify_service checks options first."""
         from custom_components.localshift.const import CONF_NOTIFY_SERVICE
 
         coordinator = LocalShiftCoordinator(mock_hass, mock_entry)
@@ -970,13 +970,13 @@ class TestCoordinatorEntityIds:
         mock_entry.data = {CONF_NOTIFY_SERVICE: "notify.data_notify"}
 
         # Should return from options, not data
-        entity_id = coordinator._get_entity_id(CONF_NOTIFY_SERVICE)
+        entity_id = coordinator.get_entity_id(CONF_NOTIFY_SERVICE)
         assert entity_id == "notify.options_notify"
 
     def test_get_entity_id_notify_service_falls_back_to_data(
         self, mock_hass, mock_entry
     ):
-        """Test _get_entity_id for notify_service falls back to data."""
+        """Test get_entity_id for notify_service falls back to data."""
         from custom_components.localshift.const import CONF_NOTIFY_SERVICE
 
         coordinator = LocalShiftCoordinator(mock_hass, mock_entry)
@@ -987,13 +987,13 @@ class TestCoordinatorEntityIds:
         mock_entry.data = {CONF_NOTIFY_SERVICE: "notify.data_notify"}
 
         # Should return from data
-        entity_id = coordinator._get_entity_id(CONF_NOTIFY_SERVICE)
+        entity_id = coordinator.get_entity_id(CONF_NOTIFY_SERVICE)
         assert entity_id == "notify.data_notify"
 
     def test_get_entity_id_notify_service_returns_empty_when_missing(
         self, mock_hass, mock_entry
     ):
-        """Test _get_entity_id for notify_service returns empty string when missing."""
+        """Test get_entity_id for notify_service returns empty string when missing."""
         from custom_components.localshift.const import CONF_NOTIFY_SERVICE
 
         coordinator = LocalShiftCoordinator(mock_hass, mock_entry)
@@ -1003,7 +1003,7 @@ class TestCoordinatorEntityIds:
         mock_entry.data = {}
 
         # Should return empty string for notify_service
-        entity_id = coordinator._get_entity_id(CONF_NOTIFY_SERVICE)
+        entity_id = coordinator.get_entity_id(CONF_NOTIFY_SERVICE)
         assert entity_id == ""
 
 

--- a/tests/coordinator/test_tick_scheduler.py
+++ b/tests/coordinator/test_tick_scheduler.py
@@ -172,9 +172,9 @@ async def test_handle_slow_tick(coordinator):
     coordinator._entity_monitor.refresh_weather_forecast = AsyncMock()
     coordinator.hass = MagicMock()
     coordinator.hass.async_create_task = MagicMock(
-        side_effect=lambda coro, name=None: coro.close()
-        if hasattr(coro, "close")
-        else None
+        side_effect=lambda coro, name=None: (
+            coro.close() if hasattr(coro, "close") else None
+        )
     )
 
     # Mock backfill method
@@ -203,7 +203,7 @@ async def test_handle_midnight_reset(coordinator):
     coordinator.data.target_reached_today = True
     coordinator._learning_orchestrator = MagicMock()
     coordinator._learning_orchestrator.handle_midnight_reset = MagicMock()
-    coordinator._notify_listeners = MagicMock()
+    coordinator.notify_listeners = MagicMock()
 
     scheduler.handle_midnight_reset(now)
 
@@ -215,7 +215,7 @@ async def test_handle_midnight_reset(coordinator):
     coordinator._learning_orchestrator.handle_midnight_reset.assert_called_once_with(
         coordinator.data
     )
-    coordinator._notify_listeners.assert_called_once()
+    coordinator.notify_listeners.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -227,9 +227,9 @@ async def test_handle_daily_summary(coordinator):
     # Mock dependencies
     coordinator.hass = MagicMock()
     coordinator.hass.async_create_task = MagicMock(
-        side_effect=lambda coro, name=None: coro.close()
-        if hasattr(coro, "close")
-        else None
+        side_effect=lambda coro, name=None: (
+            coro.close() if hasattr(coro, "close") else None
+        )
     )
     coordinator.get_switch_state = MagicMock(return_value=True)
 
@@ -323,9 +323,9 @@ async def test_handle_medium_tick_with_computation_engine(coordinator):
     coordinator._get_entity_id = MagicMock(return_value="sensor.load")
     coordinator.hass = MagicMock()
     coordinator.hass.async_create_task = MagicMock(
-        side_effect=lambda coro, name=None: coro.close()
-        if hasattr(coro, "close")
-        else None
+        side_effect=lambda coro, name=None: (
+            coro.close() if hasattr(coro, "close") else None
+        )
     )
     coordinator.data = MagicMock()
 
@@ -350,9 +350,9 @@ async def test_handle_slow_tick_with_computation_engine(coordinator):
     coordinator._computation_engine.async_save_accuracy_metrics = AsyncMock()
     coordinator.hass = MagicMock()
     coordinator.hass.async_create_task = MagicMock(
-        side_effect=lambda coro, name=None: coro.close()
-        if hasattr(coro, "close")
-        else None
+        side_effect=lambda coro, name=None: (
+            coro.close() if hasattr(coro, "close") else None
+        )
     )
     coordinator.data = MagicMock()
 
@@ -598,7 +598,7 @@ async def test_handle_midnight_reset_no_learning_orchestrator(coordinator):
     coordinator.data.battery_charge_cost = 10.0
     coordinator.data.target_reached_today = True
     coordinator._learning_orchestrator = None
-    coordinator._notify_listeners = MagicMock()
+    coordinator.notify_listeners = MagicMock()
 
     scheduler.handle_midnight_reset(now)
 
@@ -608,7 +608,7 @@ async def test_handle_midnight_reset_no_learning_orchestrator(coordinator):
     assert coordinator.data.battery_savings == 0.0
     assert coordinator.data.battery_charge_cost == 0.0
     assert coordinator.data.target_reached_today is False
-    coordinator._notify_listeners.assert_called_once()
+    coordinator.notify_listeners.assert_called_once()
 
 
 @pytest.mark.asyncio

--- a/tests/coordinator/test_tick_scheduler.py
+++ b/tests/coordinator/test_tick_scheduler.py
@@ -74,7 +74,7 @@ async def test_handle_fast_tick(coordinator):
     coordinator._evaluation_dispatcher.maybe_trigger_on_startup_ready = MagicMock()
     coordinator._evaluation_dispatcher.on_fast_tick = MagicMock()
     coordinator._state_machine = MagicMock()
-    coordinator._state_machine._startup_grace_until = None
+    coordinator._state_machine.startup_grace_until = None
     coordinator.data = MagicMock()
     coordinator.data.automation_ready = True
 
@@ -99,7 +99,7 @@ async def test_handle_fast_tick_startup_grace(coordinator):
     coordinator._evaluation_dispatcher = MagicMock()
     coordinator._evaluation_dispatcher.on_fast_tick = MagicMock()
     coordinator._state_machine = MagicMock()
-    coordinator._state_machine._startup_grace_until = (
+    coordinator._state_machine.startup_grace_until = (
         datetime.now()
     )  # Active grace period
     coordinator.data = MagicMock()
@@ -123,7 +123,7 @@ async def test_handle_medium_tick(coordinator):
     coordinator._entity_monitor.read_all_external_state = MagicMock()
     coordinator._entity_monitor.check_entity_health = MagicMock()
     coordinator._state_machine = MagicMock()
-    coordinator._state_machine._startup_grace_until = None  # No grace period
+    coordinator._state_machine.startup_grace_until = None  # No grace period
     coordinator._learning_orchestrator = MagicMock()
     coordinator._learning_orchestrator.update_medium_tick = MagicMock()
     coordinator.data = MagicMock()
@@ -150,7 +150,7 @@ async def test_handle_medium_tick_startup_grace(coordinator):
     coordinator._entity_monitor.read_all_external_state = MagicMock()
     coordinator._entity_monitor.check_entity_health = MagicMock()
     coordinator._state_machine = MagicMock()
-    coordinator._state_machine._startup_grace_until = (
+    coordinator._state_machine.startup_grace_until = (
         datetime.now()
     )  # Active grace period
 
@@ -265,12 +265,12 @@ async def test_is_in_startup_grace(coordinator):
 
     # Test when state machine has active grace period
     coordinator._state_machine = MagicMock()
-    coordinator._state_machine._startup_grace_until = datetime.now()
+    coordinator._state_machine.startup_grace_until = datetime.now()
 
     assert scheduler._is_in_startup_grace() is True
 
     # Test when state machine grace period expired
-    coordinator._state_machine._startup_grace_until = None
+    coordinator._state_machine.startup_grace_until = None
 
     assert scheduler._is_in_startup_grace() is False
 
@@ -315,12 +315,12 @@ async def test_handle_medium_tick_with_computation_engine(coordinator):
     coordinator._entity_monitor = MagicMock()
     coordinator._entity_monitor.read_all_external_state = MagicMock()
     coordinator._state_machine = MagicMock()
-    coordinator._state_machine._startup_grace_until = None  # No grace period
+    coordinator._state_machine.startup_grace_until = None  # No grace period
     coordinator._computation_engine = MagicMock()
     coordinator._computation_engine.async_get_recent_load_1hr = AsyncMock()
     coordinator._computation_engine.async_get_historical_hourly_averages = AsyncMock()
     coordinator._computation_engine.async_learn_weather_sample = AsyncMock()
-    coordinator._get_entity_id = MagicMock(return_value="sensor.load")
+    coordinator.get_entity_id = MagicMock(return_value="sensor.load")
     coordinator.hass = MagicMock()
     coordinator.hass.async_create_task = MagicMock(
         side_effect=lambda coro, name=None: (
@@ -423,16 +423,16 @@ async def test_backfill_solar_actual_first_call(coordinator):
     # Mock tracker
     coordinator.solar_accuracy_tracker = MagicMock()
     coordinator.solar_accuracy_tracker.backfill_actual = MagicMock()
-    coordinator._last_solar_power_timestamp = None
-    coordinator._last_solar_power_kw = None
+    scheduler._last_solar_power_timestamp = None
+    scheduler._last_solar_power_kw = None
     coordinator.data = MagicMock()
     coordinator.data.solar_power_kw = 5.0
 
     scheduler._backfill_solar_actual()
 
     # Should initialize timestamp and power, but NOT call backfill_actual
-    assert coordinator._last_solar_power_timestamp is not None
-    assert coordinator._last_solar_power_kw == 5.0
+    assert scheduler._last_solar_power_timestamp is not None
+    assert scheduler._last_solar_power_kw == 5.0
     coordinator.solar_accuracy_tracker.backfill_actual.assert_not_called()
 
 
@@ -449,8 +449,8 @@ async def test_backfill_solar_actual_small_time_delta(coordinator):
 
     # Set very recent timestamp (less than 0.01 hours ago)
     now = dt_util.now()
-    coordinator._last_solar_power_timestamp = now - timedelta(seconds=1)
-    coordinator._last_solar_power_kw = 5.0
+    scheduler._last_solar_power_timestamp = now - timedelta(seconds=1)
+    scheduler._last_solar_power_kw = 5.0
     coordinator.data = MagicMock()
     coordinator.data.solar_power_kw = 5.1
 
@@ -473,8 +473,8 @@ async def test_backfill_solar_actual_zero_energy(coordinator):
 
     # Set timestamp 1 hour ago with zero power
     now = dt_util.now()
-    coordinator._last_solar_power_timestamp = now - timedelta(hours=1)
-    coordinator._last_solar_power_kw = 0.0
+    scheduler._last_solar_power_timestamp = now - timedelta(hours=1)
+    scheduler._last_solar_power_kw = 0.0
     coordinator.data = MagicMock()
     coordinator.data.solar_power_kw = 0.0
 
@@ -497,8 +497,8 @@ async def test_backfill_solar_actual_success(coordinator):
 
     # Set timestamp 30 minutes ago with solar power
     now = dt_util.now()
-    coordinator._last_solar_power_timestamp = now - timedelta(minutes=30)
-    coordinator._last_solar_power_kw = 4.0
+    scheduler._last_solar_power_timestamp = now - timedelta(minutes=30)
+    scheduler._last_solar_power_kw = 4.0
     coordinator.data = MagicMock()
     coordinator.data.solar_power_kw = 6.0
 
@@ -511,7 +511,7 @@ async def test_backfill_solar_actual_success(coordinator):
     assert args[1] > 2.0  # Energy should be around 2.5 kWh
 
     # Verify timestamp updated
-    assert coordinator._last_solar_power_kw == 6.0
+    assert scheduler._last_solar_power_kw == 6.0
 
 
 @pytest.mark.asyncio
@@ -525,8 +525,8 @@ async def test_backfill_solar_actual_skips_during_boost(coordinator):
     coordinator.solar_accuracy_tracker.backfill_actual = MagicMock()
 
     now = dt_util.now()
-    coordinator._last_solar_power_timestamp = now - timedelta(minutes=30)
-    coordinator._last_solar_power_kw = 4.0
+    scheduler._last_solar_power_timestamp = now - timedelta(minutes=30)
+    scheduler._last_solar_power_kw = 4.0
     coordinator.data = MagicMock()
     coordinator.data.solar_power_kw = 6.0
     coordinator.data.boost_charge_active = True
@@ -546,7 +546,7 @@ async def test_handle_medium_tick_with_solar_tracker(coordinator):
     coordinator._entity_monitor = MagicMock()
     coordinator._entity_monitor.read_all_external_state = MagicMock()
     coordinator._state_machine = MagicMock()
-    coordinator._state_machine._startup_grace_until = None  # No grace period
+    coordinator._state_machine.startup_grace_until = None  # No grace period
 
     # Mock solar accuracy tracker
     coordinator.solar_accuracy_tracker = MagicMock()
@@ -625,7 +625,7 @@ async def test_handle_fast_tick_no_entity_monitor(coordinator):
     coordinator._evaluation_dispatcher.maybe_trigger_on_startup_ready = MagicMock()
     coordinator._evaluation_dispatcher.on_fast_tick = MagicMock()
     coordinator._state_machine = MagicMock()
-    coordinator._state_machine._startup_grace_until = None  # No grace period
+    coordinator._state_machine.startup_grace_until = None  # No grace period
     coordinator.data = MagicMock()
     coordinator.data.automation_ready = True
 
@@ -646,7 +646,7 @@ async def test_handle_medium_tick_no_entity_monitor(coordinator):
     # Mock dependencies
     coordinator._entity_monitor = None
     coordinator._state_machine = MagicMock()
-    coordinator._state_machine._startup_grace_until = None  # No grace period
+    coordinator._state_machine.startup_grace_until = None  # No grace period
     coordinator._learning_orchestrator = None
     coordinator.data = MagicMock()
 


### PR DESCRIPTION
## Summary
Establishes a clean public API boundary between TickScheduler and the coordinator, eliminating ~42 private attribute accesses across 12 distinct private members.

- Added 7 read-only `@property` methods on coordinator for sub-object access
- Renamed `_get_entity_id` → `get_entity_id` and `_notify_listeners` → `notify_listeners` (public)
- Added `startup_grace_until` public property to StateMachine
- Moved solar tracking state (2 attrs) from coordinator into TickScheduler
- Pure refactoring — zero behavioral changes

## Related Issue
Closes #${ISSUE_NUM}

## Changes
- `coordinator.py`: +7 properties, 2 method renames, removed 2 solar attrs, updated `_is_in_startup_grace()`
- `tick_scheduler.py`: replaced 42 private accesses with public API, solar state ownership
- `state/machine.py`: added `startup_grace_until` property
- `test_tick_scheduler.py`: updated all mocks for public API + moved solar mocking
- `test_coordinator.py`: updated method name references + docstrings

## Testing
- [x] ruff check passes
- [x] 2826 tests pass, 49 skipped
- [x] tick_scheduler.py at 100% coverage
- [x] Zero remaining `self._coordinator._` accesses
- [x] Code reviewed and approved