### PR TITLE
fix(optimizer): bound the urgency window so overnight doesn't sawtooth (#800)

### DIFF
--- a/custom_components/localshift/engine/constraints.py
+++ b/custom_components/localshift/engine/constraints.py
@@ -173,18 +173,29 @@ def cheap_threshold_for_slot(
 
     Issue #800 (overnight SOC floor bounce / sawtooth).
     ``effective_cheap_price`` is a "now" value that today's low-solar urgency may have
-    inflated above the genuinely-cheap base (to fund pre-charge before *today's* demand
-    window). That urgency does not apply to slots at/after the demand-window entry —
-    using the inflated value there classifies tomorrow-night slots as "cheap" and drives
-    net-negative overnight sawtooth charging. For those slots, gate on the un-inflated
-    ``base_cheap_price`` instead. Pre-demand-window slots keep the urgency-aware value.
+    inflated above the genuinely-cheap base (to fund pre-charge before the demand window).
+    That urgency only legitimately applies to slots close to the upcoming demand window, so
+    the inflated value is used only inside the urgency window
+    ``[urgency_window_start_idx, terminal_penalty_idx)``; every other slot (post-DW, and any
+    slot more than ~4h before the DW — e.g. tonight's overnight when the next horizon DW is
+    tomorrow evening) is gated on the un-inflated ``base_cheap_price``. Using the inflated
+    value outside that window classifies overnight slots as "cheap" and drives net-negative
+    sawtooth charging.
+
+    Backward compatible: when ``urgency_window_start_idx`` is None (e.g. direct unit calls),
+    the inflated price applies to all pre-DW slots (legacy: base only at/after the DW entry).
     """
     threshold = config.effective_cheap_price
-    if (
-        config.base_cheap_price is not None
-        and terminal_penalty_idx is not None
-        and slot_idx >= terminal_penalty_idx
-    ):
+    if config.base_cheap_price is None or terminal_penalty_idx is None:
+        return threshold
+
+    uw_start = config.urgency_window_start_idx
+    if uw_start is None:
+        in_urgency_window = slot_idx < terminal_penalty_idx  # legacy
+    else:
+        in_urgency_window = uw_start <= slot_idx < terminal_penalty_idx
+
+    if not in_urgency_window:
         threshold = min(threshold, config.base_cheap_price)
     return threshold
 

--- a/custom_components/localshift/engine/core.py
+++ b/custom_components/localshift/engine/core.py
@@ -60,6 +60,12 @@ _ACTION_PRIORITY: dict[PlannerAction, int] = {
     PlannerAction.EXPORT_PROACTIVE: 3,
 }
 
+# Issue #800 follow-up: hours before the demand-window entry over which the urgency-inflated
+# effective_cheap_price is considered valid. Matches the urgency ramp window in
+# price_calculator._calculate_urgency_adjusted_price (total_window = 4.0h). Slots earlier
+# than this use the un-inflated base price for the cheap-charge gate.
+_URGENCY_WINDOW_HOURS = 4.0
+
 
 class DPPlanner:
     """Deterministic dynamic-programming battery optimizer.
@@ -148,6 +154,14 @@ class DPPlanner:
 
         terminal_penalty_idx = self._determine_terminal_penalty_idx(
             config, demand_bounds
+        )
+
+        # Issue #800 follow-up: the urgency-inflated effective_cheap_price is only valid
+        # near the demand window. Record where the urgency window begins so the cheap-price
+        # gate uses the inflated value only there and the un-inflated base elsewhere
+        # (otherwise tonight's overnight — far before tomorrow's DW — sawtooths).
+        config.urgency_window_start_idx = self._determine_urgency_window_start_idx(
+            slots, terminal_penalty_idx
         )
 
         dp, terminal_penalty_by_bin = self._initialize_dp_tables(
@@ -325,6 +339,35 @@ class DPPlanner:
         # Always apply penalty at DW entry to incentivize charging before DW
 
         return demand_bounds["entry_idx"]
+
+    def _determine_urgency_window_start_idx(
+        self,
+        slots: list[SlotContext],
+        terminal_penalty_idx: int | None,
+    ) -> int | None:
+        """Index of the first slot within the urgency window before the DW entry.
+
+        The urgency-inflated ``effective_cheap_price`` only legitimately applies to slots
+        within ~``_URGENCY_WINDOW_HOURS`` of the demand-window entry (matching the urgency
+        ramp in ``price_calculator``). Slots earlier than that — notably tonight's overnight
+        when the next horizon DW is tomorrow evening — must be gated on the un-inflated base
+        instead (Issue #800 follow-up). Returns None when there is no demand window.
+        """
+        if terminal_penalty_idx is None:
+            return None
+        try:
+            dw_time = datetime.fromisoformat(slots[terminal_penalty_idx].timestamp_iso)
+        except (ValueError, IndexError, TypeError):
+            return None
+        cutoff = dw_time - timedelta(hours=_URGENCY_WINDOW_HOURS)
+        for i in range(terminal_penalty_idx + 1):
+            try:
+                slot_time = datetime.fromisoformat(slots[i].timestamp_iso)
+            except (ValueError, TypeError):
+                continue
+            if slot_time >= cutoff:
+                return i
+        return terminal_penalty_idx
 
     def _initialize_dp_tables(
         self,

--- a/custom_components/localshift/engine/types.py
+++ b/custom_components/localshift/engine/types.py
@@ -207,6 +207,19 @@ class OptimizerConfig:
     effective_cheap_price: float = 0.10
     """Price threshold for grid charging in self-consumption mode ($/kWh)."""
 
+    urgency_window_start_idx: int | None = None
+    """Solver-derived (set by ``DPPlanner._solve``): index of the first slot within the
+    urgency window (~4h) before the demand-window entry (Issue #800 follow-up).
+
+    The urgency-inflated ``effective_cheap_price`` is a "now" value that is only legitimate
+    for slots close to the upcoming demand window (its urgency ramp is ~4h). When the plan
+    recomputes after the day's demand window has begun, the first DW-entry in the rolling
+    horizon is *tomorrow* evening, so tonight's overnight slots are technically "pre-DW" —
+    but they are far outside the urgency window, so gating them on the inflated price
+    re-introduces the overnight sawtooth. ``cheap_threshold_for_slot`` therefore applies the
+    inflated price only to slots in ``[urgency_window_start_idx, terminal_penalty_idx)`` and
+    gates everything else on the un-inflated base. None ⇒ legacy (base only post-DW)."""
+
     base_cheap_price: float | None = None
     """Un-inflated "genuinely cheap" threshold (percentile-derived), $/kWh.
 

--- a/tests/engine/test_sawtooth_gate.py
+++ b/tests/engine/test_sawtooth_gate.py
@@ -291,6 +291,132 @@ class TestCheapThresholdForSlot:
         )
 
 
+class TestUrgencyWindowGate:
+    """Issue #800 follow-up: the inflated price applies only inside the urgency window.
+
+    When the plan recomputes after the day's DW has begun, the first DW-entry in the rolling
+    horizon is tomorrow evening — so tonight's overnight is technically "pre-DW" but far
+    outside the urgency window. Without bounding the urgency window, those overnight slots
+    are gated on the inflated price and the sawtooth recurs.
+    """
+
+    def _config(self, uw_start):
+        return OptimizerConfig(
+            effective_cheap_price=_INFLATED_CHEAP,
+            base_cheap_price=_BASE_CHEAP,
+            urgency_window_start_idx=uw_start,
+        )
+
+    def test_far_pre_dw_slot_uses_base(self):
+        """A pre-DW slot earlier than the urgency window gates on the base price."""
+        config = self._config(uw_start=34)
+        # slot 10 is pre-DW but well before the urgency window [34, 40) -> base.
+        assert (
+            cheap_threshold_for_slot(config, slot_idx=10, terminal_penalty_idx=40)
+            == _BASE_CHEAP
+        )
+
+    def test_in_urgency_window_uses_effective(self):
+        """A pre-DW slot inside the urgency window keeps the urgency-aware price."""
+        config = self._config(uw_start=34)
+        assert (
+            cheap_threshold_for_slot(config, slot_idx=36, terminal_penalty_idx=40)
+            == _INFLATED_CHEAP
+        )
+
+    def test_post_dw_still_uses_base(self):
+        """Post-DW slots remain base-gated regardless of the urgency window."""
+        config = self._config(uw_start=34)
+        assert (
+            cheap_threshold_for_slot(config, slot_idx=42, terminal_penalty_idx=40)
+            == _BASE_CHEAP
+        )
+
+    def test_none_window_is_legacy_all_pre_dw_effective(self):
+        """Backward compat: no urgency window => inflated price for every pre-DW slot."""
+        config = self._config(uw_start=None)
+        assert (
+            cheap_threshold_for_slot(config, slot_idx=10, terminal_penalty_idx=40)
+            == _INFLATED_CHEAP
+        )
+
+    def test_end_to_end_no_overnight_sawtooth_when_dw_is_tomorrow(self):
+        """Plan computed after today's DW: tonight's overnight must not sawtooth-charge.
+
+        Mirrors the live finding — the only DW in the horizon is tomorrow evening, the
+        overnight is priced just under the inflated threshold but above base, and there is a
+        morning peak to arbitrage against. With the urgency window bounded, the overnight is
+        base-gated and does not charge. (RED without the fix: ~3.9 kWh of overnight charge.)
+        """
+        start = datetime(2026, 6, 3, 18, 0)  # now: after today's DW
+
+        def price(t):
+            h = t.hour + t.minute / 60.0
+            if t.day == 4 and 15.0 <= h < 21.0:
+                return _DW_PEAK
+            if t.day == 4 and 0.0 <= h < 6.0:
+                return _OVERNIGHT  # cheap only by the inflated threshold
+            if t.day == 4 and 6.0 <= h < 8.0:
+                return _MORNING_PEAK
+            if t.day == 3:
+                return 0.13
+            return 0.12
+
+        def solar(t):
+            h = t.hour + t.minute / 60.0
+            return 0.5 if (t.day == 4 and 9.0 <= h < 15.0) else 0.0
+
+        n = int((datetime(2026, 6, 4, 16, 0) - start).total_seconds() / 60 / INTERVAL)
+        slots = []
+        for i in range(n):
+            t = start + timedelta(minutes=INTERVAL * i)
+            h = t.hour + t.minute / 60.0
+            slots.append(
+                SlotContext(
+                    slot_index=i,
+                    timestamp_iso=t.isoformat(),
+                    slot_interval_minutes=INTERVAL,
+                    buy_price=price(t),
+                    sell_price=0.05,
+                    solar_kwh=solar(t),
+                    consumption_kwh=0.3,
+                    is_demand_window_entry=(t.day == 4 and abs(h - 15.0) < 1e-9),
+                    is_demand_window_slot=(t.day == 4 and 15.0 <= h < 21.0),
+                )
+            )
+        config = OptimizerConfig(
+            min_soc_pct=10.0,
+            max_soc_pct=100.0,
+            demand_window_target_soc_pct=95.0,
+            optimization_mode="self_consumption",
+            effective_cheap_price=_INFLATED_CHEAP,
+            base_cheap_price=_BASE_CHEAP,
+            target_shortfall_penalty_per_pct=0.03,
+            soc_bins=100,
+        )
+        result = DPPlanner(config).plan(
+            OptimizerInputs(
+                cycle_id="overnight-gap",
+                initial_soc_pct=60.0,
+                slots=slots,
+                config=config,
+                all_solcast=[],
+            )
+        )
+        overnight_charges = [
+            d
+            for d in result.decisions
+            if d.action in _CHARGE_ACTIONS
+            and datetime.fromisoformat(d.timestamp_iso).day == 4
+            and datetime.fromisoformat(d.timestamp_iso).hour < 6
+            and d.buy_price > _BASE_CHEAP
+        ]
+        assert overnight_charges == [], (
+            "overnight slots before tomorrow's DW must gate on base, not the inflated "
+            f"price; got charges at {[c.timestamp_iso for c in overnight_charges]}"
+        )
+
+
 class TestPostDwConsistency:
     """Issue #800 follow-up: penalty + reason-code labels agree with the gate.
 


### PR DESCRIPTION
Closes a gap in the sawtooth fix (#842), **found while observing it on live**.

## The gap
#842 base-gates slots with `slot_idx >= terminal_penalty_idx` (the first DW-entry **in the horizon**). But when the optimizer recomputes **after the day's demand window has begun** (i.e. most evenings/overnights), the first DW-entry in the rolling horizon is **tomorrow** evening — so tonight's overnight slots are technically "pre-DW" and were gated on the urgency-**inflated** `effective_cheap_price` (live = $0.13 today) instead of the base. Result: the overnight sawtooth recurs (observed on live: ~3 kWh charged at $0.118 around 01:30/02:30, then drained through the morning peak).

## The fix
The inflated `effective_cheap_price` is a "now" value whose urgency ramp is ~4h (`price_calculator._calculate_urgency_adjusted_price`, `total_window=4.0`). So it's only legitimate for slots within ~4h of the demand window. Apply it **only inside the urgency window** `[urgency_window_start_idx, terminal_penalty_idx)`; gate everything else (post-DW, and any slot >4h before the DW) on the un-inflated base.

- `core.py`: `_determine_urgency_window_start_idx()` finds the first slot within `_URGENCY_WINDOW_HOURS` (4.0) of the DW entry; `_solve` records it on the config.
- `types.py`: `OptimizerConfig.urgency_window_start_idx` (solver-derived; `None` = legacy).
- `constraints.py`: `cheap_threshold_for_slot` applies the inflated price only inside the window, base elsewhere. Read via `config`, so the gate, the futile-cycling penalty, and the reason-code labels stay consistent automatically.

## Why it's safe
- **Conservative:** strictly *less* charging (base is ≤ effective), never more.
- **Scoped:** only changes slots >4h before the DW, so existing tests (whose DW sits near the horizon start ⇒ window starts at slot 0 ⇒ legacy behaviour) are unaffected.
- Reproduced + fixed deterministically (legacy: 3.9 kWh overnight charge → **0 kWh**), matching the live observation.

## Tests
- `tests/engine/test_sawtooth_gate.py::TestUrgencyWindowGate`: the per-slot threshold (far-pre-DW → base, in-window → effective, post-DW → base, `None` → legacy) + an end-to-end "DW is tomorrow evening" scenario (no overnight sawtooth; RED without the fix).
- Full repo suite **2971 passed / 1 xfailed**; changed-file coverage ≥98%; ruff clean.

Builds on #842/#843/#844 (merged).