### PR TITLE
fix: use realistic solar credit in shortfall risk detection

### DIFF
--- a/custom_components/localshift/engine/reason_codes.py
+++ b/custom_components/localshift/engine/reason_codes.py
@@ -2,14 +2,12 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta
-
 from custom_components.localshift.engine.penalties import (
     get_solar_opportunity_penalty_factor,
 )
 from custom_components.localshift.engine.solar import (
+    get_forecast_accuracy,
     projected_solar_soc_gain_pct,
-    projected_solcast_gain_pct,
 )
 from custom_components.localshift.engine.types import (
     NegativeFitAvoidanceContext,
@@ -20,7 +18,6 @@ from custom_components.localshift.engine.types import (
     PlannerReasonCode,
     SlotContext,
 )
-from custom_components.localshift.forecast.analysis_resolver import ConfidenceResolver
 
 
 def classify_reason(
@@ -187,46 +184,27 @@ def _is_target_shortfall_risk(
     terminal_penalty_idx: int | None,
     inputs: OptimizerInputs | None = None,
 ) -> bool:
-    """Check if grid charge is needed for demand window target.
-
-    Incorporates future solar gain from Solcast beyond the horizon (Issue #619).
-    """
+    """Check if grid charge is needed for demand window target."""
     if terminal_penalty_idx is None or slot_idx >= terminal_penalty_idx:
         return False
     soc_deficit = config.demand_window_target_soc_pct - soc
     if soc_deficit <= 0:
         return False
 
-    # 1. Gain from solar within slots
     potential_soc_gain_pct = projected_solar_soc_gain_pct(
         slot_idx=slot_idx,
         slots=slots,
         terminal_penalty_idx=terminal_penalty_idx,
         battery_capacity_kwh=config.battery_capacity_kwh,
+        initial_soc_pct=soc,
+        config=config,
     )
 
-    # 2. Gain from solar beyond horizon (Issue #619)
-    if inputs and inputs.all_solcast:
-        last_slot = slots[-1]
-        last_slot_start = datetime.fromisoformat(last_slot.timestamp_iso)
-        last_slot_end = last_slot_start + timedelta(
-            minutes=last_slot.slot_interval_minutes
-        )
-        target_slot = slots[terminal_penalty_idx]
-        target_time = datetime.fromisoformat(target_slot.timestamp_iso)
-        confidence_resolver = ConfidenceResolver(
-            getattr(inputs, "solcast_analysis_today", None),
-            getattr(inputs, "solcast_analysis_tomorrow", None),
-        )
-
-        future_gain = projected_solcast_gain_pct(
-            inputs.all_solcast,
-            start_time=last_slot_end,
-            end_time=target_time,
-            battery_capacity_kwh=config.battery_capacity_kwh,
-            confidence_resolver=confidence_resolver,
-        )
-        potential_soc_gain_pct += future_gain
+    forecast_accuracy = (
+        get_forecast_accuracy(inputs.solar_accuracy_tracker) if inputs else 1.0
+    )
+    accuracy_discount = max(0.0, min(1.0, forecast_accuracy))
+    potential_soc_gain_pct *= accuracy_discount
 
     return potential_soc_gain_pct < soc_deficit
 

--- a/custom_components/localshift/engine/solar.py
+++ b/custom_components/localshift/engine/solar.py
@@ -73,23 +73,29 @@ def can_solar_reach_target_feasible(
 
 
 def projected_solar_soc_gain_pct(
+    *,
     slot_idx: int,
     slots: list[SlotContext],
     terminal_penalty_idx: int,
     battery_capacity_kwh: float,
+    initial_soc_pct: float,
+    config: OptimizerConfig,
 ) -> float:
-    """
-    Estimate the net SOC gain (%) achievable from solar between slot_idx
-    (inclusive) and terminal_penalty_idx (exclusive), after subtracting
-    household consumption.
-
-    A positive return value means solar surplus exceeds consumption over the
-    window; negative means consumption exceeds solar (net grid draw expected).
-    """
-    projected_net_kwh = sum(
-        s.solar_kwh - s.consumption_kwh for s in slots[slot_idx:terminal_penalty_idx]
+    """Estimate realistic SOC gain (%) from solar before the terminal deadline."""
+    from custom_components.localshift.engine.dp_math import (
+        _simulate_solar_only_terminal_soc,
     )
-    return (projected_net_kwh / battery_capacity_kwh) * 100.0
+
+    if terminal_penalty_idx <= slot_idx:
+        return 0.0
+
+    terminal_soc = _simulate_solar_only_terminal_soc(
+        initial_soc_pct=initial_soc_pct,
+        slots=slots[slot_idx:terminal_penalty_idx],
+        terminal_penalty_idx=terminal_penalty_idx - slot_idx,
+        config=config,
+    )
+    return max(0.0, terminal_soc - initial_soc_pct)
 
 
 def projected_solcast_gain_pct(

--- a/tests/engine/test_reason_codes.py
+++ b/tests/engine/test_reason_codes.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime, timedelta
+from unittest.mock import Mock
+
 import custom_components.localshift.engine.reason_codes as _rc_module
 from custom_components.localshift.engine.reason_codes import (
     _is_blind_to_future_solar,
+    _is_target_shortfall_risk,
     classify_export_reason,
     classify_hold_reason,
     classify_reason,
@@ -234,3 +238,132 @@ class TestIsBlindToFutureSolar:
             inputs=None,
         )
         assert result is True
+
+
+class TestIsTargetShortfallRisk:
+    """Tests for _is_target_shortfall_risk with accuracy discount."""
+
+    def test_shortfall_risk_scales_with_accuracy_discount(self):
+        base = datetime(2026, 3, 20, 10, 0, tzinfo=UTC)
+        slots = [
+            SlotContext(
+                slot_index=i,
+                timestamp_iso=(base + timedelta(minutes=30 * i)).isoformat(),
+                slot_interval_minutes=30,
+                buy_price=0.30,
+                sell_price=0.05,
+                solar_kwh=2.0,
+                consumption_kwh=0.1,
+                is_demand_window_entry=i == 3,
+                is_demand_window_slot=i >= 3,
+            )
+            for i in range(4)
+        ]
+        config = OptimizerConfig(
+            battery_capacity_kwh=13.5,
+            charge_rate_kw=3.3,
+            solar_charge_rate_kw=5.0,
+            discharge_rate_kw=5.0,
+            demand_window_target_soc_pct=80.0,
+            optimization_mode="self_consumption",
+            allow_dw_entry_under_target=False,
+            switching_penalty=0.02,
+            cycle_penalty_per_kwh=0.08,
+            target_shortfall_penalty_per_pct=0.015,
+        )
+
+        tracker_high = Mock()
+        tracker_high.metrics.accuracy = 100
+        inputs_high = OptimizerInputs(
+            cycle_id="test_accuracy_high",
+            initial_soc_pct=60.0,
+            slots=slots,
+            config=config,
+            solar_accuracy_tracker=tracker_high,
+            all_solcast=[],
+        )
+
+        tracker_low = Mock()
+        tracker_low.metrics.accuracy = 10
+        inputs_low = OptimizerInputs(
+            cycle_id="test_accuracy_low",
+            initial_soc_pct=60.0,
+            slots=slots,
+            config=config,
+            solar_accuracy_tracker=tracker_low,
+            all_solcast=[],
+        )
+
+        assert (
+            _is_target_shortfall_risk(
+                slot_idx=0,
+                slots=slots,
+                soc=inputs_high.initial_soc_pct,
+                config=config,
+                terminal_penalty_idx=3,
+                inputs=inputs_high,
+            )
+            is False
+        )
+        assert (
+            _is_target_shortfall_risk(
+                slot_idx=0,
+                slots=slots,
+                soc=inputs_low.initial_soc_pct,
+                config=config,
+                terminal_penalty_idx=3,
+                inputs=inputs_low,
+            )
+            is True
+        )
+
+    def test_shortfall_risk_ignores_beyond_horizon_solcast(self):
+        base = datetime(2026, 3, 20, 10, 0, tzinfo=UTC)
+        slots = [
+            SlotContext(
+                slot_index=i,
+                timestamp_iso=(base + timedelta(minutes=30 * i)).isoformat(),
+                slot_interval_minutes=30,
+                buy_price=0.30,
+                sell_price=0.05,
+                solar_kwh=0.2,
+                consumption_kwh=0.6,
+                is_demand_window_entry=i == 3,
+                is_demand_window_slot=i >= 3,
+            )
+            for i in range(4)
+        ]
+        config = OptimizerConfig(
+            battery_capacity_kwh=13.5,
+            charge_rate_kw=3.3,
+            solar_charge_rate_kw=5.0,
+            discharge_rate_kw=5.0,
+            demand_window_target_soc_pct=80.0,
+            optimization_mode="self_consumption",
+            allow_dw_entry_under_target=False,
+            switching_penalty=0.02,
+            cycle_penalty_per_kwh=0.08,
+            target_shortfall_penalty_per_pct=0.015,
+        )
+
+        tracker = Mock()
+        tracker.metrics.accuracy = 100
+        inputs = OptimizerInputs(
+            cycle_id="test_no_solcast",
+            initial_soc_pct=60.0,
+            slots=slots,
+            config=config,
+            solar_accuracy_tracker=tracker,
+            all_solcast=[],
+        )
+
+        result = _is_target_shortfall_risk(
+            slot_idx=0,
+            slots=slots,
+            soc=inputs.initial_soc_pct,
+            config=config,
+            terminal_penalty_idx=3,
+            inputs=inputs,
+        )
+
+        assert isinstance(result, bool)

--- a/tests/engine/test_solar.py
+++ b/tests/engine/test_solar.py
@@ -1,10 +1,12 @@
 """Tests for solar.py functions."""
 
-import pytest
+
+from datetime import UTC
 
 from custom_components.localshift.engine.solar import (
     can_solar_reach_target,
     can_solar_reach_target_feasible,
+    projected_solar_soc_gain_pct,
 )
 from custom_components.localshift.engine.types import (
     OptimizerConfig,
@@ -390,3 +392,54 @@ class TestCanSolarReachTargetFeasible:
         # Both should return True since can_solar_reach_target_feasible is not affected by the gate
         assert result_with_gate is True
         assert result_without_gate is True
+
+
+class TestProjectedSolarSocGainPct:
+    """Tests for projected_solar_soc_gain_pct with simulation-based calculation."""
+
+    def test_projected_solar_gain_respects_charge_rate_and_efficiency(self):
+        """Simulation caps gain at solar_charge_rate, not at full solar_kwh.
+
+        Even with 6.0 kWh solar in one slot, the gain is capped by
+        solar_charge_rate_kw * slot_hours * efficiency.
+        """
+        from datetime import datetime
+
+        base = datetime(2026, 3, 20, 10, 0, tzinfo=UTC)
+        slots = [
+            SlotContext(
+                slot_index=0,
+                timestamp_iso=base.isoformat(),
+                slot_interval_minutes=30,
+                buy_price=0.30,
+                sell_price=0.05,
+                solar_kwh=6.0,
+                consumption_kwh=0.1,
+                is_demand_window_entry=True,
+                is_demand_window_slot=True,
+            )
+        ]
+        config = OptimizerConfig(
+            battery_capacity_kwh=13.5,
+            charge_rate_kw=5.0,
+            solar_charge_rate_kw=1.0,
+            discharge_rate_kw=5.0,
+            charge_efficiency=0.9,
+            demand_window_target_soc_pct=95.0,
+            optimization_mode="self_consumption",
+            allow_dw_entry_under_target=False,
+            switching_penalty=0.02,
+            cycle_penalty_per_kwh=0.08,
+            target_shortfall_penalty_per_pct=0.015,
+        )
+
+        gain_pct = projected_solar_soc_gain_pct(
+            slot_idx=0,
+            slots=slots,
+            terminal_penalty_idx=1,
+            battery_capacity_kwh=config.battery_capacity_kwh,
+            initial_soc_pct=60.0,
+            config=config,
+        )
+
+        assert gain_pct < 10.0

--- a/tests/engine/test_terminal_cost_accuracy.py
+++ b/tests/engine/test_terminal_cost_accuracy.py
@@ -21,18 +21,12 @@ from custom_components.localshift.forecast.solcast_analysis import (
 )
 
 
-def test_target_shortfall_risk_passes_confidence_resolver(monkeypatch):
-    seen: dict[str, object] = {}
+def test_target_shortfall_risk_uses_forecast_accuracy_discount(monkeypatch):
+    """_is_target_shortfall_risk applies forecast accuracy as a discount multiplier.
 
-    def fake_projected_solcast_gain_pct(*args, confidence_resolver=None, **kwargs):
-        seen["resolver"] = confidence_resolver
-        return 0.0
-
-    monkeypatch.setattr(
-        "custom_components.localshift.engine.reason_codes.projected_solcast_gain_pct",
-        fake_projected_solcast_gain_pct,
-    )
-
+    With low accuracy, the projected solar gain is discounted, making shortfall
+    risk more likely even if solar projection is nominally sufficient.
+    """
     slots = [
         SlotContext(
             slot_index=0,
@@ -40,8 +34,8 @@ def test_target_shortfall_risk_passes_confidence_resolver(monkeypatch):
             slot_interval_minutes=30,
             buy_price=0.10,
             sell_price=0.05,
-            solar_kwh=0.0,
-            consumption_kwh=0.0,
+            solar_kwh=2.0,
+            consumption_kwh=0.1,
             is_demand_window_slot=False,
         ),
         SlotContext(
@@ -50,40 +44,62 @@ def test_target_shortfall_risk_passes_confidence_resolver(monkeypatch):
             slot_interval_minutes=30,
             buy_price=0.10,
             sell_price=0.05,
-            solar_kwh=0.0,
-            consumption_kwh=0.0,
+            solar_kwh=2.0,
+            consumption_kwh=0.1,
             is_demand_window_slot=True,
         ),
     ]
     config = OptimizerConfig(
         demand_window_target_soc_pct=80.0,
         battery_capacity_kwh=13.5,
+        charge_rate_kw=5.0,
+        solar_charge_rate_kw=5.0,
+        discharge_rate_kw=5.0,
+        charge_efficiency=0.9,
+        min_soc_pct=5.0,
     )
-    inputs = OptimizerInputs(
-        cycle_id="resolver-check",
+
+    tracker_high = Mock()
+    tracker_high.metrics.accuracy = 100
+    inputs_high = OptimizerInputs(
+        cycle_id="accuracy-high",
         initial_soc_pct=70.0,
         slots=slots,
         config=config,
-        all_solcast=[
-            {
-                "period_start": "2026-03-20T09:00:00+00:00",
-                "pv_estimate": 4.0,
-            }
-        ],
-        solcast_analysis_today=None,
-        solcast_analysis_tomorrow=None,
+        all_solcast=[],
+        solar_accuracy_tracker=tracker_high,
     )
 
-    _is_target_shortfall_risk(
+    tracker_low = Mock()
+    tracker_low.metrics.accuracy = 30
+    inputs_low = OptimizerInputs(
+        cycle_id="accuracy-low",
+        initial_soc_pct=70.0,
+        slots=slots,
+        config=config,
+        all_solcast=[],
+        solar_accuracy_tracker=tracker_low,
+    )
+
+    result_high = _is_target_shortfall_risk(
         slot_idx=0,
         slots=slots,
         soc=70.0,
         config=config,
         terminal_penalty_idx=1,
-        inputs=inputs,
+        inputs=inputs_high,
+    )
+    result_low = _is_target_shortfall_risk(
+        slot_idx=0,
+        slots=slots,
+        soc=70.0,
+        config=config,
+        terminal_penalty_idx=1,
+        inputs=inputs_low,
     )
 
-    assert seen["resolver"] is not None
+    assert result_high is False
+    assert result_low is True
 
 
 class TestGetForecastAccuracy:

--- a/tests/test_optimizer_dp_solve.py
+++ b/tests/test_optimizer_dp_solve.py
@@ -16,26 +16,8 @@ from custom_components.localshift.engine.constraints import (
     feasible_actions,
 )
 from custom_components.localshift.engine.cost import stage_cost
-from custom_components.localshift.engine.penalties import (
-    get_futile_cycling_penalty_factor,
-)
-from custom_components.localshift.engine.reason_codes import (
-    _is_cheap_import_window,
-    _is_target_shortfall_risk,
-    classify_charge_reason,
-    classify_export_reason,
-    classify_reason,
-)
-from custom_components.localshift.engine.solar import (
-    projected_solar_soc_gain_pct,
-    projected_solcast_gain_pct,
-)
 from custom_components.localshift.engine.negative_fit import (
     derive_negative_fit_avoidance_context,
-)
-from custom_components.localshift.engine.transitions import (
-    transition,
-    _transition_hold_deficit,
 )
 from custom_components.localshift.engine.optimizer_dp import (
     DPPlanner,
@@ -50,6 +32,24 @@ from custom_components.localshift.engine.optimizer_dp import (
     _build_soc_grid,
     _map_soc_to_bin,
     _simulate_max_soc_in_demand_window,
+)
+from custom_components.localshift.engine.penalties import (
+    get_futile_cycling_penalty_factor,
+)
+from custom_components.localshift.engine.reason_codes import (
+    _is_cheap_import_window,
+    _is_target_shortfall_risk,
+    classify_charge_reason,
+    classify_export_reason,
+    classify_reason,
+)
+from custom_components.localshift.engine.solar import (
+    projected_solar_soc_gain_pct,
+    projected_solcast_gain_pct,
+)
+from custom_components.localshift.engine.transitions import (
+    _transition_hold_deficit,
+    transition,
 )
 
 # ---------------------------------------------------------------------------
@@ -1163,52 +1163,96 @@ def test_feasible_actions_gate_not_fired_when_soc_already_at_target():
 
 
 def test_projected_solar_soc_gain_pct_positive_surplus():
-    """_projected_solar_soc_gain_pct returns positive when solar > consumption."""
+    """projected_solar_soc_gain_pct returns positive gain when solar > consumption.
+
+    Simulation caps gain at solar_charge_rate * slot_hours, so actual gain is
+    less than the naive sum would suggest.
+    """
     slots = [
         _make_slot(slot_index=i, solar_kwh=1.0, consumption_kwh=0.3) for i in range(4)
     ]
-    # 4 slots * (1.0 - 0.3) = 2.8 kWh net; 2.8/13.5 * 100 = ~20.7%
+    config = OptimizerConfig(
+        battery_capacity_kwh=13.5,
+        charge_rate_kw=5.0,
+        solar_charge_rate_kw=5.0,
+        discharge_rate_kw=5.0,
+        charge_efficiency=0.9,
+        discharge_efficiency=0.95,
+        min_soc_pct=5.0,
+    )
+    # net=0.7 kWh/slot, solar_charge allows 2.5 kWh/slot, so 0.7 is the cap
+    # 4 slots * 0.7 kWh * 0.9 eff / 13.5 * 100 = ~18.67%
     result = projected_solar_soc_gain_pct(  # noqa: SLF001
         slot_idx=0,
         slots=slots,
         terminal_penalty_idx=4,
         battery_capacity_kwh=13.5,
+        initial_soc_pct=50.0,
+        config=config,
     )
-    assert result == pytest.approx((4 * 0.7 / 13.5) * 100.0, rel=1e-6)
+    assert result == pytest.approx(18.67, rel=0.01)
 
 
-def test_projected_solar_soc_gain_pct_negative_when_consumption_dominates():
-    """_projected_solar_soc_gain_pct returns negative when consumption > solar."""
+def test_projected_solar_soc_gain_pct_zero_when_consumption_dominates():
+    """When consumption dominates, projected solar gain is zero (not negative).
+
+    The function returns max(0, terminal_soc - initial_soc), so any net
+    consumption shortfall results in 0 gain, not negative.
+    """
     slots = [
         _make_slot(slot_index=i, solar_kwh=0.1, consumption_kwh=0.5) for i in range(4)
     ]
+    config = OptimizerConfig(
+        battery_capacity_kwh=13.5,
+        charge_rate_kw=5.0,
+        solar_charge_rate_kw=5.0,
+        discharge_rate_kw=5.0,
+        charge_efficiency=0.9,
+        discharge_efficiency=0.95,
+        min_soc_pct=5.0,
+    )
     result = projected_solar_soc_gain_pct(  # noqa: SLF001
         slot_idx=0,
         slots=slots,
         terminal_penalty_idx=4,
         battery_capacity_kwh=13.5,
+        initial_soc_pct=50.0,
+        config=config,
     )
-    assert result < 0.0
+    assert result == 0.0
 
 
 def test_projected_solar_soc_gain_pct_respects_slot_range():
-    """Only slots in [slot_idx, terminal_penalty_idx) are counted."""
+    """Only slots in [slot_idx, terminal_penalty_idx) are counted.
+
+    Slot 0 (large surplus) is excluded by slot_idx=1. Slots 1-2 have net
+    deficit, so terminal SOC ends below initial → gain is 0.
+    """
     slots = [
         _make_slot(slot_index=0, solar_kwh=3.0, consumption_kwh=0.1),  # large surplus
         _make_slot(slot_index=1, solar_kwh=0.0, consumption_kwh=0.5),  # deficit
         _make_slot(slot_index=2, solar_kwh=0.0, consumption_kwh=0.5),  # deficit
         _make_slot(slot_index=3, solar_kwh=3.0, consumption_kwh=0.1),  # ignored
     ]
-    # Only slots 1–2 (slot_idx=1, terminal=3); both are net deficit
+    config = OptimizerConfig(
+        battery_capacity_kwh=13.5,
+        charge_rate_kw=5.0,
+        solar_charge_rate_kw=5.0,
+        discharge_rate_kw=5.0,
+        charge_efficiency=0.9,
+        discharge_efficiency=0.95,
+        min_soc_pct=5.0,
+    )
+    # slot_idx=1, terminal=3 → slots 1 and 2 (net deficit)
     result = projected_solar_soc_gain_pct(  # noqa: SLF001
         slot_idx=1,
         slots=slots,
         terminal_penalty_idx=3,
         battery_capacity_kwh=13.5,
+        initial_soc_pct=50.0,
+        config=config,
     )
-    # 2 slots * (0.0 - 0.5) = -1.0 kWh; -1.0/13.5*100 = -7.4%
-    assert result < 0.0
-    assert result == pytest.approx((2 * -0.5 / 13.5) * 100.0, rel=1e-6)
+    assert result == 0.0
 
 
 def test_optimizer_does_not_grid_charge_during_solar_peak_with_sufficient_solar():
@@ -2608,7 +2652,7 @@ def test_simulate_max_soc_with_demand_bounds():
 
 def test_projected_solcast_gain_pct():
     """Lines 1672-1689: _projected_solcast_gain_pct with valid solcast data."""
-    from datetime import datetime, timedelta
+    from datetime import datetime
 
     all_solcast = [
         {"period_start": "2026-01-03T10:00:00", "pv_estimate": 4.0},


### PR DESCRIPTION
## Summary

Implements realistic solar credit in shortfall risk detection for issue #800.

**Changes:**
- `projected_solar_soc_gain_pct` now uses simulation-based calculation that respects charge rate/efficiency caps
- Removed beyond-horizon `projected_solcast_gain_pct` call from `_is_target_shortfall_risk`
- Added accuracy discount with 0.0 floor (instead of 0.5)

**Tests:** 2865 tests pass

**Related Issues:** Closes #800, Closes #802