### PR TITLE
refactor(optimizer): per-slot cheap threshold consistency (#800 follow-up)

### DIFF
--- a/custom_components/localshift/engine/constraints.py
+++ b/custom_components/localshift/engine/constraints.py
@@ -137,7 +137,7 @@ def feasible_actions(
         and not (_solar_covers_deficit or _global_solar_covers)
     ):
         if config.optimization_mode == "self_consumption":
-            cheap_threshold = _cheap_threshold_for_slot(
+            cheap_threshold = cheap_threshold_for_slot(
                 config, slot_idx, terminal_penalty_idx
             )
             price_is_cheap = slot.buy_price <= cheap_threshold
@@ -160,12 +160,16 @@ def feasible_actions(
     return actions
 
 
-def _cheap_threshold_for_slot(
+def cheap_threshold_for_slot(
     config: OptimizerConfig,
     slot_idx: int,
     terminal_penalty_idx: int | None,
 ) -> float:
     """Return the cheap-price threshold to apply to a slot's grid-charge gate.
+
+    Shared by the feasibility gate (``feasible_actions``), the futile-cycling penalty
+    (``penalties``), and the reason-code labels (``reason_codes``) so all three agree on
+    what counts as "cheap" for a given slot.
 
     Issue #800 (overnight SOC floor bounce / sawtooth).
     ``effective_cheap_price`` is a "now" value that today's low-solar urgency may have

--- a/custom_components/localshift/engine/core.py
+++ b/custom_components/localshift/engine/core.py
@@ -627,6 +627,7 @@ class DPPlanner:
                 config=config,
                 soc_after_charge_pct=next_soc,
                 charge_kwh=charge_kwh,
+                terminal_penalty_idx=terminal_penalty_idx,
             )
 
             stage = _cost_stage_cost(
@@ -745,6 +746,7 @@ class DPPlanner:
                 config=config,
                 soc_after_charge_pct=next_soc,
                 charge_kwh=recon_charge_kwh,
+                terminal_penalty_idx=terminal_penalty_idx,
             )
 
             stage = _cost_stage_cost(

--- a/custom_components/localshift/engine/penalties.py
+++ b/custom_components/localshift/engine/penalties.py
@@ -84,6 +84,7 @@ def get_futile_cycling_penalty_factor(
     config: OptimizerConfig,
     soc_after_charge_pct: float,
     charge_kwh: float,
+    terminal_penalty_idx: int | None = None,
 ) -> float:
     """Compute penalty factor for grid charging that will be drained before a useful period.
 
@@ -118,18 +119,29 @@ def get_futile_cycling_penalty_factor(
     min_soc = config.min_soc_pct
     discharge_eff = config.discharge_efficiency
 
-    for future_slot in slots[slot_idx + 1 :]:
+    from custom_components.localshift.engine.constraints import (
+        cheap_threshold_for_slot,
+    )
+
+    charge_slot_price = slots[slot_idx].buy_price
+    for future_idx in range(slot_idx + 1, len(slots)):
+        future_slot = slots[future_idx]
         # A "useful period" is where solar surplus, demand window, or a cheaper
         # feasible charge window makes the charged energy valuable — stop draining here.
         if future_slot.solar_kwh > future_slot.consumption_kwh:
             break
         if future_slot.is_demand_window_slot:
             break
-        # A cheaper feasible charge window: charging is allowed (price <= cheap threshold)
-        # and meaningfully cheaper than now — energy can be stored for the later cheap charge.
+        # A cheaper feasible charge window: charging is allowed (price <= the gate's
+        # per-slot cheap threshold — Issue #800, so post-demand-window slots use the
+        # un-inflated base) and meaningfully cheaper than now — energy can be stored
+        # for the later cheap charge.
+        future_threshold = cheap_threshold_for_slot(
+            config, future_idx, terminal_penalty_idx
+        )
         if (
-            future_slot.buy_price <= config.effective_cheap_price
-            and future_slot.buy_price < slots[slot_idx].buy_price - 0.02
+            future_slot.buy_price <= future_threshold
+            and future_slot.buy_price < charge_slot_price - 0.02
         ):
             break
 

--- a/custom_components/localshift/engine/reason_codes.py
+++ b/custom_components/localshift/engine/reason_codes.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from custom_components.localshift.engine.constraints import (
+    cheap_threshold_for_slot,
+)
 from custom_components.localshift.engine.penalties import (
     get_solar_opportunity_penalty_factor,
 )
@@ -99,9 +102,12 @@ def classify_hold_reason(
 
     # Check if we are waiting for solar (Issue #619)
     # If price is cheap but we aren't charging, and solar is coming, label it.
+    # Issue #800: use the per-slot cheap threshold so a post-demand-window HOLD priced
+    # above the un-inflated base is not mislabeled as a suppressed cheap-charge window.
     if (
         config.optimization_mode == "self_consumption"
-        and slot.buy_price <= config.effective_cheap_price
+        and slot.buy_price
+        <= cheap_threshold_for_slot(config, slot_idx, terminal_penalty_idx)
         and slots is not None
         and inputs is not None
         and inputs.all_solcast
@@ -165,6 +171,7 @@ def classify_charge_reason(
         return PlannerReasonCode.TARGET_SHORTFALL_RISK
     if _is_cheap_import_window(
         slot,
+        slot_idx,
         config,
         terminal_penalty_idx,
         slots,
@@ -211,17 +218,23 @@ def _is_target_shortfall_risk(
 
 def _is_cheap_import_window(
     slot: SlotContext,
+    slot_idx: int,
     config: OptimizerConfig,
     terminal_penalty_idx: int | None,
     slots: list[SlotContext],
     *,
     inputs: OptimizerInputs | None = None,
 ) -> bool:
-    """Check if this is a cheap import window opportunity."""
-    if slot.buy_price > config.effective_cheap_price:
+    """Check if this is a cheap import window opportunity.
+
+    Issue #800: uses the per-slot cheap threshold (post-demand-window slots gate on the
+    un-inflated base) so the label matches the feasibility gate.
+    """
+    threshold = cheap_threshold_for_slot(config, slot_idx, terminal_penalty_idx)
+    if slot.buy_price > threshold:
         return False
     is_blind = _is_blind_to_future_solar(terminal_penalty_idx, slots, inputs=inputs)
-    return not is_blind or slot.buy_price <= (config.effective_cheap_price * 0.8)
+    return not is_blind or slot.buy_price <= (threshold * 0.8)
 
 
 def _is_blind_to_future_solar(

--- a/tests/engine/test_sawtooth_gate.py
+++ b/tests/engine/test_sawtooth_gate.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 
 from custom_components.localshift.engine.constraints import (
-    _cheap_threshold_for_slot,
+    cheap_threshold_for_slot,
     feasible_actions,
 )
 from custom_components.localshift.engine.core import DPPlanner
@@ -247,7 +247,7 @@ class TestCheapThresholdForSlot:
         """Slots before the demand window keep the urgency-aware threshold."""
         config = self._config(_BASE_CHEAP)
         assert (
-            _cheap_threshold_for_slot(config, slot_idx=2, terminal_penalty_idx=6)
+            cheap_threshold_for_slot(config, slot_idx=2, terminal_penalty_idx=6)
             == _INFLATED_CHEAP
         )
 
@@ -255,12 +255,12 @@ class TestCheapThresholdForSlot:
         """Slots at/after the demand window gate on the un-inflated base."""
         config = self._config(_BASE_CHEAP)
         assert (
-            _cheap_threshold_for_slot(config, slot_idx=30, terminal_penalty_idx=6)
+            cheap_threshold_for_slot(config, slot_idx=30, terminal_penalty_idx=6)
             == _BASE_CHEAP
         )
         # The DW entry slot itself counts as "at/after".
         assert (
-            _cheap_threshold_for_slot(config, slot_idx=6, terminal_penalty_idx=6)
+            cheap_threshold_for_slot(config, slot_idx=6, terminal_penalty_idx=6)
             == _BASE_CHEAP
         )
 
@@ -268,7 +268,7 @@ class TestCheapThresholdForSlot:
         """Backward compat: unset base => effective threshold everywhere."""
         config = self._config(None)
         assert (
-            _cheap_threshold_for_slot(config, slot_idx=30, terminal_penalty_idx=6)
+            cheap_threshold_for_slot(config, slot_idx=30, terminal_penalty_idx=6)
             == _INFLATED_CHEAP
         )
 
@@ -276,7 +276,7 @@ class TestCheapThresholdForSlot:
         """With no demand window there is no urgency leak to correct."""
         config = self._config(_BASE_CHEAP)
         assert (
-            _cheap_threshold_for_slot(config, slot_idx=30, terminal_penalty_idx=None)
+            cheap_threshold_for_slot(config, slot_idx=30, terminal_penalty_idx=None)
             == _INFLATED_CHEAP
         )
 
@@ -286,6 +286,139 @@ class TestCheapThresholdForSlot:
             effective_cheap_price=_BASE_CHEAP, base_cheap_price=_INFLATED_CHEAP
         )
         assert (
-            _cheap_threshold_for_slot(config, slot_idx=30, terminal_penalty_idx=6)
+            cheap_threshold_for_slot(config, slot_idx=30, terminal_penalty_idx=6)
             == _BASE_CHEAP
         )
+
+
+class TestPostDwConsistency:
+    """Issue #800 follow-up: penalty + reason-code labels agree with the gate.
+
+    The futile-cycling penalty and the reason-code classifiers must treat post-DW
+    cheapness with the same per-slot threshold the feasibility gate uses, so an
+    inflated effective price cannot leak back in through those paths.
+    """
+
+    def _slot(self, idx, price, *, solar=0.0, load=0.3, dw=False):
+        return SlotContext(
+            slot_index=idx,
+            timestamp_iso=f"2026-06-04T{(idx % 24):02d}:00:00",
+            slot_interval_minutes=INTERVAL,
+            buy_price=price,
+            sell_price=0.05,
+            solar_kwh=solar,
+            consumption_kwh=load,
+            is_demand_window_slot=dw,
+        )
+
+    def test_futile_penalty_ignores_inflated_cheaper_window_post_dw(self):
+        """A post-DW slot above base must not count as a 'cheaper charge window' break.
+
+        The drain loop should keep draining through a post-DW slot priced in
+        (base, effective], so the futile factor is higher (more futile) than if that
+        slot were wrongly treated as a re-charge opportunity.
+        """
+        from custom_components.localshift.engine.penalties import (
+            get_futile_cycling_penalty_factor,
+        )
+
+        # slot 0 = the (hypothetical) charge slot at a higher price; slots 1.. drain.
+        # slot 2 is priced between base and effective and is >0.02 cheaper than slot 0.
+        slots = [
+            self._slot(0, 0.16),
+            self._slot(1, 0.15),
+            self._slot(2, 0.119),  # in (base 0.08, effective 0.12]; 0.041 < 0.16-0.02
+            self._slot(3, 0.15),
+            self._slot(4, 0.15),
+        ]
+        base_cfg = OptimizerConfig(
+            optimization_mode="self_consumption",
+            effective_cheap_price=_INFLATED_CHEAP,
+            base_cheap_price=_BASE_CHEAP,
+            min_soc_pct=10.0,
+            max_soc_pct=100.0,
+        )
+        no_base_cfg = OptimizerConfig(
+            optimization_mode="self_consumption",
+            effective_cheap_price=_INFLATED_CHEAP,
+            base_cheap_price=None,
+            min_soc_pct=10.0,
+            max_soc_pct=100.0,
+        )
+        kwargs = dict(
+            action=PlannerAction.CHARGE_GRID_NORMAL,
+            slot_idx=0,
+            slots=slots,
+            soc_after_charge_pct=80.0,
+            charge_kwh=2.0,
+            terminal_penalty_idx=0,  # all of slots 1.. are post-DW
+        )
+        gated = get_futile_cycling_penalty_factor(config=base_cfg, **kwargs)
+        unguarded = get_futile_cycling_penalty_factor(config=no_base_cfg, **kwargs)
+        # Unguarded breaks at slot 2 (treated as cheaper window) -> less drain.
+        # Gated keeps draining past slot 2 -> at least as much drain (higher factor).
+        assert gated >= unguarded
+        assert gated > 0.0
+
+    def test_charge_label_uses_per_slot_threshold(self):
+        """A post-DW charge above base is not labelled CHEAP_IMPORT_WINDOW."""
+        from custom_components.localshift.engine.reason_codes import (
+            classify_charge_reason,
+        )
+        from custom_components.localshift.engine.types import (
+            OptimizerInputs,
+            PlannerReasonCode,
+        )
+
+        slots = [self._slot(i, 0.119) for i in range(10)]
+        config = OptimizerConfig(
+            optimization_mode="self_consumption",
+            effective_cheap_price=_INFLATED_CHEAP,
+            base_cheap_price=_BASE_CHEAP,
+        )
+        inputs = OptimizerInputs(
+            cycle_id="c", initial_soc_pct=50.0, slots=slots, all_solcast=[]
+        )
+        # slot_idx 5 is post-DW (terminal_penalty_idx=2); price 0.119 > base 0.08.
+        reason = classify_charge_reason(
+            slots[5], 5, slots, 50.0, config, 2, inputs=inputs
+        )
+        assert reason != PlannerReasonCode.CHEAP_IMPORT_WINDOW
+
+    def test_hold_label_uses_per_slot_threshold(self):
+        """A post-DW HOLD above base is not labelled SOLAR_OPPORTUNITY_WAIT."""
+        from custom_components.localshift.engine.reason_codes import (
+            classify_hold_reason,
+        )
+        from custom_components.localshift.engine.types import (
+            OptimizerInputs,
+            PlannerReasonCode,
+        )
+
+        # solar later so the opportunity factor would be > 0 if the slot were "cheap".
+        slots = [self._slot(i, 0.119) for i in range(6)] + [
+            self._slot(6, 0.119, solar=5.0, load=0.0)
+        ]
+        config = OptimizerConfig(
+            optimization_mode="self_consumption",
+            effective_cheap_price=_INFLATED_CHEAP,
+            base_cheap_price=_BASE_CHEAP,
+        )
+        inputs = OptimizerInputs(
+            cycle_id="c",
+            initial_soc_pct=50.0,
+            slots=slots,
+            all_solcast=[{"period_start": "2026-06-04T05:00:00", "pv_estimate": 5.0}],
+        )
+        reason = classify_hold_reason(
+            50.0,
+            slots[3],
+            49.0,
+            config,
+            None,
+            slot_idx=3,
+            slots=slots,
+            terminal_penalty_idx=2,  # slot 3 is post-DW; 0.119 > base 0.08
+            inputs=inputs,
+        )
+        assert reason != PlannerReasonCode.SOLAR_OPPORTUNITY_WAIT

--- a/tests/test_optimizer_dp_solve.py
+++ b/tests/test_optimizer_dp_solve.py
@@ -2525,7 +2525,7 @@ def test_is_cheap_import_window_expensive_price():
         soc_bins=20,
     )
 
-    result = _is_cheap_import_window(slot, config, None, [slot])
+    result = _is_cheap_import_window(slot, 0, config, None, [slot])
     assert result is False
 
 


### PR DESCRIPTION
Re-lands the consistency follow-up that **missed the #842 merge window** — it was committed ~15 min after #842 was merged, so #842 captured only the sawtooth gate (`dfc61bf`) and this work was left orphaned on the merged branch. It is not in `test` or on live. This PR restores it (cherry-pick, suite green).

Makes the futile-cycling penalty and the reason-code labels use the **same per-slot cheap threshold** the feasibility gate uses, so an inflated `effective_cheap_price` can't leak back in through those paths on an inflation day:

- `engine/constraints.py`: promote `_cheap_threshold_for_slot` → public `cheap_threshold_for_slot` (now shared by the gate, the penalty, and the labels).
- `engine/penalties.py`: `get_futile_cycling_penalty_factor` takes `terminal_penalty_idx` and uses the per-slot threshold for its "cheaper feasible charge window" drain break — a post-DW slot above base is no longer mistaken for a re-charge window (which had under-counted futility for charges that drain across the DW).
- `engine/core.py`: pass `terminal_penalty_idx` at both call sites.
- `engine/reason_codes.py`: `_is_cheap_import_window` (now takes `slot_idx`) and `classify_hold_reason` gate their labels on the per-slot threshold.

**No-op whenever `base == effective`** (benign days) or `base_cheap_price is None`, so all existing behaviour is preserved. Full repo suite **2963 passed / 1 xfailed**; changed-file coverage ≥98%. This was reviewed inline when first written (it's identical to the orphaned `c8ed11c`).