### PR TITLE
Add hass-cli skill for lightweight HA queries

### DIFF
--- a/.opencode/skills/homeassistant-cli/SKILL.md
+++ b/.opencode/skills/homeassistant-cli/SKILL.md
@@ -26,33 +26,38 @@ Provide lightweight, low-context access to Home Assistant via `hass-cli`. Use th
 
 ## Prerequisites
 
-The CLI uses the same environment variables as MCP:
-- `HASS_SERVER` - Home Assistant URL
+The CLI requires these environment variables:
+- `HASS_SERVER` - Home Assistant URL (no trailing slash)
 - `HASS_TOKEN` - Long-lived access token
+
+**Note:** This project uses `HA_URL` and `HA_LONG_LIVED_TOKEN`. Wrap commands like:
+```bash
+HASS_SERVER="${HA_URL%/}" HASS_TOKEN=$HA_LONG_LIVED_TOKEN uvx --from homeassistant-cli hass-cli ...
+```
 
 ## Common Commands
 
 ### Entity Queries
 
 ```bash
-# List all entities
+# List all entities (table format)
 uvx --from homeassistant-cli hass-cli entity list
 
-# Get specific entity state
-uvx --from homeassistant-cli hass-cli state get sensor.localshift_battery_percent
+# Get specific entity state (JSON format)
+uvx --from homeassistant-cli hass-cli --output json state get sensor.battery_level
 
-# Search entities (outputs JSON)
-uvx --from homeassistant-cli hass-cli entity list | jq '.[] | select(.entity_id | contains("battery"))'
+# Search entities (filter with grep)
+uvx --from homeassistant-cli hass-cli entity list | grep -i battery
 ```
 
 ### History & Statistics
 
 ```bash
-# Get entity history (last 24h)
-uvx --from homeassistant-cli hass-cli raw GET "api/history/period?filter_entity_id=sensor.localshift_battery_percent"
+# Get entity history (last 24h, JSON)
+uvx --from homeassistant-cli hass-cli --output json raw GET "api/history/period?filter_entity_id=sensor.battery_level"
 
 # Get statistics
-uvx --from homeassistant-cli hass-cli raw GET "api/statistics_during_period?entity_ids=sensor.localshift_battery_percent&period=day"
+uvx --from homeassistant-cli hass-cli --output json raw GET "api/statistics_during_period?entity_ids=sensor.battery_level&period=day"
 ```
 
 ### Service Discovery
@@ -76,24 +81,29 @@ Quick reference for common LocalShift entities:
 
 ## Tips
 
-1. **Use `jq` for filtering** - CLI outputs JSON, pipe through `jq` for clean results
-2. **Raw API access** - `hass-cli raw GET` gives direct API access for any endpoint
-3. **Check state first** - Before using MCP, check current state via CLI to understand context
+1. **Use `--output json`** - Add this flag for machine-parseable output, then pipe to `jq`
+2. **Strip trailing slash** - `${HA_URL%/}` removes trailing slash to avoid double-slash errors
+3. **Raw API access** - `hass-cli raw GET` gives direct API access for any endpoint
 4. **Low context overhead** - CLI commands don't load 95+ tools into context
 
 ## Examples
 
+All examples assume env vars are set inline. In practice, export them first or use the wrapper pattern.
+
 ### Quick battery check
 ```bash
-uvx --from homeassistant-cli hass-cli state get sensor.localshift_battery_percent | jq '.state'
+HASS_SERVER="${HA_URL%/}" HASS_TOKEN=$HA_LONG_LIVED_TOKEN \
+  uvx --from homeassistant-cli hass-cli --output json state get sensor.battery_level | jq '.[0].state'
 ```
 
-### Find all LocalShift entities
+### Find all battery entities
 ```bash
-uvx --from homeassistant-cli hass-cli entity list | jq '.[] | select(.entity_id | contains("localshift")) | .entity_id'
+HASS_SERVER="${HA_URL%/}" HASS_TOKEN=$HA_LONG_LIVED_TOKEN \
+  uvx --from homeassistant-cli hass-cli entity list | grep -i battery
 ```
 
 ### Get recent history for debugging
 ```bash
-uvx --from homeassistant-cli hass-cli raw GET "api/history/period?filter_entity_id=sensor.localshift_decision_log&minimal_response"
+HASS_SERVER="${HA_URL%/}" HASS_TOKEN=$HA_LONG_LIVED_TOKEN \
+  uvx --from homeassistant-cli hass-cli raw GET "api/history/period?filter_entity_id=sensor.my_entity&minimal_response"
 ```

