### PR TITLE
fix: coalesce state-change evaluations to prevent mode flip-flop

### DIFF
--- a/.opencode/skills/deploy-and-validate/SKILL.md
+++ b/.opencode/skills/deploy-and-validate/SKILL.md
@@ -32,14 +32,33 @@ Ensure environment variables are set:
 - `HA_LONG_LIVED_TOKEN` - HA API token for restart/reload
 - `HA_URL` - HA URL (default: `http://homeassistant:8123`)
 
+Recommended pattern (avoid relying on interactive shell inheritance):
+
+```bash
+# Store once (outside repo/worktree)
+mkdir -p ~/.config/localshift
+cat > ~/.config/localshift/ha.env <<'EOF'
+export HA_URL='https://your-ha-host:8123'
+export HA_CONFIG='/homeassistant'
+export HA_LONG_LIVED_TOKEN='YOUR_TOKEN'
+EOF
+chmod 600 ~/.config/localshift/ha.env
+
+# Prefix every deploy/validation command
+source ~/.config/localshift/ha.env && ./deploy.sh --status
+```
+
 ## Step 1: Check Prerequisites
 
 ```bash
 # Verify HA connection
-curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer $HA_LONG_LIVED_TOKEN" "$HA_URL/api/config"
+source ~/.config/localshift/ha.env && \
+  curl -s -o /dev/null -w "%{http_code}" \
+  -H "Authorization: Bearer $HA_LONG_LIVED_TOKEN" \
+  "${HA_URL%/}/api/config"
 
 # Check existing reservations
-./deploy.sh --status
+source ~/.config/localshift/ha.env && ./deploy.sh --status
 ```
 
 If another agent has reservation, either wait or use `--force` (emergency only).
@@ -47,7 +66,7 @@ If another agent has reservation, either wait or use `--force` (emergency only).
 ## Step 2: Reserve HA Instance
 
 ```bash
-./deploy.sh --reserve
+source ~/.config/localshift/ha.env && ./deploy.sh --reserve
 ```
 
 This creates reservation file preventing other agents from overwriting your deployment.
@@ -55,7 +74,7 @@ This creates reservation file preventing other agents from overwriting your depl
 ## Step 3: Deploy with Restart
 
 ```bash
-./deploy.sh --restart
+source ~/.config/localshift/ha.env && printf 'y\n' | ./deploy.sh --restart
 ```
 
 **Important:** Use `--restart` not plain deploy. The integration requires restart to load new code properly.
@@ -134,16 +153,16 @@ Query: ha_get_state(entity_id="binary_sensor.localshift_solar_can_reach_target")
 Pass: state reflects actual solar conditions (on=can reach, off=cannot)
 Fail: contradictory to forecast data
 
-### Check 4: Plan Has 96 Slots
+### Check 4: Plan Slot Count Matches Hybrid Horizon
 
 ```
 Entity: sensor.localshift_optimizer_plan
-Expected: state is "96" (or close)
+Expected: rolling hybrid slot count (typically ~54-60, not fixed 96)
 Query: ha_get_state(entity_id="sensor.localshift_optimizer_plan")
 ```
 
-Pass: state shows 96 slots
-Fail: incorrect slot count
+Pass: state is an integer in expected hybrid range for current horizon (usually 50-60)
+Fail: non-numeric, zero, or clearly out-of-range for hybrid planning
 
 ### Check 5: Terminal Shortfall Reasonable
 
@@ -156,17 +175,17 @@ Query: ha_get_state with attributes
 Pass: matches expectation (0% for sunny, >0% for cloudy)
 Fail: contradictory to solar conditions
 
-### Check 6: No Grid Charge at Expensive Prices
+### Check 6: No Grid Charge in Top Price Quartile (Unless Shortfall Risk)
 
 ```
 Entity: sensor.localshift_optimizer_plan_detailed
 Attribute: decisions array
-Expected: no charge_grid_* actions at above-median buy_price
+Expected: no charge_grid_* actions at buy_price > P75 unless `reason_code == TARGET_SHORTFALL_RISK`
 Query: ha_get_state with attributes, analyze decisions array
 ```
 
