### PR TITLE
fix: migrate weather correlation storage across schema versions

### DIFF
--- a/custom_components/localshift/learning/correlation.py
+++ b/custom_components/localshift/learning/correlation.py
@@ -302,6 +302,7 @@ class WeatherCorrelation:
         self._store = Store[dict[str, Any]](
             hass, STORAGE_VERSION, f"{DOMAIN}_{STORAGE_KEY}"
         )
+        self._store._async_migrate_func = self._async_migrate_store_data
         self._data: WeatherCorrelationData = WeatherCorrelationData()
         self._initialized = False
 
@@ -314,6 +315,24 @@ class WeatherCorrelation:
             hass, entry, self._data.weather_entity_id
         )
         self._anomaly_detector = WeatherAnomalyDetector(self._data.temperature_history)
+
+    async def _async_migrate_store_data(
+        self,
+        old_major_version: int,
+        old_minor_version: int,
+        old_data: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Migrate persisted weather-correlation payload to current schema."""
+        if old_major_version == STORAGE_VERSION:
+            return old_data
+
+        if old_major_version == 1:
+            return WeatherCorrelationData.from_dict(old_data).to_dict()
+
+        raise NotImplementedError(
+            "Unsupported weather correlation storage version: "
+            f"{old_major_version}.{old_minor_version}"
+        )
 
     async def async_initialize(self) -> None:
         """Load persisted data from storage."""

--- a/tests/learning/test_correlation.py
+++ b/tests/learning/test_correlation.py
@@ -7,12 +7,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+import custom_components.localshift.learning.correlation as correlation_module
 from custom_components.localshift.const import (
     CONF_COOLING_THRESHOLD,
     CONF_HEATING_THRESHOLD,
     CONF_WEATHER_ENTITY,
 )
-import custom_components.localshift.learning.correlation as correlation_module
 from custom_components.localshift.learning.correlation import (
     DailySnapshot,
     HourlyRegressionData,
@@ -381,6 +381,44 @@ class TestLearningAndPrediction:
 
 
 class TestMigrationAndReset:
+    @pytest.mark.asyncio
+    async def test_store_migration_callback_is_configured(self, mock_hass, mock_entry):
+        with patch(
+            "custom_components.localshift.learning.correlation.Store",
+        ):
+            correlation = WeatherCorrelation(mock_hass, mock_entry)
+
+        assert (
+            correlation._store._async_migrate_func
+            == correlation._async_migrate_store_data
+        )
+
+        migrated = await correlation._async_migrate_store_data(
+            1,
+            1,
+            {
+                "version": 1,
+                "weather_entity_id": "weather.home",
+                "hourly_coefficients": {"8": {"cooling_coefficient": 12.761}},
+                "learning_stats": {"note": "keep"},
+                "temperature_history": {"2026-03-25": 22.5},
+            },
+        )
+
+        assert migrated["version"] == correlation_module.STORAGE_VERSION
+        assert migrated["weather_entity_id"] == "weather.home"
+        assert migrated["daily_regression_stats"] == {}
+        assert migrated["learning_stats"] == {"note": "keep"}
+        assert migrated["temperature_history"] == {"2026-03-25": 22.5}
+
+    @pytest.mark.asyncio
+    async def test_store_migration_rejects_unknown_major_version(self, correlation):
+        with pytest.raises(
+            NotImplementedError,
+            match="Unsupported weather correlation storage version",
+        ):
+            await correlation._async_migrate_store_data(7, 1, {"version": 7})
+
     @pytest.mark.asyncio
     async def test_async_initialize_migrates_v1_storage_and_discards_hourly_coefficients(
         self, correlation, mock_weather_store


### PR DESCRIPTION
## Summary
- add an explicit Home Assistant Store migration callback for weather-correlation storage so persisted v1 payloads load safely after the v2 schema bump
- preserve existing v1 payload compatibility semantics (drop legacy hourly coefficients, keep metadata/history) through migration path tests
- add regression tests that verify migration wiring and unsupported-version failure behavior

## Testing
- uv run ruff check custom_components/localshift tests/learning/test_correlation.py
- uv run pytest tests/learning/test_correlation.py -q
- uv run pytest -q
- uv run pytest --cov=custom_components/localshift --cov-report=term-missing