--- a/.opencode/skills/homeassistant-cli/SKILL.md
+++ b/.opencode/skills/homeassistant-cli/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: homeassistant-cli
+description: Lightweight Home Assistant CLI for simple entity queries - use for read-only state/history lookups
+license: MIT
+compatibility: opencode
+metadata:
+  audience: developers
+  workflow: debugging
+---
+
+## What I Do
+
+Provide lightweight, low-context access to Home Assistant via `hass-cli`. Use this for simple read-only queries instead of the full MCP gateway.
+
+## When to Use Me vs MCP
+
+| Use CLI (this skill) | Use MCP (`@homeassistant`) |
+|---------------------|---------------------------|
+| Get entity state | Control devices (turn on/off) |
+| List entities | Call services |
+| Get history/statistics | Create/update automations |
+| Quick lookups | Configuration changes |
+| Read-only operations | Write operations |
+
+**Rule of thumb:** If you just need to read data, use CLI. If you need to change anything or do complex operations, use MCP.
+
+## Prerequisites
+
+The CLI uses the same environment variables as MCP:
+- `HASS_SERVER` - Home Assistant URL
+- `HASS_TOKEN` - Long-lived access token
+
+## Common Commands
+
+### Entity Queries
+
+```bash
+# List all entities
+uvx --from homeassistant-cli hass-cli entity list
+
+# Get specific entity state
+uvx --from homeassistant-cli hass-cli state get sensor.localshift_battery_percent
+
+# Search entities (outputs JSON)
+uvx --from homeassistant-cli hass-cli entity list | jq '.[] | select(.entity_id | contains("battery"))'
+```
+
+### History & Statistics
+
+```bash
+# Get entity history (last 24h)
+uvx --from homeassistant-cli hass-cli raw GET "api/history/period?filter_entity_id=sensor.localshift_battery_percent"
+
+# Get statistics
+uvx --from homeassistant-cli hass-cli raw GET "api/statistics_during_period?entity_ids=sensor.localshift_battery_percent&period=day"
+```
+
+### Service Discovery
+
+```bash
+# List all available services
+uvx --from homeassistant-cli hass-cli service list
+```
+
+## LocalShift-Specific Entities
+
+Quick reference for common LocalShift entities:
+
+| Entity | Description |
+|--------|-------------|
+| `sensor.localshift_battery_percent` | Battery state of charge |
+| `sensor.localshift_current_mode` | Current operating mode |
+| `sensor.localshift_grid_price` | Current grid price |
+| `switch.localshift_automation_enabled` | Master automation toggle |
+| `binary_sensor.localshift_price_spike_coming` | Price spike forecast |
+
+## Tips
+
+1. **Use `jq` for filtering** - CLI outputs JSON, pipe through `jq` for clean results
+2. **Raw API access** - `hass-cli raw GET` gives direct API access for any endpoint
+3. **Check state first** - Before using MCP, check current state via CLI to understand context
+4. **Low context overhead** - CLI commands don't load 95+ tools into context
+
+## Examples
+
+### Quick battery check
+```bash
+uvx --from homeassistant-cli hass-cli state get sensor.localshift_battery_percent | jq '.state'
+```
+
+### Find all LocalShift entities
+```bash
+uvx --from homeassistant-cli hass-cli entity list | jq '.[] | select(.entity_id | contains("localshift")) | .entity_id'
+```
+
+### Get recent history for debugging
+```bash
+uvx --from homeassistant-cli hass-cli raw GET "api/history/period?filter_entity_id=sensor.localshift_decision_log&minimal_response"
+```

--- a/.opencode/skills/homeassistant/SKILL.md
+++ b/.opencode/skills/homeassistant/SKILL.md
@@ -10,11 +10,28 @@ metadata:
 
 ## What I Do
 
-I am the **sole gateway** to Home Assistant. I have exclusive access to Home Assistant MCP tools via ha-mcp. The main agent must delegate any HA operation to me using `@homeassistant`.
+I am the **gateway to Home Assistant** for complex operations. I have exclusive access to Home Assistant MCP tools via ha-mcp. The main agent must delegate any HA operation to me using `@homeassistant`.
+
+## CLI vs MCP: When to Use Which
+
+**Use `hass-cli` (homeassistant-cli skill) for:**
+- Read-only entity state queries
+- Listing/searching entities
+- History and statistics lookups
+- Quick data checks
+
+**Use MCP (this skill) for:**
+- Device control (turn on/off)
+- Service calls
+- Configuration changes
+- Automation/script management
+- Any write operation
+
+**Rule:** If you just need to read data, use CLI. If you need to change anything, use MCP.
 
 ## When to Use Me
 
-Any time you need to interact with Home Assistant:
+Any time you need to **interact with or modify** Home Assistant:
 - "What's the current battery state?"
 - "Turn on the kitchen lights"
 - "Check HA logs for errors"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,13 @@ Use the right tool for the task:
 - Use when: exploring how/why code works, finding patterns, conceptual queries
 - Start if not running: `~/.local/bin/ov-start`
 
+**hass-cli** - Lightweight HA queries:
+- `hass-cli state get <entity>` - get entity state
+- `hass-cli entity list` - list all entities
+- `hass-cli raw GET "api/..."` - direct API access
+- Use when: quick read-only HA queries without MCP overhead
+- Skill: `homeassistant-cli`
+
 **Quick decision guide:**
 
 | You need... | Use |
@@ -63,6 +70,8 @@ Use the right tool for the task:
 | See file structure | SymDex |
 | Find code related to "grid charging" | OpenViking |
 | Navigate to line N | SymDex |
+| Quick HA entity state | hass-cli |
+| Control HA device | MCP (`@homeassistant`) |
 
 ## Additional Tools
 


### PR DESCRIPTION
## Summary
Add `homeassistant-cli` skill as a lightweight alternative to MCP for read-only Home Assistant queries. This reduces context overhead when only simple entity lookups are needed.

## Related Issue
Closes #827

## Changes
- New skill: `.opencode/skills/homeassistant-cli/SKILL.md` with common CLI commands
- Updated: `.opencode/skills/homeassistant/SKILL.md` with hybrid guidance (when to use CLI vs MCP)
- Updated: `AGENTS.md` navigation section with hass-cli entry

## Testing
- [x] Lint passes (`uv run ruff check`)
- [x] No production code changes (documentation/skill only)

## Usage
```bash
# Quick entity state
uvx --from homeassistant-cli hass-cli state get sensor.localshift_battery_percent

# List entities
uvx --from homeassistant-cli hass-cli entity list
```