-Pass: charging only at <= median prices
-Fail: charging at expensive peak prices
+Pass: expensive charging occurs only when justified by terminal shortfall risk
+Fail: expensive charging without shortfall-risk justification
 
 ### Check 7: No Export at Negative FIT
 
@@ -224,9 +243,9 @@ echo "- Deployment ready for PR"
 | 1 | sensor.localshift_optimizer_summary | state == "success" |
 | 2 | sensor.localshift_integration_status | state != "error" |
 | 3 | binary_sensor.localshift_solar_can_reach_target | matches forecast |
-| 4 | sensor.localshift_optimizer_plan | 96 slots |
+| 4 | sensor.localshift_optimizer_plan | hybrid rolling count (typically 50-60) |
 | 5 | sensor.localshift_optimizer_summary.terminal_shortfall_pct | reasonable |
-| 6 | decisions array | no charge at peak prices |
+| 6 | decisions array | no unjustified charge in top quartile |
 | 7 | decisions array | no export at negative FIT |
 | 8 | /homeassistant/home-assistant.log | no errors |
 
@@ -245,8 +264,8 @@ echo "- Deployment ready for PR"
 
 ### Plan has fewer than 96 slots
 
-- Forecast may not be fully populated
-- Wait for next coordinator cycle
+- This is expected for hybrid planning (5-min near-term + 30-min extended)
+- Validate structure/range, not fixed 96
 
 ### Terminal shortfall incorrect
 

--- a/.opencode/skills/homeassistant/SKILL.md
+++ b/.opencode/skills/homeassistant/SKILL.md
@@ -113,18 +113,38 @@ This project uses `HA_URL` and `HA_LONG_LIVED_TOKEN`. Wrap commands:
 HASS_SERVER="${HA_URL%/}" HASS_TOKEN=$HA_LONG_LIVED_TOKEN uvx --from homeassistant-cli hass-cli ...
 ```
 
+### Environment Bootstrapping (Critical)
+
+Do not assume interactive shell exports are available to subprocesses. Source env explicitly.
+
+```bash
+# Recommended location (outside repo/worktree)
+source ~/.config/localshift/ha.env
+
+# Quick connectivity check before CLI reads
+curl -s -o /dev/null -w "%{http_code}" \
+  -H "Authorization: Bearer $HA_LONG_LIVED_TOKEN" \
+  "${HA_URL%/}/api/config"
+```
+
+If the check returns `000` or DNS errors, `HA_URL` is not reachable from current runtime.
+Use a resolvable URL (for example, your LAN or public HA URL), then retry CLI commands.
+
 ### Entity Queries
 
 ```bash
 # Get specific entity state (JSON)
+source ~/.config/localshift/ha.env && \
 HASS_SERVER="${HA_URL%/}" HASS_TOKEN=$HA_LONG_LIVED_TOKEN \
   uvx --from homeassistant-cli hass-cli --output json state get sensor.battery_level
 
 # List all entities
+source ~/.config/localshift/ha.env && \
 HASS_SERVER="${HA_URL%/}" HASS_TOKEN=$HA_LONG_LIVED_TOKEN \
   uvx --from homeassistant-cli hass-cli entity list
 
 # Search entities
+source ~/.config/localshift/ha.env && \
 HASS_SERVER="${HA_URL%/}" HASS_TOKEN=$HA_LONG_LIVED_TOKEN \
   uvx --from homeassistant-cli hass-cli entity list | grep -i battery
 ```
@@ -133,10 +153,12 @@ HASS_SERVER="${HA_URL%/}" HASS_TOKEN=$HA_LONG_LIVED_TOKEN \
 
 ```bash
 # Get entity history (last 24h, JSON)
+source ~/.config/localshift/ha.env && \
 HASS_SERVER="${HA_URL%/}" HASS_TOKEN=$HA_LONG_LIVED_TOKEN \
   uvx --from homeassistant-cli hass-cli --output json raw GET "api/history/period?filter_entity_id=sensor.battery_level"
 
 # Get statistics
