### PR TITLE
Replace weather correlation EMA learner with bounded regression

### DIFF
--- a/custom_components/localshift/button.py
+++ b/custom_components/localshift/button.py
@@ -122,6 +122,15 @@ class ResetLearningDataButton(LocalShiftButtonBase):
             tracker._completed_decisions.clear()
             await tracker.async_save()
 
+        computation_engine = getattr(self.coordinator, "_computation_engine", None)
+        weather_correlation = None
+        if computation_engine is not None:
+            engine_dict = getattr(computation_engine, "__dict__", {})
+            if "_weather_correlation" in engine_dict:
+                weather_correlation = engine_dict["_weather_correlation"]
+        if weather_correlation is not None:
+            await weather_correlation.async_reset()
+
         # Reset learning status
         self.coordinator.data.learning_status = "observing"
 

--- a/custom_components/localshift/button.py
+++ b/custom_components/localshift/button.py
@@ -122,12 +122,18 @@ class ResetLearningDataButton(LocalShiftButtonBase):
             tracker._completed_decisions.clear()
             await tracker.async_save()
 
-        computation_engine = getattr(self.coordinator, "_computation_engine", None)
+        coordinator_dict = getattr(self.coordinator, "__dict__", {})
+        computation_engine = coordinator_dict.get("_computation_engine")
         weather_correlation = None
         if computation_engine is not None:
-            engine_dict = getattr(computation_engine, "__dict__", {})
-            if "_weather_correlation" in engine_dict:
-                weather_correlation = engine_dict["_weather_correlation"]
+            if hasattr(type(computation_engine), "weather_correlation"):
+                weather_correlation = getattr(
+                    computation_engine, "weather_correlation", None
+                )
+            if weather_correlation is None:
+                weather_correlation = getattr(
+                    computation_engine, "_weather_correlation", None
+                )
         if weather_correlation is not None:
             await weather_correlation.async_reset()
 

--- a/custom_components/localshift/coordinator/data.py
+++ b/custom_components/localshift/coordinator/data.py
@@ -357,12 +357,9 @@ class CoordinatorData:
     weather_correlation_confidence: str = "low"  # low/medium/high
     weather_adjustment_applied: bool = False  # Whether weather adjustment was used
     weather_learning_enabled: bool = True  # Whether learning is enabled
-    weather_cooling_coefficient: float = (
-        0.0  # Learned kW per °C above cooling threshold
-    )
-    weather_heating_coefficient: float = (
-        0.0  # Learned kW per °C below heating threshold
-    )
+    weather_avg_cooling_slope: float = 0.0  # Average kW per °C above cooling threshold
+    weather_avg_heating_slope: float = 0.0  # Average kW per °C below heating threshold
+    weather_avg_r_squared: float = 0.0  # Average regression fit quality
     weather_sample_count: int = 0  # Number of samples used for learning
     weather_anomaly_weight: float = 1.0  # Issue #681: Weight for rollback evaluation
 

--- a/custom_components/localshift/dashboard.yaml
+++ b/custom_components/localshift/dashboard.yaml
@@ -858,9 +858,11 @@ views:
 
               Total Samples: {{ state_attr('sensor.localshift_forecast_diagnostics', 'weather_sample_count') | default(0) }}
 
-              Cooling Coefficient: {{ state_attr('sensor.localshift_forecast_diagnostics', 'weather_cooling_coefficient') | default(0) }} kW/°C
+              Cooling Slope: {{ state_attr('sensor.localshift_forecast_diagnostics', 'weather_avg_cooling_slope') | default(0) }} kW/°C
 
-              Heating Coefficient: {{ state_attr('sensor.localshift_forecast_diagnostics', 'weather_heating_coefficient') | default(0) }} kW/°C
+              Heating Slope: {{ state_attr('sensor.localshift_forecast_diagnostics', 'weather_avg_heating_slope') | default(0) }} kW/°C
+
+              Average R²: {{ state_attr('sensor.localshift_forecast_diagnostics', 'weather_avg_r_squared') | default(0) }}
 
               Adjustment Applied: {{ state_attr('sensor.localshift_forecast_diagnostics', 'weather_adjustment_applied') | default(false) }}
 

--- a/custom_components/localshift/engine/weather_diagnostics.py
+++ b/custom_components/localshift/engine/weather_diagnostics.py
@@ -37,8 +37,9 @@ class WeatherDiagnosticsEngine:
         if not weather_learning_enabled or weather_correlation is None:
             data.weather_correlation_confidence = "low"
             data.weather_adjustment_applied = False
-            data.weather_cooling_coefficient = 0.0
-            data.weather_heating_coefficient = 0.0
+            data.weather_avg_cooling_slope = 0.0
+            data.weather_avg_heating_slope = 0.0
+            data.weather_avg_r_squared = 0.0
             data.weather_sample_count = 0
             data.weather_anomaly_weight = 1.0
             return
@@ -47,17 +48,14 @@ class WeatherDiagnosticsEngine:
 
         data.weather_correlation_confidence = "low"
         data.weather_sample_count = diagnostics.get("total_samples", 0)
-        data.weather_cooling_coefficient = diagnostics.get(
-            "average_cooling_coefficient", 0.0
-        )
-        data.weather_heating_coefficient = diagnostics.get(
-            "average_heating_coefficient", 0.0
-        )
+        data.weather_avg_cooling_slope = diagnostics.get("average_cooling_slope", 0.0)
+        data.weather_avg_heating_slope = diagnostics.get("average_heating_slope", 0.0)
+        data.weather_avg_r_squared = diagnostics.get("average_r_squared", 0.0)
 
-        hourly_coefs = diagnostics.get("hourly_coefficients", {})
+        hourly_results = diagnostics.get("hourly_regression", {})
         has_medium_confidence = any(
             coef.get("confidence") in ("medium", "high")
-            for coef in hourly_coefs.values()
+            for coef in hourly_results.values()
         )
         if has_medium_confidence:
             data.weather_correlation_confidence = "medium"
@@ -72,9 +70,10 @@ class WeatherDiagnosticsEngine:
             data.weather_anomaly_weight = 1.0
 
         _LOGGER.debug(
-            "Weather diagnostics: samples=%d, cooling=%.4f, heating=%.4f, confidence=%s",
+            "Weather diagnostics: samples=%d, cooling=%.4f, heating=%.4f, r2=%.3f, confidence=%s",
             data.weather_sample_count,
-            data.weather_cooling_coefficient,
-            data.weather_heating_coefficient,
+            data.weather_avg_cooling_slope,
+            data.weather_avg_heating_slope,
+            data.weather_avg_r_squared,
             data.weather_correlation_confidence,
         )

--- a/custom_components/localshift/engine/weather_diagnostics.py
+++ b/custom_components/localshift/engine/weather_diagnostics.py
@@ -53,11 +53,15 @@ class WeatherDiagnosticsEngine:
         data.weather_avg_r_squared = diagnostics.get("average_r_squared", 0.0)
 
         hourly_results = diagnostics.get("hourly_regression", {})
-        has_medium_confidence = any(
-            coef.get("confidence") in ("medium", "high")
-            for coef in hourly_results.values()
+        has_high_confidence = any(
+            coef.get("confidence") == "high" for coef in hourly_results.values()
         )
-        if has_medium_confidence:
+        has_medium_confidence = any(
+            coef.get("confidence") == "medium" for coef in hourly_results.values()
+        )
+        if has_high_confidence:
+            data.weather_correlation_confidence = "high"
+        elif has_medium_confidence:
             data.weather_correlation_confidence = "medium"
 
         # Issue #681: Weather anomaly detection for rollback protection

--- a/custom_components/localshift/forecast/load.py
+++ b/custom_components/localshift/forecast/load.py
@@ -362,6 +362,7 @@ class LoadForecaster:
             "no_coefficients",
             "low_confidence",
             "invalid_hour",
+            "weather_none",
         ):
             self._weather_adjustment_applied = True
             return weather_adjusted, adjustment_source

--- a/custom_components/localshift/learning/anomaly.py
+++ b/custom_components/localshift/learning/anomaly.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+from homeassistant.util import dt as dt_util
+
+# Issue #681: Weather anomaly detection constants
+WEATHER_TEMPERATURE_HISTORY_DAYS = 14  # Days of temperature history to keep
+WEATHER_ANOMALY_MIN_HISTORY_DAYS = 7  # Minimum days needed for anomaly detection
+WEATHER_ANOMALY_SIGMA_THRESHOLD = 2.0  # Standard deviations for anomaly
+WEATHER_ANOMALY_NORMAL_WEIGHT = 1.0  # Weight for normal days
+WEATHER_ANOMALY_ANOMALOUS_WEIGHT = 0.3  # Weight for anomalous days (30%)
+
+
+@dataclass
+class WeatherAnomalyResult:
+    """Result of weather anomaly detection (Issue #681).
+
+    Attributes:
+        is_anomalous: Whether the temperature is anomalous (±2σ from mean)
+        weight: Weight to apply in rollback evaluation (0.3 or 1.0)
+        temperature: The temperature that was evaluated
+        deviation_sigma: How many standard deviations from mean (negative = below)
+        mean_temperature: Mean of historical temperatures
+        std_temperature: Standard deviation of historical temperatures
+
+    """
+
+    is_anomalous: bool
+    weight: float
+    temperature: float
+    deviation_sigma: float
+    mean_temperature: float
+    std_temperature: float
+
+
+class WeatherAnomalyDetector:
+    """Detects anomalous weather based on temperature history."""
+
+    def __init__(self, temperature_history: dict[str, float]) -> None:
+        self._temperature_history = temperature_history
+
+    @property
+    def temperature_history(self) -> dict[str, float]:
+        return self._temperature_history
+
+    def set_temperature_history(self, temperature_history: dict[str, float]) -> None:
+        self._temperature_history = temperature_history
+
+    def record_daily_temperature(
+        self, temperature: float, date_key: str | None = None
+    ) -> None:
+        """Record a daily temperature for anomaly detection (Issue #681).
+
+        Idempotent: recording the same date twice overwrites the previous value.
+        Automatically prunes history to WEATHER_TEMPERATURE_HISTORY_DAYS.
+
+        Args:
+            temperature: Temperature in °C
+            date_key: ISO date string (YYYY-MM-DD), defaults to today
+
+        """
+        resolved_date_key: str
+        if date_key is None:
+            now = dt_util.now()
+            if now is None:
+                return
+            resolved_date_key = now.strftime("%Y-%m-%d")
+        else:
+            resolved_date_key = date_key
+
+        self._temperature_history[resolved_date_key] = temperature
+
+        # Prune to keep only recent days
+        if len(self._temperature_history) > WEATHER_TEMPERATURE_HISTORY_DAYS:
+            sorted_dates = sorted(self._temperature_history.keys())
+            for old_date in sorted_dates[
+                : len(self._temperature_history) - WEATHER_TEMPERATURE_HISTORY_DAYS
+            ]:
+                del self._temperature_history[old_date]
+
+    def detect_weather_anomaly(self, current_temp: float) -> WeatherAnomalyResult:
+        """Detect if current temperature is anomalous (Issue #681).
+
+        Anomalous means ±WEATHER_ANOMALY_SIGMA_THRESHOLD standard deviations
+        from the WEATHER_TEMPERATURE_HISTORY_DAYS moving average.
+
+        Args:
+            current_temp: Current temperature in °C
+
+        Returns:
+            WeatherAnomalyResult with weight for rollback evaluation
+
+        """
+        history = self._temperature_history
+        history_count = len(history)
+
+        # Not enough history for reliable anomaly detection
+        if history_count < WEATHER_ANOMALY_MIN_HISTORY_DAYS:
+            return WeatherAnomalyResult(
+                is_anomalous=False,
+                weight=WEATHER_ANOMALY_NORMAL_WEIGHT,
+                temperature=current_temp,
+                deviation_sigma=0.0,
+                mean_temperature=0.0,
+                std_temperature=0.0,
+            )
+
+        temps = list(history.values())
+        mean_temp = sum(temps) / len(temps)
+
+        # Calculate standard deviation
+        variance = sum((t - mean_temp) ** 2 for t in temps) / len(temps)
+        std_temp = math.sqrt(variance)
+
+        # Handle zero variance (all temperatures identical)
+        if std_temp < 0.01:
+            return WeatherAnomalyResult(
+                is_anomalous=False,
+                weight=WEATHER_ANOMALY_NORMAL_WEIGHT,
+                temperature=current_temp,
+                deviation_sigma=0.0,
+                mean_temperature=mean_temp,
+                std_temperature=std_temp,
+            )
+
+        deviation = (current_temp - mean_temp) / std_temp
+        is_anomalous = abs(deviation) >= WEATHER_ANOMALY_SIGMA_THRESHOLD
+
+        return WeatherAnomalyResult(
+            is_anomalous=is_anomalous,
+            weight=(
+                WEATHER_ANOMALY_ANOMALOUS_WEIGHT
+                if is_anomalous
+                else WEATHER_ANOMALY_NORMAL_WEIGHT
+            ),
+            temperature=current_temp,
+            deviation_sigma=deviation,
+            mean_temperature=mean_temp,
+            std_temperature=std_temp,
+        )

--- a/custom_components/localshift/learning/correlation.py
+++ b/custom_components/localshift/learning/correlation.py
@@ -720,6 +720,8 @@ class WeatherCorrelation:
         """Return today's date key in ISO format."""
         if now is None:
             now = dt_util.now()
+        if now is None:
+            now = datetime.now()
         return now.date().isoformat()
 
     def _get_or_create_daily_snapshot(self, hour: int, date_key: str) -> DailySnapshot:
@@ -736,6 +738,8 @@ class WeatherCorrelation:
         """Prune snapshots older than the 30-day sliding window."""
         if now is None:
             now = dt_util.now()
