### PR TITLE
chore: ignore agent-tooling clutter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,8 @@ snapshots/
 # Worktrees (local development only)
 worktrees/
 
+# Agent frameworks / local tooling (not project code)
+_bmad/
+_bmad-output/
+.claude/
+


### PR DESCRIPTION
## Summary
Small working-tree hygiene: gitignore local agent frameworks that were showing as hundreds of untracked files.

- `.gitignore` += `_bmad/`, `_bmad-output/`, `.claude/`

## Deliberately held back (need a decision — see PR discussion)
- **docs/ reorg** (delete 21 legacy docs, add new summary docs): the new docs reference `docs.bak/` as *authoritative*, so gitignoring `docs.bak/` + deleting the originals would erase authoritative docs. Not done.
- **`.opencode/`**: partially tracked (committed skills/rules), so not blanket-ignored.
- **`install.shnbash`**: turns out to be a real OpenCode installer with a typo'd name — should be renamed to `install.sh`, not deleted.