### PR TITLE
fix(optimizer): apply target penalty at DW entry, not horizon end (#811/#816)

### DIFF
--- a/custom_components/localshift/engine/core.py
+++ b/custom_components/localshift/engine/core.py
@@ -150,7 +150,7 @@ class DPPlanner:
             config, demand_bounds
         )
 
-        dp = self._initialize_dp_tables(
+        dp, terminal_penalty_by_bin = self._initialize_dp_tables(
             n_slots, soc_grid, config, terminal_penalty_idx, solar_capable, inputs
         )
 
@@ -166,6 +166,7 @@ class DPPlanner:
             terminal_penalty_idx,
             inputs,
             negative_fit_avoidance_context,
+            terminal_penalty_by_bin,
         )
 
         decisions, totals, reason_histogram = self._forward_reconstruct(
@@ -333,22 +334,45 @@ class DPPlanner:
         terminal_penalty_idx: int | None,
         solar_can_reach_target: bool,
         inputs: OptimizerInputs,
-    ) -> list[dict[int, tuple[float, PlannerAction, int, float, float, float]]]:
-        """Initialize DP tables with terminal costs.
+    ) -> tuple[
+        list[dict[int, tuple[float, PlannerAction, int, float, float, float]]],
+        dict[int, float],
+    ]:
+        """Initialize DP tables and compute the per-bin demand-window-entry penalty.
 
         In self-consumption mode, credits future solar gain (Issue #619) to
-
         prevent grid charging when solar will cover the shortfall.
 
-        Issue #624: In self_consumption mode, treat target as hard constraint by
+        Issue #624: In self_consumption mode, treat target as a hard constraint by
+        using a very high cost for states below target.
 
-        using infinite cost for states below target at terminal penalty index.
+        Issue #811/#816 (horizon-end myopia): in the strict target mode
+        (``allow_dw_entry_under_target=False``) the target/shortfall penalty is applied
+        at the DEMAND-WINDOW ENTRY (``terminal_penalty_idx``) during backward induction,
+        NOT at the end of the planning horizon. Applying it at the horizon boundary made
+        the optimizer grid-charge overnight to hit a target at an arbitrary cutoff (which
+        moves every cycle as the rolling horizon slides), contradicting the Control
+        Philosophy and producing horizon-dependent overnight charging.
 
+        When ``allow_dw_entry_under_target=True`` (Issue #505), the target may instead be
+        met at any point DURING the demand window via solar, so the penalty stays at the
+        horizon boundary (``dp[n_slots]``) as before — relocating it to the entry would
+        wrongly force pre-charge that mid-DW solar was meant to cover.
+
+        Returns ``(dp, terminal_penalty_by_bin)`` where ``terminal_penalty_by_bin`` maps
+        soc-bin index -> shortfall penalty to add at ``terminal_penalty_idx`` (empty when
+        there is no demand window, or when the penalty stays at the horizon boundary).
         """
 
         dp: list[dict[int, tuple[float, PlannerAction, int, float, float, float]]] = [
             {} for _ in range(n_slots + 1)
         ]
+
+        # Horizon-end boundary carries no target (Issue #811): always zero.
+        for bin_idx in range(len(soc_grid)):
+            dp[n_slots][bin_idx] = (0.0, PlannerAction.HOLD, bin_idx, 0.0, 0.0, 0.0)
+
+        terminal_penalty_by_bin: dict[int, float] = {}
 
         if terminal_penalty_idx is not None:
             target = config.demand_window_target_soc_pct
@@ -431,22 +455,24 @@ class DPPlanner:
                         effective_soc, target, config
                     )
 
-                dp[n_slots][bin_idx] = (
-                    shortfall_penalty,
-                    PlannerAction.HOLD,
-                    bin_idx,
-                    0.0,
-                    0.0,
-                    0.0,
-                )
+                if config.allow_dw_entry_under_target:
+                    # Issue #505: target may be met mid-DW via solar — keep the penalty
+                    # at the horizon boundary (legacy behaviour) so it does not force
+                    # pre-charge before the demand window.
+                    dp[n_slots][bin_idx] = (
+                        shortfall_penalty,
+                        PlannerAction.HOLD,
+                        bin_idx,
+                        0.0,
+                        0.0,
+                        0.0,
+                    )
+                else:
+                    # Issue #811/#816: strict mode — apply at the DW entry during backward
+                    # induction, not at the arbitrary horizon boundary.
+                    terminal_penalty_by_bin[bin_idx] = shortfall_penalty
 
-        else:
-            n_bins = len(soc_grid)
-
-            for bin_idx in range(n_bins):
-                dp[n_slots][bin_idx] = (0.0, PlannerAction.HOLD, bin_idx, 0.0, 0.0, 0.0)
-
-        return dp
+        return dp, terminal_penalty_by_bin
 
     def _get_terminal_diagnostics(
         self,
@@ -494,6 +520,7 @@ class DPPlanner:
         terminal_penalty_idx: int | None,
         inputs: OptimizerInputs,
         negative_fit_avoidance_context: NegativeFitAvoidanceContext | None = None,
+        terminal_penalty_by_bin: dict[int, float] | None = None,
     ) -> int:
         """Perform backward induction to fill DP tables.
 
@@ -505,6 +532,10 @@ class DPPlanner:
             config: Optimizer config
             terminal_penalty_idx: Terminal penalty index
             inputs: Optimizer inputs
+            terminal_penalty_by_bin: Per-bin shortfall penalty applied at the DW-entry
+                slot (Issue #811/#816); the cost of entering the demand window at that
+                bin's SOC. Constant across actions at that slot, so it is added after
+                action selection.
 
         Returns:
 
@@ -514,9 +545,11 @@ class DPPlanner:
 
         n_slots = len(slots)
         states_explored = 0
+        penalty_by_bin = terminal_penalty_by_bin or {}
 
         for slot_idx in range(n_slots - 1, -1, -1):
             slot = slots[slot_idx]
+            apply_terminal_penalty = slot_idx == terminal_penalty_idx
 
             for bin_idx, soc in enumerate(soc_grid):
                 best, action_count = self._compute_best_action(
@@ -531,6 +564,11 @@ class DPPlanner:
                     inputs,
                     negative_fit_avoidance_context,
                 )
+                if apply_terminal_penalty:
+                    # Cost of entering the demand window at this SOC (Issue #811/#816).
+                    penalty = penalty_by_bin.get(bin_idx, 0.0)
+                    if penalty:
+                        best = (best[0] + penalty, *best[1:])
                 dp[slot_idx][bin_idx] = best
                 states_explored += action_count
 

--- a/tests/engine/test_horizon_invariance.py
+++ b/tests/engine/test_horizon_invariance.py
@@ -1,0 +1,149 @@
+"""Horizon-invariance gate (Issue #811/#816 — horizon-end myopia).
+
+In strict target mode the shortfall penalty used to be applied at the END of the planning
+horizon (``dp[n_slots]``) rather than at the demand-window entry. On a genuinely-cheap night
+with insufficient solar to refill by that boundary, the optimizer grid-charged overnight purely
+to hit a target at *wherever the horizon happened to be cut*. Because the production horizon is
+a rolling ~24-48h window, that boundary lands at a different clock time every cycle, so the
+overnight recommendation swung with it (measured: ~16 kWh when the horizon ended pre-solar vs
+~5.6 kWh when it extended past the morning solar refill — same near-term scenario).
+
+The fix relocates the strict-mode penalty to the demand-window entry, so near-term decisions no
+longer depend on the arbitrary horizon cutoff. These tests hold the near-term scenario fixed and
+vary only the horizon length.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+from custom_components.localshift.engine.core import DPPlanner
+from custom_components.localshift.engine.types import (
+    OptimizerConfig,
+    OptimizerInputs,
+    PlannerAction,
+    SlotContext,
+)
+
+INTERVAL = 30
+_START = datetime(2026, 6, 3, 12, 0)  # day-1 noon
+_CHARGE = (PlannerAction.CHARGE_GRID_NORMAL, PlannerAction.CHARGE_GRID_BOOST)
+
+
+def _price(t: datetime) -> float:
+    h = t.hour + t.minute / 60.0
+    if t.day == 3 and 15.0 <= h < 21.0:
+        return 0.30  # day-1 evening demand window
+    if t.day == 3 and 12.0 <= h < 15.0:
+        return 0.16
+    if t.day == 3 and h >= 21.0:
+        return 0.13
+    if t.day == 4 and 0.0 <= h < 6.0:
+        return 0.06  # day-2 overnight: GENUINELY cheap (<= base), charging is feasible
+    if t.day == 4 and 6.0 <= h < 8.0:
+        return 0.16
+    return 0.14
+
+
+def _solar(t: datetime) -> float:
+    h = t.hour + t.minute / 60.0
+    if t.day == 3 and 9.0 <= h < 15.0:
+        return 0.5
+    if t.day == 4 and 9.0 <= h < 15.0:
+        return (
+            3.0  # day-2 solar refills to target — only visible to a long-enough horizon
+        )
+    return 0.0
+
+
+def _build_slots(n: int) -> list[SlotContext]:
+    slots: list[SlotContext] = []
+    for i in range(n):
+        t = _START + timedelta(minutes=INTERVAL * i)
+        h = t.hour + t.minute / 60.0
+        is_dw = t.day == 3 and 15.0 <= h < 21.0
+        slots.append(
+            SlotContext(
+                slot_index=i,
+                timestamp_iso=t.isoformat(),
+                slot_interval_minutes=INTERVAL,
+                buy_price=_price(t),
+                sell_price=0.05,
+                solar_kwh=_solar(t),
+                consumption_kwh=0.3,
+                is_demand_window_entry=(t.day == 3 and abs(h - 15.0) < 1e-9),
+                is_demand_window_slot=is_dw,
+            )
+        )
+    return slots
+
+
+def _overnight_charge_kwh(n: int) -> float:
+    """Day-2 00:00-06:00 grid charge for a horizon of n slots (strict mode)."""
+    config = OptimizerConfig(
+        min_soc_pct=10.0,
+        max_soc_pct=100.0,
+        demand_window_target_soc_pct=95.0,
+        optimization_mode="self_consumption",
+        effective_cheap_price=0.12,
+        base_cheap_price=0.08,
+        allow_dw_entry_under_target=False,  # strict mode
+        target_shortfall_penalty_per_pct=0.03,
+        soc_bins=100,
+    )
+    inputs = OptimizerInputs(
+        cycle_id="horizon-invariance",
+        initial_soc_pct=50.0,
+        slots=_build_slots(n),
+        config=config,
+        all_solcast=[],
+    )
+    result = DPPlanner(config).plan(inputs)
+    assert result.success
+    return sum(
+        d.grid_import_kwh
+        for d in result.decisions
+        if d.action in _CHARGE
+        and datetime.fromisoformat(d.timestamp_iso).day == 4
+        and datetime.fromisoformat(d.timestamp_iso).hour < 6
+    )
+
+
+# day1 12:00 + 30-min slots: day2 06:00 = slot 36; day2 09:00 = slot 42; day2 16:00 = slot 56
+_SHORT = 37  # horizon ends pre-solar (the boundary that used to drive over-charging)
+_MED = 43  # horizon ends as solar starts
+_LONG = 57  # horizon extends past the full solar refill
+
+
+class TestHorizonInvariance:
+    """Near-term overnight charging must not depend on the arbitrary horizon cutoff."""
+
+    def test_short_horizon_does_not_overcharge_vs_long(self):
+        """A pre-solar cutoff must not grid-charge MORE than a horizon that sees the refill.
+
+        This is the core myopia signature: on the old code the short horizon charged ~3x
+        the long horizon to hit a phantom end-of-horizon target.
+        """
+        short = _overnight_charge_kwh(_SHORT)
+        long = _overnight_charge_kwh(_LONG)
+        assert short <= long + 0.5, (
+            f"short-horizon overnight charge ({short:.2f} kWh) exceeds long-horizon "
+            f"({long:.2f} kWh) — horizon-end target is leaking into near-term decisions"
+        )
+
+    def test_overnight_charge_converges_with_horizon_length(self):
+        """Once the horizon is long enough to see the refill, extending it changes nothing."""
+        med = _overnight_charge_kwh(_MED)
+        long = _overnight_charge_kwh(_LONG)
+        assert abs(med - long) <= 0.5, (
+            f"overnight charge still depends on horizon length: med={med:.2f} kWh, "
+            f"long={long:.2f} kWh"
+        )
+
+    def test_no_runaway_overnight_charge(self):
+        """Sanity bound: a single battery's overnight charge can't be a multiple of capacity.
+
+        The old myopia drove ~16 kWh into a 13.5 kWh battery (charge + simultaneous load
+        coverage) to chase the boundary target.
+        """
+        assert _overnight_charge_kwh(_SHORT) < 13.5

--- a/tests/test_optimizer_dp_solve.py
+++ b/tests/test_optimizer_dp_solve.py
@@ -1255,7 +1255,13 @@ def test_projected_solar_soc_gain_pct_respects_slot_range():
 
 
 def test_optimizer_does_not_grid_charge_during_solar_peak_with_sufficient_solar():
-    """Integration: on a sunny day with enough solar, no grid charging before demand window."""
+    """Integration: on a sunny day with enough solar, no grid charging before demand window.
+
+    Issue #811/#816: in strict mode the target is enforced at DW *entry*, not held to the
+    end of the DW. The battery is expected to discharge during the demand window to cover
+    its load (that is the point of pre-charging), so end-of-DW SOC may fall below target —
+    that is correct, not a shortfall.
+    """
     # 8 pre-DW slots (09:00–13:00) with strong solar; DW entry at slot 8
     # SOC deficit: 80% - 70% = 10% (1.35 kWh)
     # Solar surplus: 8 slots * (0.6 kWh solar - 0.2 kWh consumption) = 3.2 kWh net
@@ -1314,11 +1320,18 @@ def test_optimizer_does_not_grid_charge_during_solar_peak_with_sufficient_solar(
         f"Expected SOC ≥80% at DW entry (slot 8), got {soc_at_dw_entry:.1f}%"
     )
 
-    # Terminal shortfall should be zero (target is met)
-    final_decision = result.decisions[-1]
-    terminal_shortfall = max(0.0, 80.0 - final_decision.predicted_soc_pct)
-    assert terminal_shortfall == 0.0, (
-        f"Expected zero terminal shortfall, got {terminal_shortfall:.1f}%"
+    # Issue #811/#816: the target is enforced at DW entry, not held to the end of the DW.
+    # The battery should discharge during the demand window (slots 8-11, $0.30, no solar)
+    # to cover its load rather than hoard charge to a horizon-end target — so no grid
+    # import at the peak, and end-of-DW SOC is allowed to fall below target.
+    dw_decisions = result.decisions[8:]
+    dw_grid_import = sum(d.grid_import_kwh for d in dw_decisions)
+    assert dw_grid_import == 0.0, (
+        f"battery should cover DW load from storage, not import at the peak; "
+        f"got {dw_grid_import:.2f} kWh of DW grid import"
+    )
+    assert result.decisions[-1].predicted_soc_pct < soc_at_dw_entry, (
+        "battery should discharge through the demand window (it was pre-charged to be used)"
     )
 
     # Any grid charging in the pre-DW solar window (slots 0-7) should be economically


### PR DESCRIPTION
**Stacked on #843** (per-slot cheap-threshold consistency). The diff shown is only this commit; it will re-target to `test` once #843 merges. Builds on the merged sawtooth work (#842).

## Problem: horizon-end myopia (#811 / #816)

In **strict** target mode the shortfall/target penalty was applied at `dp[n_slots]` — the **end of the planning horizon** — not at the demand-window entry. On a genuinely-cheap night with insufficient solar to refill by that boundary, the optimizer grid-charged overnight purely to hit a target at *wherever the horizon happened to be cut*. The production horizon is a rolling ~24-48h window, so that boundary lands at a different clock time every cycle and the overnight recommendation swung with it.

**Measured** (fixed near-term scenario, only the horizon cutoff varies):

| Horizon ends | Overnight grid charge — before | after |
|---|---|---|
| pre-solar (day2 06:00) | **15.95 kWh** | 2.80 kWh |
| day2 09:00 | 14.00 kWh | 5.60 kWh |
| post solar-refill (day2 16:00) | 5.60 kWh | 5.60 kWh |

The ~3× swing collapses; once the horizon is long enough to see the refill, the near-term plan converges and a short cutoff no longer over-charges.

## Fix (scoped to strict mode — the live default)

- `engine/core.py` `_initialize_dp_tables`: in strict mode (`allow_dw_entry_under_target=False`) the per-bin shortfall penalty is applied at `terminal_penalty_idx` (DW entry) during backward induction; the horizon boundary `dp[n_slots]` carries no target. The penalty is the cost of *entering* the DW at a given SOC — constant across actions at that slot — so it's added after action selection; action choice and forward reconstruction are unchanged.
- `allow_dw_entry_under_target=True` (#505) is left **exactly as before** (penalty at the horizon boundary): in that mode the target may be met mid-DW via solar, so relocating it would wrongly force pre-charge. #505/#624/#633 tests unaffected.

Also fixes a related inefficiency: with the penalty at the boundary the battery would refuse to discharge during the DW to protect an end-of-DW target (importing at the peak instead of using stored energy). It now discharges through the DW correctly.

## Tests

- `tests/engine/test_horizon_invariance.py` (new gate): near-term overnight charging must not depend on the horizon cutoff — **RED on the old code, GREEN now** (verified by reverting).
- `tests/test_optimizer_dp_solve.py`: updated the sunny-day test to assert the target at DW **entry** + that the battery discharges through the DW (it previously asserted SOC held to target at the **end** of the DW — the myopic behaviour).
- Full repo suite **2966 passed / 1 xfailed**; `core.py` coverage **99%**; ruff clean.

Not deployed to live — structural DP change; awaiting review. Suggested live check: observe an actual low-solar night (overnight SOC should ride to a reserve instead of grid-charging to a boundary target, and the next DW still reaches target).