+source ~/.config/localshift/ha.env && \
 HASS_SERVER="${HA_URL%/}" HASS_TOKEN=$HA_LONG_LIVED_TOKEN \
   uvx --from homeassistant-cli hass-cli --output json raw GET "api/statistics_during_period?entity_ids=sensor.battery_level&period=day"
 ```

--- a/custom_components/localshift/const.py
+++ b/custom_components/localshift/const.py
@@ -532,6 +532,9 @@ STATE_MACHINE_MIN_CORRECTION_INTERVAL_MINUTES = 5
 # Prevents false positives when Tesla API is still propagating state changes.
 STATE_MACHINE_TRANSITION_GRACE_SECONDS = 30
 
+# Coalesce entity state changes before running expensive reevaluation.
+STATE_CHANGE_COALESCE_SECONDS = 15
+
 # -----------------------------------------------------------------------------
 # Proactive Export Constants
 # -----------------------------------------------------------------------------

--- a/custom_components/localshift/services/evaluation_dispatcher.py
+++ b/custom_components/localshift/services/evaluation_dispatcher.py
@@ -7,9 +7,10 @@ from collections.abc import Callable, Coroutine
 from datetime import datetime
 from typing import Any
 
-from homeassistant.core import Event, HomeAssistant, callback
+from homeassistant.core import CALLBACK_TYPE, Event, HomeAssistant, callback
+from homeassistant.helpers.event import async_call_later
 
-from ..const import CONF_PRICING_GENERAL_PRICE
+from ..const import CONF_PRICING_GENERAL_PRICE, STATE_CHANGE_COALESCE_SECONDS
 from ..forecast.load_deviation import LoadDeviationDetector
 from ..forecast.solar_events import SolarEventDetector
 
@@ -38,6 +39,8 @@ class EvaluationDispatcher:
         self._stale_price_threshold = stale_price_threshold
         self._load_deviation_detector = LoadDeviationDetector()
         self._solar_event_detector = SolarEventDetector()
+        self._coalesce_unsub: CALLBACK_TYPE | None = None
+        self._coalesce_count = 0
 
     @callback
     def on_state_change(self, _event: Event) -> None:
@@ -51,11 +54,56 @@ class EvaluationDispatcher:
 
         self._read_state()
         self._notify_listeners()
+        self._schedule_coalesced_evaluation()
 
+    @callback
+    def _schedule_coalesced_evaluation(self) -> None:
+        """Schedule or reschedule coalesced evaluation."""
+        if self._coalesce_unsub is not None:
+            self._coalesce_unsub()
+
+        self._coalesce_count += 1
+        self._coalesce_unsub = async_call_later(
+            self.hass,
+            STATE_CHANGE_COALESCE_SECONDS,
+            self._on_coalesce_timer_expired,
+        )
+
+    @callback
+    def _on_coalesce_timer_expired(self, _now: datetime) -> None:
+        """Run evaluation after the coalesce window has settled."""
+        coalesced_changes = self._coalesce_count
+        self._coalesce_count = 0
+        self._coalesce_unsub = None
+
+        if self._state_machine is None:
+            return
+
+        if self._state_machine.in_mode_transition:
+            _LOGGER.debug(
+                "Skipping coalesced re-evaluation during mode transition (%d coalesced changes)",
+                coalesced_changes,
+            )
+            return
+
+        _LOGGER.debug(
+            "Dispatching coalesced state-change evaluation (%d coalesced changes)",
+            coalesced_changes,
+        )
         self.hass.async_create_task(
             self._evaluate_state_machine(),
-            "localshift_evaluate_state_change",
+            "localshift_evaluate_coalesced",
         )
+
+    @callback
+    def cancel_pending_coalesce(self) -> None:
+        """Cancel any pending coalesced evaluation timer."""
+        if self._coalesce_unsub is None:
+            return
+
+        self._coalesce_unsub()
+        self._coalesce_unsub = None
+        self._coalesce_count = 0
 
     @callback
     def on_fast_tick(self, _now: datetime) -> bool:

--- a/tests/sensors/test_solcast.py
+++ b/tests/sensors/test_solcast.py
@@ -6,7 +6,7 @@ analysis attribute data.
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timedelta
 from unittest.mock import Mock
 
 import pytest
@@ -20,6 +20,20 @@ from custom_components.localshift.sensors.solcast import (
     SolcastConfidenceTodaySensor,
     SolcastConfidenceTomorrowSensor,
 )
+
+
+def _next_hour(ts: datetime) -> datetime:
+    """Return timestamp one hour after input, including day rollover."""
+    return ts + timedelta(hours=1)
+
+
+def test_next_hour_handles_midnight_rollover():
+    """One-hour increment should roll over date at midnight."""
+    ts = datetime(2026, 3, 27, 23, 30, 0)
+
+    result = _next_hour(ts)
+
+    assert result == datetime(2026, 3, 28, 0, 30, 0)
 
 
 @pytest.fixture
@@ -45,7 +59,7 @@ def coordinator_with_analysis():
                 confidence=0.8,
             ),
             ConfidenceInterval(
-                period_start=now.replace(hour=now.hour + 1),
+                period_start=_next_hour(now),
                 spread_kwh=0.6,
                 confidence=0.7,
             ),

--- a/tests/services/test_evaluation_dispatcher.py
+++ b/tests/services/test_evaluation_dispatcher.py
@@ -1,7 +1,7 @@
 """Tests for EvaluationDispatcher."""
 
 from datetime import timedelta
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from homeassistant.util import dt as dt_util
 
@@ -21,8 +21,12 @@ class StubCoordinator:
         return None
 
 
-def test_state_change_dispatches_evaluation():
-    """State change triggers read, notify, and evaluation scheduling."""
+@patch("custom_components.localshift.services.evaluation_dispatcher.async_call_later")
+def test_state_change_dispatches_evaluation(mock_call_later):
+    """State change triggers read, notify, and deferred evaluation scheduling."""
+    mock_unsub = MagicMock()
+    mock_call_later.return_value = mock_unsub
+
     hass = MagicMock()
     hass.async_create_task = MagicMock()
 
@@ -47,10 +51,147 @@ def test_state_change_dispatches_evaluation():
 
     read_state.assert_called_once()
     notify_listeners.assert_called_once()
+    hass.async_create_task.assert_not_called()
+    mock_call_later.assert_called_once()
+
+    timer_callback = mock_call_later.call_args[0][2]
+    timer_callback(MagicMock())
+
     hass.async_create_task.assert_called_once()
-    assert (
-        hass.async_create_task.call_args.args[1] == "localshift_evaluate_state_change"
+    assert hass.async_create_task.call_args.args[1] == "localshift_evaluate_coalesced"
+
+
+@patch("custom_components.localshift.services.evaluation_dispatcher.async_call_later")
+def test_multiple_state_changes_coalesce_into_single_evaluation(mock_call_later):
+    """Multiple entity changes within the window trigger one evaluation."""
+    timer_unsubs = [MagicMock(), MagicMock(), MagicMock()]
+    mock_call_later.side_effect = timer_unsubs
+
+    hass = MagicMock()
+    hass.async_create_task = MagicMock()
+
+    state_machine = MagicMock()
+    state_machine.in_mode_transition = False
+
+    read_state = MagicMock()
+
+    dispatcher = EvaluationDispatcher(
+        hass,
+        lambda _key: "sensor.price",
+        read_state,
+        MagicMock(),
+        AsyncMock(),
+        state_machine,
+        timedelta(minutes=10),
     )
+
+    dispatcher.on_state_change(MagicMock())
+    dispatcher.on_state_change(MagicMock())
+    dispatcher.on_state_change(MagicMock())
+
+    assert read_state.call_count == 3
+    assert mock_call_later.call_count == 3
+    timer_unsubs[0].assert_called_once()
+    timer_unsubs[1].assert_called_once()
+    timer_unsubs[2].assert_not_called()
+    hass.async_create_task.assert_not_called()
+
+    timer_callback = mock_call_later.call_args[0][2]
+    timer_callback(MagicMock())
+
+    hass.async_create_task.assert_called_once()
+
+
+@patch("custom_components.localshift.services.evaluation_dispatcher.async_call_later")
+def test_cancel_pending_coalesce(mock_call_later):
+    """Pending coalesced evaluation can be cancelled."""
+    mock_unsub = MagicMock()
+    mock_call_later.return_value = mock_unsub
+
+    hass = MagicMock()
+    hass.async_create_task = MagicMock()
+
+    state_machine = MagicMock()
+    state_machine.in_mode_transition = False
+
+    dispatcher = EvaluationDispatcher(
+        hass,
+        lambda _key: "sensor.price",
+        MagicMock(),
+        MagicMock(),
+        AsyncMock(),
+        state_machine,
+        timedelta(minutes=10),
+    )
+
+    dispatcher.on_state_change(MagicMock())
+
+    dispatcher.cancel_pending_coalesce()
+    mock_unsub.assert_called_once()
+    assert dispatcher._coalesce_unsub is None
+    assert dispatcher._coalesce_count == 0
+
+
+@patch("custom_components.localshift.services.evaluation_dispatcher.async_call_later")
+def test_coalesce_timer_skips_if_transition_started(mock_call_later):
+    """Timer callback skips evaluation if transition starts before expiry."""
+    mock_unsub = MagicMock()
+    mock_call_later.return_value = mock_unsub
+
+    hass = MagicMock()
+    hass.async_create_task = MagicMock()
+
+    state_machine = MagicMock()
+    state_machine.in_mode_transition = False
+
+    dispatcher = EvaluationDispatcher(
+        hass,
+        lambda _key: "sensor.price",
+        MagicMock(),
+        MagicMock(),
+        AsyncMock(),
+        state_machine,
+        timedelta(minutes=10),
+    )
+
+    dispatcher.on_state_change(MagicMock())
+    state_machine.in_mode_transition = True
+
+    timer_callback = mock_call_later.call_args[0][2]
+    timer_callback(MagicMock())
+
+    hass.async_create_task.assert_not_called()
+
+
+@patch("custom_components.localshift.services.evaluation_dispatcher.async_call_later")
+def test_coalesce_timer_skips_if_state_machine_removed(mock_call_later):
+    """Timer callback skips evaluation if state machine is missing."""
+    mock_unsub = MagicMock()
+    mock_call_later.return_value = mock_unsub
+
+    hass = MagicMock()
+    hass.async_create_task = MagicMock()
+
+    state_machine = MagicMock()
+    state_machine.in_mode_transition = False
+
+    dispatcher = EvaluationDispatcher(
+        hass,
+        lambda _key: "sensor.price",
+        MagicMock(),
+        MagicMock(),
+        AsyncMock(),
+        state_machine,
+        timedelta(minutes=10),
+    )
+
+    dispatcher.on_state_change(MagicMock())
+    dispatcher._state_machine = None
+
+    timer_callback = mock_call_later.call_args[0][2]
+    timer_callback(MagicMock())
+
+    hass.async_create_task.assert_not_called()
 
 
 def test_state_change_skips_during_transition():


### PR DESCRIPTION
## Summary
- Coalesce monitored state-change evaluations in `EvaluationDispatcher` using a 15-second sliding window so optimizer runs after Amber batch updates settle.
- Add targeted tests for deferred scheduling, timer reset behavior, cancellation, and transition/missing-state-machine guards.
- Update HA deployment/validation skill docs to use explicit env sourcing and hybrid-plan-aware validation criteria.

## Related Issue
Closes #832

## Testing
- `uv run pytest tests/services/test_evaluation_dispatcher.py -v`
- `uv run pytest tests/services/test_evaluation_dispatcher.py tests/coordinator/test_tick_scheduler.py -v`
- pre-commit hook TDD checks during commit:
  - `tests/test_const.py`
  - `tests/services/test_evaluation_dispatcher.py`
  - `tests/services/test_evaluation_dispatcher_startup_trigger.py`
  - per-file coverage: `const.py` 99%, `evaluation_dispatcher.py` 96%