+        if now is None:
+            now = datetime.now()
         cutoff_date = (now.date() - timedelta(days=SLIDING_WINDOW_DAYS - 1)).isoformat()
         for hour, snapshots in list(self._data.daily_regression_stats.items()):
             kept = [

--- a/custom_components/localshift/learning/correlation.py
+++ b/custom_components/localshift/learning/correlation.py
@@ -72,51 +72,6 @@ MAX_LOAD_MULTIPLIER = 3.0
 SLIDING_WINDOW_DAYS = 30
 
 
-@dataclass
-class HourlyTemperatureCoefficients:
-    """Temperature sensitivity coefficients for a single hour.
-
-    Attributes:
-        base_load_kw: Minimum load at mild temperatures (18-24°C band)
-        cooling_coefficient: Additional kW per degree above cooling threshold
-        heating_coefficient: Additional kW per degree below heating threshold
-        sample_count: Number of data points used for learning
-        last_updated: When coefficients were last recalculated
-        confidence: low/medium/high based on sample count
-
-    """
-
-    base_load_kw: float = 0.0
-    cooling_coefficient: float = 0.0  # kW per °C above cooling threshold
-    heating_coefficient: float = 0.0  # kW per °C below heating threshold
-    sample_count: int = 0
-    last_updated: str = ""  # ISO format datetime
-    confidence: str = "low"
-
-    def to_dict(self) -> dict[str, Any]:
-        """Convert to dictionary for storage."""
-        return {
-            "base_load_kw": self.base_load_kw,
-            "cooling_coefficient": self.cooling_coefficient,
-            "heating_coefficient": self.heating_coefficient,
-            "sample_count": self.sample_count,
-            "last_updated": self.last_updated,
-            "confidence": self.confidence,
-        }
-
-    @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> HourlyTemperatureCoefficients:
-        """Create from dictionary."""
-        return cls(
-            base_load_kw=data.get("base_load_kw", 0.0),
-            cooling_coefficient=data.get("cooling_coefficient", 0.0),
-            heating_coefficient=data.get("heating_coefficient", 0.0),
-            sample_count=data.get("sample_count", 0),
-            last_updated=data.get("last_updated", ""),
-            confidence=data.get("confidence", "low"),
-        )
-
-
 @dataclass(slots=True)
 class ZoneStats:
     """Sufficient statistics for regression fitting."""
@@ -255,7 +210,6 @@ class WeatherCorrelationData:
         weather_entity_id: Configured weather entity
         cooling_threshold: Temperature above which cooling load increases
         heating_threshold: Temperature below which heating load increases
-        hourly_coefficients: Dict mapping hour (0-23) to coefficients
         learning_stats: Aggregated statistics for diagnostics
 
     """
@@ -264,9 +218,6 @@ class WeatherCorrelationData:
     weather_entity_id: str = ""
     cooling_threshold: float = 24.0  # °C
     heating_threshold: float = 18.0  # °C
-    hourly_coefficients: dict[int, HourlyTemperatureCoefficients] = field(
-        default_factory=dict
-    )
     daily_regression_stats: dict[int, list[DailySnapshot]] = field(default_factory=dict)
     learning_stats: dict[str, Any] = field(default_factory=dict)
     temperature_history: dict[str, float] = field(
@@ -302,7 +253,6 @@ class WeatherCorrelationData:
                 weather_entity_id=data.get("weather_entity_id", ""),
                 cooling_threshold=data.get("cooling_threshold", 24.0),
                 heating_threshold=data.get("heating_threshold", 18.0),
-                hourly_coefficients={},
                 daily_regression_stats={},
                 learning_stats=data.get("learning_stats", {}),
                 temperature_history=data.get("temperature_history", {}),
@@ -320,7 +270,6 @@ class WeatherCorrelationData:
             weather_entity_id=data.get("weather_entity_id", ""),
             cooling_threshold=data.get("cooling_threshold", 24.0),
             heating_threshold=data.get("heating_threshold", 18.0),
-            hourly_coefficients={},
             daily_regression_stats=daily_regression_stats,
             learning_stats=data.get("learning_stats", {}),
             temperature_history=data.get("temperature_history", {}),  # Issue #681
@@ -726,7 +675,7 @@ class WeatherCorrelation:
             hour: Hour of day (0-23)
 
         Returns:
-            HourlyTemperatureCoefficients or None if not available
+            HourlyRegressionResult or None if not available
 
         """
         if not (0 <= hour <= 23):
@@ -787,7 +736,7 @@ class WeatherCorrelation:
         """Prune snapshots older than the 30-day sliding window."""
         if now is None:
             now = dt_util.now()
-        cutoff_date = (now.date() - timedelta(days=SLIDING_WINDOW_DAYS)).isoformat()
+        cutoff_date = (now.date() - timedelta(days=SLIDING_WINDOW_DAYS - 1)).isoformat()
         for hour, snapshots in list(self._data.daily_regression_stats.items()):
             kept = [
                 snapshot for snapshot in snapshots if snapshot.date_key >= cutoff_date

--- a/custom_components/localshift/learning/correlation.py
+++ b/custom_components/localshift/learning/correlation.py
@@ -15,7 +15,6 @@ Each hour of the day has its own coefficients to capture daily patterns.
 from __future__ import annotations
 
 import logging
-import math
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from typing import Any
@@ -33,48 +32,44 @@ from ..const import (
     DEFAULT_HEATING_THRESHOLD,
     DOMAIN,
 )
+from .anomaly import (
+    WEATHER_ANOMALY_ANOMALOUS_WEIGHT,
+    WEATHER_ANOMALY_MIN_HISTORY_DAYS,
+    WEATHER_ANOMALY_NORMAL_WEIGHT,
+    WEATHER_ANOMALY_SIGMA_THRESHOLD,
+    WEATHER_TEMPERATURE_HISTORY_DAYS,
+    WeatherAnomalyDetector,
+    WeatherAnomalyResult,
+)
+from .temperature import TemperatureForecast, TemperatureForecastProvider
 
 _LOGGER = logging.getLogger(__name__)
 
+__all__ = [
+    "TemperatureForecast",
+    "WeatherAnomalyResult",
+    "WEATHER_ANOMALY_ANOMALOUS_WEIGHT",
+    "WEATHER_ANOMALY_MIN_HISTORY_DAYS",
+    "WEATHER_ANOMALY_NORMAL_WEIGHT",
+    "WEATHER_ANOMALY_SIGMA_THRESHOLD",
+    "WEATHER_TEMPERATURE_HISTORY_DAYS",
+]
+
 # Storage version for migrations
-STORAGE_VERSION = 1
+STORAGE_VERSION = 2
 STORAGE_KEY = "weather_correlation"
 
-# Confidence thresholds based on sample count
+# Confidence thresholds based on sample count (legacy, retained for compatibility)
 CONFIDENCE_LOW_THRESHOLD = 7  # Less than 7 samples = low confidence
 CONFIDENCE_MEDIUM_THRESHOLD = 30  # 7-30 samples = medium, 30+ = high
 
-# Forecast cache settings
-FORECAST_CACHE_TTL = timedelta(minutes=30)
-
-# Issue #681: Weather anomaly detection constants
-WEATHER_TEMPERATURE_HISTORY_DAYS = 14  # Days of temperature history to keep
-WEATHER_ANOMALY_MIN_HISTORY_DAYS = 7  # Minimum days needed for anomaly detection
-WEATHER_ANOMALY_SIGMA_THRESHOLD = 2.0  # Standard deviations for anomaly
-WEATHER_ANOMALY_NORMAL_WEIGHT = 1.0  # Weight for normal days
-WEATHER_ANOMALY_ANOMALOUS_WEIGHT = 0.3  # Weight for anomalous days (30%)
-
-
-@dataclass
-class WeatherAnomalyResult:
-    """Result of weather anomaly detection (Issue #681).
-
-    Attributes:
-        is_anomalous: Whether the temperature is anomalous (±2σ from mean)
-        weight: Weight to apply in rollback evaluation (0.3 or 1.0)
-        temperature: The temperature that was evaluated
-        deviation_sigma: How many standard deviations from mean (negative = below)
-        mean_temperature: Mean of historical temperatures
-        std_temperature: Standard deviation of historical temperatures
-
-    """
-
-    is_anomalous: bool
-    weight: float
-    temperature: float
-    deviation_sigma: float
-    mean_temperature: float
-    std_temperature: float
+# Regression configuration
+MIN_TEMP_DELTA = 1.0
+MIN_SAMPLES_PER_ZONE = 20
+MIN_R_SQUARED = 0.10
+MAX_SLOPE_KW_PER_DEGREE = 2.0
+MAX_LOAD_MULTIPLIER = 3.0
+SLIDING_WINDOW_DAYS = 30
 
 
 @dataclass
@@ -122,6 +117,135 @@ class HourlyTemperatureCoefficients:
         )
 
 
+@dataclass(slots=True)
+class ZoneStats:
+    """Sufficient statistics for regression fitting."""
+
+    n: int = 0
+    sum_x: float = 0.0
+    sum_y: float = 0.0
+    sum_xx: float = 0.0
+    sum_xy: float = 0.0
+    sum_yy: float = 0.0
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for storage."""
+        return {
+            "n": self.n,
+            "sum_x": self.sum_x,
+            "sum_y": self.sum_y,
+            "sum_xx": self.sum_xx,
+            "sum_xy": self.sum_xy,
+            "sum_yy": self.sum_yy,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ZoneStats:
+        """Create from dictionary."""
+        return cls(
+            n=data.get("n", 0),
+            sum_x=data.get("sum_x", 0.0),
+            sum_y=data.get("sum_y", 0.0),
+            sum_xx=data.get("sum_xx", 0.0),
+            sum_xy=data.get("sum_xy", 0.0),
+            sum_yy=data.get("sum_yy", 0.0),
+        )
+
+
+@dataclass(slots=True)
+class HourlyRegressionData:
+    """Per-hour regression data for daily snapshots."""
+
+    mild: ZoneStats = field(default_factory=ZoneStats)
+    heating: ZoneStats = field(default_factory=ZoneStats)
+    cooling: ZoneStats = field(default_factory=ZoneStats)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for storage."""
+        return {
+            "mild": self.mild.to_dict(),
+            "heating": self.heating.to_dict(),
+            "cooling": self.cooling.to_dict(),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> HourlyRegressionData:
+        """Create from dictionary."""
+        return cls(
+            mild=ZoneStats.from_dict(data.get("mild", {})),
+            heating=ZoneStats.from_dict(data.get("heating", {})),
+            cooling=ZoneStats.from_dict(data.get("cooling", {})),
+        )
+
+
+@dataclass(slots=True)
+class DailySnapshot:
+    """Regression snapshot for a single day."""
+
+    date_key: str
+    data: HourlyRegressionData = field(default_factory=HourlyRegressionData)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for storage."""
+        return {"date_key": self.date_key, "data": self.data.to_dict()}
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> DailySnapshot:
+        """Create from dictionary."""
+        return cls(
+            date_key=data.get("date_key", ""),
+            data=HourlyRegressionData.from_dict(data.get("data", {})),
+        )
+
+
+@dataclass(slots=True)
+class HourlyRegressionResult:
+    """Computed regression results for a single hour."""
+
+    base_load_kw: float = 0.0
+    heating_slope: float = 0.0
+    cooling_slope: float = 0.0
+    r_squared: float = 0.0
+    sample_count: int = 0
+    confidence: str = "low"
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for diagnostics."""
+        return {
+            "base_load_kw": self.base_load_kw,
+            "heating_slope": self.heating_slope,
+            "cooling_slope": self.cooling_slope,
+            "r_squared": self.r_squared,
+            "sample_count": self.sample_count,
+            "confidence": self.confidence,
+        }
+
+
+def _fit_zone_regression(
+    stats: ZoneStats, base_load_kw: float = 0.0
+) -> tuple[float, float]:
+    """Fit a zero-intercept regression for a zone.
+
+    Uses sufficient statistics to compute slope and R^2. The base load is
+    treated as a fixed intercept and removed from the dependent variable.
+    """
+    if stats.n < 2 or stats.sum_xx <= 0:
+        return 0.0, 0.0
+
+    adjusted_sum_xy = stats.sum_xy - base_load_kw * stats.sum_x
+    adjusted_sum_yy = (
+        stats.sum_yy - 2 * base_load_kw * stats.sum_y + stats.n * base_load_kw**2
+    )
+
+    slope = adjusted_sum_xy / stats.sum_xx
+
+    if adjusted_sum_yy <= 0:
+        return slope, 0.0
+
+    r_squared = (adjusted_sum_xy * adjusted_sum_xy) / (stats.sum_xx * adjusted_sum_yy)
+    return slope, r_squared
+
+
 @dataclass
 class WeatherCorrelationData:
     """Complete weather correlation data structure for storage.
@@ -136,13 +260,14 @@ class WeatherCorrelationData:
 
     """
 
-    version: int = 1
+    version: int = STORAGE_VERSION
     weather_entity_id: str = ""
     cooling_threshold: float = 24.0  # °C
     heating_threshold: float = 18.0  # °C
     hourly_coefficients: dict[int, HourlyTemperatureCoefficients] = field(
         default_factory=dict
     )
+    daily_regression_stats: dict[int, list[DailySnapshot]] = field(default_factory=dict)
     learning_stats: dict[str, Any] = field(default_factory=dict)
     temperature_history: dict[str, float] = field(
         default_factory=dict
@@ -155,9 +280,9 @@ class WeatherCorrelationData:
             "weather_entity_id": self.weather_entity_id,
             "cooling_threshold": self.cooling_threshold,
             "heating_threshold": self.heating_threshold,
-            "hourly_coefficients": {
-                str(hour): coef.to_dict()
-                for hour, coef in self.hourly_coefficients.items()
+            "daily_regression_stats": {
+                str(hour): [snapshot.to_dict() for snapshot in snapshots]
+                for hour, snapshots in self.daily_regression_stats.items()
             },
             "learning_stats": self.learning_stats,
             "temperature_history": self.temperature_history,  # Issue #681
@@ -166,38 +291,40 @@ class WeatherCorrelationData:
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> WeatherCorrelationData:
         """Create from dictionary."""
-        hourly_coefficients = {}
-        for hour_str, coef_data in data.get("hourly_coefficients", {}).items():
-            hour = int(hour_str)
-            hourly_coefficients[hour] = HourlyTemperatureCoefficients.from_dict(
-                coef_data
+        version = data.get("version", 1)
+        if version == 1:
+            _LOGGER.info(
+                "Migrating weather correlation storage from v1 to v2; "
+                "discarding hourly coefficients"
+            )
+            return cls(
+                version=STORAGE_VERSION,
+                weather_entity_id=data.get("weather_entity_id", ""),
+                cooling_threshold=data.get("cooling_threshold", 24.0),
+                heating_threshold=data.get("heating_threshold", 18.0),
+                hourly_coefficients={},
+                daily_regression_stats={},
+                learning_stats=data.get("learning_stats", {}),
+                temperature_history=data.get("temperature_history", {}),
             )
 
+        daily_regression_stats: dict[int, list[DailySnapshot]] = {}
+        for hour_str, snapshots in data.get("daily_regression_stats", {}).items():
+            hour = int(hour_str)
+            daily_regression_stats[hour] = [
+                DailySnapshot.from_dict(snapshot) for snapshot in snapshots
+            ]
+
         return cls(
-            version=data.get("version", 1),
+            version=data.get("version", STORAGE_VERSION),
             weather_entity_id=data.get("weather_entity_id", ""),
             cooling_threshold=data.get("cooling_threshold", 24.0),
             heating_threshold=data.get("heating_threshold", 18.0),
-            hourly_coefficients=hourly_coefficients,
+            hourly_coefficients={},
+            daily_regression_stats=daily_regression_stats,
             learning_stats=data.get("learning_stats", {}),
             temperature_history=data.get("temperature_history", {}),  # Issue #681
         )
-
-
-@dataclass
-class TemperatureForecast:
-    """Temperature forecast for a time slot.
-
-    Attributes:
-        slot_time: The datetime this forecast applies to
-        temperature: Forecasted temperature in °C
-        condition: Weather condition (sunny, cloudy, etc.)
-
-    """
-
-    slot_time: datetime
-    temperature: float | None = None
-    condition: str = "unknown"
 
 
 class WeatherCorrelation:
@@ -234,9 +361,10 @@ class WeatherCorrelation:
             tuple[int, float, float]
         ] = []  # (hour, temp, load)
 
-        # Cached temperature forecast (updated periodically)
-        self._cached_forecasts: list[TemperatureForecast] = []
-        self._forecast_cache_time: datetime | None = None
+        self._temperature_provider = TemperatureForecastProvider(
+            hass, entry, self._data.weather_entity_id
+        )
+        self._anomaly_detector = WeatherAnomalyDetector(self._data.temperature_history)
 
     async def async_initialize(self) -> None:
         """Load persisted data from storage."""
@@ -246,10 +374,18 @@ class WeatherCorrelation:
         stored_data = await self._store.async_load()
         if stored_data is not None:
             self._data = WeatherCorrelationData.from_dict(stored_data)
+            total_samples = 0
+            for snapshots in self._data.daily_regression_stats.values():
+                for snapshot in snapshots:
+                    total_samples += (
+                        snapshot.data.mild.n
+                        + snapshot.data.heating.n
+                        + snapshot.data.cooling.n
+                    )
             _LOGGER.info(
-                "Loaded weather correlation data: %d hourly coefficients, %d total samples",
-                len(self._data.hourly_coefficients),
-                sum(c.sample_count for c in self._data.hourly_coefficients.values()),
+                "Loaded weather correlation data: %d hours, %d total samples",
+                len(self._data.daily_regression_stats),
+                total_samples,
             )
         else:
             # Initialize with config values
@@ -266,12 +402,20 @@ class WeatherCorrelation:
             )
             _LOGGER.info("Initialized new weather correlation data")
 
+        self._temperature_provider.set_weather_entity_id(self._data.weather_entity_id)
+        self._anomaly_detector.set_temperature_history(self._data.temperature_history)
+
         self._initialized = True
 
     async def async_save(self) -> None:
         """Persist coefficients to storage."""
         await self._store.async_save(self._data.to_dict())
         _LOGGER.debug("Saved weather correlation data to storage")
+
+    async def async_reset(self) -> None:
+        """Clear regression stats without touching temperature history."""
+        self._data.daily_regression_stats.clear()
+        await self.async_save()
 
     def get_temperature_forecast(self) -> list[TemperatureForecast]:
         """Fetch forecasted temperatures from weather entity.
@@ -280,80 +424,7 @@ class WeatherCorrelation:
             List of TemperatureForecast objects for upcoming hours.
 
         """
-        weather_entity = self._data.weather_entity_id
-        if not weather_entity:
-            _LOGGER.debug("No weather entity configured")
-            return []
-
-        state = self.hass.states.get(weather_entity)
-        if state is None:
-            _LOGGER.warning("Weather entity %s not found", weather_entity)
-            return []
-
-        forecasts: list[TemperatureForecast] = []
-
-        # Get forecast from weather entity attributes
-        # Most weather integrations provide forecast in attributes
-        forecast_data = state.attributes.get("forecast", [])
-        now = dt_util.now()
-
-        _LOGGER.debug(
-            "Forecast data for %s: %d entries, now=%s",
-            weather_entity,
-            len(forecast_data) if forecast_data else 0,
-            now.isoformat(),
-        )
-
-        for forecast_entry in forecast_data:
-            # Parse forecast datetime
-            forecast_time_str = forecast_entry.get("datetime")
-            if not forecast_time_str:
-                continue
-
-            try:
-                forecast_time = dt_util.parse_datetime(forecast_time_str)
-                if forecast_time is None:
-                    continue
-            except (ValueError, TypeError):
-                continue
-
-            # Only include forecasts for the next 24 hours
-            hours_ahead = (forecast_time - now).total_seconds() / 3600
-            if hours_ahead < 0 or hours_ahead > 24:
-                continue
-
-            temperature = forecast_entry.get("temperature")
-            condition = forecast_entry.get("condition", "unknown")
-
-            forecasts.append(
-                TemperatureForecast(
-                    slot_time=forecast_time,
-                    temperature=temperature,
-                    condition=condition,
-                )
-            )
-
-        _LOGGER.debug(
-            "Got %d temperature forecasts from %s (legacy attribute)",
-            len(forecasts),
-            weather_entity,
-        )
-
-        return forecasts
-
-    def _refresh_weather_entity_from_config(self) -> str:
-        """Get the current weather entity from config entry.
-
-        Always reads fresh from config to pick up user changes without
-        requiring a restart. Checks options first (Configure UI), then data.
-
-        Returns:
-            Current weather entity ID from config, or empty string.
-
-        """
-        return self.entry.options.get(CONF_WEATHER_ENTITY, "") or self.entry.data.get(
-            CONF_WEATHER_ENTITY, ""
-        )
+        return self._temperature_provider.get_temperature_forecast()
 
     async def async_get_temperature_forecast(
         self, force_refresh: bool = False
@@ -370,299 +441,11 @@ class WeatherCorrelation:
             List of TemperatureForecast objects for upcoming hours.
 
         """
-        # Always get fresh entity ID from config to pick up user changes
-        weather_entity = self._refresh_weather_entity_from_config()
-        if not weather_entity:
-            _LOGGER.debug("No weather entity configured")
-            return []
-
-        # Update cached entity ID if changed
-        if weather_entity != self._data.weather_entity_id:
-            _LOGGER.info(
-                "Weather entity changed from %s to %s, clearing forecast cache",
-                self._data.weather_entity_id,
-                weather_entity,
-            )
-            self._data.weather_entity_id = weather_entity
-            # Clear cache to force fresh fetch with new entity
-            self._cached_forecasts = []
-            self._forecast_cache_time = None
-
-        now = dt_util.now()
-
-        # Return cached forecasts if still valid
-        if (
-            not force_refresh
-            and self._forecast_cache_time is not None
-            and self._cached_forecasts
-            and (now - self._forecast_cache_time) < FORECAST_CACHE_TTL
-        ):
-            _LOGGER.debug(
-                "Returning %d cached temperature forecasts (age: %s)",
-                len(self._cached_forecasts),
-                now - self._forecast_cache_time,
-            )
-            return self._cached_forecasts
-
-        forecasts: list[TemperatureForecast] = []
-
-        try:
-            response = await self.hass.services.async_call(
-                "weather",
-                "get_forecasts",
-                {"entity_id": weather_entity, "type": "hourly"},
-                blocking=True,
-                return_response=True,
-            )
-
-            _LOGGER.info(
-                "weather.get_forecasts response for %s: %s",
-                weather_entity,
-                "found" if response else "None",
-            )
-
-            if response and weather_entity in response:
-                forecast_data = self._extract_forecast_list(response, weather_entity)
-                if forecast_data:
-                    forecasts = self._parse_forecast_entries(forecast_data, now)
-            else:
-                _LOGGER.debug(
-                    "No response from weather.get_forecasts for entity %s, "
-                    "trying legacy attribute",
-                    weather_entity,
-                )
-
-        except Exception as e:
-            _LOGGER.debug(
-                "Failed to fetch forecasts via weather.get_forecasts service: %s, "
-                "falling back to legacy attribute",
-                e,
-            )
-
-        if not forecasts:
-            forecasts = self.get_temperature_forecast()
-
-        self._cached_forecasts = forecasts
-        self._forecast_cache_time = now
-
+        forecasts = await self._temperature_provider.async_get_temperature_forecast(
+            force_refresh=force_refresh
+        )
+        self._data.weather_entity_id = self._temperature_provider.weather_entity_id
         return forecasts
-
-    def _extract_forecast_list(
-        self, response: dict, weather_entity: str
-    ) -> list | None:
-        """Extract forecast list from API response.
-
-        Args:
-            response: Service call response dictionary
-            weather_entity: Weather entity ID
-
-        Returns:
-            List of forecast entries or None
-
-        """
-        forecast_data = response.get(weather_entity)
-        if forecast_data is None:
-            return None
-
-        _LOGGER.info(
-            "forecast_data type=%s, len=%s, keys=%s",
-            type(forecast_data).__name__,
-            len(forecast_data) if isinstance(forecast_data, list) else "N/A",
-            list(forecast_data.keys()) if isinstance(forecast_data, dict) else "N/A",
-        )
-
-        if isinstance(forecast_data, dict):
-            _LOGGER.info("forecast_data is dict, checking for forecast/hourly keys")
-            if "forecast" in forecast_data:
-                forecast_data = forecast_data["forecast"]
-                _LOGGER.info(
-                    "Found 'forecast' key with %d entries",
-                    len(forecast_data) if isinstance(forecast_data, list) else 0,
-                )
-            elif "hourly" in forecast_data:
-                forecast_data = forecast_data["hourly"]
-                _LOGGER.info(
-                    "Found 'hourly' key with %d entries",
-                    len(forecast_data) if isinstance(forecast_data, list) else 0,
-                )
-
-        if isinstance(forecast_data, list):
-            return forecast_data
-
-        _LOGGER.debug(
-            "Unexpected forecast_data format: %s",
-            type(forecast_data).__name__,
-        )
-        return None
-
-    def _parse_forecast_entries(
-        self, forecast_data: list, now: datetime
-    ) -> list[TemperatureForecast]:
-        """Parse forecast entries into TemperatureForecast objects.
-
-        Args:
-            forecast_data: List of forecast entry dictionaries
-            now: Current datetime for filtering
-
-        Returns:
-            List of TemperatureForecast objects
-
-        """
-        forecasts: list[TemperatureForecast] = []
-        parse_failed_count = 0
-        skipped_no_datetime = 0
-        filtered_count = 0
-
-        _LOGGER.info(
-            "Processing %d forecast entries, first entry keys: %s",
-            len(forecast_data),
-            list(forecast_data[0].keys())
-            if forecast_data and isinstance(forecast_data[0], dict)
-            else "empty",
-        )
-
-        for i, forecast_entry in enumerate(forecast_data):
-            result = self._parse_single_forecast_entry(
-                forecast_entry,
-                now,
-                i,
-                parse_failed_count,
-                skipped_no_datetime,
-                filtered_count,
-            )
-            if result is None:
-                continue
-            forecast, parse_failed_count, skipped_no_datetime, filtered_count = result
-            if forecast:
-                forecasts.append(forecast)
-
-        _LOGGER.info(
-            "Fetched %d temperature forecasts via weather.get_forecasts service",
-            len(forecasts),
-        )
-        return forecasts
-
-    def _parse_single_forecast_entry(
-        self,
-        entry: dict,
-        now: datetime,
-        index: int,
-        parse_failed_count: int,
-        skipped_no_datetime: int,
-        filtered_count: int,
-    ) -> tuple[TemperatureForecast | None, int, int, int] | None:
-        """Parse a single forecast entry.
-
-        Args:
-            entry: Forecast entry dictionary
-            now: Current datetime for filtering
-            index: Entry index for logging
-            parse_failed_count: Running count of parse failures
-            skipped_no_datetime: Running count of entries skipped for missing datetime
-            filtered_count: Running count of filtered entries
-
-        Returns:
-            Tuple of (forecast or None, updated counts) or None if entry invalid
-
-        """
-        if not isinstance(entry, dict):
-            return None
-
-        forecast_time_str = entry.get("datetime")
-        if not forecast_time_str:
-            skipped_no_datetime += 1
-            if skipped_no_datetime <= 2:
-                _LOGGER.info(
-                    "Entry missing 'datetime', keys: %s",
-                    list(entry.keys()),
-                )
-            return (None, parse_failed_count, skipped_no_datetime, filtered_count)
-
-        forecast_time = self._parse_forecast_datetime(
-            forecast_time_str, index, parse_failed_count
-        )
-        if forecast_time is None:
-            parse_failed_count += 1
-            return (None, parse_failed_count, skipped_no_datetime, filtered_count)
-
-        hours_ahead = (forecast_time - now).total_seconds() / 3600
-        if hours_ahead < 0 or hours_ahead > 24:
-            filtered_count += 1
-            if filtered_count <= 3:
-                _LOGGER.info(
-                    "Filtering out forecast: time=%s, now=%s, hours_ahead=%.1f",
-                    forecast_time.isoformat(),
-                    now.isoformat(),
-                    hours_ahead,
-                )
-            return (None, parse_failed_count, skipped_no_datetime, filtered_count)
-
-        temperature = entry.get("temperature")
-        condition = entry.get("condition", "unknown")
-
-        forecast = TemperatureForecast(
-            slot_time=forecast_time,
-            temperature=temperature,
-            condition=condition,
-        )
-        return (forecast, parse_failed_count, skipped_no_datetime, filtered_count)
-
-    def _parse_forecast_datetime(
-        self, time_str: str, index: int, parse_failed_count: int
-    ) -> datetime | None:
-        """Parse forecast datetime string.
-
-        Args:
-            time_str: Datetime string to parse
-            index: Entry index for logging
-            parse_failed_count: Current parse failure count
-
-        Returns:
-            Parsed datetime or None if parsing failed
-
-        """
-        try:
-            from datetime import datetime as dt
-
-            forecast_time = dt_util.parse_datetime(time_str)
-            if forecast_time is None:
-                try:
-                    naive_dt = dt.fromisoformat(time_str)
-                    forecast_time = dt_util.as_local(naive_dt)
-                    if index == 0:
-                        _LOGGER.info(
-                            "First entry: datetime='%s' parsed as naive=%s, localized=%s",
-                            time_str,
-                            naive_dt,
-                            forecast_time,
-                        )
-                except (ValueError, TypeError) as e:
-                    if parse_failed_count < 3:
-                        _LOGGER.info(
-                            "Failed to parse datetime '%s': %s",
-                            time_str,
-                            e,
-                        )
-                    return None
-            else:
-                if forecast_time.tzinfo is None:
-                    forecast_time = dt_util.as_local(forecast_time)
-                if index == 0:
-                    _LOGGER.info(
-                        "First entry: datetime='%s' parsed as %s (tzinfo=%s)",
-                        time_str,
-                        forecast_time,
-                        forecast_time.tzinfo,
-                    )
-            return forecast_time
-        except (ValueError, TypeError) as e:
-            if parse_failed_count < 3:
-                _LOGGER.info(
-                    "Exception parsing datetime '%s': %s",
-                    time_str,
-                    e,
-                )
-            return None
 
     def get_current_temperature(self) -> float | None:
         """Get current temperature from weather entity.
@@ -671,26 +454,14 @@ class WeatherCorrelation:
             Current temperature in °C, or None if unavailable.
 
         """
-        weather_entity = self._data.weather_entity_id
-        if not weather_entity:
-            return None
-
-        state = self.hass.states.get(weather_entity)
-        if state is None:
-            return None
-
-        try:
-            return float(state.attributes.get("temperature", 0))
-        except (ValueError, TypeError):
-            return None
+        return self._temperature_provider.get_current_temperature()
 
     def learn_from_sample(
         self, hour: int, temperature: float, actual_load_kw: float
     ) -> None:
         """Update coefficients based on observed temperature/load pair.
 
-        This implements an incremental learning algorithm that updates
-        coefficients using a simple moving average approach.
+        This implements a sliding-window regression based on sufficient statistics.
 
         Args:
             hour: Hour of day (0-23)
@@ -702,95 +473,34 @@ class WeatherCorrelation:
             _LOGGER.warning("Invalid hour %d, must be 0-23", hour)
             return
 
-        if hour not in self._data.hourly_coefficients:
-            self._data.hourly_coefficients[hour] = HourlyTemperatureCoefficients()
-
-        coef = self._data.hourly_coefficients[hour]
+        date_key = self._today_key()
+        snapshot = self._get_or_create_daily_snapshot(hour, date_key)
         cooling_threshold = self._data.cooling_threshold
         heating_threshold = self._data.heating_threshold
 
         if temperature > cooling_threshold:
-            self._update_cooling_coefficient(
-                coef, temperature, actual_load_kw, cooling_threshold
-            )
+            temp_delta = temperature - cooling_threshold
+            if temp_delta >= MIN_TEMP_DELTA:
+                self._update_zone_stats(
+                    snapshot.data.cooling, temp_delta, actual_load_kw
+                )
         elif temperature < heating_threshold:
-            self._update_heating_coefficient(
-                coef, temperature, actual_load_kw, heating_threshold
-            )
+            temp_delta = heating_threshold - temperature
+            if temp_delta >= MIN_TEMP_DELTA:
+                self._update_zone_stats(
+                    snapshot.data.heating, temp_delta, actual_load_kw
+                )
         else:
-            self._update_mild_temperature_base_load(coef, actual_load_kw)
+            self._update_zone_stats(snapshot.data.mild, 0.0, actual_load_kw)
 
-        coef.sample_count += 1
-        coef.last_updated = dt_util.now().isoformat()
-        coef.confidence = self._calculate_confidence(coef.sample_count)
+        self._prune_daily_snapshots()
 
         _LOGGER.debug(
-            "Learned sample for hour %d: temp=%.1f°C, load=%.2fkW, "
-            "base=%.2f, cooling=%.3f, heating=%.3f, samples=%d, confidence=%s",
+            "Learned sample for hour %d: temp=%.1f°C, load=%.2fkW",
             hour,
             temperature,
             actual_load_kw,
-            coef.base_load_kw,
-            coef.cooling_coefficient,
-            coef.heating_coefficient,
-            coef.sample_count,
-            coef.confidence,
         )
-
-    def _update_cooling_coefficient(
-        self,
-        coef: HourlyTemperatureCoefficients,
-        temperature: float,
-        actual_load_kw: float,
-        cooling_threshold: float,
-    ) -> None:
-        """Update cooling coefficient for above-threshold temperatures."""
-        temp_delta = temperature - cooling_threshold
-        if temp_delta <= 0:
-            return
-        if coef.base_load_kw > 0:
-            implied = (actual_load_kw - coef.base_load_kw) / temp_delta
-            if coef.cooling_coefficient == 0:
-                coef.cooling_coefficient = implied
-            else:
-                coef.cooling_coefficient = (
-                    0.1 * implied + 0.9 * coef.cooling_coefficient
-                )
-        else:
-            coef.base_load_kw = actual_load_kw * 0.8
-
-    def _update_heating_coefficient(
-        self,
-        coef: HourlyTemperatureCoefficients,
-        temperature: float,
-        actual_load_kw: float,
-        heating_threshold: float,
-    ) -> None:
-        """Update heating coefficient for below-threshold temperatures."""
-        temp_delta = heating_threshold - temperature
-        if temp_delta <= 0:
-            return
-        if coef.base_load_kw > 0:
-            implied = (actual_load_kw - coef.base_load_kw) / temp_delta
-            if coef.heating_coefficient == 0:
-                coef.heating_coefficient = implied
-            else:
-                coef.heating_coefficient = (
-                    0.1 * implied + 0.9 * coef.heating_coefficient
-                )
-        else:
-            coef.base_load_kw = actual_load_kw * 0.8
-
-    def _update_mild_temperature_base_load(
-        self,
-        coef: HourlyTemperatureCoefficients,
-        actual_load_kw: float,
-    ) -> None:
-        """Update base load estimate for mild temperatures."""
-        if coef.base_load_kw == 0:
-            coef.base_load_kw = actual_load_kw
-        else:
-            coef.base_load_kw = 0.1 * actual_load_kw + 0.9 * coef.base_load_kw
 
     def predict_load(
         self, hour: int, temperature: float, base_load_kw: float
@@ -809,53 +519,48 @@ class WeatherCorrelation:
         if not (0 <= hour <= 23):
             return base_load_kw, "invalid_hour"
 
-        if hour not in self._data.hourly_coefficients:
-            # No learned data for this hour
+        aggregated = self._aggregate_hourly_stats(hour)
+        if aggregated is None:
             return base_load_kw, "no_coefficients"
 
-        coef = self._data.hourly_coefficients[hour]
-
-        # Only apply adjustment if we have sufficient confidence
-        if coef.confidence == "low":
-            return base_load_kw, "low_confidence"
+        base_load = self._average_mild_load(aggregated.mild)
+        if base_load <= 0:
+            base_load = base_load_kw
 
         cooling_threshold = self._data.cooling_threshold
         heating_threshold = self._data.heating_threshold
 
-        # Start with the learned base load or fall back to provided base
-        predicted_load = coef.base_load_kw if coef.base_load_kw > 0 else base_load_kw
-
-        adjustment = 0.0
-        adjustment_type = "none"
-
-        if temperature > cooling_threshold and coef.cooling_coefficient > 0:
-            # Apply cooling adjustment
+        if temperature > cooling_threshold:
             temp_delta = temperature - cooling_threshold
-            adjustment = coef.cooling_coefficient * temp_delta
-            adjustment_type = "cooling"
+            if temp_delta < MIN_TEMP_DELTA:
+                return base_load_kw, "weather_none"
+            slope, r_squared = _fit_zone_regression(aggregated.cooling, base_load)
+            slope = min(max(slope, 0.0), MAX_SLOPE_KW_PER_DEGREE)
+            if aggregated.cooling.n < MIN_SAMPLES_PER_ZONE or r_squared < MIN_R_SQUARED:
+                return base_load_kw, "low_confidence"
+            predicted_load = base_load_kw + slope * temp_delta
+            cap = max(base_load_kw, 0.1) * MAX_LOAD_MULTIPLIER
+            predicted_load = min(predicted_load, cap)
+            return max(0.0, predicted_load), "weather_cooling"
 
-        elif temperature < heating_threshold and coef.heating_coefficient > 0:
-            # Apply heating adjustment
+        if temperature < heating_threshold:
             temp_delta = heating_threshold - temperature
-            adjustment = coef.heating_coefficient * temp_delta
-            adjustment_type = "heating"
+            if temp_delta < MIN_TEMP_DELTA:
+                return base_load_kw, "weather_none"
+            slope, r_squared = _fit_zone_regression(aggregated.heating, base_load)
+            slope = min(max(slope, 0.0), MAX_SLOPE_KW_PER_DEGREE)
+            if aggregated.heating.n < MIN_SAMPLES_PER_ZONE or r_squared < MIN_R_SQUARED:
+                return base_load_kw, "low_confidence"
+            predicted_load = base_load_kw + slope * temp_delta
+            cap = max(base_load_kw, 0.1) * MAX_LOAD_MULTIPLIER
+            predicted_load = min(predicted_load, cap)
+            return max(0.0, predicted_load), "weather_heating"
 
-        predicted_load += adjustment
+        return base_load_kw, "weather_none"
 
-        _LOGGER.debug(
-            "Predicted load for hour %d: temp=%.1f°C, base=%.2fkW, "
-            "adjustment=%.2fkW (%s), total=%.2fkW",
-            hour,
-            temperature,
-            base_load_kw,
-            adjustment,
-            adjustment_type,
-            predicted_load,
-        )
-
-        return round(predicted_load, 3), f"weather_{adjustment_type}"
-
-    def _calculate_confidence(self, sample_count: int) -> str:
+    def _calculate_confidence(
+        self, sample_count: int, r_squared: float | None = None
+    ) -> str:
         """Calculate confidence level based on sample count.
 
         Args:
@@ -865,12 +570,91 @@ class WeatherCorrelation:
             Confidence level: "low", "medium", or "high"
 
         """
-        if sample_count < CONFIDENCE_LOW_THRESHOLD:
+        if sample_count < MIN_SAMPLES_PER_ZONE:
             return "low"
-        elif sample_count < CONFIDENCE_MEDIUM_THRESHOLD:
+        if r_squared is not None and r_squared < MIN_R_SQUARED:
+            return "low"
+        if sample_count < CONFIDENCE_MEDIUM_THRESHOLD:
             return "medium"
         else:
             return "high"
+
+    @staticmethod
+    def _update_zone_stats(stats: ZoneStats, x_value: float, y_value: float) -> None:
+        stats.n += 1
+        stats.sum_x += x_value
+        stats.sum_y += y_value
+        stats.sum_xx += x_value * x_value
+        stats.sum_xy += x_value * y_value
+        stats.sum_yy += y_value * y_value
+
+    @staticmethod
+    def _merge_zone_stats(target: ZoneStats, source: ZoneStats) -> None:
+        target.n += source.n
+        target.sum_x += source.sum_x
+        target.sum_y += source.sum_y
+        target.sum_xx += source.sum_xx
+        target.sum_xy += source.sum_xy
+        target.sum_yy += source.sum_yy
+
+    def _aggregate_hourly_stats(self, hour: int) -> HourlyRegressionData | None:
+        snapshots = self._data.daily_regression_stats.get(hour)
+        if not snapshots:
+            return None
+        aggregated = HourlyRegressionData()
+        for snapshot in snapshots:
+            self._merge_zone_stats(aggregated.mild, snapshot.data.mild)
+            self._merge_zone_stats(aggregated.heating, snapshot.data.heating)
+            self._merge_zone_stats(aggregated.cooling, snapshot.data.cooling)
+        return aggregated
+
+    @staticmethod
+    def _average_mild_load(stats: ZoneStats) -> float:
+        if stats.n <= 0:
+            return 0.0
+        return stats.sum_y / stats.n
+
+    def _build_hourly_result(
+        self, aggregated: HourlyRegressionData
+    ) -> HourlyRegressionResult:
+        base_load = self._average_mild_load(aggregated.mild)
+        heating_slope, heating_r2 = _fit_zone_regression(aggregated.heating, base_load)
+        cooling_slope, cooling_r2 = _fit_zone_regression(aggregated.cooling, base_load)
+
+        heating_slope = min(max(heating_slope, 0.0), MAX_SLOPE_KW_PER_DEGREE)
+        cooling_slope = min(max(cooling_slope, 0.0), MAX_SLOPE_KW_PER_DEGREE)
+
+        heating_conf = self._calculate_confidence(aggregated.heating.n, heating_r2)
+        cooling_conf = self._calculate_confidence(aggregated.cooling.n, cooling_r2)
+
+        confidence = "low"
+        if "high" in (heating_conf, cooling_conf):
+            confidence = "high"
+        elif "medium" in (heating_conf, cooling_conf):
+            confidence = "medium"
+
+        r_squared_values = [
+            value
+            for value, count in (
+                (heating_r2, aggregated.heating.n),
+                (cooling_r2, aggregated.cooling.n),
+            )
+            if count >= MIN_SAMPLES_PER_ZONE
+        ]
+        r_squared = 0.0
+        if r_squared_values:
+            r_squared = sum(r_squared_values) / len(r_squared_values)
+
+        sample_count = aggregated.mild.n + aggregated.heating.n + aggregated.cooling.n
+
+        return HourlyRegressionResult(
+            base_load_kw=base_load,
+            heating_slope=heating_slope,
+            cooling_slope=cooling_slope,
+            r_squared=r_squared,
+            sample_count=sample_count,
+            confidence=confidence,
+        )
 
     def get_diagnostics(self) -> dict[str, Any]:
         """Return learning statistics for diagnostics.
@@ -879,54 +663,63 @@ class WeatherCorrelation:
             Dictionary with learning stats and coefficient summaries.
 
         """
-        total_samples = sum(
-            c.sample_count for c in self._data.hourly_coefficients.values()
-        )
-
-        # Calculate average coefficients
+        total_samples = 0
         avg_cooling = 0.0
         avg_heating = 0.0
-        avg_base = 0.0
+        avg_r_squared = 0.0
         cooling_count = 0
         heating_count = 0
+        r_squared_count = 0
 
-        for coef in self._data.hourly_coefficients.values():
-            if coef.cooling_coefficient > 0:
-                avg_cooling += coef.cooling_coefficient
+        hourly_results: dict[int, HourlyRegressionResult] = {}
+        for hour in sorted(self._data.daily_regression_stats.keys()):
+            aggregated = self._aggregate_hourly_stats(hour)
+            if aggregated is None:
+                continue
+            result = self._build_hourly_result(aggregated)
+            hourly_results[hour] = result
+            total_samples += result.sample_count
+
+            if result.cooling_slope > 0:
+                avg_cooling += result.cooling_slope
                 cooling_count += 1
-            if coef.heating_coefficient > 0:
-                avg_heating += coef.heating_coefficient
+            if result.heating_slope > 0:
+                avg_heating += result.heating_slope
                 heating_count += 1
-            avg_base += coef.base_load_kw
+            if result.r_squared > 0:
+                avg_r_squared += result.r_squared
+                r_squared_count += 1
 
-        num_hours = len(self._data.hourly_coefficients)
-        if num_hours > 0:
-            avg_base /= num_hours
         if cooling_count > 0:
             avg_cooling /= cooling_count
         if heating_count > 0:
             avg_heating /= heating_count
+        if r_squared_count > 0:
+            avg_r_squared /= r_squared_count
+
+        avg_base = 0.0
+        if hourly_results:
+            avg_base = sum(result.base_load_kw for result in hourly_results.values())
+            avg_base /= len(hourly_results)
 
         return {
             "weather_entity_id": self._data.weather_entity_id,
             "cooling_threshold": self._data.cooling_threshold,
             "heating_threshold": self._data.heating_threshold,
             "total_samples": total_samples,
-            "hours_with_data": num_hours,
+            "hours_with_data": len(hourly_results),
             "average_base_load_kw": round(avg_base, 3),
-            "average_cooling_coefficient": round(avg_cooling, 4),
-            "average_heating_coefficient": round(avg_heating, 4),
+            "average_cooling_slope": round(avg_cooling, 4),
+            "average_heating_slope": round(avg_heating, 4),
+            "average_r_squared": round(avg_r_squared, 4),
             "cooling_hours": cooling_count,
             "heating_hours": heating_count,
-            "hourly_coefficients": {
-                hour: coef.to_dict()
-                for hour, coef in sorted(self._data.hourly_coefficients.items())
+            "hourly_regression": {
+                hour: result.to_dict() for hour, result in hourly_results.items()
             },
         }
 
-    def get_coefficients_for_hour(
-        self, hour: int
-    ) -> HourlyTemperatureCoefficients | None:
+    def get_coefficients_for_hour(self, hour: int) -> HourlyRegressionResult | None:
         """Get coefficients for a specific hour.
 
         Args:
@@ -936,7 +729,12 @@ class WeatherCorrelation:
             HourlyTemperatureCoefficients or None if not available
 
         """
-        return self._data.hourly_coefficients.get(hour)
+        if not (0 <= hour <= 23):
+            return None
+        aggregated = self._aggregate_hourly_stats(hour)
+        if aggregated is None:
+            return None
+        return self._build_hourly_result(aggregated)
 
     def record_daily_temperature(
         self, temperature: float, date_key: str | None = None
@@ -951,24 +749,7 @@ class WeatherCorrelation:
             date_key: ISO date string (YYYY-MM-DD), defaults to today
 
         """
-        resolved_date_key: str
-        if date_key is None:
-            now = dt_util.now()
-            if now is None:
-                return
-            resolved_date_key = now.strftime("%Y-%m-%d")
-        else:
-            resolved_date_key = date_key
-
-        self._data.temperature_history[resolved_date_key] = temperature
-
-        # Prune to keep only recent days
-        if len(self._data.temperature_history) > WEATHER_TEMPERATURE_HISTORY_DAYS:
-            sorted_dates = sorted(self._data.temperature_history.keys())
-            for old_date in sorted_dates[
-                : len(self._data.temperature_history) - WEATHER_TEMPERATURE_HISTORY_DAYS
-            ]:
-                del self._data.temperature_history[old_date]
+        self._anomaly_detector.record_daily_temperature(temperature, date_key)
 
     def detect_weather_anomaly(self, current_temp: float) -> WeatherAnomalyResult:
         """Detect if current temperature is anomalous (Issue #681).
@@ -983,50 +764,35 @@ class WeatherCorrelation:
             WeatherAnomalyResult with weight for rollback evaluation
 
         """
-        history = self._data.temperature_history
-        history_count = len(history)
+        return self._anomaly_detector.detect_weather_anomaly(current_temp)
 
-        # Not enough history for reliable anomaly detection
-        if history_count < WEATHER_ANOMALY_MIN_HISTORY_DAYS:
-            return WeatherAnomalyResult(
-                is_anomalous=False,
-                weight=WEATHER_ANOMALY_NORMAL_WEIGHT,
-                temperature=current_temp,
-                deviation_sigma=0.0,
-                mean_temperature=0.0,
-                std_temperature=0.0,
-            )
+    @staticmethod
+    def _today_key(now: datetime | None = None) -> str:
+        """Return today's date key in ISO format."""
+        if now is None:
+            now = dt_util.now()
+        return now.date().isoformat()
 
-        temps = list(history.values())
-        mean_temp = sum(temps) / len(temps)
+    def _get_or_create_daily_snapshot(self, hour: int, date_key: str) -> DailySnapshot:
+        """Return a daily snapshot for the given hour and date."""
+        snapshots = self._data.daily_regression_stats.setdefault(hour, [])
+        for snapshot in snapshots:
+            if snapshot.date_key == date_key:
+                return snapshot
+        snapshot = DailySnapshot(date_key=date_key)
+        snapshots.append(snapshot)
+        return snapshot
 
-        # Calculate standard deviation
-        variance = sum((t - mean_temp) ** 2 for t in temps) / len(temps)
-        std_temp = math.sqrt(variance)
-
-        # Handle zero variance (all temperatures identical)
-        if std_temp < 0.01:
-            return WeatherAnomalyResult(
-                is_anomalous=False,
-                weight=WEATHER_ANOMALY_NORMAL_WEIGHT,
-                temperature=current_temp,
-                deviation_sigma=0.0,
-                mean_temperature=mean_temp,
-                std_temperature=std_temp,
-            )
-
-        deviation = (current_temp - mean_temp) / std_temp
-        is_anomalous = abs(deviation) >= WEATHER_ANOMALY_SIGMA_THRESHOLD
-
-        return WeatherAnomalyResult(
-            is_anomalous=is_anomalous,
-            weight=(
-                WEATHER_ANOMALY_ANOMALOUS_WEIGHT
-                if is_anomalous
-                else WEATHER_ANOMALY_NORMAL_WEIGHT
-            ),
-            temperature=current_temp,
-            deviation_sigma=deviation,
-            mean_temperature=mean_temp,
-            std_temperature=std_temp,
-        )
+    def _prune_daily_snapshots(self, now: datetime | None = None) -> None:
+        """Prune snapshots older than the 30-day sliding window."""
+        if now is None:
+            now = dt_util.now()
+        cutoff_date = (now.date() - timedelta(days=SLIDING_WINDOW_DAYS)).isoformat()
+        for hour, snapshots in list(self._data.daily_regression_stats.items()):
+            kept = [
+                snapshot for snapshot in snapshots if snapshot.date_key >= cutoff_date
+            ]
+            if kept:
+                self._data.daily_regression_stats[hour] = kept
+            else:
+                self._data.daily_regression_stats.pop(hour, None)

--- a/custom_components/localshift/learning/temperature.py
+++ b/custom_components/localshift/learning/temperature.py
@@ -1,0 +1,467 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Any
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.util import dt as dt_util
+
+from ..const import CONF_WEATHER_ENTITY
+
+_LOGGER = logging.getLogger(__name__)
+
+# Forecast cache settings
+FORECAST_CACHE_TTL = timedelta(minutes=30)
+
+
+@dataclass
+class TemperatureForecast:
+    """Temperature forecast for a time slot.
+
+    Attributes:
+        slot_time: The datetime this forecast applies to
+        temperature: Forecasted temperature in °C
+        condition: Weather condition (sunny, cloudy, etc.)
+
+    """
+
+    slot_time: datetime
+    temperature: float | None = None
+    condition: str = "unknown"
+
+
+class TemperatureForecastProvider:
+    """Provides temperature forecasts with caching and parsing helpers."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        entry: ConfigEntry[Any],
+        weather_entity_id: str | None,
+    ) -> None:
+        self.hass = hass
+        self.entry = entry
+        self._weather_entity_id = weather_entity_id or ""
+        self._cached_forecasts: list[TemperatureForecast] = []
+        self._forecast_cache_time: datetime | None = None
+
+    @property
+    def weather_entity_id(self) -> str:
+        return self._weather_entity_id
+
+    def set_weather_entity_id(self, weather_entity_id: str | None) -> None:
+        self._weather_entity_id = weather_entity_id or ""
+
+    def get_temperature_forecast(self) -> list[TemperatureForecast]:
+        """Fetch forecasted temperatures from weather entity.
+
+        Returns:
+            List of TemperatureForecast objects for upcoming hours.
+
+        """
+        weather_entity = self._weather_entity_id
+        if not weather_entity:
+            _LOGGER.debug("No weather entity configured")
+            return []
+
+        state = self.hass.states.get(weather_entity)
+        if state is None:
+            _LOGGER.warning("Weather entity %s not found", weather_entity)
+            return []
+
+        forecasts: list[TemperatureForecast] = []
+
+        # Get forecast from weather entity attributes
+        # Most weather integrations provide forecast in attributes
+        forecast_data = state.attributes.get("forecast", [])
+        now = dt_util.now()
+
+        _LOGGER.debug(
+            "Forecast data for %s: %d entries, now=%s",
+            weather_entity,
+            len(forecast_data) if forecast_data else 0,
+            now.isoformat(),
+        )
+
+        for forecast_entry in forecast_data:
+            # Parse forecast datetime
+            forecast_time_str = forecast_entry.get("datetime")
+            if not forecast_time_str:
+                continue
+
+            try:
+                forecast_time = dt_util.parse_datetime(forecast_time_str)
+                if forecast_time is None:
+                    continue
+            except (ValueError, TypeError):
+                continue
+
+            # Only include forecasts for the next 24 hours
+            hours_ahead = (forecast_time - now).total_seconds() / 3600
+            if hours_ahead < 0 or hours_ahead > 24:
+                continue
+
+            temperature = forecast_entry.get("temperature")
+            condition = forecast_entry.get("condition", "unknown")
+
+            forecasts.append(
+                TemperatureForecast(
+                    slot_time=forecast_time,
+                    temperature=temperature,
+                    condition=condition,
+                )
+            )
+
+        _LOGGER.debug(
+            "Got %d temperature forecasts from %s (legacy attribute)",
+            len(forecasts),
+            weather_entity,
+        )
+
+        return forecasts
+
+    def _refresh_weather_entity_from_config(self) -> str:
+        """Get the current weather entity from config entry.
+
+        Always reads fresh from config to pick up user changes without
+        requiring a restart. Checks options first (Configure UI), then data.
+
+        Returns:
+            Current weather entity ID from config, or empty string.
+
+        """
+        return self.entry.options.get(CONF_WEATHER_ENTITY, "") or self.entry.data.get(
+            CONF_WEATHER_ENTITY, ""
+        )
+
+    async def async_get_temperature_forecast(
+        self, force_refresh: bool = False
+    ) -> list[TemperatureForecast]:
+        """Fetch forecasted temperatures using weather.get_forecasts service.
+
+        Uses Home Assistant's modern weather.get_forecasts service (HA 2024.3+)
+        with caching to avoid excessive service calls.
+
+        Args:
+            force_refresh: If True, bypass cache and fetch fresh data
+
+        Returns:
+            List of TemperatureForecast objects for upcoming hours.
+
+        """
+        # Always get fresh entity ID from config to pick up user changes
+        weather_entity = self._refresh_weather_entity_from_config()
+        if not weather_entity:
+            _LOGGER.debug("No weather entity configured")
+            return []
+
+        # Update cached entity ID if changed
+        if weather_entity != self._weather_entity_id:
+            _LOGGER.info(
+                "Weather entity changed from %s to %s, clearing forecast cache",
+                self._weather_entity_id,
+                weather_entity,
+            )
+            self._weather_entity_id = weather_entity
+            # Clear cache to force fresh fetch with new entity
+            self._cached_forecasts = []
+            self._forecast_cache_time = None
+
+        now = dt_util.now()
+
+        # Return cached forecasts if still valid
+        if (
+            not force_refresh
+            and self._forecast_cache_time is not None
+            and self._cached_forecasts
+            and (now - self._forecast_cache_time) < FORECAST_CACHE_TTL
+        ):
+            _LOGGER.debug(
+                "Returning %d cached temperature forecasts (age: %s)",
+                len(self._cached_forecasts),
+                now - self._forecast_cache_time,
+            )
+            return self._cached_forecasts
+
+        forecasts: list[TemperatureForecast] = []
+
+        try:
+            response = await self.hass.services.async_call(
+                "weather",
+                "get_forecasts",
+                {"entity_id": weather_entity, "type": "hourly"},
+                blocking=True,
+                return_response=True,
+            )
+
+            _LOGGER.info(
+                "weather.get_forecasts response for %s: %s",
+                weather_entity,
+                "found" if response else "None",
+            )
+
+            if response and weather_entity in response:
+                forecast_data = self._extract_forecast_list(response, weather_entity)
+                if forecast_data:
+                    forecasts = self._parse_forecast_entries(forecast_data, now)
+            else:
+                _LOGGER.debug(
+                    "No response from weather.get_forecasts for entity %s, "
+                    "trying legacy attribute",
+                    weather_entity,
+                )
+
+        except Exception as e:
+            _LOGGER.debug(
+                "Failed to fetch forecasts via weather.get_forecasts service: %s, "
+                "falling back to legacy attribute",
+                e,
+            )
+
+        if not forecasts:
+            forecasts = self.get_temperature_forecast()
+
+        self._cached_forecasts = forecasts
+        self._forecast_cache_time = now
+
+        return forecasts
+
+    def _extract_forecast_list(
+        self, response: dict, weather_entity: str
+    ) -> list | None:
+        """Extract forecast list from API response.
+
+        Args:
+            response: Service call response dictionary
+            weather_entity: Weather entity ID
+
+        Returns:
+            List of forecast entries or None
+
+        """
+        forecast_data = response.get(weather_entity)
+        if forecast_data is None:
+            return None
+
+        _LOGGER.info(
+            "forecast_data type=%s, len=%s, keys=%s",
+            type(forecast_data).__name__,
+            len(forecast_data) if isinstance(forecast_data, list) else "N/A",
+            list(forecast_data.keys()) if isinstance(forecast_data, dict) else "N/A",
+        )
+
+        if isinstance(forecast_data, dict):
+            _LOGGER.info("forecast_data is dict, checking for forecast/hourly keys")
+            if "forecast" in forecast_data:
+                forecast_data = forecast_data["forecast"]
+                _LOGGER.info(
+                    "Found 'forecast' key with %d entries",
+                    len(forecast_data) if isinstance(forecast_data, list) else 0,
+                )
+            elif "hourly" in forecast_data:
+                forecast_data = forecast_data["hourly"]
+                _LOGGER.info(
+                    "Found 'hourly' key with %d entries",
+                    len(forecast_data) if isinstance(forecast_data, list) else 0,
+                )
+
+        if isinstance(forecast_data, list):
+            return forecast_data
+
+        _LOGGER.debug(
+            "Unexpected forecast_data format: %s",
+            type(forecast_data).__name__,
+        )
+        return None
+
+    def _parse_forecast_entries(
+        self, forecast_data: list, now: datetime
+    ) -> list[TemperatureForecast]:
+        """Parse forecast entries into TemperatureForecast objects.
+
+        Args:
+            forecast_data: List of forecast entry dictionaries
+            now: Current datetime for filtering
+
+        Returns:
+            List of TemperatureForecast objects
+
+        """
+        forecasts: list[TemperatureForecast] = []
+        parse_failed_count = 0
+        skipped_no_datetime = 0
+        filtered_count = 0
+
+        _LOGGER.info(
+            "Processing %d forecast entries, first entry keys: %s",
+            len(forecast_data),
+            list(forecast_data[0].keys())
+            if forecast_data and isinstance(forecast_data[0], dict)
+            else "empty",
+        )
+
+        for i, forecast_entry in enumerate(forecast_data):
+            result = self._parse_single_forecast_entry(
+                forecast_entry,
+                now,
+                i,
+                parse_failed_count,
+                skipped_no_datetime,
+                filtered_count,
+            )
+            if result is None:
+                continue
+            forecast, parse_failed_count, skipped_no_datetime, filtered_count = result
+            if forecast:
+                forecasts.append(forecast)
+
+        _LOGGER.info(
+            "Fetched %d temperature forecasts via weather.get_forecasts service",
+            len(forecasts),
+        )
+        return forecasts
+
+    def _parse_single_forecast_entry(
+        self,
+        entry: dict,
+        now: datetime,
+        index: int,
+        parse_failed_count: int,
+        skipped_no_datetime: int,
+        filtered_count: int,
+    ) -> tuple[TemperatureForecast | None, int, int, int] | None:
+        """Parse a single forecast entry.
+
+        Args:
+            entry: Forecast entry dictionary
+            now: Current datetime for filtering
+            index: Entry index for logging
+            parse_failed_count: Running count of parse failures
+            skipped_no_datetime: Running count of entries skipped for missing datetime
+            filtered_count: Running count of filtered entries
+
+        Returns:
+            Tuple of (forecast or None, updated counts) or None if entry invalid
+
+        """
+        if not isinstance(entry, dict):
+            return None
+
+        forecast_time_str = entry.get("datetime")
+        if not forecast_time_str:
+            skipped_no_datetime += 1
+            if skipped_no_datetime <= 2:
+                _LOGGER.info(
+                    "Entry missing 'datetime', keys: %s",
+                    list(entry.keys()),
+                )
+            return (None, parse_failed_count, skipped_no_datetime, filtered_count)
+
+        forecast_time = self._parse_forecast_datetime(
+            forecast_time_str, index, parse_failed_count
+        )
+        if forecast_time is None:
+            parse_failed_count += 1
+            return (None, parse_failed_count, skipped_no_datetime, filtered_count)
+
+        hours_ahead = (forecast_time - now).total_seconds() / 3600
+        if hours_ahead < 0 or hours_ahead > 24:
+            filtered_count += 1
+            if filtered_count <= 3:
+                _LOGGER.info(
+                    "Filtering out forecast: time=%s, now=%s, hours_ahead=%.1f",
+                    forecast_time.isoformat(),
+                    now.isoformat(),
+                    hours_ahead,
+                )
+            return (None, parse_failed_count, skipped_no_datetime, filtered_count)
+
+        temperature = entry.get("temperature")
+        condition = entry.get("condition", "unknown")
+
+        forecast = TemperatureForecast(
+            slot_time=forecast_time,
+            temperature=temperature,
+            condition=condition,
+        )
+        return (forecast, parse_failed_count, skipped_no_datetime, filtered_count)
+
+    def _parse_forecast_datetime(
+        self, time_str: str, index: int, parse_failed_count: int
+    ) -> datetime | None:
+        """Parse forecast datetime string.
+
+        Args:
+            time_str: Datetime string to parse
+            index: Entry index for logging
+            parse_failed_count: Current parse failure count
+
+        Returns:
+            Parsed datetime or None if parsing failed
+
+        """
+        try:
+            from datetime import datetime as dt
+
+            forecast_time = dt_util.parse_datetime(time_str)
+            if forecast_time is None:
+                try:
+                    naive_dt = dt.fromisoformat(time_str)
+                    forecast_time = dt_util.as_local(naive_dt)
+                    if index == 0:
+                        _LOGGER.info(
+                            "First entry: datetime='%s' parsed as naive=%s, localized=%s",
+                            time_str,
+                            naive_dt,
+                            forecast_time,
+                        )
+                except (ValueError, TypeError) as e:
+                    if parse_failed_count < 3:
+                        _LOGGER.info(
+                            "Failed to parse datetime '%s': %s",
+                            time_str,
+                            e,
+                        )
+                    return None
+            else:
+                if forecast_time.tzinfo is None:
+                    forecast_time = dt_util.as_local(forecast_time)
+                if index == 0:
+                    _LOGGER.info(
+                        "First entry: datetime='%s' parsed as %s (tzinfo=%s)",
+                        time_str,
+                        forecast_time,
+                        forecast_time.tzinfo,
+                    )
+            return forecast_time
+        except (ValueError, TypeError) as e:
+            if parse_failed_count < 3:
+                _LOGGER.info(
+                    "Exception parsing datetime '%s': %s",
+                    time_str,
+                    e,
+                )
+            return None
+
+    def get_current_temperature(self) -> float | None:
+        """Get current temperature from weather entity.
+
+        Returns:
+            Current temperature in °C, or None if unavailable.
+
+        """
+        weather_entity = self._weather_entity_id
+        if not weather_entity:
+            return None
+
+        state = self.hass.states.get(weather_entity)
+        if state is None:
+            return None
+
+        try:
+            return float(state.attributes.get("temperature", 0))
+        except (ValueError, TypeError):
+            return None

--- a/custom_components/localshift/sensors/forecast.py
+++ b/custom_components/localshift/sensors/forecast.py
@@ -326,11 +326,14 @@ class ForecastDiagnosticsSensor(LocalShiftSensorBase):
             "weather_correlation_confidence": self.coordinator.data.weather_correlation_confidence,
             "weather_adjustment_applied": self.coordinator.data.weather_adjustment_applied,
             "weather_learning_enabled": self.coordinator.data.weather_learning_enabled,
-            "weather_cooling_coefficient": round(
-                self.coordinator.data.weather_cooling_coefficient, 4
+            "weather_avg_cooling_slope": round(
+                self.coordinator.data.weather_avg_cooling_slope, 4
             ),
-            "weather_heating_coefficient": round(
-                self.coordinator.data.weather_heating_coefficient, 4
+            "weather_avg_heating_slope": round(
+                self.coordinator.data.weather_avg_heating_slope, 4
+            ),
+            "weather_avg_r_squared": round(
+                self.coordinator.data.weather_avg_r_squared, 4
             ),
             "weather_sample_count": self.coordinator.data.weather_sample_count,
             "load_forecast_slots_sample": {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -198,7 +198,9 @@ custom_components/localshift/
 │
 ├── learning/                 # Adaptive learning system
 │   ├── orchestrator.py       # Learning system coordinator
-│   └── correlation.py        # Weather correlation engine
+│   ├── correlation.py        # Weather correlation regression + storage facade
+│   ├── temperature.py        # Weather forecast fetching/parsing/caching
+│   └── anomaly.py            # Weather anomaly detection
 │
 ├── services/                 # Core services
 │   ├── evaluation_dispatcher.py # Decides when to trigger re-evaluation

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -58,7 +58,9 @@ custom_components/localshift/
 │
 ├── learning/                # Adaptive learning system
 │   ├── orchestrator.py      # Learning system coordinator
-│   └── correlation.py       # Weather correlation engine
+│   ├── correlation.py       # Weather correlation regression + storage facade
+│   ├── temperature.py       # Weather forecast fetching/parsing/caching
+│   └── anomaly.py           # Weather anomaly detection
 │
 ├── services/                # Core services
 │   ├── evaluation_dispatcher.py # Decides when to trigger re-evaluation

--- a/docs/ENTITY_REFERENCE.md
+++ b/docs/ENTITY_REFERENCE.md
@@ -310,7 +310,9 @@ Attributes:
   weather_condition: rainy
   weather_correlation_confidence: medium
   weather_learning_enabled: true
-  weather_cooling_coefficient: 0.3022
+  weather_avg_cooling_slope: 0.3022
+  weather_avg_heating_slope: 0.1845
+  weather_avg_r_squared: 0.42
   weather_sample_count: 5723
 ```
 

--- a/docs/LEARNING_SYSTEM.md
+++ b/docs/LEARNING_SYSTEM.md
@@ -201,9 +201,9 @@ When disabled, the system still tracks decisions but uses default (zero-offset) 
 
 **Entity:** `button.localshift_reset_learning`
 
-Clears all learning data and starts fresh.
+Clears decision tracking data and weather regression statistics, then restarts the learning phase.
 
-**Warning:** This erases all learned parameters and decision history. The system will return to the "observing" phase.
+**Warning:** This resets decision history and weather regression stats. Parameter optimizer and pattern analysis data are not reset by this button yet.
 
 ## FAQ
 
@@ -242,11 +242,11 @@ Yes. Use the **Enable Learning** switch to disable parameter optimization. When 
 
 ### What happens when I reset learning data?
 
-1. All decision records are cleared
-2. All learned parameters are reset to defaults
+1. Decision records are cleared
+2. Weather regression statistics are cleared (temperature history retained)
 3. The system returns to "observing" phase
-4. Parameter optimization history is erased
-5. Pattern analysis data is cleared
+4. Recent decision log and performance metrics are reset
+5. Parameter optimizer and pattern analysis data remain unchanged for now
 
 ### Is my learning data persisted?
 

--- a/docs/LOAD_FORECASTING.md
+++ b/docs/LOAD_FORECASTING.md
@@ -47,15 +47,16 @@ The system also grabs your **average load over the last 1 hour** from 5-minute s
 
 The system has a **weather correlation module** that learns how temperature affects your energy use. It works like this:
 
-- It uses a **degree-day model** — a well-known energy industry approach. It learns:
+- It uses a **degree-day model** with **bounded OLS regression** over a 30-day sliding window. It learns:
   - Your **base load** per hour (electricity use at comfortable temperatures)
-  - A **cooling coefficient** (how much extra power you use when it's hot — air conditioning)
-  - A **heating coefficient** (how much extra power you use when it's cold — heating)
+  - A **cooling slope** (kW per °C above the cooling threshold)
+  - A **heating slope** (kW per °C below the heating threshold)
 - It defines **temperature thresholds** for cooling and heating (e.g., above 25°C you start cooling, below 18°C you start heating).
-- It **learns incrementally** over time using a moving-average approach — every hour, it observes the actual temperature and actual load, and slightly adjusts its model. The more data it sees, the more confident it becomes.
-- It can pull **temperature forecasts** from your weather entity and predict load adjustments for future hours.
-- Each hour of the day gets its own coefficients (because your 2 PM cooling behaviour is different from your 8 PM behaviour).
-- It tracks a **confidence score** per hour, and predictions are only applied when confidence is sufficient.
+- It only learns from meaningful temperature changes (`min delta = 1.0°C`) and uses per-hour sufficient statistics to fit slopes.
+- Slopes are **bounded** (max 2.0 kW/°C), and predicted adjustments are **capped** at `max(base_load, 0.1) × 3.0`.
+- It can pull **temperature forecasts** from your weather entity and predict additive load adjustments for future hours.
+- Each hour of the day gets its own regression results (because your 2 PM cooling behaviour is different from your 8 PM behaviour).
+- It tracks **confidence** per hour based on sample count and R², and predictions are only applied when confidence is sufficient.
 
 **Example:** The system has learned that at 3 PM on a 38°C day, your house uses an extra 1.5 kW for cooling compared to a 22°C day. Tomorrow's weather forecast says 36°C at 3 PM, so it bumps up the predicted load accordingly.
 
@@ -93,7 +94,7 @@ The system exposes several diagnostic attributes so you can see what it's doing:
 - **Sample counts per hour** — how much historical data backs each hour's estimate
 - **Recent 1-hour load** — the real-time average it's blending in
 - **Weighting** — the configured balance between recent and historical data
-- **Weather correlation diagnostics** — the learned coefficients, confidence, and current temperature adjustments
+- **Weather correlation diagnostics** — average heating/cooling slopes, average R², confidence, and current temperature adjustments
 
 ---
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -252,11 +252,13 @@ For specific entity issues:
 3. Press the button
 
 **What Gets Reset:**
-- All decision records cleared
-- Learned parameters reset to defaults
-- Pattern analysis data cleared
-- Optimization weights reset
+- Decision records cleared
+- Weather regression statistics cleared (temperature history retained)
+- Recent decision log cleared
+- Performance metrics reset
 - Learning status returns to "observing"
+
+**Note:** Parameter optimizer and pattern analysis data are not reset by this button yet.
 
 **Note:** The system will need another 2-3 days of observation before parameter optimization resumes.
 

--- a/docs/superpowers/specs/2026-03-26-weather-correlation-regression-design.md
+++ b/docs/superpowers/specs/2026-03-26-weather-correlation-regression-design.md
@@ -1,0 +1,303 @@
+# Weather Correlation Regression Rewrite
+
+**Date:** 2026-03-26
+**Status:** Approved
+**Issue:** Load forecast inflation from corrupted EMA-based weather coefficients
+
+## Problem
+
+The weather correlation learning system uses per-observation EMA (exponential moving average) to learn temperature-load coefficients. Three compounding bugs cause wildly inflated load forecasts:
+
+1. **Small temp_delta amplification**: `implied = (actual_load - base) / temp_delta` — when temperature is barely outside the threshold (delta < 1°C), normal load variation produces absurd implied coefficients (5-12 kW/°C).
+2. **No coefficient magnitude cap**: The 0.1/0.9 EMA blending drifts to arbitrarily high values over 12,000+ samples.
+3. **No output cap on predict_load()**: Raw math goes straight to the optimizer — `base + 12.76 × delta = 40 kW` predictions are possible.
+
+The result: the optimizer sees 12-15 kW load forecasts for hours that historically average 0.5 kW, causing excessive grid import planning.
+
+### Evidence
+
+Actual coefficients found in production storage (before tactical reset):
+
+| Hour | Coefficient | Value | Impact |
+|------|-------------|-------|--------|
+| 8 | heating | 2.739 kW/°C | At 13°C (delta 5): +13.7 kW |
+| 9 | heating | 3.586 kW/°C | At 14°C (delta 4): +14.3 kW |
+| 17 | cooling | 3.511 kW/°C | — |
+| 21 | cooling | 12.761 kW/°C | 1°C above threshold: +12.8 kW |
+
+HA statistics confirmed hour 8 actual mean load is 0.57 kW (7-day average). The coefficient produced a 12 kW prediction — a 21× overestimate.
+
+## Solution
+
+Replace the EMA-based learning with OLS (Ordinary Least Squares) regression using sufficient statistics. Regression fits a best-fit line across ALL observations simultaneously, making it inherently resistant to individual outliers and small-delta amplification.
+
+## Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Algorithm | OLS regression | Fits all data at once; outlier-resistant |
+| Storage | Sufficient statistics | Fixed-size per day, no raw samples needed |
+| Window | 30-day sliding | Balances stability vs seasonal adaptation |
+| Buckets | 24 hours × 3 zones = 72 | Per-hour granularity, no weekday split |
+| Output cap | Relative (3× historical base) | Adapts to home's actual usage |
+| Confidence | Sample count + R² dual gate | Only apply when temperature actually explains load |
+| Prediction | Additive adjustment only | Historical base + slope × delta; never replace base |
+| Scope | Full module rewrite | Split monolith into 3 focused modules |
+
+## Module Structure
+
+```
+learning/
+  correlation.py      — Regression engine: learn, predict, storage, diagnostics
+  temperature.py      — Forecast fetching + caching (extracted, no logic changes)
+  anomaly.py          — Anomaly detection (extracted, no logic changes)
+```
+
+### correlation.py — Regression Engine
+
+Public API (signature-compatible with current system):
+
+```python
+class WeatherCorrelation:
+    def learn_from_sample(self, hour: int, temperature: float, actual_load_kw: float) -> None
+    def predict_load(self, hour: int, temperature: float, base_load_kw: float) -> tuple[float, str]
+    def get_coefficients_for_hour(self, hour: int) -> HourlyRegressionResult | None
+    def get_diagnostics(self) -> dict[str, Any]
+    def get_temperature_forecast(self) -> list[TemperatureForecast]  # delegates to temperature.py
+    def get_current_temperature(self) -> float | None  # delegates to temperature.py
+    def detect_weather_anomaly(self, current_temp: float) -> WeatherAnomalyResult  # delegates to anomaly.py
+    def record_daily_temperature(self, temperature: float, ...) -> None  # delegates to anomaly.py
+    async def async_initialize(self) -> None
+    async def async_save(self) -> None
+    async def async_reset(self) -> None  # NEW: clears regression stats
+```
+
+### temperature.py — Forecast Provider (Extracted)
+
+```python
+class TemperatureForecastProvider:
+    def get_temperature_forecast(self) -> list[TemperatureForecast]
+    async def async_get_temperature_forecast(self, force_refresh: bool = False) -> list[TemperatureForecast]
+    def get_current_temperature(self) -> float | None
+```
+
+Pure extraction of ~300 lines of service calls, response parsing, and caching. No logic changes.
+
+### anomaly.py — Anomaly Detector (Extracted)
+
+```python
+class WeatherAnomalyDetector:
+    def record_daily_temperature(self, temperature: float, date_key: str | None = None) -> None
+    def detect_weather_anomaly(self, current_temp: float) -> WeatherAnomalyResult
+```
+
+Pure extraction. Preserves 14-day history, ±2σ detection. No logic changes.
+
+## Core Algorithm
+
+### Data Structures
+
+```python
+@dataclass
+class ZoneStats:
+    n: int = 0            # sample count
+    sum_x: float = 0.0    # Σ(temp_delta)
+    sum_y: float = 0.0    # Σ(load_kw)
+    sum_xx: float = 0.0   # Σ(temp_delta²)
+    sum_xy: float = 0.0   # Σ(temp_delta × load_kw)
+    sum_yy: float = 0.0   # Σ(load_kw²)  — needed for R²
+
+@dataclass
+class HourlyRegressionData:
+    heating: ZoneStats     # T < heating_threshold
+    mild: ZoneStats        # heating_threshold ≤ T ≤ cooling_threshold
+    cooling: ZoneStats     # T > cooling_threshold
+
+@dataclass
+class DailySnapshot:
+    date: str              # ISO date "YYYY-MM-DD"
+    data: HourlyRegressionData
+
+@dataclass
+class HourlyRegressionResult:
+    """Returned by get_coefficients_for_hour(). Replaces HourlyTemperatureCoefficients."""
+    heating_slope: float      # kW/°C for heating zone
+    cooling_slope: float      # kW/°C for cooling zone
+    base_load_kw: float       # average mild-zone load
+    heating_r_squared: float
+    cooling_r_squared: float
+    sample_count: int         # total across all zones
+    confidence: str           # "low" / "medium" / "high"
+```
+
+### Zone Classification
+
+- **Heating zone** (T < heating_threshold): `delta = heating_threshold - temperature` (positive, larger = colder)
+- **Cooling zone** (T > cooling_threshold): `delta = temperature - cooling_threshold` (positive, larger = hotter)
+- **Mild zone** (heating_threshold ≤ T ≤ cooling_threshold): No delta — accumulate `n` and `sum_y` for average base load
+
+### Learning: learn_from_sample(hour, temperature, actual_load_kw)
+
+1. Classify observation into zone by temperature
+2. Compute `temp_delta` (if heating or cooling zone)
+3. **Guard: skip if `temp_delta < MIN_TEMP_DELTA` (1.0°C)** — prevents small-delta amplification
+4. Get or create today's `DailySnapshot` for this hour
+5. Accumulate into the appropriate `ZoneStats`:
+   - `n += 1`
+   - `sum_x += delta`
+   - `sum_y += load`
+   - `sum_xx += delta²`
+   - `sum_xy += delta × load`
+   - `sum_yy += load²`
+6. Prune snapshots older than 30 days
+
+### Fitting: fit_slope(aggregated_stats)
+
+1. Aggregate `ZoneStats` across all retained daily snapshots (sum the sums)
+2. If `n < MIN_SAMPLES_PER_ZONE` (20): return `(slope=0.0, r_squared=0.0)`
+3. Compute OLS slope:
+   ```
+   denom = n × sum_xx - sum_x²
+   slope = (n × sum_xy - sum_x × sum_y) / denom
+   ```
+4. **Clamp slope ≥ 0** — physically, more temperature deviation can only increase load
+5. **Clamp slope ≤ MAX_SLOPE_KW_PER_DEGREE** (2.0 kW/°C)
+6. Compute R²:
+   ```
+   ss_xy = n × sum_xy - sum_x × sum_y
+   ss_xx = n × sum_xx - sum_x²
+   ss_yy = n × sum_yy - sum_y²
+   r² = ss_xy² / (ss_xx × ss_yy)
+   ```
+7. Return `(slope, r_squared)`
+
+### Prediction: predict_load(hour, temperature, base_load_kw)
+
+1. If mild zone (heating_threshold ≤ T ≤ cooling_threshold): return `(base_load_kw, "weather_none")`
+2. Determine zone and delta
+3. Fit slope from aggregated stats for the relevant zone
+4. **Confidence gate**: require `n ≥ MIN_SAMPLES` AND `r² ≥ MIN_R_SQUARED` (0.10)
+5. If gate fails: return `(base_load_kw, "low_confidence")`
+6. Compute: `predicted = base_load_kw + slope × delta`
+7. **Safety cap**: `predicted = min(predicted, base_load_kw × MAX_LOAD_MULTIPLIER)` (3.0×)
+8. Return `(max(0.0, predicted), f"weather_{zone}")`
+
+## Sliding Window
+
+Daily snapshots are stored per hour. Each day's data is one `DailySnapshot` containing the day's accumulated `ZoneStats` for each zone.
+
+**Pruning**: On each `learn_from_sample()` call, remove snapshots with `date` older than 30 days.
+
+**Storage size**: 30 days × 24 hours × 3 zones × 6 numbers = 12,960 floats. With JSON overhead, roughly 150-200 KB.
+
+## Storage Format (v2)
+
+```json
+{
+    "version": 2,
+    "weather_entity_id": "weather.crows_nest_hourly",
+    "cooling_threshold": 24.0,
+    "heating_threshold": 18.0,
+    "daily_regression_stats": {
+        "8": [
+            {
+                "date": "2026-03-25",
+                "heating": {"n": 12, "sum_x": 48.0, "sum_y": 7.2, "sum_xx": 210.0, "sum_xy": 30.5, "sum_yy": 5.8},
+                "mild": {"n": 0, "sum_x": 0, "sum_y": 0, "sum_xx": 0, "sum_xy": 0, "sum_yy": 0},
+                "cooling": {"n": 0, "sum_x": 0, "sum_y": 0, "sum_xx": 0, "sum_xy": 0, "sum_yy": 0}
+            }
+        ]
+    },
+    "temperature_history": {"2026-03-25": 22.5, "2026-03-24": 21.0},
+    "learning_stats": {}
+}
+```
+
+### Migration (v1 → v2)
+
+On load, detect version 1 data:
+1. Discard `hourly_coefficients` entirely (EMA-corrupted)
+2. Preserve `temperature_history` and config fields (`weather_entity_id`, thresholds)
+3. Initialize empty `daily_regression_stats`
+4. Log migration event
+
+`STORAGE_VERSION` bumps to 2.
+
+## Diagnostics
+
+`get_diagnostics()` returns:
+
+```python
+{
+    "total_samples": 5400,
+    "active_hours": 18,
+    "average_heating_slope": 0.25,
+    "average_cooling_slope": 0.18,
+    "average_r_squared": 0.35,
+    "hourly_coefficients": {
+        "8": {
+            "heating_slope": 0.31,
+            "heating_r_squared": 0.42,
+            "heating_samples": 120,
+            "cooling_slope": 0.0,
+            "cooling_r_squared": 0.0,
+            "cooling_samples": 15,
+            "mild_avg_kw": 0.72,
+            "mild_samples": 90,
+            "confidence": "medium"
+        }
+    }
+}
+```
+
+Sensor attribute renames:
+- `weather_cooling_coefficient` → `weather_avg_cooling_slope`
+- `weather_heating_coefficient` → `weather_avg_heating_slope`
+- NEW: `weather_avg_r_squared`
+
+## Reset Button Fix
+
+`ResetLearningDataButton.async_press()` adds a call to clear weather correlation data:
+
+```python
+weather_correlation = getattr(self.coordinator._computation_engine, '_weather_correlation', None)
+if weather_correlation is not None:
+    await weather_correlation.async_reset()
+```
+
+`async_reset()` clears `daily_regression_stats`, preserves `temperature_history`, calls `async_save()`.
+
+## Constants
+
+```python
+STORAGE_VERSION = 2
+MIN_SAMPLES_PER_ZONE = 20        # minimum before regression is used
+MIN_R_SQUARED = 0.10             # minimum fit quality
+MAX_SLOPE_KW_PER_DEGREE = 2.0    # physical cap on learned slope
+MAX_LOAD_MULTIPLIER = 3.0        # output cap: predicted ≤ 3× historical base
+SLIDING_WINDOW_DAYS = 30         # rolling window
+MIN_TEMP_DELTA = 1.0             # ignore observations with delta < 1°C
+```
+
+## Testing Strategy
+
+1. **Unit tests for ZoneStats and OLS fit**: Known inputs with hand-calculated expected slopes and R²
+2. **Unit tests for learn_from_sample**: Zone classification, daily snapshot creation, accumulation, window pruning
+3. **Unit tests for predict_load**: Confidence gate, additive adjustment, safety cap, mild zone passthrough
+4. **Integration test**: Learn 100+ samples → predict → verify reasonable output
+5. **Migration test**: Load v1 storage → verify v2 structure, coefficients discarded, temperature_history preserved
+6. **Reset test**: Verify async_reset clears regression stats but preserves anomaly history
+7. **Extraction tests**: Verify temperature.py and anomaly.py behave identically to the extracted code
+8. **Regression test**: Replay the exact scenario from the bug (hour 8, temp 13°C, historical 0.72 kW) and verify the output is bounded
+
+## Why This Fixes the Original Bug
+
+The original bug had three root causes. This design eliminates all three:
+
+| Root Cause | Old System | New System |
+|------------|-----------|------------|
+| Small temp_delta amplification | `implied = load / delta` per observation | Regression fits ALL data; `MIN_TEMP_DELTA` guard rejects < 1°C |
+| No coefficient cap | EMA drifts to any value | `MAX_SLOPE_KW_PER_DEGREE` caps slope at 2.0 kW/°C |
+| No output cap | `predict_load` returns raw math | `MAX_LOAD_MULTIPLIER` caps at 3× historical base |
+| Base load replacement | Learned base overrides historical | Additive only: historical base is never replaced |
+| Confidence without quality | Sample count alone | Sample count + R² dual gate |

--- a/docs/superpowers/specs/2026-03-26-weather-correlation-regression-design.md
+++ b/docs/superpowers/specs/2026-03-26-weather-correlation-regression-design.md
@@ -158,6 +158,7 @@ class HourlyRegressionResult:
 3. Compute OLS slope:
    ```
    denom = n × sum_xx - sum_x²
+   if denom ≤ 0: return (slope=0.0, r_squared=0.0)   # degenerate: all deltas identical
    slope = (n × sum_xy - sum_x × sum_y) / denom
    ```
 4. **Clamp slope ≥ 0** — physically, more temperature deviation can only increase load
@@ -167,9 +168,28 @@ class HourlyRegressionResult:
    ss_xy = n × sum_xy - sum_x × sum_y
    ss_xx = n × sum_xx - sum_x²
    ss_yy = n × sum_yy - sum_y²
-   r² = ss_xy² / (ss_xx × ss_yy)
+   if ss_xx ≤ 0 or ss_yy ≤ 0: r² = 0.0   # degenerate: no variance in x or y
+   else: r² = ss_xy² / (ss_xx × ss_yy)
    ```
 7. Return `(slope, r_squared)`
+
+### Coefficient Lookup: get_coefficients_for_hour(hour)
+
+Returns `HourlyRegressionResult` for a given hour, or `None` if no data exists.
+
+1. If no daily snapshots exist for this hour: return `None`
+2. Aggregate `ZoneStats` across all daily snapshots for this hour (sum the sums for each zone)
+3. Run `fit_slope()` on the aggregated heating zone → `(heating_slope, heating_r²)`
+4. Run `fit_slope()` on the aggregated cooling zone → `(cooling_slope, cooling_r²)`
+5. Compute `base_load_kw` from mild zone: `sum_y / n` if `n > 0`, else `0.0`
+6. Compute total `sample_count` across all three zones
+7. Determine confidence:
+   - `"high"` if any zone has `n ≥ MIN_SAMPLES` AND `r² ≥ 0.30`
+   - `"medium"` if any zone has `n ≥ MIN_SAMPLES` AND `r² ≥ MIN_R_SQUARED` (0.10)
+   - `"low"` otherwise
+8. Return `HourlyRegressionResult(heating_slope, cooling_slope, base_load_kw, heating_r², cooling_r², sample_count, confidence)`
+
+**Note:** The caller (LoadForecaster) checks confidence from this method *before* calling `predict_load()`. `predict_load()` also has its own internal confidence gate. This double-gate is intentional — belt and suspenders.
 
 ### Prediction: predict_load(hour, temperature, base_load_kw)
 
@@ -179,7 +199,7 @@ class HourlyRegressionResult:
 4. **Confidence gate**: require `n ≥ MIN_SAMPLES` AND `r² ≥ MIN_R_SQUARED` (0.10)
 5. If gate fails: return `(base_load_kw, "low_confidence")`
 6. Compute: `predicted = base_load_kw + slope × delta`
-7. **Safety cap**: `predicted = min(predicted, base_load_kw × MAX_LOAD_MULTIPLIER)` (3.0×)
+7. **Safety cap**: `predicted = min(predicted, max(base_load_kw, 0.1) × MAX_LOAD_MULTIPLIER)` (3.0×; floor of 0.1 kW prevents zero-base zeroing out the adjustment)
 8. Return `(max(0.0, predicted), f"weather_{zone}")`
 
 ## Sliding Window
@@ -301,3 +321,8 @@ The original bug had three root causes. This design eliminates all three:
 | No output cap | `predict_load` returns raw math | `MAX_LOAD_MULTIPLIER` caps at 3× historical base |
 | Base load replacement | Learned base overrides historical | Additive only: historical base is never replaced |
 | Confidence without quality | Sample count alone | Sample count + R² dual gate |
+
+## Breaking Changes
+
+- **Sensor attribute renames**: `weather_cooling_coefficient` → `weather_avg_cooling_slope`, `weather_heating_coefficient` → `weather_avg_heating_slope`. Any dashboard cards or automations referencing the old attribute names will need updating.
+- **Storage format v2**: Existing learned coefficients are discarded on migration (intentional — the EMA data is corrupted). Learning restarts from zero. Temperature history is preserved.

--- a/scripts/snapshot_charging_plan.py
+++ b/scripts/snapshot_charging_plan.py
@@ -585,10 +585,13 @@ class SnapshotGenerator:
             "sensor.localshift_forecast_diagnostics", "weather_sample_count", 0
         )
         cooling = self.attr(
-            "sensor.localshift_forecast_diagnostics", "weather_cooling_coefficient", 0
+            "sensor.localshift_forecast_diagnostics", "weather_avg_cooling_slope", 0
         )
         heating = self.attr(
-            "sensor.localshift_forecast_diagnostics", "weather_heating_coefficient", 0
+            "sensor.localshift_forecast_diagnostics", "weather_avg_heating_slope", 0
+        )
+        r_squared = self.attr(
+            "sensor.localshift_forecast_diagnostics", "weather_avg_r_squared", 0
         )
         adjustment = self.attr(
             "sensor.localshift_forecast_diagnostics",
@@ -607,8 +610,9 @@ class SnapshotGenerator:
 | **Learning Enabled** | {learning} |
 | **Confidence** | {confidence} |
 | **Total Samples** | {samples} |
-| **Cooling Coefficient** | {cooling} kW/°C |
-| **Heating Coefficient** | {heating} kW/°C |
+| **Cooling Slope** | {cooling} kW/°C |
+| **Heating Slope** | {heating} kW/°C |
+| **Average R²** | {r_squared} |
 | **Adjustment Applied** | {adjustment} |"""
 
     def _system_info(self) -> str:

--- a/tests/engine/test_weather_diagnostics.py
+++ b/tests/engine/test_weather_diagnostics.py
@@ -41,9 +41,10 @@ class TestWeatherDiagnosticsAnomalyPopulation:
         corr = MagicMock()
         corr.get_diagnostics.return_value = {
             "total_samples": 0,
-            "average_cooling_coefficient": 0.0,
-            "average_heating_coefficient": 0.0,
-            "hourly_coefficients": {},
+            "average_cooling_slope": 0.0,
+            "average_heating_slope": 0.0,
+            "average_r_squared": 0.0,
+            "hourly_regression": {},
         }
         return corr
 
@@ -131,3 +132,22 @@ class TestWeatherDiagnosticsAnomalyPopulation:
         data = CoordinatorData()
         engine.populate_weather_diagnostics(data, mock_weather_correlation)
         mock_weather_correlation.detect_weather_anomaly.assert_called_once_with(18.0)
+
+    def test_populates_average_slopes_and_r_squared(
+        self, mock_entry_enabled, mock_weather_correlation
+    ):
+        mock_weather_correlation.get_diagnostics.return_value = {
+            "total_samples": 42,
+            "average_cooling_slope": 0.18,
+            "average_heating_slope": 0.25,
+            "average_r_squared": 0.35,
+            "hourly_regression": {},
+        }
+        engine = WeatherDiagnosticsEngine(mock_entry_enabled)
+        data = CoordinatorData()
+
+        engine.populate_weather_diagnostics(data, mock_weather_correlation)
+
+        assert data.weather_avg_cooling_slope == pytest.approx(0.18)
+        assert data.weather_avg_heating_slope == pytest.approx(0.25)
+        assert data.weather_avg_r_squared == pytest.approx(0.35)

--- a/tests/engine/test_weather_diagnostics.py
+++ b/tests/engine/test_weather_diagnostics.py
@@ -151,3 +151,24 @@ class TestWeatherDiagnosticsAnomalyPopulation:
         assert data.weather_avg_cooling_slope == pytest.approx(0.18)
         assert data.weather_avg_heating_slope == pytest.approx(0.25)
         assert data.weather_avg_r_squared == pytest.approx(0.35)
+
+    def test_sets_high_confidence_when_any_hour_is_high(
+        self, mock_entry_enabled, mock_weather_correlation
+    ):
+        mock_weather_correlation.get_diagnostics.return_value = {
+            "total_samples": 60,
+            "average_cooling_slope": 0.18,
+            "average_heating_slope": 0.25,
+            "average_r_squared": 0.35,
+            "hourly_regression": {
+                8: {"confidence": "high"},
+                9: {"confidence": "medium"},
+            },
+        }
+        mock_weather_correlation.get_current_temperature.return_value = None
+        engine = WeatherDiagnosticsEngine(mock_entry_enabled)
+        data = CoordinatorData()
+
+        engine.populate_weather_diagnostics(data, mock_weather_correlation)
+
+        assert data.weather_correlation_confidence == "high"

--- a/tests/forecast/test_load.py
+++ b/tests/forecast/test_load.py
@@ -258,16 +258,12 @@ class TestLoadForecasterExponentialDecay:
         assert "NO_LOAD_DATA" in caplog.text
 
     def test_weather_correlation_applied(self, mock_weather_correlation):
-        """Test weather correlation adjustment when confidence is high.
-
-        When temperature is provided and weather correlation has high confidence,
-        should apply temperature-based adjustment.
-        """
+        """Test weather correlation adjustment when confidence is high."""
         mock_entry = _create_mock_entry()
         mock_weather_correlation.get_coefficients_for_hour.return_value = MagicMock(
             confidence="high"
         )
-        mock_weather_correlation.predict_load.return_value = (0.75, "weather_adjusted")
+        mock_weather_correlation.predict_load.return_value = (0.75, "weather_heating")
 
         forecaster = LoadForecaster(
             mock_entry, weather_correlation=mock_weather_correlation
@@ -283,7 +279,7 @@ class TestLoadForecasterExponentialDecay:
             temperature=25.0,
         )
 
-        assert source == "weather_adjusted"
+        assert source == "weather_heating"
         assert kw == 0.75
 
     def test_weather_correlation_skipped_low_confidence(self, mock_weather_correlation):
@@ -525,6 +521,26 @@ class TestLoadForecasterExponentialDecay:
         assert abs(kw - round(expected, 3)) < 0.001
         assert source == "blended_live"
 
+    def test_weather_correlation_weather_none_keeps_base_load(self):
+        mock_entry = _create_mock_entry()
+        weather = MagicMock()
+        weather.get_coefficients_for_hour.return_value = MagicMock(confidence="high")
+        weather.predict_load.return_value = (0.6, "weather_none")
+
+        forecaster = LoadForecaster(mock_entry, weather_correlation=weather)
+        kw, source = forecaster.estimate_hourly_consumption_kw(
+            hourly_avg_kw={11: 0.5},
+            slot_hour=11,
+            current_hour=11,
+            current_load_kw=0.45,
+            recent_load_kw=0.5,
+            temperature=22.0,
+        )
+
+        expected = 0.3 * 0.45 + 0.7 * 0.5
+        assert abs(kw - round(expected, 3)) < 0.001
+        assert source == "blended_live"
+
 
 @pytest.fixture
 def mock_weather_correlation():
@@ -558,7 +574,7 @@ class TestWeatherAdjustmentTracking:
         mock_entry = _create_mock_entry()
         weather = MagicMock()
         weather.get_coefficients_for_hour.return_value = MagicMock(confidence="medium")
-        weather.predict_load.return_value = (1.5, "weather_adjusted")
+        weather.predict_load.return_value = (1.5, "weather_heating")
 
         forecaster = LoadForecaster(mock_entry, weather_correlation=weather)
         forecaster.reset_weather_adjustment_applied()
@@ -629,6 +645,26 @@ class TestWeatherAdjustmentTracking:
             current_load_kw=0.5,
             recent_load_kw=0.6,
             temperature=30.0,
+        )
+
+        assert forecaster.get_weather_adjustment_applied() is False
+
+    def test_weather_adjustment_flag_not_set_for_weather_none(self):
+        mock_entry = _create_mock_entry()
+        weather = MagicMock()
+        weather.get_coefficients_for_hour.return_value = MagicMock(confidence="medium")
+        weather.predict_load.return_value = (0.99, "weather_none")
+
+        forecaster = LoadForecaster(mock_entry, weather_correlation=weather)
+        forecaster.reset_weather_adjustment_applied()
+
+        forecaster.estimate_hourly_consumption_kw(
+            hourly_avg_kw={11: 1.0},
+            slot_hour=11,
+            current_hour=10,
+            current_load_kw=0.5,
+            recent_load_kw=0.6,
+            temperature=21.0,
         )
 
         assert forecaster.get_weather_adjustment_applied() is False

--- a/tests/learning/conftest.py
+++ b/tests/learning/conftest.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.localshift.const import (
+    CONF_COOLING_THRESHOLD,
+    CONF_HEATING_THRESHOLD,
+    CONF_WEATHER_ENTITY,
+    DEFAULT_COOLING_THRESHOLD,
+    DEFAULT_HEATING_THRESHOLD,
+)
+from custom_components.localshift.learning.correlation import WeatherCorrelation
+from custom_components.localshift.learning.temperature import (
+    TemperatureForecastProvider,
+)
+from custom_components.localshift.learning.anomaly import WeatherAnomalyDetector
+
+
+@pytest.fixture
+def mock_hass():
+    """Create a minimal mock HomeAssistant instance."""
+    hass = MagicMock()
+    hass.states = MagicMock()
+    hass.states.get = MagicMock(return_value=None)
+    hass.services = MagicMock()
+    hass.services.async_call = AsyncMock(return_value=None)
+    return hass
+
+
+@pytest.fixture
+def mock_entry():
+    """Create a mock ConfigEntry with weather correlation settings."""
+    entry = MagicMock()
+    entry.options = {
+        CONF_WEATHER_ENTITY: "weather.home",
+        CONF_COOLING_THRESHOLD: DEFAULT_COOLING_THRESHOLD,
+        CONF_HEATING_THRESHOLD: DEFAULT_HEATING_THRESHOLD,
+    }
+    entry.data = {
+        CONF_WEATHER_ENTITY: "weather.home",
+    }
+    return entry
+
+
+@pytest.fixture
+def mock_entry_no_weather():
+    """Create a mock ConfigEntry with no weather entity configured."""
+    entry = MagicMock()
+    entry.options = {}
+    entry.data = {}
+    return entry
+
+
+@pytest.fixture
+def mock_weather_store() -> AsyncMock:
+    store = AsyncMock()
+    store.async_load.return_value = None
+    store.async_save.return_value = None
+    return store
+
+
+@pytest.fixture
+def correlation(mock_hass, mock_entry, mock_weather_store):
+    """Create a WeatherCorrelation instance with mocked store."""
+    with patch(
+        "custom_components.localshift.learning.correlation.Store"
+    ) as mock_store_cls:
+        mock_store_cls.return_value = mock_weather_store
+
+        instance = WeatherCorrelation(mock_hass, mock_entry)
+        instance._store = mock_weather_store
+        return instance
+
+
+@pytest.fixture
+def correlation_no_weather(mock_hass, mock_entry_no_weather, mock_weather_store):
+    """Create a WeatherCorrelation with no weather entity."""
+    with patch(
+        "custom_components.localshift.learning.correlation.Store"
+    ) as mock_store_cls:
+        mock_store_cls.return_value = mock_weather_store
+
+        instance = WeatherCorrelation(mock_hass, mock_entry_no_weather)
+        instance._store = mock_weather_store
+        return instance
+
+
+@pytest.fixture
+def weather_provider(mock_hass, mock_entry) -> TemperatureForecastProvider:
+    return TemperatureForecastProvider(mock_hass, mock_entry, "weather.home")
+
+
+@pytest.fixture
+def weather_provider_no_weather(
+    mock_hass, mock_entry_no_weather
+) -> TemperatureForecastProvider:
+    return TemperatureForecastProvider(mock_hass, mock_entry_no_weather, None)
+
+
+@pytest.fixture
+def anomaly_detector() -> WeatherAnomalyDetector:
+    return WeatherAnomalyDetector({})
+
+
+def make_weather_state(temperature: float = 22.0, forecast_list: list | None = None):
+    """Create a mock weather entity state."""
+    state = MagicMock()
+    state.attributes = {
+        "temperature": temperature,
+        "forecast": forecast_list or [],
+    }
+    return state
+
+
+def make_forecast_entry(
+    hours_ahead: float = 1.0,
+    temperature: float = 22.0,
+    condition: str = "sunny",
+    now: datetime | None = None,
+) -> dict:
+    """Create a single forecast entry dict."""
+    if now is None:
+        now = datetime.now(UTC)
+    forecast_time = now + timedelta(hours=hours_ahead)
+    return {
+        "datetime": forecast_time.isoformat(),
+        "temperature": temperature,
+        "condition": condition,
+    }

--- a/tests/learning/test_anomaly.py
+++ b/tests/learning/test_anomaly.py
@@ -1,0 +1,132 @@
+"""Tests for learning/anomaly.py - weather anomaly detector."""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from unittest.mock import patch
+
+import pytest
+
+from custom_components.localshift.learning.anomaly import (
+    WEATHER_ANOMALY_ANOMALOUS_WEIGHT,
+    WEATHER_ANOMALY_NORMAL_WEIGHT,
+    WEATHER_TEMPERATURE_HISTORY_DAYS,
+    WeatherAnomalyDetector,
+)
+
+
+def _populate_anomaly_history(
+    detector: WeatherAnomalyDetector,
+    temps: list[float],
+    base_date: date | None = None,
+) -> None:
+    """Populate temperature history for anomaly detection tests."""
+    if base_date is None:
+        base_date = date(2024, 1, 1)
+    for i, temp in enumerate(temps):
+        d = base_date + timedelta(days=i)
+        detector.record_daily_temperature(temp, date_key=d.isoformat())
+
+
+class TestWeatherAnomalyDetection:
+    """Tests for weather anomaly detection features."""
+
+    def test_record_daily_temperature_stores_value(self, anomaly_detector):
+        """Test that record_daily_temperature stores temperature values."""
+        anomaly_detector.record_daily_temperature(22.5, date_key="2024-01-01")
+        assert anomaly_detector.temperature_history["2024-01-01"] == 22.5
+
+    def test_record_daily_temperature_is_idempotent_per_day(self, anomaly_detector):
+        """Test that recording same day overwrites previous value."""
+        anomaly_detector.record_daily_temperature(20.0, date_key="2024-01-01")
+        anomaly_detector.record_daily_temperature(25.0, date_key="2024-01-01")
+        assert anomaly_detector.temperature_history["2024-01-01"] == 25.0
+
+    def test_record_daily_temperature_prunes_to_14_days(self, anomaly_detector):
+        """Test that history is pruned to WEATHER_TEMPERATURE_HISTORY_DAYS."""
+        for i in range(20):
+            d = date(2024, 1, 1) + timedelta(days=i)
+            anomaly_detector.record_daily_temperature(20.0, date_key=d.isoformat())
+        assert (
+            len(anomaly_detector.temperature_history)
+            == WEATHER_TEMPERATURE_HISTORY_DAYS
+        )
+
+    def test_record_daily_temperature_keeps_newest_dates(self, anomaly_detector):
+        """Test that pruning keeps the most recent dates."""
+        for i in range(20):
+            d = date(2024, 1, 1) + timedelta(days=i)
+            anomaly_detector.record_daily_temperature(float(i), date_key=d.isoformat())
+        oldest_retained = min(anomaly_detector.temperature_history.keys())
+        assert oldest_retained == "2024-01-07"
+
+    def test_record_daily_temperature_uses_today_by_default(self, anomaly_detector):
+        """Test that record_daily_temperature uses today's date when not specified."""
+        with patch("custom_components.localshift.learning.anomaly.dt_util") as mock_dt:
+            mock_dt.now.return_value.strftime.return_value = "2024-06-15"
+            anomaly_detector.record_daily_temperature(22.0)
+        assert "2024-06-15" in anomaly_detector.temperature_history
+
+    def test_insufficient_history_returns_normal_weight(self, anomaly_detector):
+        """Test that insufficient history (<7 days) returns normal weight."""
+        _populate_anomaly_history(anomaly_detector, [20.0, 21.0, 22.0, 20.0, 21.0])
+        result = anomaly_detector.detect_weather_anomaly(35.0)
+        assert result.is_anomalous is False
+        assert result.weight == WEATHER_ANOMALY_NORMAL_WEIGHT
+        assert result.deviation_sigma == 0.0
+        assert result.mean_temperature == 0.0
+        assert result.std_temperature == 0.0
+
+    def test_exactly_7_days_history_is_enough(self, anomaly_detector):
+        """Test that exactly 7 days of history is sufficient."""
+        _populate_anomaly_history(anomaly_detector, [20.0] * 7)
+        result = anomaly_detector.detect_weather_anomaly(20.0)
+        assert result.mean_temperature is not None
+
+    def test_normal_temperature_not_flagged(self, anomaly_detector):
+        """Test that normal temperature is not flagged as anomalous."""
+        temps = [20.0, 21.0, 19.0, 20.5, 21.5, 20.0, 21.0, 20.0, 19.5, 21.0]
+        _populate_anomaly_history(anomaly_detector, temps)
+        result = anomaly_detector.detect_weather_anomaly(21.0)
+        assert result.is_anomalous is False
+        assert result.weight == WEATHER_ANOMALY_NORMAL_WEIGHT
+
+    def test_extreme_high_temperature_is_anomalous(self, anomaly_detector):
+        """Test that extreme high temperature is flagged as anomalous."""
+        temps = [20.0] * 8 + [21.0, 19.0]
+        _populate_anomaly_history(anomaly_detector, temps)
+        result = anomaly_detector.detect_weather_anomaly(40.0)
+        assert result.is_anomalous is True
+        assert result.weight == WEATHER_ANOMALY_ANOMALOUS_WEIGHT
+        assert result.deviation_sigma is not None
+        assert result.deviation_sigma > 2.0
+
+    def test_extreme_low_temperature_is_anomalous(self, anomaly_detector):
+        """Test that extreme low temperature is flagged as anomalous."""
+        temps = [20.0] * 8 + [21.0, 19.0]
+        _populate_anomaly_history(anomaly_detector, temps)
+        result = anomaly_detector.detect_weather_anomaly(0.0)
+        assert result.is_anomalous is True
+        assert result.weight == WEATHER_ANOMALY_ANOMALOUS_WEIGHT
+
+    def test_anomaly_result_temperature_field(self, anomaly_detector):
+        """Test that WeatherAnomalyResult includes the input temperature."""
+        _populate_anomaly_history(anomaly_detector, [20.0] * 10)
+        result = anomaly_detector.detect_weather_anomaly(35.0)
+        assert result.temperature == 35.0
+
+    def test_anomaly_result_mean_and_std_fields(self, anomaly_detector):
+        """Test that WeatherAnomalyResult includes mean and std."""
+        temps = [20.0] * 10
+        _populate_anomaly_history(anomaly_detector, temps)
+        result = anomaly_detector.detect_weather_anomaly(20.0)
+        assert result.mean_temperature == pytest.approx(20.0)
+        assert result.std_temperature == pytest.approx(0.0)
+
+    def test_zero_std_does_not_raise(self, anomaly_detector):
+        """Test that zero standard deviation is handled gracefully."""
+        temps = [20.0] * 10
+        _populate_anomaly_history(anomaly_detector, temps)
+        result = anomaly_detector.detect_weather_anomaly(20.0)
+        assert result.is_anomalous is False
+        assert result.weight == WEATHER_ANOMALY_NORMAL_WEIGHT

--- a/tests/learning/test_correlation.py
+++ b/tests/learning/test_correlation.py
@@ -15,7 +15,6 @@ from custom_components.localshift.const import (
 import custom_components.localshift.learning.correlation as correlation_module
 from custom_components.localshift.learning.correlation import (
     DailySnapshot,
-    HourlyTemperatureCoefficients,
     HourlyRegressionData,
     HourlyRegressionResult,
     WeatherCorrelation,
@@ -38,20 +37,6 @@ def _linear_stats(n: int, slope: float) -> ZoneStats:
         sum_xy=float(sum_xy),
         sum_yy=float(sum_yy),
     )
-
-
-class TestHourlyTemperatureCoefficients:
-    def test_roundtrip(self):
-        coef = HourlyTemperatureCoefficients(
-            base_load_kw=1.1,
-            cooling_coefficient=0.2,
-            heating_coefficient=0.3,
-            sample_count=4,
-            last_updated="2026-03-26T10:00:00",
-            confidence="medium",
-        )
-        restored = HourlyTemperatureCoefficients.from_dict(coef.to_dict())
-        assert restored == coef
 
 
 class TestZoneStats:
@@ -153,6 +138,10 @@ class TestWeatherCorrelationData:
         data.temperature_history["2024-01-01"] = 22.0
         restored = WeatherCorrelationData.from_dict(data.to_dict())
         assert restored.temperature_history == {"2024-01-01": 22.0}
+
+    def test_no_hourly_coefficients_field(self):
+        data = WeatherCorrelationData()
+        assert not hasattr(data, "hourly_coefficients")
 
 
 class TestAsyncInitialize:
@@ -439,7 +428,7 @@ class TestMigrationAndReset:
             snap.date_key for snap in correlation._data.daily_regression_stats[8]
         ]
         assert "2026-02-23" not in remaining
-        assert "2026-02-24" in remaining
+        assert "2026-02-24" not in remaining
         assert "2026-03-25" in remaining
 
     def test_prune_daily_snapshots_removes_empty_hours(self, correlation):

--- a/tests/learning/test_correlation.py
+++ b/tests/learning/test_correlation.py
@@ -1,18 +1,8 @@
-"""Tests for learning/correlation.py - weather correlation module.
-
-Tests are structured to achieve 70%+ coverage of WeatherCorrelation and
-related dataclasses, covering:
-- Learning algorithm (learn_from_sample, coefficient updates)
-- Prediction logic (predict_load)
-- Weather integration (get_temperature_forecast, async_get_temperature_forecast)
-- Storage persistence (async_initialize, async_save)
-- Diagnostics (get_diagnostics)
-- Edge cases (missing weather, invalid inputs, low confidence)
-"""
+"""Tests for learning/correlation.py - weather correlation regression."""
 
 from __future__ import annotations
 
-from datetime import UTC, date, datetime, timedelta
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -21,312 +11,174 @@ from custom_components.localshift.const import (
     CONF_COOLING_THRESHOLD,
     CONF_HEATING_THRESHOLD,
     CONF_WEATHER_ENTITY,
-    DEFAULT_COOLING_THRESHOLD,
-    DEFAULT_HEATING_THRESHOLD,
 )
+import custom_components.localshift.learning.correlation as correlation_module
 from custom_components.localshift.learning.correlation import (
-    CONFIDENCE_LOW_THRESHOLD,
-    CONFIDENCE_MEDIUM_THRESHOLD,
+    DailySnapshot,
     HourlyTemperatureCoefficients,
-    TemperatureForecast,
-    WEATHER_ANOMALY_ANOMALOUS_WEIGHT,
-    WEATHER_ANOMALY_NORMAL_WEIGHT,
-    WEATHER_TEMPERATURE_HISTORY_DAYS,
-    WeatherAnomalyResult,
+    HourlyRegressionData,
+    HourlyRegressionResult,
     WeatherCorrelation,
     WeatherCorrelationData,
+    ZoneStats,
 )
 
-# =============================================================================
-# FIXTURES
-# =============================================================================
 
-
-@pytest.fixture
-def mock_hass():
-    """Create a minimal mock HomeAssistant instance."""
-    hass = MagicMock()
-    hass.states = MagicMock()
-    hass.states.get = MagicMock(return_value=None)
-    hass.services = MagicMock()
-    hass.services.async_call = AsyncMock(return_value=None)
-    return hass
-
-
-@pytest.fixture
-def mock_entry():
-    """Create a mock ConfigEntry with weather correlation settings."""
-    entry = MagicMock()
-    entry.options = {
-        CONF_WEATHER_ENTITY: "weather.home",
-        CONF_COOLING_THRESHOLD: DEFAULT_COOLING_THRESHOLD,
-        CONF_HEATING_THRESHOLD: DEFAULT_HEATING_THRESHOLD,
-    }
-    entry.data = {
-        CONF_WEATHER_ENTITY: "weather.home",
-    }
-    return entry
-
-
-@pytest.fixture
-def mock_entry_no_weather():
-    """Create a mock ConfigEntry with no weather entity configured."""
-    entry = MagicMock()
-    entry.options = {}
-    entry.data = {}
-    return entry
-
-
-@pytest.fixture
-def correlation(mock_hass, mock_entry):
-    """Create a WeatherCorrelation instance with mocked store."""
-    with patch(
-        "custom_components.localshift.learning.correlation.Store"
-    ) as mock_store_cls:
-        mock_store = AsyncMock()
-        mock_store.async_load = AsyncMock(return_value=None)
-        mock_store.async_save = AsyncMock(return_value=None)
-        mock_store_cls.return_value = mock_store
-
-        instance = WeatherCorrelation(mock_hass, mock_entry)
-        instance._store = mock_store
-        return instance
-
-
-@pytest.fixture
-def correlation_no_weather(mock_hass, mock_entry_no_weather):
-    """Create a WeatherCorrelation with no weather entity."""
-    with patch(
-        "custom_components.localshift.learning.correlation.Store"
-    ) as mock_store_cls:
-        mock_store = AsyncMock()
-        mock_store.async_load = AsyncMock(return_value=None)
-        mock_store.async_save = AsyncMock(return_value=None)
-        mock_store_cls.return_value = mock_store
-
-        instance = WeatherCorrelation(mock_hass, mock_entry_no_weather)
-        instance._store = mock_store
-        return instance
-
-
-def make_weather_state(temperature: float = 22.0, forecast_list: list | None = None):
-    """Create a mock weather entity state."""
-    state = MagicMock()
-    state.attributes = {
-        "temperature": temperature,
-        "forecast": forecast_list or [],
-    }
-    return state
-
-
-def make_forecast_entry(
-    hours_ahead: float = 1.0,
-    temperature: float = 22.0,
-    condition: str = "sunny",
-    now: datetime | None = None,
-) -> dict:
-    """Create a single forecast entry dict."""
-    if now is None:
-        now = datetime.now(UTC)
-    forecast_time = now + timedelta(hours=hours_ahead)
-    return {
-        "datetime": forecast_time.isoformat(),
-        "temperature": temperature,
-        "condition": condition,
-    }
-
-
-# =============================================================================
-# HourlyTemperatureCoefficients
-# =============================================================================
+def _linear_stats(n: int, slope: float) -> ZoneStats:
+    sum_x = n * (n + 1) / 2
+    sum_xx = n * (n + 1) * (2 * n + 1) / 6
+    sum_y = slope * sum_x
+    sum_xy = slope * sum_xx
+    sum_yy = slope * slope * sum_xx
+    return ZoneStats(
+        n=n,
+        sum_x=float(sum_x),
+        sum_y=float(sum_y),
+        sum_xx=float(sum_xx),
+        sum_xy=float(sum_xy),
+        sum_yy=float(sum_yy),
+    )
 
 
 class TestHourlyTemperatureCoefficients:
-    """Tests for the HourlyTemperatureCoefficients dataclass."""
-
-    def test_default_values(self):
-        """Default instance should have zero coefficients."""
-        coef = HourlyTemperatureCoefficients()
-        assert coef.base_load_kw == 0.0
-        assert coef.cooling_coefficient == 0.0
-        assert coef.heating_coefficient == 0.0
-        assert coef.sample_count == 0
-        assert coef.last_updated == ""
-        assert coef.confidence == "low"
-
-    def test_to_dict(self):
-        """to_dict should serialise all fields."""
+    def test_roundtrip(self):
         coef = HourlyTemperatureCoefficients(
-            base_load_kw=1.5,
+            base_load_kw=1.1,
             cooling_coefficient=0.2,
             heating_coefficient=0.3,
-            sample_count=10,
-            last_updated="2024-01-01T12:00:00",
+            sample_count=4,
+            last_updated="2026-03-26T10:00:00",
             confidence="medium",
         )
-        d = coef.to_dict()
-        assert d["base_load_kw"] == 1.5
-        assert d["cooling_coefficient"] == 0.2
-        assert d["heating_coefficient"] == 0.3
-        assert d["sample_count"] == 10
-        assert d["last_updated"] == "2024-01-01T12:00:00"
+        restored = HourlyTemperatureCoefficients.from_dict(coef.to_dict())
+        assert restored == coef
+
+
+class TestZoneStats:
+    def test_roundtrip(self):
+        stats = ZoneStats(n=2, sum_x=3.0, sum_y=4.0, sum_xx=5.0, sum_xy=6.0, sum_yy=7.0)
+        restored = ZoneStats.from_dict(stats.to_dict())
+        assert restored == stats
+
+
+class TestHourlyRegressionData:
+    def test_roundtrip(self):
+        data = HourlyRegressionData(
+            mild=ZoneStats(n=1, sum_y=2.0),
+            heating=ZoneStats(n=2, sum_x=3.0, sum_y=4.0),
+            cooling=ZoneStats(n=3, sum_x=4.0, sum_y=5.0),
+        )
+        restored = HourlyRegressionData.from_dict(data.to_dict())
+        assert restored.mild.n == 1
+        assert restored.heating.sum_x == 3.0
+        assert restored.cooling.sum_y == 5.0
+
+
+class TestDailySnapshot:
+    def test_roundtrip(self):
+        snapshot = DailySnapshot(
+            date_key="2026-03-26",
+            data=HourlyRegressionData(mild=ZoneStats(n=1, sum_y=2.0)),
+        )
+        restored = DailySnapshot.from_dict(snapshot.to_dict())
+        assert restored.date_key == "2026-03-26"
+        assert restored.data.mild.sum_y == 2.0
+
+
+class TestHourlyRegressionResult:
+    def test_to_dict(self):
+        result = HourlyRegressionResult(
+            base_load_kw=1.2,
+            heating_slope=0.4,
+            cooling_slope=0.3,
+            r_squared=0.5,
+            sample_count=40,
+            confidence="medium",
+        )
+        d = result.to_dict()
+        assert d["base_load_kw"] == 1.2
+        assert d["r_squared"] == 0.5
         assert d["confidence"] == "medium"
 
-    def test_from_dict_full(self):
-        """from_dict should restore all fields."""
-        data = {
-            "base_load_kw": 2.0,
-            "cooling_coefficient": 0.15,
-            "heating_coefficient": 0.25,
-            "sample_count": 35,
-            "last_updated": "2024-06-01T08:00:00",
-            "confidence": "high",
-        }
-        coef = HourlyTemperatureCoefficients.from_dict(data)
-        assert coef.base_load_kw == 2.0
-        assert coef.cooling_coefficient == 0.15
-        assert coef.heating_coefficient == 0.25
-        assert coef.sample_count == 35
-        assert coef.last_updated == "2024-06-01T08:00:00"
-        assert coef.confidence == "high"
 
-    def test_from_dict_defaults(self):
-        """from_dict with empty dict should return defaults."""
-        coef = HourlyTemperatureCoefficients.from_dict({})
-        assert coef.base_load_kw == 0.0
-        assert coef.cooling_coefficient == 0.0
-        assert coef.heating_coefficient == 0.0
-        assert coef.sample_count == 0
-        assert coef.confidence == "low"
-
-    def test_roundtrip(self):
-        """to_dict → from_dict should be lossless."""
-        original = HourlyTemperatureCoefficients(
-            base_load_kw=3.5,
-            cooling_coefficient=0.1,
-            heating_coefficient=0.4,
-            sample_count=50,
-            last_updated="2024-01-15T10:00:00",
-            confidence="high",
+class TestRegressionMath:
+    def test_fit_zone_regression_returns_expected_slope_and_r_squared(self):
+        stats = ZoneStats(
+            n=3,
+            sum_x=6.0,
+            sum_y=12.0,
+            sum_xx=14.0,
+            sum_xy=28.0,
+            sum_yy=56.0,
         )
-        restored = HourlyTemperatureCoefficients.from_dict(original.to_dict())
-        assert restored.base_load_kw == original.base_load_kw
-        assert restored.cooling_coefficient == original.cooling_coefficient
-        assert restored.confidence == original.confidence
+        fit_fn = getattr(correlation_module, "_fit_zone_regression", None)
+        assert callable(fit_fn)
+        slope, r_squared = fit_fn(stats)
+        assert slope == pytest.approx(2.0)
+        assert r_squared == pytest.approx(1.0)
 
+    def test_fit_zone_regression_handles_insufficient_stats(self):
+        fit_fn = getattr(correlation_module, "_fit_zone_regression", None)
+        assert callable(fit_fn)
+        slope, r_squared = fit_fn(ZoneStats(n=1, sum_xx=0.0))
+        assert slope == 0.0
+        assert r_squared == 0.0
 
-# =============================================================================
-# WeatherCorrelationData
-# =============================================================================
+    def test_fit_zone_regression_handles_zero_variance(self):
+        fit_fn = getattr(correlation_module, "_fit_zone_regression", None)
+        assert callable(fit_fn)
+        stats = ZoneStats(n=2, sum_x=2.0, sum_y=2.0, sum_xx=2.0, sum_xy=2.0, sum_yy=0.0)
+        slope, r_squared = fit_fn(stats)
+        assert slope == pytest.approx(1.0)
+        assert r_squared == 0.0
 
 
 class TestWeatherCorrelationData:
-    """Tests for the WeatherCorrelationData dataclass."""
-
-    def test_default_values(self):
-        """Default instance should have expected values."""
-        data = WeatherCorrelationData()
-        assert data.version == 1
-        assert data.weather_entity_id == ""
-        assert data.cooling_threshold == 24.0
-        assert data.heating_threshold == 18.0
-        assert data.hourly_coefficients == {}
-        assert data.learning_stats == {}
-
-    def test_to_dict(self):
-        """to_dict should serialise all fields including nested coefficients."""
-        coef = HourlyTemperatureCoefficients(base_load_kw=2.0, sample_count=5)
-        data = WeatherCorrelationData(
-            weather_entity_id="weather.test",
-            cooling_threshold=25.0,
-            heating_threshold=17.0,
-            hourly_coefficients={14: coef},
-            learning_stats={"note": "test"},
-        )
-        d = data.to_dict()
-        assert d["weather_entity_id"] == "weather.test"
-        assert d["cooling_threshold"] == 25.0
-        assert d["heating_threshold"] == 17.0
-        assert "14" in d["hourly_coefficients"]
-        assert d["hourly_coefficients"]["14"]["base_load_kw"] == 2.0
-        assert d["learning_stats"] == {"note": "test"}
-
-    def test_from_dict_full(self):
-        """from_dict should restore all fields including nested coefficients."""
-        raw = {
-            "version": 2,
-            "weather_entity_id": "weather.bureau",
-            "cooling_threshold": 26.0,
-            "heating_threshold": 16.0,
-            "hourly_coefficients": {
-                "8": {
-                    "base_load_kw": 1.2,
-                    "cooling_coefficient": 0.05,
-                    "heating_coefficient": 0.1,
-                    "sample_count": 20,
-                    "last_updated": "2024-03-01",
-                    "confidence": "medium",
-                }
-            },
-            "learning_stats": {},
-        }
-        data = WeatherCorrelationData.from_dict(raw)
-        assert data.version == 2
-        assert data.weather_entity_id == "weather.bureau"
-        assert data.cooling_threshold == 26.0
-        assert 8 in data.hourly_coefficients
-        assert data.hourly_coefficients[8].base_load_kw == 1.2
-        assert data.hourly_coefficients[8].sample_count == 20
-
-    def test_from_dict_defaults(self):
-        """from_dict with empty dict should return safe defaults."""
-        data = WeatherCorrelationData.from_dict({})
-        assert data.version == 1
-        assert data.hourly_coefficients == {}
-
     def test_roundtrip(self):
-        """to_dict → from_dict should be lossless for nested structures."""
-        coef = HourlyTemperatureCoefficients(base_load_kw=5.0, sample_count=100)
+        snapshot = DailySnapshot(
+            date_key="2026-03-26",
+            data=HourlyRegressionData(mild=ZoneStats(n=2, sum_y=5.0)),
+        )
         original = WeatherCorrelationData(
             weather_entity_id="weather.home",
-            hourly_coefficients={12: coef},
+            daily_regression_stats={12: [snapshot]},
         )
         restored = WeatherCorrelationData.from_dict(original.to_dict())
         assert restored.weather_entity_id == "weather.home"
-        assert 12 in restored.hourly_coefficients
-        assert restored.hourly_coefficients[12].base_load_kw == 5.0
+        assert 12 in restored.daily_regression_stats
+        assert restored.daily_regression_stats[12][0].data.mild.sum_y == 5.0
 
-
-# =============================================================================
-# WeatherCorrelation.async_initialize
-# =============================================================================
+    def test_temperature_history_roundtrip(self):
+        data = WeatherCorrelationData()
+        data.temperature_history["2024-01-01"] = 22.0
+        restored = WeatherCorrelationData.from_dict(data.to_dict())
+        assert restored.temperature_history == {"2024-01-01": 22.0}
 
 
 class TestAsyncInitialize:
-    """Tests for WeatherCorrelation.async_initialize."""
-
     @pytest.mark.asyncio
     async def test_initialize_from_storage(self, correlation):
-        """Should load existing data from storage."""
         stored = WeatherCorrelationData(
             weather_entity_id="weather.stored",
             cooling_threshold=25.0,
             heating_threshold=17.0,
         )
-        stored.hourly_coefficients[10] = HourlyTemperatureCoefficients(
-            base_load_kw=2.0, sample_count=15
-        )
+        stored.daily_regression_stats[10] = [
+            DailySnapshot(
+                date_key="2026-03-26",
+                data=HourlyRegressionData(mild=ZoneStats(n=1, sum_y=2.0)),
+            )
+        ]
         correlation._store.async_load.return_value = stored.to_dict()
 
         await correlation.async_initialize()
 
         assert correlation._initialized is True
         assert correlation._data.weather_entity_id == "weather.stored"
-        assert 10 in correlation._data.hourly_coefficients
+        assert 10 in correlation._data.daily_regression_stats
 
     @pytest.mark.asyncio
     async def test_initialize_fresh(self, correlation, mock_entry):
-        """With no stored data, should init from config entry."""
         correlation._store.async_load.return_value = None
         mock_entry.options = {
             CONF_WEATHER_ENTITY: "weather.new",
@@ -344,17 +196,13 @@ class TestAsyncInitialize:
 
     @pytest.mark.asyncio
     async def test_initialize_idempotent(self, correlation):
-        """Calling async_initialize twice should not re-load storage."""
         correlation._store.async_load.return_value = None
         await correlation.async_initialize()
         await correlation.async_initialize()
-
-        # async_load called only once
         assert correlation._store.async_load.call_count == 1
 
     @pytest.mark.asyncio
     async def test_initialize_falls_back_to_data(self, correlation, mock_entry):
-        """Weather entity should come from entry.data when options is empty."""
         correlation._store.async_load.return_value = None
         mock_entry.options = {}
         mock_entry.data = {CONF_WEATHER_ENTITY: "weather.fallback"}
@@ -364,17 +212,9 @@ class TestAsyncInitialize:
         assert correlation._data.weather_entity_id == "weather.fallback"
 
 
-# =============================================================================
-# WeatherCorrelation.async_save
-# =============================================================================
-
-
 class TestAsyncSave:
-    """Tests for WeatherCorrelation.async_save."""
-
     @pytest.mark.asyncio
     async def test_save_calls_store(self, correlation):
-        """async_save should persist current data to the store."""
         correlation._data.weather_entity_id = "weather.test"
         await correlation.async_save()
 
@@ -383,1240 +223,369 @@ class TestAsyncSave:
         assert saved["weather_entity_id"] == "weather.test"
 
 
-# =============================================================================
-# WeatherCorrelation.get_temperature_forecast (legacy)
-# =============================================================================
+class TestLearningAndPrediction:
+    def test_learn_ignores_invalid_hour(self, correlation):
+        correlation.learn_from_sample(-1, 25.0, 2.0)
+        assert correlation._data.daily_regression_stats == {}
 
-
-class TestGetTemperatureForecast:
-    """Tests for the legacy get_temperature_forecast method."""
-
-    def test_no_weather_entity(self, correlation):
-        """Returns empty list when no entity is configured."""
-        correlation._data.weather_entity_id = ""
-        result = correlation.get_temperature_forecast()
-        assert result == []
-
-    def test_entity_not_found(self, correlation):
-        """Returns empty list when entity state is None."""
-        correlation._data.weather_entity_id = "weather.missing"
-        correlation.hass.states.get.return_value = None
-
-        result = correlation.get_temperature_forecast()
-        assert result == []
-
-    def test_empty_forecast(self, correlation):
-        """Returns empty list when weather entity has no forecast attribute."""
-        correlation._data.weather_entity_id = "weather.home"
-        state = MagicMock()
-        state.attributes = {"forecast": []}
-        correlation.hass.states.get.return_value = state
-
-        result = correlation.get_temperature_forecast()
-        assert result == []
-
-    def test_valid_forecast_entries(self, correlation):
-        """Should parse valid forecast entries within 24h window."""
+    def test_learn_records_mild_zone_stats(self, correlation):
         now = datetime.now(UTC)
-        correlation._data.weather_entity_id = "weather.home"
-
-        entries = [
-            make_forecast_entry(hours_ahead=2, temperature=28.0, now=now),
-            make_forecast_entry(hours_ahead=8, temperature=32.0, now=now),
-        ]
-        state = make_weather_state(forecast_list=entries)
-        correlation.hass.states.get.return_value = state
-
-        with patch(
-            "custom_components.localshift.learning.correlation.dt_util.now",
-            return_value=now,
-        ):
-            result = correlation.get_temperature_forecast()
-
-        assert len(result) == 2
-        assert isinstance(result[0], TemperatureForecast)
-        assert result[0].temperature == 28.0
-
-    def test_forecast_outside_24h_filtered(self, correlation):
-        """Forecasts more than 24h ahead or in the past should be excluded."""
-        now = datetime.now(UTC)
-        correlation._data.weather_entity_id = "weather.home"
-
-        entries = [
-            make_forecast_entry(hours_ahead=25, temperature=20.0, now=now),  # too far
-            make_forecast_entry(hours_ahead=-1, temperature=20.0, now=now),  # past
-            make_forecast_entry(hours_ahead=12, temperature=22.0, now=now),  # valid
-        ]
-        state = make_weather_state(forecast_list=entries)
-        correlation.hass.states.get.return_value = state
-
-        with patch(
-            "custom_components.localshift.learning.correlation.dt_util.now",
-            return_value=now,
-        ):
-            result = correlation.get_temperature_forecast()
-
-        assert len(result) == 1
-        assert result[0].temperature == 22.0
-
-    def test_forecast_entry_missing_datetime(self, correlation):
-        """Entries without 'datetime' key should be skipped."""
-        now = datetime.now(UTC)
-        correlation._data.weather_entity_id = "weather.home"
-
-        entries = [
-            {"temperature": 25.0, "condition": "sunny"},  # no datetime
-            make_forecast_entry(hours_ahead=3, temperature=27.0, now=now),
-        ]
-        state = make_weather_state(forecast_list=entries)
-        correlation.hass.states.get.return_value = state
-
-        with patch(
-            "custom_components.localshift.learning.correlation.dt_util.now",
-            return_value=now,
-        ):
-            result = correlation.get_temperature_forecast()
-
-        assert len(result) == 1
-        assert result[0].temperature == 27.0
-
-    def test_forecast_entry_invalid_datetime(self, correlation):
-        """Entries with unparseable datetime should be skipped."""
-        now = datetime.now(UTC)
-        correlation._data.weather_entity_id = "weather.home"
-
-        entries = [
-            {"datetime": "not-a-date", "temperature": 25.0},
-            make_forecast_entry(hours_ahead=4, temperature=29.0, now=now),
-        ]
-        state = make_weather_state(forecast_list=entries)
-        correlation.hass.states.get.return_value = state
-
-        with patch(
-            "custom_components.localshift.learning.correlation.dt_util.now",
-            return_value=now,
-        ):
-            with patch(
-                "custom_components.localshift.learning.correlation.dt_util.parse_datetime",
-                return_value=None,
-            ):
-                result = correlation.get_temperature_forecast()
-
-        # Only the valid one (even though parse_datetime returns None for all,
-        # the invalid "not-a-date" will fail; the valid entry will also fail
-        # in this mock but that is the expected tested behaviour)
-        assert isinstance(result, list)
-
-
-# =============================================================================
-# WeatherCorrelation.async_get_temperature_forecast
-# =============================================================================
-
-
-class TestAsyncGetTemperatureForecast:
-    """Tests for async_get_temperature_forecast."""
-
-    @pytest.mark.asyncio
-    async def test_no_weather_entity(self, correlation_no_weather):
-        """Returns empty list when no weather entity configured."""
-        result = await correlation_no_weather.async_get_temperature_forecast()
-        assert result == []
-
-    @pytest.mark.asyncio
-    async def test_returns_cached_within_ttl(self, correlation):
-        """Returns cached forecasts when cache is still fresh."""
-        now = datetime.now(UTC)
-        cached = [TemperatureForecast(slot_time=now, temperature=22.0)]
-        correlation._cached_forecasts = cached
-        correlation._forecast_cache_time = now - timedelta(minutes=5)  # fresh
-        correlation._data.weather_entity_id = "weather.home"
-
-        with patch(
-            "custom_components.localshift.learning.correlation.dt_util.now",
-            return_value=now,
-        ):
-            result = await correlation.async_get_temperature_forecast()
-
-        assert result is cached
-
-    @pytest.mark.asyncio
-    async def test_force_refresh_bypasses_cache(self, correlation):
-        """force_refresh=True should bypass the cache."""
-        now = datetime.now(UTC)
-        cached = [TemperatureForecast(slot_time=now, temperature=22.0)]
-        correlation._cached_forecasts = cached
-        correlation._forecast_cache_time = now - timedelta(minutes=1)  # very fresh
-        correlation._data.weather_entity_id = "weather.home"
-
-        # Service returns empty response so it falls back to legacy (also empty)
-        correlation.hass.services.async_call = AsyncMock(return_value=None)
-        correlation.hass.states.get.return_value = make_weather_state(forecast_list=[])
-
-        with patch(
-            "custom_components.localshift.learning.correlation.dt_util.now",
-            return_value=now,
-        ):
-            result = await correlation.async_get_temperature_forecast(
-                force_refresh=True
-            )
-
-        # Cache was bypassed; result is the fresh (empty) forecast
-        assert result == []
-
-    @pytest.mark.asyncio
-    async def test_service_call_success_list_response(self, correlation):
-        """Should parse forecasts when service returns a list directly."""
-        now = datetime.now(UTC)
-        correlation._data.weather_entity_id = "weather.home"
-        correlation._cached_forecasts = []
-        correlation._forecast_cache_time = None
-
-        entry = make_forecast_entry(hours_ahead=3, temperature=30.0, now=now)
-        response = {"weather.home": [entry]}
-        correlation.hass.services.async_call = AsyncMock(return_value=response)
-
-        with patch(
-            "custom_components.localshift.learning.correlation.dt_util.now",
-            return_value=now,
-        ):
-            result = await correlation.async_get_temperature_forecast()
-
-        assert len(result) == 1
-        assert result[0].temperature == 30.0
-
-    @pytest.mark.asyncio
-    async def test_service_call_success_dict_response_forecast_key(self, correlation):
-        """Should parse forecasts when service response has 'forecast' key."""
-        now = datetime.now(UTC)
-        correlation._data.weather_entity_id = "weather.home"
-        correlation._cached_forecasts = []
-        correlation._forecast_cache_time = None
-
-        entry = make_forecast_entry(hours_ahead=5, temperature=18.0, now=now)
-        response = {"weather.home": {"forecast": [entry]}}
-        correlation.hass.services.async_call = AsyncMock(return_value=response)
-
-        with patch(
-            "custom_components.localshift.learning.correlation.dt_util.now",
-            return_value=now,
-        ):
-            result = await correlation.async_get_temperature_forecast()
-
-        assert len(result) == 1
-        assert result[0].temperature == 18.0
-
-    @pytest.mark.asyncio
-    async def test_service_call_no_entity_in_response(self, correlation):
-        """Falls back to legacy when entity is missing from response."""
-        now = datetime.now(UTC)
-        correlation._data.weather_entity_id = "weather.home"
-        correlation._cached_forecasts = []
-        correlation._forecast_cache_time = None
-
-        # Response doesn't contain our entity
-        response = {"weather.other": []}
-        correlation.hass.services.async_call = AsyncMock(return_value=response)
-        # Legacy forecast also empty
-        correlation.hass.states.get.return_value = make_weather_state(forecast_list=[])
-
-        with patch(
-            "custom_components.localshift.learning.correlation.dt_util.now",
-            return_value=now,
-        ):
-            result = await correlation.async_get_temperature_forecast()
-
-        assert result == []
-
-    @pytest.mark.asyncio
-    async def test_service_call_exception_falls_back_to_legacy(self, correlation):
-        """Falls back to legacy attribute when service call raises exception."""
-        now = datetime.now(UTC)
-        correlation._data.weather_entity_id = "weather.home"
-        correlation._cached_forecasts = []
-        correlation._forecast_cache_time = None
-
-        correlation.hass.services.async_call = AsyncMock(
-            side_effect=Exception("service unavailable")
-        )
-        entry = make_forecast_entry(hours_ahead=2, temperature=20.0, now=now)
-        correlation.hass.states.get.return_value = make_weather_state(
-            forecast_list=[entry]
-        )
-
-        with patch(
-            "custom_components.localshift.learning.correlation.dt_util.now",
-            return_value=now,
-        ):
-            result = await correlation.async_get_temperature_forecast()
-
-        assert len(result) == 1
-        assert result[0].temperature == 20.0
-
-    @pytest.mark.asyncio
-    async def test_weather_entity_change_clears_cache(self, correlation, mock_entry):
-        """Changing weather entity should clear the forecast cache."""
-        now = datetime.now(UTC)
-        # Start with a cached entry from old entity
-        correlation._data.weather_entity_id = "weather.old"
-        old_forecast = [TemperatureForecast(slot_time=now, temperature=22.0)]
-        correlation._cached_forecasts = old_forecast
-        correlation._forecast_cache_time = now - timedelta(minutes=1)
-
-        # Config now points to new entity
-        mock_entry.options = {CONF_WEATHER_ENTITY: "weather.new"}
-        mock_entry.data = {}
-
-        correlation.hass.services.async_call = AsyncMock(return_value=None)
-        correlation.hass.states.get.return_value = make_weather_state(forecast_list=[])
-
-        with patch(
-            "custom_components.localshift.learning.correlation.dt_util.now",
-            return_value=now,
-        ):
-            result = await correlation.async_get_temperature_forecast()
-
-        # Cache should have been cleared for new entity
-        assert correlation._data.weather_entity_id == "weather.new"
-        assert result == []
-
-
-# =============================================================================
-# WeatherCorrelation._extract_forecast_list
-# =============================================================================
-
-
-class TestExtractForecastList:
-    """Tests for the _extract_forecast_list helper."""
-
-    def test_list_response(self, correlation):
-        """Direct list response should be returned as-is."""
-        data = [{"datetime": "2024-01-01T12:00:00"}]
-        result = correlation._extract_forecast_list(
-            {"weather.home": data}, "weather.home"
-        )
-        assert result == data
-
-    def test_dict_with_forecast_key(self, correlation):
-        """Dict response with 'forecast' key should extract nested list."""
-        inner = [{"datetime": "2024-01-01T12:00:00"}]
-        response = {"weather.home": {"forecast": inner}}
-        result = correlation._extract_forecast_list(response, "weather.home")
-        assert result == inner
-
-    def test_dict_with_hourly_key(self, correlation):
-        """Dict response with 'hourly' key should extract nested list."""
-        inner = [{"datetime": "2024-01-01T12:00:00"}]
-        response = {"weather.home": {"hourly": inner}}
-        result = correlation._extract_forecast_list(response, "weather.home")
-        assert result == inner
-
-    def test_entity_not_in_response(self, correlation):
-        """Missing entity key should return None."""
-        result = correlation._extract_forecast_list({}, "weather.home")
-        assert result is None
-
-    def test_unexpected_format(self, correlation):
-        """Unexpected data type should return None."""
-        response = {"weather.home": "unexpected_string"}
-        result = correlation._extract_forecast_list(response, "weather.home")
-        assert result is None
-
-    def test_dict_without_known_keys(self, correlation):
-        """Dict without forecast/hourly keys should return None."""
-        response = {"weather.home": {"other_key": []}}
-        result = correlation._extract_forecast_list(response, "weather.home")
-        assert result is None
-
-
-# =============================================================================
-# WeatherCorrelation._parse_forecast_entries
-# =============================================================================
-
-
-class TestParseForecastEntries:
-    """Tests for _parse_forecast_entries."""
-
-    def test_empty_list(self, correlation):
-        """Empty list should return empty list."""
-        now = datetime.now(UTC)
-        result = correlation._parse_forecast_entries([], now)
-        assert result == []
-
-    def test_valid_entries(self, correlation):
-        """Valid entries within 24h should be returned."""
-        now = datetime.now(UTC)
-        entries = [
-            make_forecast_entry(hours_ahead=1, temperature=20.0, now=now),
-            make_forecast_entry(hours_ahead=6, temperature=25.0, now=now),
-            make_forecast_entry(hours_ahead=12, temperature=30.0, now=now),
-        ]
-
-        with patch(
-            "custom_components.localshift.learning.correlation.dt_util.now",
-            return_value=now,
-        ):
-            result = correlation._parse_forecast_entries(entries, now)
-
-        assert len(result) == 3
-
-    def test_non_dict_entries_skipped(self, correlation):
-        """Non-dict entries should be silently skipped."""
-        now = datetime.now(UTC)
-        entries = [
-            "not_a_dict",
-            None,
-            make_forecast_entry(hours_ahead=2, temperature=22.0, now=now),
-        ]
-
-        result = correlation._parse_forecast_entries(entries, now)
-
-        # Only the valid dict entry should be in result
-        valid = [r for r in result if r is not None]
-        assert len(valid) <= 1
-
-
-# =============================================================================
-# WeatherCorrelation._parse_single_forecast_entry
-# =============================================================================
-
-
-class TestParseSingleForecastEntry:
-    """Tests for _parse_single_forecast_entry."""
-
-    def test_non_dict_returns_none(self, correlation):
-        """Non-dict entry should return None."""
-        now = datetime.now(UTC)
-        result = correlation._parse_single_forecast_entry("not_a_dict", now, 0, 0, 0, 0)
-        assert result is None
-
-    def test_missing_datetime(self, correlation):
-        """Entry without 'datetime' key should return (None, updated_counts)."""
-        now = datetime.now(UTC)
-        entry = {"temperature": 25.0}
-        result = correlation._parse_single_forecast_entry(entry, now, 0, 0, 0, 0)
-        # Returns tuple with None as first element
-        assert result is not None
-        forecast, _, skipped, _ = result
-        assert forecast is None
-        assert skipped == 1
-
-    def test_invalid_datetime(self, correlation):
-        """Entry with unparseable datetime should return (None, updated_counts)."""
-        now = datetime.now(UTC)
-        entry = {"datetime": "bad-datetime", "temperature": 25.0}
-
-        with patch(
-            "custom_components.localshift.learning.correlation.dt_util.parse_datetime",
-            return_value=None,
-        ):
-            result = correlation._parse_single_forecast_entry(entry, now, 0, 0, 0, 0)
-
-        assert result is not None
-        forecast, parse_failed, _, _ = result
-        assert forecast is None
-        assert parse_failed == 1
-
-    def test_forecast_outside_window(self, correlation):
-        """Forecast too far in the future should return (None, updated_counts)."""
-        now = datetime.now(UTC)
-        future = now + timedelta(hours=30)
-        entry = {
-            "datetime": future.isoformat(),
-            "temperature": 25.0,
-        }
-        result = correlation._parse_single_forecast_entry(entry, now, 0, 0, 0, 0)
-        assert result is not None
-        forecast, _, _, filtered = result
-        assert forecast is None
-        assert filtered == 1
-
-    def test_valid_entry(self, correlation):
-        """Valid entry within window should return TemperatureForecast."""
-        now = datetime.now(UTC)
-        future = now + timedelta(hours=5)
-        entry = {
-            "datetime": future.isoformat(),
-            "temperature": 22.0,
-            "condition": "cloudy",
-        }
-        result = correlation._parse_single_forecast_entry(entry, now, 0, 0, 0, 0)
-        assert result is not None
-        forecast, _, _, _ = result
-        assert forecast is not None
-        assert isinstance(forecast, TemperatureForecast)
-        assert forecast.temperature == 22.0
-        assert forecast.condition == "cloudy"
-
-
-# =============================================================================
-# WeatherCorrelation._parse_forecast_datetime
-# =============================================================================
-
-
-class TestParseForecastDatetime:
-    """Tests for _parse_forecast_datetime."""
-
-    def test_valid_iso_with_timezone(self, correlation):
-        """Valid ISO datetime with timezone should parse correctly."""
-        now = datetime.now(UTC)
-        time_str = now.isoformat()
-        result = correlation._parse_forecast_datetime(time_str, 0, 0)
-        assert result is not None
-
-    def test_naive_iso_localized(self, correlation):
-        """Naive ISO datetime should be localized."""
-        naive_str = "2024-06-15T14:30:00"
-
-        with patch(
-            "custom_components.localshift.learning.correlation.dt_util.parse_datetime",
-            return_value=None,
-        ):
-            with patch(
-                "custom_components.localshift.learning.correlation.dt_util.as_local"
-            ) as mock_local:
-                mock_local.return_value = datetime(2024, 6, 15, 14, 30, 0, tzinfo=UTC)
-                result = correlation._parse_forecast_datetime(naive_str, 0, 0)
-
-        assert result is not None
-
-    def test_completely_invalid_string(self, correlation):
-        """Completely invalid string should return None."""
-        with patch(
-            "custom_components.localshift.learning.correlation.dt_util.parse_datetime",
-            return_value=None,
-        ):
-            result = correlation._parse_forecast_datetime("not-a-date", 0, 0)
-
-        assert result is None
-
-    def test_first_entry_logged(self, correlation):
-        """First entry (index=0) should log debug info."""
-        now = datetime.now(UTC)
-        time_str = now.isoformat()
-
-        with patch(
-            "custom_components.localshift.learning.correlation.dt_util.parse_datetime",
-            return_value=now,
-        ):
-            result = correlation._parse_forecast_datetime(time_str, 0, 0)
-
-        assert result is not None
-
-    def test_none_after_parse(self, correlation):
-        """When parse_datetime returns valid result with no tzinfo, should localize."""
-        naive_dt = datetime(2024, 1, 1, 12, 0, 0)  # no timezone
-        with patch(
-            "custom_components.localshift.learning.correlation.dt_util.parse_datetime",
-            return_value=naive_dt,
-        ):
-            with patch(
-                "custom_components.localshift.learning.correlation.dt_util.as_local",
-                return_value=datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC),
-            ):
-                result = correlation._parse_forecast_datetime(
-                    "2024-01-01T12:00:00", 0, 0
-                )
-
-        assert result is not None
-
-
-# =============================================================================
-# WeatherCorrelation.get_current_temperature
-# =============================================================================
-
-
-class TestGetCurrentTemperature:
-    """Tests for get_current_temperature."""
-
-    def test_no_weather_entity(self, correlation):
-        """Returns None when no entity configured."""
-        correlation._data.weather_entity_id = ""
-        assert correlation.get_current_temperature() is None
-
-    def test_entity_not_found(self, correlation):
-        """Returns None when entity state is None."""
-        correlation._data.weather_entity_id = "weather.home"
-        correlation.hass.states.get.return_value = None
-        assert correlation.get_current_temperature() is None
-
-    def test_valid_temperature(self, correlation):
-        """Returns the current temperature from entity attributes."""
-        correlation._data.weather_entity_id = "weather.home"
-        state = make_weather_state(temperature=23.5)
-        correlation.hass.states.get.return_value = state
-
-        result = correlation.get_current_temperature()
-
-        assert result == 23.5
-
-    def test_invalid_temperature_returns_none(self, correlation):
-        """Returns None (as 0.0 float conversion) for missing temperature."""
-        correlation._data.weather_entity_id = "weather.home"
-        state = MagicMock()
-        state.attributes = {"temperature": "not_a_number"}
-        correlation.hass.states.get.return_value = state
-
-        # "not_a_number" raises ValueError in float(), returns None
-        result = correlation.get_current_temperature()
-        assert result is None
-
-    def test_temperature_zero_degrees(self, correlation):
-        """Temperature of 0 should be returned as 0.0."""
-        correlation._data.weather_entity_id = "weather.home"
-        state = make_weather_state(temperature=0.0)
-        correlation.hass.states.get.return_value = state
-
-        result = correlation.get_current_temperature()
-        # attributes.get("temperature", 0) returns 0.0, float(0.0) = 0.0
-        assert result == 0.0
-
-
-# =============================================================================
-# WeatherCorrelation.learn_from_sample
-# =============================================================================
-
-
-class TestLearnFromSample:
-    """Tests for the learn_from_sample method."""
-
-    @pytest.mark.asyncio
-    async def test_invalid_hour_negative(self, correlation):
-        """Negative hour should log warning and return without updating."""
-        with patch(
-            "custom_components.localshift.learning.correlation.dt_util.now",
-            return_value=datetime.now(UTC),
-        ):
-            correlation.learn_from_sample(-1, 22.0, 3.0)
-
-        assert -1 not in correlation._data.hourly_coefficients
-
-    @pytest.mark.asyncio
-    async def test_invalid_hour_too_large(self, correlation):
-        """Hour > 23 should log warning and return without updating."""
-        correlation.learn_from_sample(24, 22.0, 3.0)
-        assert 24 not in correlation._data.hourly_coefficients
-
-    def test_mild_temperature_updates_base_load(self, correlation):
-        """Mild temperature should update base load."""
-        now = datetime.now(UTC)
-        # Default thresholds: heating=18, cooling=24 → mild is 18-24°C
         with patch(
             "custom_components.localshift.learning.correlation.dt_util.now",
             return_value=now,
         ):
             correlation.learn_from_sample(12, 21.0, 3.0)
 
-        coef = correlation._data.hourly_coefficients[12]
-        assert coef.base_load_kw == 3.0  # first sample: set directly
-        assert coef.sample_count == 1
-        assert coef.confidence in ("low", "medium", "high")
+        snapshot = correlation._data.daily_regression_stats[12][0]
+        assert snapshot.data.mild.n == 1
+        assert snapshot.data.mild.sum_y == 3.0
 
-    def test_cooling_temperature_updates_coefficient(self, correlation):
-        """Above-threshold temperature should update cooling coefficient."""
+    def test_learn_skips_small_temp_delta(self, correlation):
         now = datetime.now(UTC)
-        # Pre-seed base load so cooling coefficient can be calculated
-        correlation._data.hourly_coefficients[14] = HourlyTemperatureCoefficients(
-            base_load_kw=2.0
-        )
-
         with patch(
             "custom_components.localshift.learning.correlation.dt_util.now",
             return_value=now,
         ):
-            correlation.learn_from_sample(14, 30.0, 5.0)  # 30°C > 24°C threshold
+            correlation.learn_from_sample(8, 24.5, 4.0)
 
-        coef = correlation._data.hourly_coefficients[14]
-        assert coef.cooling_coefficient > 0
+        snapshot = correlation._data.daily_regression_stats[8][0]
+        assert snapshot.data.cooling.n == 0
 
-    def test_heating_temperature_updates_coefficient(self, correlation):
-        """Below-threshold temperature should update heating coefficient."""
+    def test_learn_records_cooling_zone_stats(self, correlation):
         now = datetime.now(UTC)
-        # Pre-seed base load
-        correlation._data.hourly_coefficients[6] = HourlyTemperatureCoefficients(
-            base_load_kw=2.0
-        )
-
         with patch(
             "custom_components.localshift.learning.correlation.dt_util.now",
             return_value=now,
         ):
-            correlation.learn_from_sample(6, 10.0, 4.5)  # 10°C < 18°C threshold
+            correlation.learn_from_sample(8, 26.0, 4.0)
 
-        coef = correlation._data.hourly_coefficients[6]
-        assert coef.heating_coefficient > 0
+        snapshot = correlation._data.daily_regression_stats[8][0]
+        assert snapshot.data.cooling.n == 1
 
-    def test_new_hour_initializes_coefficients(self, correlation):
-        """Learning for a previously unseen hour should create the entry."""
+    def test_predict_load_returns_weather_none_for_mild_zone(self, correlation):
         now = datetime.now(UTC)
-        assert 20 not in correlation._data.hourly_coefficients
-
         with patch(
             "custom_components.localshift.learning.correlation.dt_util.now",
             return_value=now,
         ):
-            correlation.learn_from_sample(20, 20.0, 2.5)
+            min_samples = getattr(correlation_module, "MIN_SAMPLES_PER_ZONE", None)
+            assert min_samples is not None
+            for _ in range(min_samples):
+                correlation.learn_from_sample(10, 21.0, 0.72)
 
-        assert 20 in correlation._data.hourly_coefficients
+        predicted, reason = correlation.predict_load(10, 21.0, 0.72)
+        assert predicted == pytest.approx(0.72)
+        assert reason == "weather_none"
 
-    def test_confidence_progression(self, correlation):
-        """Confidence should progress from low → medium → high as samples grow."""
+    def test_predict_load_caps_output(self, correlation):
         now = datetime.now(UTC)
-
         with patch(
             "custom_components.localshift.learning.correlation.dt_util.now",
             return_value=now,
         ):
-            for _ in range(3):
-                correlation.learn_from_sample(10, 20.0, 2.0)
+            min_samples = getattr(correlation_module, "MIN_SAMPLES_PER_ZONE", None)
+            assert min_samples is not None
+            for _ in range(min_samples):
+                correlation.learn_from_sample(8, 10.0, 5.0)
+                correlation.learn_from_sample(8, 0.0, 10.0)
 
-        assert correlation._data.hourly_coefficients[10].confidence == "low"
+        predicted, reason = correlation.predict_load(8, 0.0, 0.5)
+        assert reason == "weather_heating"
+        max_multiplier = getattr(correlation_module, "MAX_LOAD_MULTIPLIER", None)
+        assert max_multiplier is not None
+        cap = max(0.5, 0.1) * max_multiplier
+        assert predicted <= cap + 1e-6
 
+    def test_regression_replay_caps_original_bug(self, correlation):
+        now = datetime.now(UTC)
         with patch(
             "custom_components.localshift.learning.correlation.dt_util.now",
             return_value=now,
         ):
-            for _ in range(10):
-                correlation.learn_from_sample(10, 20.0, 2.0)
+            min_samples = getattr(correlation_module, "MIN_SAMPLES_PER_ZONE", None)
+            assert min_samples is not None
+            for _ in range(min_samples):
+                correlation.learn_from_sample(8, 15.0, 2.0)
+                correlation.learn_from_sample(8, 5.0, 6.0)
 
-        assert correlation._data.hourly_coefficients[10].confidence == "medium"
+        predicted, reason = correlation.predict_load(8, 5.0, 0.72)
+        assert reason == "weather_heating"
+        max_multiplier = getattr(correlation_module, "MAX_LOAD_MULTIPLIER", None)
+        assert max_multiplier is not None
+        cap = max(0.72, 0.1) * max_multiplier
+        assert predicted <= cap + 1e-6
 
-        with patch(
-            "custom_components.localshift.learning.correlation.dt_util.now",
-            return_value=now,
-        ):
-            for _ in range(25):
-                correlation.learn_from_sample(10, 20.0, 2.0)
+    def test_predict_load_returns_invalid_hour(self, correlation):
+        predicted, reason = correlation.predict_load(-1, 20.0, 1.0)
+        assert predicted == 1.0
+        assert reason == "invalid_hour"
 
-        assert correlation._data.hourly_coefficients[10].confidence == "high"
+    def test_predict_load_returns_no_coefficients(self, correlation):
+        predicted, reason = correlation.predict_load(8, 20.0, 1.0)
+        assert predicted == 1.0
+        assert reason == "no_coefficients"
 
-
-# =============================================================================
-# WeatherCorrelation._update_cooling_coefficient
-# =============================================================================
-
-
-class TestUpdateCoolingCoefficient:
-    """Tests for _update_cooling_coefficient."""
-
-    def test_zero_temp_delta_is_noop(self, correlation):
-        """Temperature exactly at threshold (delta=0) should not update."""
-        coef = HourlyTemperatureCoefficients(base_load_kw=2.0)
-        cooling_threshold = 24.0
-        # temperature == threshold → delta = 0
-        correlation._update_cooling_coefficient(coef, 24.0, 4.0, cooling_threshold)
-        assert coef.cooling_coefficient == 0.0
-
-    def test_first_cooling_sample_no_base_load(self, correlation):
-        """Without base load, should set base_load to 80% of actual."""
-        coef = HourlyTemperatureCoefficients(base_load_kw=0.0)
-        correlation._update_cooling_coefficient(coef, 28.0, 5.0, 24.0)
-        assert coef.base_load_kw == pytest.approx(4.0)  # 5.0 * 0.8
-        assert coef.cooling_coefficient == 0.0  # not updated without base
-
-    def test_first_cooling_sample_with_base_load(self, correlation):
-        """With existing base_load and no cooling_coef, should set directly."""
-        coef = HourlyTemperatureCoefficients(base_load_kw=2.0, cooling_coefficient=0.0)
-        correlation._update_cooling_coefficient(coef, 28.0, 6.0, 24.0)
-        # implied = (6.0 - 2.0) / (28 - 24) = 1.0
-        assert coef.cooling_coefficient == pytest.approx(1.0)
-
-    def test_subsequent_cooling_uses_moving_average(self, correlation):
-        """Subsequent samples should apply 10% weight EMA."""
-        coef = HourlyTemperatureCoefficients(base_load_kw=2.0, cooling_coefficient=0.5)
-        # implied = (6.0 - 2.0) / 4.0 = 1.0
-        # new = 0.1 * 1.0 + 0.9 * 0.5 = 0.55
-        correlation._update_cooling_coefficient(coef, 28.0, 6.0, 24.0)
-        assert coef.cooling_coefficient == pytest.approx(0.55)
-
-
-# =============================================================================
-# WeatherCorrelation._update_heating_coefficient
-# =============================================================================
-
-
-class TestUpdateHeatingCoefficient:
-    """Tests for _update_heating_coefficient."""
-
-    def test_zero_temp_delta_is_noop(self, correlation):
-        """Temperature exactly at threshold (delta=0) should not update."""
-        coef = HourlyTemperatureCoefficients(base_load_kw=2.0)
-        correlation._update_heating_coefficient(coef, 18.0, 4.0, 18.0)
-        assert coef.heating_coefficient == 0.0
-
-    def test_first_heating_sample_no_base_load(self, correlation):
-        """Without base load, should set base_load to 80% of actual."""
-        coef = HourlyTemperatureCoefficients(base_load_kw=0.0)
-        correlation._update_heating_coefficient(coef, 10.0, 5.0, 18.0)
-        assert coef.base_load_kw == pytest.approx(4.0)  # 5.0 * 0.8
-
-    def test_first_heating_sample_with_base_load(self, correlation):
-        """With existing base_load and no heating_coef, should set directly."""
-        coef = HourlyTemperatureCoefficients(base_load_kw=2.0, heating_coefficient=0.0)
-        # implied = (5.0 - 2.0) / (18.0 - 10.0) = 0.375
-        correlation._update_heating_coefficient(coef, 10.0, 5.0, 18.0)
-        assert coef.heating_coefficient == pytest.approx(0.375)
-
-    def test_subsequent_heating_uses_moving_average(self, correlation):
-        """Subsequent samples should apply 10% weight EMA."""
-        coef = HourlyTemperatureCoefficients(base_load_kw=2.0, heating_coefficient=0.5)
-        # implied = (5.0 - 2.0) / 8.0 = 0.375
-        # new = 0.1 * 0.375 + 0.9 * 0.5 = 0.4875
-        correlation._update_heating_coefficient(coef, 10.0, 5.0, 18.0)
-        assert coef.heating_coefficient == pytest.approx(0.4875)
-
-
-# =============================================================================
-# WeatherCorrelation._update_mild_temperature_base_load
-# =============================================================================
-
-
-class TestUpdateMildTemperatureBaseLoad:
-    """Tests for _update_mild_temperature_base_load."""
-
-    def test_first_sample_sets_base_load_directly(self, correlation):
-        """First mild sample should set base_load directly."""
-        coef = HourlyTemperatureCoefficients(base_load_kw=0.0)
-        correlation._update_mild_temperature_base_load(coef, 3.5)
-        assert coef.base_load_kw == 3.5
-
-    def test_subsequent_sample_uses_moving_average(self, correlation):
-        """Subsequent samples should use 10% EMA."""
-        coef = HourlyTemperatureCoefficients(base_load_kw=4.0)
-        # new = 0.1 * 2.0 + 0.9 * 4.0 = 3.8
-        correlation._update_mild_temperature_base_load(coef, 2.0)
-        assert coef.base_load_kw == pytest.approx(3.8)
-
-
-# =============================================================================
-# WeatherCorrelation.predict_load
-# =============================================================================
-
-
-class TestPredictLoad:
-    """Tests for predict_load."""
-
-    def test_invalid_hour(self, correlation):
-        """Invalid hour returns base_load unchanged."""
-        result_load, source = correlation.predict_load(25, 20.0, 3.0)
-        assert result_load == 3.0
-        assert source == "invalid_hour"
-
-    def test_no_coefficients_for_hour(self, correlation):
-        """Hour with no learned data returns base_load."""
-        # Ensure hour 5 has no coefficients
-        correlation._data.hourly_coefficients.pop(5, None)
-        result_load, source = correlation.predict_load(5, 20.0, 3.0)
-        assert result_load == 3.0
-        assert source == "no_coefficients"
-
-    def test_low_confidence_returns_base(self, correlation):
-        """Low-confidence data should not modify base_load."""
-        correlation._data.hourly_coefficients[8] = HourlyTemperatureCoefficients(
-            base_load_kw=2.0, cooling_coefficient=0.5, confidence="low"
-        )
-        result_load, source = correlation.predict_load(8, 30.0, 3.0)
-        assert result_load == 3.0
-        assert source == "low_confidence"
-
-    def test_cooling_adjustment(self, correlation):
-        """Above cooling threshold should increase load."""
-        correlation._data.hourly_coefficients[14] = HourlyTemperatureCoefficients(
-            base_load_kw=2.0, cooling_coefficient=0.5, confidence="medium"
-        )
-        # 28°C - 24°C = 4°C delta × 0.5 = 2.0 adjustment
-        result_load, source = correlation.predict_load(14, 28.0, 2.0)
-        assert result_load == pytest.approx(4.0)
-        assert source == "weather_cooling"
-
-    def test_heating_adjustment(self, correlation):
-        """Below heating threshold should increase load."""
-        correlation._data.hourly_coefficients[6] = HourlyTemperatureCoefficients(
-            base_load_kw=2.0, heating_coefficient=0.4, confidence="high"
-        )
-        # 18°C - 10°C = 8°C delta × 0.4 = 3.2 adjustment
-        result_load, source = correlation.predict_load(6, 10.0, 2.0)
-        assert result_load == pytest.approx(5.2)
-        assert source == "weather_heating"
-
-    def test_mild_temperature_no_adjustment(self, correlation):
-        """Mild temperature should return base load with no adjustment."""
-        correlation._data.hourly_coefficients[12] = HourlyTemperatureCoefficients(
-            base_load_kw=3.0,
-            cooling_coefficient=0.5,
-            heating_coefficient=0.3,
-            confidence="medium",
-        )
-        result_load, source = correlation.predict_load(12, 21.0, 3.0)
-        assert result_load == pytest.approx(3.0)
-        assert source == "weather_none"
-
-    def test_cooling_coefficient_zero(self, correlation):
-        """Zero cooling coefficient should not apply adjustment."""
-        correlation._data.hourly_coefficients[14] = HourlyTemperatureCoefficients(
-            base_load_kw=2.0, cooling_coefficient=0.0, confidence="medium"
-        )
-        result_load, source = correlation.predict_load(14, 30.0, 2.0)
-        assert result_load == pytest.approx(2.0)
-        assert source == "weather_none"
-
-    def test_uses_learned_base_load_over_provided(self, correlation):
-        """When base_load_kw > 0, prediction uses learned value."""
-        correlation._data.hourly_coefficients[10] = HourlyTemperatureCoefficients(
-            base_load_kw=5.0, confidence="high"
-        )
-        result_load, source = correlation.predict_load(10, 21.0, 2.0)
-        # Mild temp, no adjustment → uses learned base_load=5.0
-        assert result_load == pytest.approx(5.0)
-
-    def test_falls_back_to_provided_base_when_no_learned_base(self, correlation):
-        """When base_load_kw == 0, uses provided base_load_kw."""
-        correlation._data.hourly_coefficients[10] = HourlyTemperatureCoefficients(
-            base_load_kw=0.0, confidence="high"
-        )
-        result_load, source = correlation.predict_load(10, 21.0, 3.5)
-        assert result_load == pytest.approx(3.5)
-
-    def test_result_is_rounded(self, correlation):
-        """predict_load should return result rounded to 3 decimal places."""
-        correlation._data.hourly_coefficients[10] = HourlyTemperatureCoefficients(
-            base_load_kw=2.0, cooling_coefficient=0.333, confidence="medium"
-        )
-        # 28 - 24 = 4 × 0.333 = 1.332 → 2.0 + 1.332 = 3.332
-        result_load, _ = correlation.predict_load(10, 28.0, 2.0)
-        assert result_load == round(result_load, 3)
-
-
-# =============================================================================
-# WeatherCorrelation._calculate_confidence
-# =============================================================================
-
-
-class TestCalculateConfidence:
-    """Tests for _calculate_confidence."""
-
-    def test_low_confidence(self, correlation):
-        """Fewer than CONFIDENCE_LOW_THRESHOLD samples → low."""
-        for count in range(CONFIDENCE_LOW_THRESHOLD):
-            assert correlation._calculate_confidence(count) == "low"
-
-    def test_medium_confidence(self, correlation):
-        """Between LOW and MEDIUM thresholds → medium."""
-        for count in range(CONFIDENCE_LOW_THRESHOLD, CONFIDENCE_MEDIUM_THRESHOLD):
-            assert correlation._calculate_confidence(count) == "medium"
-
-    def test_high_confidence(self, correlation):
-        """At or above CONFIDENCE_MEDIUM_THRESHOLD → high."""
-        for count in [CONFIDENCE_MEDIUM_THRESHOLD, 50, 100]:
-            assert correlation._calculate_confidence(count) == "high"
-
-    def test_boundary_values(self, correlation):
-        """Boundary values should have correct confidence."""
-        assert correlation._calculate_confidence(CONFIDENCE_LOW_THRESHOLD - 1) == "low"
-        assert correlation._calculate_confidence(CONFIDENCE_LOW_THRESHOLD) == "medium"
-        assert (
-            correlation._calculate_confidence(CONFIDENCE_MEDIUM_THRESHOLD - 1)
-            == "medium"
-        )
-        assert correlation._calculate_confidence(CONFIDENCE_MEDIUM_THRESHOLD) == "high"
-
-
-# =============================================================================
-# WeatherCorrelation.get_diagnostics
-# =============================================================================
-
-
-class TestGetDiagnostics:
-    """Tests for get_diagnostics."""
-
-    def test_empty_coefficients(self, correlation):
-        """Diagnostics with no learned data should have zeros."""
-        correlation._data.hourly_coefficients = {}
-        diag = correlation.get_diagnostics()
-
-        assert diag["total_samples"] == 0
-        assert diag["hours_with_data"] == 0
-        assert diag["average_base_load_kw"] == 0.0
-        assert diag["average_cooling_coefficient"] == 0.0
-        assert diag["average_heating_coefficient"] == 0.0
-        assert diag["cooling_hours"] == 0
-        assert diag["heating_hours"] == 0
-        assert diag["hourly_coefficients"] == {}
-
-    def test_with_coefficients(self, correlation):
-        """Diagnostics should aggregate across all hours correctly."""
-        correlation._data.weather_entity_id = "weather.test"
-        correlation._data.cooling_threshold = 24.0
-        correlation._data.heating_threshold = 18.0
-        correlation._data.hourly_coefficients = {
-            10: HourlyTemperatureCoefficients(
-                base_load_kw=2.0,
-                cooling_coefficient=0.4,
-                heating_coefficient=0.3,
-                sample_count=20,
-            ),
-            15: HourlyTemperatureCoefficients(
-                base_load_kw=4.0,
-                cooling_coefficient=0.6,
-                sample_count=35,
-            ),
+    def test_predict_load_applies_cooling_adjustment(self, correlation):
+        correlation._data.daily_regression_stats = {
+            8: [
+                DailySnapshot(
+                    date_key="2026-03-26",
+                    data=HourlyRegressionData(
+                        mild=ZoneStats(),
+                        heating=ZoneStats(),
+                        cooling=_linear_stats(20, 1.0),
+                    ),
+                )
+            ]
         }
 
-        diag = correlation.get_diagnostics()
+        predicted, reason = correlation.predict_load(8, 26.0, 1.0)
 
-        assert diag["total_samples"] == 55
-        assert diag["hours_with_data"] == 2
-        assert diag["average_base_load_kw"] == pytest.approx(3.0)
-        assert diag["average_cooling_coefficient"] == pytest.approx(0.5)
-        assert diag["average_heating_coefficient"] == pytest.approx(0.3)
-        assert diag["cooling_hours"] == 2
-        assert diag["heating_hours"] == 1
-        assert 10 in diag["hourly_coefficients"]
-        assert 15 in diag["hourly_coefficients"]
+        assert reason == "weather_cooling"
+        assert predicted > 1.0
 
-    def test_diagnostics_includes_entity_config(self, correlation):
-        """Diagnostics should include weather entity and threshold settings."""
-        correlation._data.weather_entity_id = "weather.home"
-        diag = correlation.get_diagnostics()
+    def test_predict_load_returns_weather_none_for_small_delta(self, correlation):
+        correlation._data.daily_regression_stats = {
+            8: [
+                DailySnapshot(
+                    date_key="2026-03-26",
+                    data=HourlyRegressionData(
+                        mild=ZoneStats(),
+                        heating=_linear_stats(20, 1.0),
+                        cooling=_linear_stats(20, 1.0),
+                    ),
+                )
+            ]
+        }
 
-        assert diag["weather_entity_id"] == "weather.home"
-        assert "cooling_threshold" in diag
-        assert "heating_threshold" in diag
+        predicted, reason = correlation.predict_load(8, 24.4, 1.0)
 
+        assert predicted == 1.0
+        assert reason == "weather_none"
 
-# =============================================================================
-# WeatherCorrelation.get_coefficients_for_hour
-# =============================================================================
+    def test_predict_load_returns_low_confidence_for_poor_fit(self, correlation):
+        low_fit_stats = ZoneStats(
+            n=20,
+            sum_x=210.0,
+            sum_y=1.0,
+            sum_xx=2870.0,
+            sum_xy=1.0,
+            sum_yy=1000.0,
+        )
+        correlation._data.daily_regression_stats = {
+            8: [
+                DailySnapshot(
+                    date_key="2026-03-26",
+                    data=HourlyRegressionData(
+                        mild=ZoneStats(),
+                        heating=ZoneStats(),
+                        cooling=low_fit_stats,
+                    ),
+                )
+            ]
+        }
 
+        predicted, reason = correlation.predict_load(8, 26.0, 1.0)
 
-class TestGetCoefficientsForHour:
-    """Tests for get_coefficients_for_hour."""
-
-    def test_hour_exists(self, correlation):
-        """Returns coefficients when they exist for the hour."""
-        coef = HourlyTemperatureCoefficients(base_load_kw=3.0, sample_count=10)
-        correlation._data.hourly_coefficients[14] = coef
-
-        result = correlation.get_coefficients_for_hour(14)
-
-        assert result is coef
-        assert result.base_load_kw == 3.0
-
-    def test_hour_not_found(self, correlation):
-        """Returns None when no coefficients exist for the hour."""
-        correlation._data.hourly_coefficients.pop(5, None)
-        result = correlation.get_coefficients_for_hour(5)
-        assert result is None
-
-    def test_all_24_hours(self, correlation):
-        """Can retrieve coefficients for any hour 0-23."""
-        for hour in range(24):
-            coef = HourlyTemperatureCoefficients(base_load_kw=float(hour))
-            correlation._data.hourly_coefficients[hour] = coef
-
-        for hour in range(24):
-            result = correlation.get_coefficients_for_hour(hour)
-            assert result is not None
-            assert result.base_load_kw == float(hour)
+        assert predicted == 1.0
+        assert reason == "low_confidence"
 
 
-# =============================================================================
-# Integration-style tests
-# =============================================================================
+class TestMigrationAndReset:
+    @pytest.mark.asyncio
+    async def test_async_initialize_migrates_v1_storage_and_discards_hourly_coefficients(
+        self, correlation, mock_weather_store
+    ):
+        mock_weather_store.async_load.return_value = {
+            "version": 1,
+            "weather_entity_id": "weather.home",
+            "hourly_coefficients": {"8": {"cooling_coefficient": 12.761}},
+            "learning_stats": {"note": "keep"},
+            "temperature_history": {"2026-03-25": 22.5},
+        }
+
+        await correlation.async_initialize()
+
+        assert correlation._data.daily_regression_stats == {}
+        assert correlation._data.temperature_history == {"2026-03-25": 22.5}
+        assert correlation._data.learning_stats == {"note": "keep"}
+
+    @pytest.mark.asyncio
+    async def test_async_reset_clears_regression_stats_but_keeps_temperature_history(
+        self, correlation
+    ):
+        correlation._data.daily_regression_stats = {
+            8: [DailySnapshot(date_key="2026-03-26", data=HourlyRegressionData())]
+        }
+        correlation._data.temperature_history = {"2026-03-25": 22.5}
+
+        await correlation.async_reset()
+
+        assert correlation._data.daily_regression_stats == {}
+        assert correlation._data.temperature_history == {"2026-03-25": 22.5}
+
+    def test_prune_daily_snapshots_removes_entries_older_than_window(self, correlation):
+        correlation._data.daily_regression_stats = {
+            8: [
+                DailySnapshot(date_key="2026-02-23", data=HourlyRegressionData()),
+                DailySnapshot(date_key="2026-02-24", data=HourlyRegressionData()),
+                DailySnapshot(date_key="2026-03-25", data=HourlyRegressionData()),
+            ]
+        }
+
+        correlation._prune_daily_snapshots(datetime(2026, 3, 26, tzinfo=UTC))
+
+        remaining = [
+            snap.date_key for snap in correlation._data.daily_regression_stats[8]
+        ]
+        assert "2026-02-23" not in remaining
+        assert "2026-02-24" in remaining
+        assert "2026-03-25" in remaining
+
+    def test_prune_daily_snapshots_removes_empty_hours(self, correlation):
+        correlation._data.daily_regression_stats = {
+            8: [DailySnapshot(date_key="2026-02-01", data=HourlyRegressionData())]
+        }
+
+        correlation._prune_daily_snapshots(datetime(2026, 3, 26, tzinfo=UTC))
+
+        assert 8 not in correlation._data.daily_regression_stats
 
 
-class TestLearnAndPredict:
-    """Integration tests for the learn → predict cycle."""
+class TestDelegationsAndDiagnostics:
+    def test_get_temperature_forecast_delegates(self, correlation):
+        forecast = correlation_module.TemperatureForecast(
+            slot_time=datetime(2026, 3, 26, 8, tzinfo=UTC),
+            temperature=18.0,
+            condition="cloudy",
+        )
+        provider = MagicMock()
+        provider.get_temperature_forecast.return_value = [forecast]
+        correlation._temperature_provider = provider
 
-    def test_learn_multiple_samples_then_predict(self, correlation):
-        """Learning multiple samples should improve prediction accuracy."""
-        now = datetime.now(UTC)
-        hour = 14
+        assert correlation.get_temperature_forecast() == [forecast]
+        provider.get_temperature_forecast.assert_called_once()
 
-        # Simulate learning: at 30°C, load is 5kW; at 20°C (mild), load is 2kW
-        with patch(
-            "custom_components.localshift.learning.correlation.dt_util.now",
-            return_value=now,
-        ):
-            # Learn mild base load first
-            for _ in range(5):
-                correlation.learn_from_sample(hour, 21.0, 2.0)
+    @pytest.mark.asyncio
+    async def test_async_get_temperature_forecast_updates_weather_entity_id(
+        self, correlation
+    ):
+        forecast = correlation_module.TemperatureForecast(
+            slot_time=datetime(2026, 3, 26, 9, tzinfo=UTC),
+            temperature=19.0,
+            condition="sunny",
+        )
+        provider = MagicMock()
+        provider.weather_entity_id = "weather.updated"
+        provider.async_get_temperature_forecast = AsyncMock(return_value=[forecast])
+        correlation._temperature_provider = provider
 
-            # Learn cooling load
-            for _ in range(30):
-                correlation.learn_from_sample(hour, 30.0, 5.0)
+        result = await correlation.async_get_temperature_forecast(force_refresh=True)
 
-        coef = correlation.get_coefficients_for_hour(hour)
-        assert coef is not None
-        assert coef.base_load_kw > 0
-        assert coef.confidence == "high"
-
-        # Predict should now apply cooling adjustment
-        predicted, source = correlation.predict_load(hour, 30.0, coef.base_load_kw)
-        assert source in ("weather_cooling", "weather_none")
-        assert predicted >= coef.base_load_kw
-
-    def test_storage_roundtrip_preserves_learning(self, correlation):
-        """Learned data should survive a to_dict/from_dict roundtrip."""
-        now = datetime.now(UTC)
-
-        with patch(
-            "custom_components.localshift.learning.correlation.dt_util.now",
-            return_value=now,
-        ):
-            for _ in range(10):
-                correlation.learn_from_sample(12, 20.0, 3.0)
-
-        # Serialise and restore
-        serialised = correlation._data.to_dict()
-        restored = WeatherCorrelationData.from_dict(serialised)
-
-        assert 12 in restored.hourly_coefficients
-        assert restored.hourly_coefficients[12].sample_count == 10
-
-
-# =============================================================================
-# WEATHER ANOMALY DETECTION TESTS
-# =============================================================================
-
-
-def _populate_anomaly_history(
-    correlation: WeatherCorrelation,
-    temps: list[float],
-    base_date: date | None = None,
-) -> None:
-    """Populate temperature history for anomaly detection tests."""
-    if base_date is None:
-        base_date = date(2024, 1, 1)
-    for i, temp in enumerate(temps):
-        d = base_date + timedelta(days=i)
-        correlation.record_daily_temperature(temp, date_key=d.isoformat())
-
-
-class TestWeatherAnomalyDetection:
-    """Tests for weather anomaly detection features."""
-
-    @pytest.fixture
-    def correlation(self, mock_hass, mock_entry):
-        """Create a WeatherCorrelation instance for anomaly tests."""
-        with patch("custom_components.localshift.learning.correlation.Store"):
-            return WeatherCorrelation(mock_hass, mock_entry)
-
-    def test_record_daily_temperature_stores_value(self, correlation):
-        """Test that record_daily_temperature stores temperature values."""
-        correlation.record_daily_temperature(22.5, date_key="2024-01-01")
-        assert correlation._data.temperature_history["2024-01-01"] == 22.5
-
-    def test_record_daily_temperature_is_idempotent_per_day(self, correlation):
-        """Test that recording same day overwrites previous value."""
-        correlation.record_daily_temperature(20.0, date_key="2024-01-01")
-        correlation.record_daily_temperature(25.0, date_key="2024-01-01")
-        assert correlation._data.temperature_history["2024-01-01"] == 25.0
-
-    def test_record_daily_temperature_prunes_to_14_days(self, correlation):
-        """Test that history is pruned to WEATHER_TEMPERATURE_HISTORY_DAYS."""
-        for i in range(20):
-            d = date(2024, 1, 1) + timedelta(days=i)
-            correlation.record_daily_temperature(20.0, date_key=d.isoformat())
-        assert (
-            len(correlation._data.temperature_history)
-            == WEATHER_TEMPERATURE_HISTORY_DAYS
+        assert result == [forecast]
+        assert correlation._data.weather_entity_id == "weather.updated"
+        provider.async_get_temperature_forecast.assert_awaited_once_with(
+            force_refresh=True
         )
 
-    def test_record_daily_temperature_keeps_newest_dates(self, correlation):
-        """Test that pruning keeps the most recent dates."""
-        for i in range(20):
-            d = date(2024, 1, 1) + timedelta(days=i)
-            correlation.record_daily_temperature(float(i), date_key=d.isoformat())
-        oldest_retained = min(correlation._data.temperature_history.keys())
-        assert oldest_retained == "2024-01-07"
+    def test_get_current_temperature_delegates(self, correlation):
+        provider = MagicMock()
+        provider.get_current_temperature.return_value = 21.5
+        correlation._temperature_provider = provider
 
-    def test_record_daily_temperature_uses_today_by_default(self, correlation):
-        """Test that record_daily_temperature uses today's date when not specified."""
-        with patch(
-            "custom_components.localshift.learning.correlation.dt_util"
-        ) as mock_dt:
-            mock_dt.now.return_value.strftime.return_value = "2024-06-15"
-            correlation.record_daily_temperature(22.0)
-        assert "2024-06-15" in correlation._data.temperature_history
+        assert correlation.get_current_temperature() == 21.5
+        provider.get_current_temperature.assert_called_once()
 
-    def test_insufficient_history_returns_normal_weight(self, correlation):
-        """Test that insufficient history (<7 days) returns normal weight."""
-        _populate_anomaly_history(correlation, [20.0, 21.0, 22.0, 20.0, 21.0])
-        result = correlation.detect_weather_anomaly(35.0)
-        assert result.is_anomalous is False
-        assert result.weight == WEATHER_ANOMALY_NORMAL_WEIGHT
-        assert result.deviation_sigma == 0.0
-        assert result.mean_temperature == 0.0
-        assert result.std_temperature == 0.0
+    def test_record_daily_temperature_delegates(self, correlation):
+        detector = MagicMock()
+        correlation._anomaly_detector = detector
 
-    def test_exactly_7_days_history_is_enough(self, correlation):
-        """Test that exactly 7 days of history is sufficient."""
-        _populate_anomaly_history(correlation, [20.0] * 7)
-        result = correlation.detect_weather_anomaly(20.0)
-        assert result.mean_temperature is not None
+        correlation.record_daily_temperature(18.0, "2026-03-26")
 
-    def test_normal_temperature_not_flagged(self, correlation):
-        """Test that normal temperature is not flagged as anomalous."""
-        temps = [20.0, 21.0, 19.0, 20.5, 21.5, 20.0, 21.0, 20.0, 19.5, 21.0]
-        _populate_anomaly_history(correlation, temps)
-        result = correlation.detect_weather_anomaly(21.0)
-        assert result.is_anomalous is False
-        assert result.weight == WEATHER_ANOMALY_NORMAL_WEIGHT
+        detector.record_daily_temperature.assert_called_once_with(18.0, "2026-03-26")
 
-    def test_extreme_high_temperature_is_anomalous(self, correlation):
-        """Test that extreme high temperature is flagged as anomalous."""
-        temps = [20.0] * 8 + [21.0, 19.0]
-        _populate_anomaly_history(correlation, temps)
-        result = correlation.detect_weather_anomaly(40.0)
-        assert result.is_anomalous is True
-        assert result.weight == WEATHER_ANOMALY_ANOMALOUS_WEIGHT
-        assert result.deviation_sigma is not None
-        assert result.deviation_sigma > 2.0
+    def test_detect_weather_anomaly_delegates(self, correlation):
+        detector = MagicMock()
+        result = correlation_module.WeatherAnomalyResult(
+            is_anomalous=False,
+            weight=1.0,
+            temperature=20.0,
+            deviation_sigma=0.0,
+            mean_temperature=20.0,
+            std_temperature=1.0,
+        )
+        detector.detect_weather_anomaly.return_value = result
+        correlation._anomaly_detector = detector
 
-    def test_extreme_low_temperature_is_anomalous(self, correlation):
-        """Test that extreme low temperature is flagged as anomalous."""
-        temps = [20.0] * 8 + [21.0, 19.0]
-        _populate_anomaly_history(correlation, temps)
-        result = correlation.detect_weather_anomaly(0.0)
-        assert result.is_anomalous is True
-        assert result.weight == WEATHER_ANOMALY_ANOMALOUS_WEIGHT
+        assert correlation.detect_weather_anomaly(20.0) == result
+        detector.detect_weather_anomaly.assert_called_once_with(20.0)
 
-    def test_anomaly_result_temperature_field(self, correlation):
-        """Test that WeatherAnomalyResult includes the input temperature."""
-        _populate_anomaly_history(correlation, [20.0] * 10)
-        result = correlation.detect_weather_anomaly(35.0)
-        assert result.temperature == 35.0
+    def test_get_diagnostics_reports_averages(self, correlation):
+        heating_stats = _linear_stats(20, 2.0)
+        cooling_stats = _linear_stats(20, 1.0)
+        correlation._data.daily_regression_stats = {
+            8: [
+                DailySnapshot(
+                    date_key="2026-03-26",
+                    data=HourlyRegressionData(
+                        mild=ZoneStats(),
+                        heating=heating_stats,
+                        cooling=cooling_stats,
+                    ),
+                )
+            ]
+        }
 
-    def test_anomaly_result_mean_and_std_fields(self, correlation):
-        """Test that WeatherAnomalyResult includes mean and std."""
-        temps = [20.0] * 10
-        _populate_anomaly_history(correlation, temps)
-        result = correlation.detect_weather_anomaly(20.0)
-        assert result.mean_temperature == pytest.approx(20.0)
-        assert result.std_temperature == pytest.approx(0.0)
+        diagnostics = correlation.get_diagnostics()
 
-    def test_zero_std_does_not_raise(self, correlation):
-        """Test that zero standard deviation is handled gracefully."""
-        temps = [20.0] * 10
-        _populate_anomaly_history(correlation, temps)
-        result = correlation.detect_weather_anomaly(20.0)
-        assert result.is_anomalous is False
-        assert result.weight == WEATHER_ANOMALY_NORMAL_WEIGHT
+        assert diagnostics["average_heating_slope"] == pytest.approx(2.0, rel=1e-3)
+        assert diagnostics["average_cooling_slope"] == pytest.approx(1.0, rel=1e-3)
+        assert diagnostics["average_r_squared"] == pytest.approx(1.0, rel=1e-3)
+        assert diagnostics["total_samples"] == 40
+        assert diagnostics["hourly_regression"][8]["confidence"] == "medium"
 
-    def test_temperature_history_included_in_to_dict(self, correlation):
-        """Test that temperature_history is included in to_dict output."""
-        correlation.record_daily_temperature(22.0, date_key="2024-01-01")
-        d = correlation._data.to_dict()
-        assert "temperature_history" in d
-        assert d["temperature_history"]["2024-01-01"] == 22.0
+    def test_get_diagnostics_handles_empty_hours(self, correlation):
+        correlation._data.daily_regression_stats = {8: []}
+        diagnostics = correlation.get_diagnostics()
+        assert diagnostics["hours_with_data"] == 0
 
-    def test_temperature_history_loaded_from_dict(self):
-        """Test that temperature_history is loaded from dict."""
-        data_dict = {"temperature_history": {"2024-01-01": 22.0, "2024-01-02": 25.0}}
-        data = WeatherCorrelationData.from_dict(data_dict)
-        assert data.temperature_history == {"2024-01-01": 22.0, "2024-01-02": 25.0}
+    def test_get_diagnostics_sets_high_confidence(self, correlation):
+        correlation._data.daily_regression_stats = {
+            8: [
+                DailySnapshot(
+                    date_key="2026-03-26",
+                    data=HourlyRegressionData(
+                        mild=ZoneStats(),
+                        heating=_linear_stats(30, 2.0),
+                        cooling=_linear_stats(30, 1.0),
+                    ),
+                )
+            ]
+        }
+        diagnostics = correlation.get_diagnostics()
+        assert diagnostics["hourly_regression"][8]["confidence"] == "high"
 
-    def test_from_dict_without_history_defaults_to_empty(self):
-        """Test that missing temperature_history defaults to empty dict."""
-        data = WeatherCorrelationData.from_dict({})
-        assert data.temperature_history == {}
+    def test_get_coefficients_for_hour_invalid_hour_returns_none(self, correlation):
+        assert correlation.get_coefficients_for_hour(-1) is None
+        assert correlation.get_coefficients_for_hour(24) is None
+
+    def test_get_coefficients_for_hour_with_no_data_returns_none(self, correlation):
+        correlation._data.daily_regression_stats = {8: []}
+        assert correlation.get_coefficients_for_hour(8) is None
+
+
+class TestConfidence:
+    def test_calculate_confidence_thresholds(self, correlation):
+        assert correlation._calculate_confidence(1) == "low"
+        assert correlation._calculate_confidence(25, 0.05) == "low"
+        assert correlation._calculate_confidence(40, 0.5) == "high"
+
+
+class TestConstants:
+    def test_regression_constants(self):
+        assert getattr(correlation_module, "MIN_TEMP_DELTA", None) == 1.0
+        assert getattr(correlation_module, "MIN_SAMPLES_PER_ZONE", None) == 20
+        assert getattr(correlation_module, "MIN_R_SQUARED", None) == 0.10
+        assert getattr(correlation_module, "MAX_SLOPE_KW_PER_DEGREE", None) == 2.0
+        assert getattr(correlation_module, "MAX_LOAD_MULTIPLIER", None) == 3.0
+        assert getattr(correlation_module, "SLIDING_WINDOW_DAYS", None) == 30

--- a/tests/learning/test_temperature.py
+++ b/tests/learning/test_temperature.py
@@ -1,0 +1,566 @@
+"""Tests for learning/temperature.py - temperature forecast module."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.localshift.const import CONF_WEATHER_ENTITY
+from custom_components.localshift.learning.temperature import TemperatureForecast
+from tests.learning.conftest import make_forecast_entry, make_weather_state
+
+
+class TestGetTemperatureForecast:
+    """Tests for the legacy get_temperature_forecast method."""
+
+    def test_no_weather_entity(self, weather_provider):
+        """Returns empty list when no entity is configured."""
+        weather_provider._weather_entity_id = ""
+        result = weather_provider.get_temperature_forecast()
+        assert result == []
+
+    def test_entity_not_found(self, weather_provider):
+        """Returns empty list when entity state is None."""
+        weather_provider._weather_entity_id = "weather.missing"
+        weather_provider.hass.states.get.return_value = None
+
+        result = weather_provider.get_temperature_forecast()
+        assert result == []
+
+    def test_empty_forecast(self, weather_provider):
+        """Returns empty list when weather entity has no forecast attribute."""
+        weather_provider._weather_entity_id = "weather.home"
+        state = MagicMock()
+        state.attributes = {"forecast": []}
+        weather_provider.hass.states.get.return_value = state
+
+        result = weather_provider.get_temperature_forecast()
+        assert result == []
+
+    def test_valid_forecast_entries(self, weather_provider):
+        """Should parse valid forecast entries within 24h window."""
+        now = datetime.now(UTC)
+        weather_provider._weather_entity_id = "weather.home"
+
+        entries = [
+            make_forecast_entry(hours_ahead=2, temperature=28.0, now=now),
+            make_forecast_entry(hours_ahead=8, temperature=32.0, now=now),
+        ]
+        state = make_weather_state(forecast_list=entries)
+        weather_provider.hass.states.get.return_value = state
+
+        with patch(
+            "custom_components.localshift.learning.temperature.dt_util.now",
+            return_value=now,
+        ):
+            result = weather_provider.get_temperature_forecast()
+
+        assert len(result) == 2
+        assert isinstance(result[0], TemperatureForecast)
+        assert result[0].temperature == 28.0
+
+    def test_forecast_outside_24h_filtered(self, weather_provider):
+        """Forecasts more than 24h ahead or in the past should be excluded."""
+        now = datetime.now(UTC)
+        weather_provider._weather_entity_id = "weather.home"
+
+        entries = [
+            make_forecast_entry(hours_ahead=25, temperature=20.0, now=now),  # too far
+            make_forecast_entry(hours_ahead=-1, temperature=20.0, now=now),  # past
+            make_forecast_entry(hours_ahead=12, temperature=22.0, now=now),  # valid
+        ]
+        state = make_weather_state(forecast_list=entries)
+        weather_provider.hass.states.get.return_value = state
+
+        with patch(
+            "custom_components.localshift.learning.temperature.dt_util.now",
+            return_value=now,
+        ):
+            result = weather_provider.get_temperature_forecast()
+
+        assert len(result) == 1
+        assert result[0].temperature == 22.0
+
+    def test_forecast_entry_missing_datetime(self, weather_provider):
+        """Entries without 'datetime' key should be skipped."""
+        now = datetime.now(UTC)
+        weather_provider._weather_entity_id = "weather.home"
+
+        entries = [
+            {"temperature": 25.0, "condition": "sunny"},  # no datetime
+            make_forecast_entry(hours_ahead=3, temperature=27.0, now=now),
+        ]
+        state = make_weather_state(forecast_list=entries)
+        weather_provider.hass.states.get.return_value = state
+
+        with patch(
+            "custom_components.localshift.learning.temperature.dt_util.now",
+            return_value=now,
+        ):
+            result = weather_provider.get_temperature_forecast()
+
+        assert len(result) == 1
+        assert result[0].temperature == 27.0
+
+    def test_forecast_entry_invalid_datetime(self, weather_provider):
+        """Entries with unparseable datetime should be skipped."""
+        now = datetime.now(UTC)
+        weather_provider._weather_entity_id = "weather.home"
+
+        entries = [
+            {"datetime": "not-a-date", "temperature": 25.0},
+            make_forecast_entry(hours_ahead=4, temperature=29.0, now=now),
+        ]
+        state = make_weather_state(forecast_list=entries)
+        weather_provider.hass.states.get.return_value = state
+
+        with patch(
+            "custom_components.localshift.learning.temperature.dt_util.now",
+            return_value=now,
+        ):
+            with patch(
+                "custom_components.localshift.learning.temperature.dt_util.parse_datetime",
+                return_value=None,
+            ):
+                result = weather_provider.get_temperature_forecast()
+
+        assert isinstance(result, list)
+
+
+class TestAsyncGetTemperatureForecast:
+    """Tests for async_get_temperature_forecast."""
+
+    @pytest.mark.asyncio
+    async def test_no_weather_entity(self, weather_provider_no_weather):
+        """Returns empty list when no weather entity configured."""
+        result = await weather_provider_no_weather.async_get_temperature_forecast()
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_returns_cached_within_ttl(self, weather_provider):
+        """Returns cached forecasts when cache is still fresh."""
+        now = datetime.now(UTC)
+        cached = [TemperatureForecast(slot_time=now, temperature=22.0)]
+        weather_provider._cached_forecasts = cached
+        weather_provider._forecast_cache_time = now - timedelta(minutes=5)  # fresh
+        weather_provider._weather_entity_id = "weather.home"
+
+        with patch(
+            "custom_components.localshift.learning.temperature.dt_util.now",
+            return_value=now,
+        ):
+            result = await weather_provider.async_get_temperature_forecast()
+
+        assert result is cached
+
+    @pytest.mark.asyncio
+    async def test_force_refresh_bypasses_cache(self, weather_provider):
+        """force_refresh=True should bypass the cache."""
+        now = datetime.now(UTC)
+        cached = [TemperatureForecast(slot_time=now, temperature=22.0)]
+        weather_provider._cached_forecasts = cached
+        weather_provider._forecast_cache_time = now - timedelta(minutes=1)  # very fresh
+        weather_provider._weather_entity_id = "weather.home"
+
+        # Service returns empty response so it falls back to legacy (also empty)
+        weather_provider.hass.services.async_call = AsyncMock(return_value=None)
+        weather_provider.hass.states.get.return_value = make_weather_state(
+            forecast_list=[]
+        )
+
+        with patch(
+            "custom_components.localshift.learning.temperature.dt_util.now",
+            return_value=now,
+        ):
+            result = await weather_provider.async_get_temperature_forecast(
+                force_refresh=True
+            )
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_service_call_success_list_response(self, weather_provider):
+        """Should parse forecasts when service returns a list directly."""
+        now = datetime.now(UTC)
+        weather_provider._weather_entity_id = "weather.home"
+        weather_provider._cached_forecasts = []
+        weather_provider._forecast_cache_time = None
+
+        entry = make_forecast_entry(hours_ahead=3, temperature=30.0, now=now)
+        response = {"weather.home": [entry]}
+        weather_provider.hass.services.async_call = AsyncMock(return_value=response)
+
+        with patch(
+            "custom_components.localshift.learning.temperature.dt_util.now",
+            return_value=now,
+        ):
+            result = await weather_provider.async_get_temperature_forecast()
+
+        assert len(result) == 1
+        assert result[0].temperature == 30.0
+
+    @pytest.mark.asyncio
+    async def test_service_call_success_dict_response_forecast_key(
+        self, weather_provider
+    ):
+        """Should parse forecasts when service response has 'forecast' key."""
+        now = datetime.now(UTC)
+        weather_provider._weather_entity_id = "weather.home"
+        weather_provider._cached_forecasts = []
+        weather_provider._forecast_cache_time = None
+
+        entry = make_forecast_entry(hours_ahead=5, temperature=18.0, now=now)
+        response = {"weather.home": {"forecast": [entry]}}
+        weather_provider.hass.services.async_call = AsyncMock(return_value=response)
+
+        with patch(
+            "custom_components.localshift.learning.temperature.dt_util.now",
+            return_value=now,
+        ):
+            result = await weather_provider.async_get_temperature_forecast()
+
+        assert len(result) == 1
+        assert result[0].temperature == 18.0
+
+    @pytest.mark.asyncio
+    async def test_service_call_no_entity_in_response(self, weather_provider):
+        """Falls back to legacy when entity is missing from response."""
+        now = datetime.now(UTC)
+        weather_provider._weather_entity_id = "weather.home"
+        weather_provider._cached_forecasts = []
+        weather_provider._forecast_cache_time = None
+
+        response = {"weather.other": []}
+        weather_provider.hass.services.async_call = AsyncMock(return_value=response)
+        weather_provider.hass.states.get.return_value = make_weather_state(
+            forecast_list=[]
+        )
+
+        with patch(
+            "custom_components.localshift.learning.temperature.dt_util.now",
+            return_value=now,
+        ):
+            result = await weather_provider.async_get_temperature_forecast()
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_service_call_exception_falls_back_to_legacy(self, weather_provider):
+        """Falls back to legacy attribute when service call raises exception."""
+        now = datetime.now(UTC)
+        weather_provider._weather_entity_id = "weather.home"
+        weather_provider._cached_forecasts = []
+        weather_provider._forecast_cache_time = None
+
+        weather_provider.hass.services.async_call = AsyncMock(
+            side_effect=Exception("service unavailable")
+        )
+        entry = make_forecast_entry(hours_ahead=2, temperature=20.0, now=now)
+        weather_provider.hass.states.get.return_value = make_weather_state(
+            forecast_list=[entry]
+        )
+
+        with patch(
+            "custom_components.localshift.learning.temperature.dt_util.now",
+            return_value=now,
+        ):
+            result = await weather_provider.async_get_temperature_forecast()
+
+        assert len(result) == 1
+        assert result[0].temperature == 20.0
+
+    @pytest.mark.asyncio
+    async def test_weather_entity_change_clears_cache(
+        self, weather_provider, mock_entry
+    ):
+        """Changing weather entity should clear the forecast cache."""
+        now = datetime.now(UTC)
+        weather_provider._weather_entity_id = "weather.old"
+        old_forecast = [TemperatureForecast(slot_time=now, temperature=22.0)]
+        weather_provider._cached_forecasts = old_forecast
+        weather_provider._forecast_cache_time = now - timedelta(minutes=1)
+
+        mock_entry.options = {CONF_WEATHER_ENTITY: "weather.new"}
+        mock_entry.data = {}
+
+        weather_provider.hass.services.async_call = AsyncMock(return_value=None)
+        weather_provider.hass.states.get.return_value = make_weather_state(
+            forecast_list=[]
+        )
+
+        with patch(
+            "custom_components.localshift.learning.temperature.dt_util.now",
+            return_value=now,
+        ):
+            result = await weather_provider.async_get_temperature_forecast()
+
+        assert weather_provider._weather_entity_id == "weather.new"
+        assert result == []
+
+
+class TestExtractForecastList:
+    """Tests for the _extract_forecast_list helper."""
+
+    def test_list_response(self, weather_provider):
+        """Direct list response should be returned as-is."""
+        data = [{"datetime": "2024-01-01T12:00:00"}]
+        result = weather_provider._extract_forecast_list(
+            {"weather.home": data}, "weather.home"
+        )
+        assert result == data
+
+    def test_dict_with_forecast_key(self, weather_provider):
+        """Dict response with 'forecast' key should extract nested list."""
+        inner = [{"datetime": "2024-01-01T12:00:00"}]
+        response = {"weather.home": {"forecast": inner}}
+        result = weather_provider._extract_forecast_list(response, "weather.home")
+        assert result == inner
+
+    def test_dict_with_hourly_key(self, weather_provider):
+        """Dict response with 'hourly' key should extract nested list."""
+        inner = [{"datetime": "2024-01-01T12:00:00"}]
+        response = {"weather.home": {"hourly": inner}}
+        result = weather_provider._extract_forecast_list(response, "weather.home")
+        assert result == inner
+
+    def test_entity_not_in_response(self, weather_provider):
+        """Missing entity key should return None."""
+        result = weather_provider._extract_forecast_list({}, "weather.home")
+        assert result is None
+
+    def test_unexpected_format(self, weather_provider):
+        """Unexpected data type should return None."""
+        response = {"weather.home": "unexpected_string"}
+        result = weather_provider._extract_forecast_list(response, "weather.home")
+        assert result is None
+
+    def test_dict_without_known_keys(self, weather_provider):
+        """Dict without forecast/hourly keys should return None."""
+        response = {"weather.home": {"other_key": []}}
+        result = weather_provider._extract_forecast_list(response, "weather.home")
+        assert result is None
+
+
+class TestParseForecastEntries:
+    """Tests for _parse_forecast_entries."""
+
+    def test_empty_list(self, weather_provider):
+        """Empty list should return empty list."""
+        now = datetime.now(UTC)
+        result = weather_provider._parse_forecast_entries([], now)
+        assert result == []
+
+    def test_valid_entries(self, weather_provider):
+        """Valid entries within 24h should be returned."""
+        now = datetime.now(UTC)
+        entries = [
+            make_forecast_entry(hours_ahead=1, temperature=20.0, now=now),
+            make_forecast_entry(hours_ahead=6, temperature=25.0, now=now),
+            make_forecast_entry(hours_ahead=12, temperature=30.0, now=now),
+        ]
+
+        with patch(
+            "custom_components.localshift.learning.temperature.dt_util.now",
+            return_value=now,
+        ):
+            result = weather_provider._parse_forecast_entries(entries, now)
+
+        assert len(result) == 3
+
+    def test_non_dict_entries_skipped(self, weather_provider):
+        """Non-dict entries should be silently skipped."""
+        now = datetime.now(UTC)
+        entries = [
+            "not_a_dict",
+            None,
+            make_forecast_entry(hours_ahead=2, temperature=22.0, now=now),
+        ]
+
+        result = weather_provider._parse_forecast_entries(entries, now)
+
+        valid = [r for r in result if r is not None]
+        assert len(valid) <= 1
+
+
+class TestParseSingleForecastEntry:
+    """Tests for _parse_single_forecast_entry."""
+
+    def test_non_dict_returns_none(self, weather_provider):
+        """Non-dict entry should return None."""
+        now = datetime.now(UTC)
+        result = weather_provider._parse_single_forecast_entry(
+            "not_a_dict", now, 0, 0, 0, 0
+        )
+        assert result is None
+
+    def test_missing_datetime(self, weather_provider):
+        """Entry without 'datetime' key should return (None, updated_counts)."""
+        now = datetime.now(UTC)
+        entry = {"temperature": 25.0}
+        result = weather_provider._parse_single_forecast_entry(entry, now, 0, 0, 0, 0)
+        assert result is not None
+        forecast, _, skipped, _ = result
+        assert forecast is None
+        assert skipped == 1
+
+    def test_invalid_datetime(self, weather_provider):
+        """Entry with unparseable datetime should return (None, updated_counts)."""
+        now = datetime.now(UTC)
+        entry = {"datetime": "bad-datetime", "temperature": 25.0}
+
+        with patch(
+            "custom_components.localshift.learning.temperature.dt_util.parse_datetime",
+            return_value=None,
+        ):
+            result = weather_provider._parse_single_forecast_entry(
+                entry, now, 0, 0, 0, 0
+            )
+
+        assert result is not None
+        forecast, parse_failed, _, _ = result
+        assert forecast is None
+        assert parse_failed == 1
+
+    def test_forecast_outside_window(self, weather_provider):
+        """Forecast too far in the future should return (None, updated_counts)."""
+        now = datetime.now(UTC)
+        future = now + timedelta(hours=30)
+        entry = {
+            "datetime": future.isoformat(),
+            "temperature": 25.0,
+        }
+        result = weather_provider._parse_single_forecast_entry(entry, now, 0, 0, 0, 0)
+        assert result is not None
+        forecast, _, _, filtered = result
+        assert forecast is None
+        assert filtered == 1
+
+    def test_valid_entry(self, weather_provider):
+        """Valid entry within window should return TemperatureForecast."""
+        now = datetime.now(UTC)
+        future = now + timedelta(hours=5)
+        entry = {
+            "datetime": future.isoformat(),
+            "temperature": 22.0,
+            "condition": "cloudy",
+        }
+        result = weather_provider._parse_single_forecast_entry(entry, now, 0, 0, 0, 0)
+        assert result is not None
+        forecast, _, _, _ = result
+        assert forecast is not None
+        assert isinstance(forecast, TemperatureForecast)
+        assert forecast.temperature == 22.0
+        assert forecast.condition == "cloudy"
+
+
+class TestParseForecastDatetime:
+    """Tests for _parse_forecast_datetime."""
+
+    def test_valid_iso_with_timezone(self, weather_provider):
+        """Valid ISO datetime with timezone should parse correctly."""
+        now = datetime.now(UTC)
+        time_str = now.isoformat()
+        result = weather_provider._parse_forecast_datetime(time_str, 0, 0)
+        assert result is not None
+
+    def test_naive_iso_localized(self, weather_provider):
+        """Naive ISO datetime should be localized."""
+        naive_str = "2024-06-15T14:30:00"
+
+        with patch(
+            "custom_components.localshift.learning.temperature.dt_util.parse_datetime",
+            return_value=None,
+        ):
+            with patch(
+                "custom_components.localshift.learning.temperature.dt_util.as_local"
+            ) as mock_local:
+                mock_local.return_value = datetime(2024, 6, 15, 14, 30, 0, tzinfo=UTC)
+                result = weather_provider._parse_forecast_datetime(naive_str, 0, 0)
+
+        assert result is not None
+
+    def test_completely_invalid_string(self, weather_provider):
+        """Completely invalid string should return None."""
+        with patch(
+            "custom_components.localshift.learning.temperature.dt_util.parse_datetime",
+            return_value=None,
+        ):
+            result = weather_provider._parse_forecast_datetime("not-a-date", 0, 0)
+
+        assert result is None
+
+    def test_first_entry_logged(self, weather_provider):
+        """First entry (index=0) should log debug info."""
+        now = datetime.now(UTC)
+        time_str = now.isoformat()
+
+        with patch(
+            "custom_components.localshift.learning.temperature.dt_util.parse_datetime",
+            return_value=now,
+        ):
+            result = weather_provider._parse_forecast_datetime(time_str, 0, 0)
+
+        assert result is not None
+
+    def test_none_after_parse(self, weather_provider):
+        """When parse_datetime returns valid result with no tzinfo, should localize."""
+        naive_dt = datetime(2024, 1, 1, 12, 0, 0)
+        with patch(
+            "custom_components.localshift.learning.temperature.dt_util.parse_datetime",
+            return_value=naive_dt,
+        ):
+            with patch(
+                "custom_components.localshift.learning.temperature.dt_util.as_local",
+                return_value=datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC),
+            ):
+                result = weather_provider._parse_forecast_datetime(
+                    "2024-01-01T12:00:00", 0, 0
+                )
+
+        assert result is not None
+
+
+class TestGetCurrentTemperature:
+    """Tests for get_current_temperature."""
+
+    def test_no_weather_entity(self, weather_provider):
+        """Returns None when no entity configured."""
+        weather_provider._weather_entity_id = ""
+        assert weather_provider.get_current_temperature() is None
+
+    def test_entity_not_found(self, weather_provider):
+        """Returns None when entity state is None."""
+        weather_provider._weather_entity_id = "weather.home"
+        weather_provider.hass.states.get.return_value = None
+        assert weather_provider.get_current_temperature() is None
+
+    def test_valid_temperature(self, weather_provider):
+        """Returns the current temperature from entity attributes."""
+        weather_provider._weather_entity_id = "weather.home"
+        state = make_weather_state(temperature=23.5)
+        weather_provider.hass.states.get.return_value = state
+
+        result = weather_provider.get_current_temperature()
+
+        assert result == 23.5
+
+    def test_invalid_temperature_returns_none(self, weather_provider):
+        """Returns None (as 0.0 float conversion) for missing temperature."""
+        weather_provider._weather_entity_id = "weather.home"
+        state = MagicMock()
+        state.attributes = {"temperature": "not_a_number"}
+        weather_provider.hass.states.get.return_value = state
+
+        result = weather_provider.get_current_temperature()
+        assert result is None
+
+    def test_temperature_zero_degrees(self, weather_provider):
+        """Temperature of 0 should be returned as 0.0."""
+        weather_provider._weather_entity_id = "weather.home"
+        state = make_weather_state(temperature=0.0)
+        weather_provider.hass.states.get.return_value = state
+
+        result = weather_provider.get_current_temperature()
+        assert result == 0.0

--- a/tests/sensors/test_forecast.py
+++ b/tests/sensors/test_forecast.py
@@ -549,8 +549,9 @@ class TestForecastDiagnosticsSensor:
             weather_correlation_confidence="high",
             weather_adjustment_applied=True,
             weather_learning_enabled=True,
-            weather_cooling_coefficient=0.05,
-            weather_heating_coefficient=0.03,
+            weather_avg_cooling_slope=0.05,
+            weather_avg_heating_slope=0.03,
+            weather_avg_r_squared=0.42,
             weather_sample_count=100,
             load_forecast_slots=[0.5] * 96,
             adaptive_params=AdaptiveParameters(values={"cheap_price_percentile": 0.25}),
@@ -564,6 +565,9 @@ class TestForecastDiagnosticsSensor:
         assert attrs["consumption_statistic_id"] == "sensor.energy"
         assert attrs["consumption_profile_hours"] == 168
         assert attrs["allow_export"] == "yes"
+        assert attrs["weather_avg_cooling_slope"] == 0.05
+        assert attrs["weather_avg_heating_slope"] == 0.03
+        assert attrs["weather_avg_r_squared"] == 0.42
 
     def test_extra_state_attributes_none_adaptive_params(self):
         """Test extra_state_attributes handles None adaptive_params."""

--- a/tests/sensors/test_sensors.py
+++ b/tests/sensors/test_sensors.py
@@ -126,11 +126,12 @@ class Fixtures:
         data.weather_temperature_current = 25.0
         data.weather_temperature_forecast = {14: 28, 15: 30}
         data.weather_condition = "sunny"
-        data.weather_correlation_confidence = 0.8
+        data.weather_correlation_confidence = "medium"
         data.weather_adjustment_applied = True
         data.weather_learning_enabled = True
-        data.weather_cooling_coefficient = 0.1
-        data.weather_heating_coefficient = 0.05
+        data.weather_avg_cooling_slope = 0.1
+        data.weather_avg_heating_slope = 0.05
+        data.weather_avg_r_squared = 0.4
         data.weather_sample_count = 100
         data.load_forecast_slots = [1.0, 1.2, 1.5, 1.3, 1.1, 1.0, 0.9, 0.8, 0.7]
         data.load_deviation_diagnostics = {

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -219,6 +219,30 @@ class TestResetLearningDataButton:
 
         weather_correlation.async_reset.assert_awaited_once()
 
+    @pytest.mark.asyncio
+    async def test_async_press_calls_weather_correlation_reset_via_property(
+        self, mock_coordinator, mock_entry
+    ):
+        """Test reset uses computation engine property access when available."""
+
+        class _EngineWithProperty:
+            def __init__(self, corr):
+                self._corr = corr
+
+            @property
+            def weather_correlation(self):
+                return self._corr
+
+        mock_coordinator.decision_tracker = None
+        weather_correlation = MagicMock()
+        weather_correlation.async_reset = AsyncMock()
+        mock_coordinator._computation_engine = _EngineWithProperty(weather_correlation)
+
+        button = ResetLearningDataButton(mock_coordinator, mock_entry)
+        await button.async_press()
+
+        weather_correlation.async_reset.assert_awaited_once()
+
 
 class TestAsyncSetupEntry:
     """Tests for async_setup_entry."""

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -203,6 +203,22 @@ class TestResetLearningDataButton:
 
         assert mock_coordinator.data.learning_status == "observing"
 
+    @pytest.mark.asyncio
+    async def test_async_press_calls_weather_correlation_reset(
+        self, mock_coordinator, mock_entry
+    ):
+        """Test button press triggers weather correlation reset when available."""
+        mock_coordinator.decision_tracker = None
+        weather_correlation = MagicMock()
+        weather_correlation.async_reset = AsyncMock()
+        mock_coordinator._computation_engine = MagicMock()
+        mock_coordinator._computation_engine._weather_correlation = weather_correlation
+
+        button = ResetLearningDataButton(mock_coordinator, mock_entry)
+        await button.async_press()
+
+        weather_correlation.async_reset.assert_awaited_once()
+
 
 class TestAsyncSetupEntry:
     """Tests for async_setup_entry."""


### PR DESCRIPTION
## Summary
- Replaces the weather EMA coefficient learner with bounded per-hour regression using 30-day sufficient-statistics snapshots, migration to storage v2, and prediction safety caps to prevent runaway outputs.
- Splits weather forecast parsing/caching and anomaly detection into dedicated learning modules while keeping the `WeatherCorrelation` facade API stable and adding weather reset support.
- Updates forecast integration, diagnostics fields, dashboard/scripts, sensor/coordinator attributes, and documentation; adds focused regression/extraction/reset test coverage for the new behavior.

## Testing
- uv run pytest tests/learning/test_temperature.py tests/learning/test_anomaly.py tests/learning/test_correlation.py tests/forecast/test_load.py tests/engine/test_weather_diagnostics.py tests/sensors/test_forecast.py tests/sensors/test_sensors.py tests/test_button.py -v
- uv run ruff check custom_components/localshift
- uv run pytest --cov=custom_components/localshift --cov-report=term-missing
- uv run pytest tests/engine/test_weather_diagnostics.py tests/test_button.py tests/learning/test_correlation.py -q