### PR TITLE
fix(optimizer): gate post-demand-window charging on un-inflated cheap price (#800)

### DIFF
--- a/custom_components/localshift/coordinator/data.py
+++ b/custom_components/localshift/coordinator/data.py
@@ -234,6 +234,10 @@ class CoordinatorData:
 
     # Computed sensors
     effective_cheap_price: float = 0.0
+    # Un-inflated percentile cheap threshold (Issue #800). None = not yet computed.
+    # May legitimately be <= 0 in negative-wholesale markets, so a None sentinel (not 0.0)
+    # is used to distinguish "absent" from "genuinely cheap/negative".
+    base_cheap_price: float | None = None
     cheap_charge_stop_price: float = 0.0
     planner_threshold_used: float | None = None  # Threshold the optimizer actually used
     solar_weighted_avg_fit: float = 0.0

--- a/custom_components/localshift/engine/constraints.py
+++ b/custom_components/localshift/engine/constraints.py
@@ -137,8 +137,11 @@ def feasible_actions(
         and not (_solar_covers_deficit or _global_solar_covers)
     ):
         if config.optimization_mode == "self_consumption":
-            price_is_cheap = slot.buy_price <= config.effective_cheap_price
-            price_is_very_cheap = slot.buy_price <= config.effective_cheap_price * 0.8
+            cheap_threshold = _cheap_threshold_for_slot(
+                config, slot_idx, terminal_penalty_idx
+            )
+            price_is_cheap = slot.buy_price <= cheap_threshold
+            price_is_very_cheap = slot.buy_price <= cheap_threshold * 0.8
 
             if price_is_cheap:
                 actions.append(PlannerAction.CHARGE_GRID_NORMAL)
@@ -155,6 +158,31 @@ def feasible_actions(
     )
 
     return actions
+
+
+def _cheap_threshold_for_slot(
+    config: OptimizerConfig,
+    slot_idx: int,
+    terminal_penalty_idx: int | None,
+) -> float:
+    """Return the cheap-price threshold to apply to a slot's grid-charge gate.
+
+    Issue #800 (overnight SOC floor bounce / sawtooth).
+    ``effective_cheap_price`` is a "now" value that today's low-solar urgency may have
+    inflated above the genuinely-cheap base (to fund pre-charge before *today's* demand
+    window). That urgency does not apply to slots at/after the demand-window entry —
+    using the inflated value there classifies tomorrow-night slots as "cheap" and drives
+    net-negative overnight sawtooth charging. For those slots, gate on the un-inflated
+    ``base_cheap_price`` instead. Pre-demand-window slots keep the urgency-aware value.
+    """
+    threshold = config.effective_cheap_price
+    if (
+        config.base_cheap_price is not None
+        and terminal_penalty_idx is not None
+        and slot_idx >= terminal_penalty_idx
+    ):
+        threshold = min(threshold, config.base_cheap_price)
+    return threshold
 
 
 def check_global_solar_sufficiency(

--- a/custom_components/localshift/engine/optimizer_runner.py
+++ b/custom_components/localshift/engine/optimizer_runner.py
@@ -303,6 +303,16 @@ def _build_optimizer_config(
     cheap_price_bias = adaptive.get("cheap_price_bias", 0.0) if adaptive else 0.0
     effective_cheap_price = max(0.0, effective_cheap_price + cheap_price_bias / 100)
 
+    # Issue #800: objective un-inflated percentile floor for post-demand-window gating.
+    # Deliberately independent of the urgency/adaptive adjustments baked into
+    # effective_cheap_price: those tune how aggressively to pre-charge before *today's*
+    # demand window, whereas this is a guardrail against that inflation leaking onto
+    # tomorrow's slots. A negative cheap_price_bias still tightens the post-DW gate
+    # because the gate uses min(effective_cheap_price, base_cheap_price); a positive bias
+    # must NOT loosen it, which is exactly what keeping the bias off this floor achieves.
+    # None means "not computed yet" (distinct from a genuinely <= 0 base in negative markets).
+    base_cheap_price: float | None = getattr(data, "base_cheap_price", None)
+
     # grid_charge_soc_headroom + overnight_drain_safety_margin -> demand_window_target_soc_pct
     grid_charge_soc_headroom = (
         adaptive.get("grid_charge_soc_headroom", 0.0) if adaptive else 0.0
@@ -345,6 +355,7 @@ def _build_optimizer_config(
         optimization_mode=optimization_mode,
         self_consumption_value_per_kwh=self_consumption_value_per_kwh,
         effective_cheap_price=effective_cheap_price,
+        base_cheap_price=base_cheap_price,
         switching_penalty=switching_penalty,
         export_price_margin=export_price_margin,
         forecast_horizon_hours=float(getattr(data, "forecast_horizon_hours", 24.0)),

--- a/custom_components/localshift/engine/price_calculator.py
+++ b/custom_components/localshift/engine/price_calculator.py
@@ -383,6 +383,9 @@ class PriceCalculator:
             data.general_forecast, now_dt, data.forecast_horizon_hours
         )
 
+        # Issue #800: record un-inflated percentile base (see compute_effective_cheap_price).
+        data.base_cheap_price = base
+
         try:
             # Include tomorrow's forecast when target is tomorrow morning
             all_solcast = [*data.solcast_today, *data.solcast_tomorrow]
@@ -469,6 +472,11 @@ class PriceCalculator:
         _, base, max_price = self._collect_forecast_prices_and_base(
             data.general_forecast, now_dt, data.forecast_horizon_hours
         )
+
+        # Issue #800: record the un-inflated "genuinely cheap" percentile base so the
+        # optimizer can gate post-demand-window (tomorrow) slots on it instead of the
+        # urgency-inflated effective price (which would cause overnight sawtooth charging).
+        data.base_cheap_price = base
 
         solar_gap = not data.solar_can_reach_target
 

--- a/custom_components/localshift/engine/types.py
+++ b/custom_components/localshift/engine/types.py
@@ -207,6 +207,18 @@ class OptimizerConfig:
     effective_cheap_price: float = 0.10
     """Price threshold for grid charging in self-consumption mode ($/kWh)."""
 
+    base_cheap_price: float | None = None
+    """Un-inflated "genuinely cheap" threshold (percentile-derived), $/kWh.
+
+    ``effective_cheap_price`` is computed for *now* and may be inflated by today's
+    low-solar urgency (``_calculate_urgency_adjusted_price``) so the optimizer will
+    pay more to reach *today's* demand-window target. That urgency rationale does not
+    hold for slots at/after the demand window (i.e. tomorrow), so applying the inflated
+    threshold there wrongly classifies tomorrow-night slots as "cheap" and produces
+    net-negative overnight sawtooth charging. Past the demand-window entry, grid
+    charging is gated on this un-inflated base instead. Falls back to
+    ``effective_cheap_price`` when ``None`` (backward compatibility)."""
+
     switching_penalty: float = 0.02
     """Penalty applied when switching away from the currently commanded action ($/switch)."""
 

--- a/tests/engine/test_optimizer_runner.py
+++ b/tests/engine/test_optimizer_runner.py
@@ -177,6 +177,49 @@ class TestOptimizerRunnerHelpers:
         assert updated.export_price_margin == pytest.approx(0.11)
         assert updated.self_consumption_value_per_kwh == pytest.approx(0.10)
 
+    def test_build_optimizer_config_base_cheap_price_passthrough(self):
+        """Issue #800: base_cheap_price flows through as the objective percentile floor.
+
+        It must be independent of cheap_price_bias (the bias only tunes the urgency-aware
+        effective_cheap_price; it tightens the post-DW gate via min(), never loosens it),
+        and must tolerate <= 0 values (negative-wholesale markets) without being floored
+        to 0.0 (which would block ALL post-DW charging).
+        """
+
+        class MockData:
+            effective_cheap_price = 0.10
+            general_price = 0.20
+            base_cheap_price = 0.08
+            adaptive_params = {"cheap_price_bias": -3.0}  # negative bias
+
+        updated = _build_optimizer_config(MockData(), {})
+        # Bias applies to effective (0.10 - 0.03) but NOT to the objective base floor.
+        assert updated.effective_cheap_price == pytest.approx(0.07)
+        assert updated.base_cheap_price == pytest.approx(0.08)
+
+    def test_build_optimizer_config_base_cheap_price_negative_market(self):
+        """A genuinely-negative percentile base passes through (not coerced to None/0)."""
+
+        class MockData:
+            effective_cheap_price = 0.05
+            general_price = 0.20
+            base_cheap_price = -0.02
+            adaptive_params = None
+
+        updated = _build_optimizer_config(MockData(), {})
+        assert updated.base_cheap_price == pytest.approx(-0.02)
+
+    def test_build_optimizer_config_base_cheap_price_absent_is_none(self):
+        """When the coordinator has not computed a base yet, gating is disabled (None)."""
+
+        class MockData:
+            effective_cheap_price = 0.10
+            general_price = 0.20
+            adaptive_params = None
+
+        updated = _build_optimizer_config(MockData(), {})
+        assert updated.base_cheap_price is None
+
     def test_compute_legacy_energy_totals(self):
         """Legacy totals should ignore invalid numeric inputs."""
         totals = _compute_legacy_energy_totals([

--- a/tests/engine/test_sawtooth_gate.py
+++ b/tests/engine/test_sawtooth_gate.py
@@ -1,0 +1,291 @@
+"""Gate test for the overnight cheap-window sawtooth (Issue #800).
+
+Background
+----------
+``effective_cheap_price`` is computed for *now* and may be inflated above the
+genuinely-cheap percentile base by today's low-solar urgency (so the optimizer will pay
+more to pre-charge before *today's* demand window). The DP applies that single scalar to
+every slot in the (multi-day) horizon, so *tomorrow night's* slots — priced just under the
+inflated threshold but above the real base — get classed as "CHEAP IMPORT WINDOW". A
+marginal grid charge then fires and immediately drains through house load before any useful
+period: a net-negative "sawtooth" SOC (Issue #800 "overnight SOC floor bounce").
+
+Because the optimizer re-plans every cycle, today's urgency price is only ever legitimately
+needed for the *near* (pre-demand-window) slots; far slots are re-evaluated with their own
+urgency when they become "now". The fix gates slots at/after the demand-window entry on the
+un-inflated ``base_cheap_price`` instead.
+
+These tests reproduce the sawtooth deterministically and assert the fix removes it without
+suppressing genuinely-cheap (<= base) overnight charging.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+from custom_components.localshift.engine.constraints import (
+    _cheap_threshold_for_slot,
+    feasible_actions,
+)
+from custom_components.localshift.engine.core import DPPlanner
+from custom_components.localshift.engine.types import (
+    OptimizerConfig,
+    OptimizerInputs,
+    PlannerAction,
+    SlotContext,
+)
+
+INTERVAL = 30
+_START = datetime(2026, 6, 3, 12, 0)  # day-1 noon
+
+# Price bands ($/kWh)
+_BASE_CHEAP = 0.08  # genuinely-cheap percentile base
+_INFLATED_CHEAP = 0.12  # today's urgency-inflated "now" value
+_OVERNIGHT = 0.119  # just under the inflated threshold, well above the real base
+_MORNING_PEAK = 0.16
+_DW_PEAK = 0.30
+
+_CHARGE_ACTIONS = (PlannerAction.CHARGE_GRID_NORMAL, PlannerAction.CHARGE_GRID_BOOST)
+
+
+def _price_for(t: datetime) -> float:
+    h = t.hour + t.minute / 60.0
+    if t.day == 3 and 15.0 <= h < 21.0:
+        return _DW_PEAK  # day-1 evening demand window
+    if t.day == 3 and 12.0 <= h < 15.0:
+        return 0.16  # day-1 pre-DW shoulder (above both thresholds: no pre-charge here)
+    if t.day == 3 and h >= 21.0:
+        return 0.13  # day-1 late evening
+    if t.day == 4 and 0.0 <= h < 6.0:
+        return _OVERNIGHT  # day-2 overnight: "cheap" only by the inflated threshold
+    if t.day == 4 and 6.0 <= h < 8.0:
+        return _MORNING_PEAK  # day-2 morning peak (the drain target)
+    return 0.14
+
+
+def _solar_for(t: datetime) -> float:
+    h = t.hour + t.minute / 60.0
+    if t.day == 3 and 9.0 <= h < 15.0:
+        return 0.5
+    # Strong day-2 morning solar refills to target by horizon end, so the
+    # end-of-horizon target does NOT motivate the overnight charge — isolating the
+    # pure cheap-window arbitrage sawtooth.
+    if t.day == 4 and 9.0 <= h < 15.0:
+        return 3.0
+    return 0.0
+
+
+def _build_slots(n: int) -> list[SlotContext]:
+    slots: list[SlotContext] = []
+    for i in range(n):
+        t = _START + timedelta(minutes=INTERVAL * i)
+        h = t.hour + t.minute / 60.0
+        is_dw = t.day == 3 and 15.0 <= h < 21.0
+        is_dw_entry = t.day == 3 and abs(h - 15.0) < 1e-9
+        slots.append(
+            SlotContext(
+                slot_index=i,
+                timestamp_iso=t.isoformat(),
+                slot_interval_minutes=INTERVAL,
+                buy_price=_price_for(t),
+                sell_price=0.05,
+                solar_kwh=_solar_for(t),
+                consumption_kwh=0.3,
+                is_demand_window_entry=is_dw_entry,
+                is_demand_window_slot=is_dw,
+            )
+        )
+    return slots
+
+
+def _plan(base_cheap_price: float | None):
+    slots = _build_slots(56)  # 12:00 day-1 -> 16:00 day-2 (28h)
+    config = OptimizerConfig(
+        min_soc_pct=10.0,
+        max_soc_pct=100.0,
+        demand_window_target_soc_pct=95.0,
+        optimization_mode="self_consumption",
+        effective_cheap_price=_INFLATED_CHEAP,
+        base_cheap_price=base_cheap_price,
+        target_shortfall_penalty_per_pct=0.03,
+        soc_bins=100,
+    )
+    inputs = OptimizerInputs(
+        cycle_id="sawtooth-gate",
+        initial_soc_pct=50.0,
+        slots=slots,
+        config=config,
+        all_solcast=[],
+    )
+    return DPPlanner(config).plan(inputs)
+
+
+def _dw_entry_idx(decisions) -> int:
+    for d in decisions:
+        t = datetime.fromisoformat(d.timestamp_iso)
+        if t.day == 3 and t.hour == 15 and t.minute == 0:
+            return d.slot_index
+    raise AssertionError("demand-window entry slot not found in scenario")
+
+
+def _post_dw_overnight_charges(result):
+    """Grid charges in post-DW slots priced above the real base (the sawtooth)."""
+    entry = _dw_entry_idx(result.decisions)
+    return [
+        d
+        for d in result.decisions
+        if d.slot_index >= entry
+        and d.action in _CHARGE_ACTIONS
+        and d.buy_price > _BASE_CHEAP
+    ]
+
+
+class TestSawtoothGate:
+    """End-to-end DP behaviour for the overnight sawtooth."""
+
+    def test_inflated_threshold_reproduces_sawtooth_when_unguarded(self):
+        """Without base gating (base_cheap_price=None) the inflated threshold leaks.
+
+        Documents the bug: post-DW overnight slots (price > base, <= inflated) get
+        charged then drained — the sawtooth.
+        """
+        result = _plan(base_cheap_price=None)
+        charges = _post_dw_overnight_charges(result)
+        assert charges, (
+            "expected the unguarded inflated threshold to produce net-negative "
+            "post-DW overnight grid charging (the sawtooth)"
+        )
+        # All such charges are classed CHEAP_IMPORT_WINDOW, matching the field report.
+        assert any(c.reason_code.value == "CHEAP_IMPORT_WINDOW" for c in charges)
+
+    def test_base_gating_eliminates_sawtooth(self):
+        """With base gating, no post-DW overnight charge above the real base occurs."""
+        result = _plan(base_cheap_price=_BASE_CHEAP)
+        charges = _post_dw_overnight_charges(result)
+        assert charges == [], (
+            "post-DW slots priced above the genuinely-cheap base must not grid charge; "
+            f"got charges at slots {[c.slot_index for c in charges]}"
+        )
+
+    def test_base_gating_preserves_morning_solar_refill(self):
+        """Target is still reached by horizon end via solar (no functional loss)."""
+        result = _plan(base_cheap_price=_BASE_CHEAP)
+        assert result.success
+        # End-of-horizon SOC reaches the target from free morning solar alone.
+        assert result.decisions[-1].predicted_soc_pct >= 94.0
+
+    def test_genuinely_cheap_overnight_still_charges(self):
+        """A post-DW overnight slot priced <= base is still a feasible charge window.
+
+        The fix must only remove urgency-inflation leakage, not block real cheap charging.
+        """
+        config = OptimizerConfig(
+            optimization_mode="self_consumption",
+            effective_cheap_price=_INFLATED_CHEAP,
+            base_cheap_price=_BASE_CHEAP,
+            max_soc_pct=100.0,
+        )
+        cheap_slot = SlotContext(
+            slot_index=30,
+            timestamp_iso="2026-06-04T03:00:00",
+            slot_interval_minutes=INTERVAL,
+            buy_price=0.07,  # <= base
+            sell_price=0.05,
+            solar_kwh=0.0,
+            consumption_kwh=0.3,
+        )
+        actions = feasible_actions(
+            50.0, cheap_slot, config, slot_idx=30, terminal_penalty_idx=6
+        )
+        assert PlannerAction.CHARGE_GRID_NORMAL in actions
+
+    def test_negative_base_gates_post_dw_to_sub_zero_only(self):
+        """Negative-market base: post-DW charging only when price is at/below it.
+
+        Guards the negative-wholesale regression (a non-positive base must remain an
+        active, meaningful threshold rather than disabling the gate or blocking all).
+        """
+        config = OptimizerConfig(
+            optimization_mode="self_consumption",
+            effective_cheap_price=_INFLATED_CHEAP,
+            base_cheap_price=-0.02,
+            max_soc_pct=100.0,
+        )
+
+        def _slot(price: float) -> SlotContext:
+            return SlotContext(
+                slot_index=30,
+                timestamp_iso="2026-06-04T03:00:00",
+                slot_interval_minutes=INTERVAL,
+                buy_price=price,
+                sell_price=0.05,
+                solar_kwh=0.0,
+                consumption_kwh=0.3,
+            )
+
+        # A normal positive overnight price is NOT cheap under a negative base.
+        actions = feasible_actions(
+            50.0, _slot(0.05), config, slot_idx=30, terminal_penalty_idx=6
+        )
+        assert PlannerAction.CHARGE_GRID_NORMAL not in actions
+        # A price at/below the negative base IS a feasible charge window.
+        actions = feasible_actions(
+            50.0, _slot(-0.03), config, slot_idx=30, terminal_penalty_idx=6
+        )
+        assert PlannerAction.CHARGE_GRID_NORMAL in actions
+
+
+class TestCheapThresholdForSlot:
+    """Unit tests for the per-slot cheap-threshold selector."""
+
+    def _config(self, base):
+        return OptimizerConfig(
+            effective_cheap_price=_INFLATED_CHEAP, base_cheap_price=base
+        )
+
+    def test_pre_dw_slot_uses_effective_cheap_price(self):
+        """Slots before the demand window keep the urgency-aware threshold."""
+        config = self._config(_BASE_CHEAP)
+        assert (
+            _cheap_threshold_for_slot(config, slot_idx=2, terminal_penalty_idx=6)
+            == _INFLATED_CHEAP
+        )
+
+    def test_post_dw_slot_uses_base_cheap_price(self):
+        """Slots at/after the demand window gate on the un-inflated base."""
+        config = self._config(_BASE_CHEAP)
+        assert (
+            _cheap_threshold_for_slot(config, slot_idx=30, terminal_penalty_idx=6)
+            == _BASE_CHEAP
+        )
+        # The DW entry slot itself counts as "at/after".
+        assert (
+            _cheap_threshold_for_slot(config, slot_idx=6, terminal_penalty_idx=6)
+            == _BASE_CHEAP
+        )
+
+    def test_none_base_falls_back_to_effective(self):
+        """Backward compat: unset base => effective threshold everywhere."""
+        config = self._config(None)
+        assert (
+            _cheap_threshold_for_slot(config, slot_idx=30, terminal_penalty_idx=6)
+            == _INFLATED_CHEAP
+        )
+
+    def test_no_terminal_penalty_uses_effective(self):
+        """With no demand window there is no urgency leak to correct."""
+        config = self._config(_BASE_CHEAP)
+        assert (
+            _cheap_threshold_for_slot(config, slot_idx=30, terminal_penalty_idx=None)
+            == _INFLATED_CHEAP
+        )
+
+    def test_base_above_effective_never_raises_threshold(self):
+        """min() guard: a base above effective must not loosen the post-DW gate."""
+        config = OptimizerConfig(
+            effective_cheap_price=_BASE_CHEAP, base_cheap_price=_INFLATED_CHEAP
+        )
+        assert (
+            _cheap_threshold_for_slot(config, slot_idx=30, terminal_penalty_idx=6)
+            == _BASE_CHEAP
+        )


### PR DESCRIPTION
## Problem (Issue #800 — overnight SOC floor bounce / "sawtooth")

The optimizer grid-charges in a cheap overnight slot then immediately drains it — a sawtooth SOC (field data: SOC oscillating ~9.5%↔12.9% overnight). The arbitrage saving is less than the round-trip + cycle cost it incurs → net-negative cycling.

## Root cause (confirmed by deterministic reproduction, not assumed)

A single `effective_cheap_price` scalar is applied to **every** slot in the multi-day horizon. That value is computed for *now* and is inflated above the genuinely-cheap percentile base by today's low-solar urgency (`_calculate_urgency_adjusted_price`) so the optimizer will pay more to pre-charge before *today's* demand window. Applied to slots **at/after** the demand window, it mis-classifies tomorrow-night slots (priced just under the inflated threshold but above the real base) as `CHEAP_IMPORT_WINDOW`; a marginal charge fires and drains through morning load before any useful period.

A trace confirms the lever: with the genuine base price → **0** overnight charges; with the inflated price → the sawtooth (charge at 04:00/05:30, drain through the morning peak). The existing `futile_cycling_penalty` fires (~\$0.099) but is marginally insufficient once the gate is open.

## Fix

Past the demand-window entry, gate grid charging on a new un-inflated `base_cheap_price` (the percentile floor) via `min(effective, base)`. Pre-DW slots — including pre-charge-to-target — are untouched. Correct because the optimizer re-plans every cycle: today's urgency price is only ever needed for *near* slots; far slots re-evaluate their own urgency when they become "now". Aligns with the Control Philosophy (low overnight SOC is acceptable; grid charging gated by price **and** solar sufficiency).

- `engine/types.py`: `OptimizerConfig.base_cheap_price` (`float | None`, None ⇒ fall back to `effective_cheap_price`; backward compatible).
- `engine/constraints.py`: `_cheap_threshold_for_slot()` selects base for `slot_idx >= terminal_penalty_idx`, effective otherwise — via `min()`, so it can only **tighten** the post-DW gate, never loosen it.
- `engine/price_calculator.py`: record the percentile base on `CoordinatorData` (both preliminary and final compute paths).
- `engine/optimizer_runner.py`: thread base as the **objective** floor, intentionally independent of the adaptive `cheap_price_bias` (a negative bias still tightens via `min(effective, base)`; a positive bias must not loosen it).
- `coordinator/data.py`: `base_cheap_price: float | None = None` — a None sentinel (not 0.0) distinguishes "not computed" from a genuinely ≤0 base in negative-wholesale markets, and avoids a `max(0.0,…)` floor collapsing the threshold to 0.0 (which would block **all** post-DW charging).

## Tests / validation

- `tests/engine/test_sawtooth_gate.py`: deterministic reproduction, the per-slot threshold selector, genuinely-cheap + negative-market gates.
- `tests/engine/test_optimizer_runner.py`: `base_cheap_price` wiring (pass-through, bias-independence, negative market, absent ⇒ None).
- Engine suite **545 green**; full repo **2960 passed / 1 xfailed**; changed-file coverage **≥95%**. Gate test confirmed RED when the gate is neutralized.
- High-effort code review caught and fixed 2 real bugs in this PR (the bias-floor-to-0.0 over-suppression and the negative-market sentinel disable).

## Known follow-ups (not in this PR — kept minimal)

`penalties.get_futile_cycling_penalty_factor` and `reason_codes` still reference `effective_cheap_price` for post-DW slots — a penalty/label inconsistency that's largely non-reachable for pre-DW charges (the demand-window break in the drain loop intercepts first). Worth a separate cleanup.