### PR TITLE
fix(optimizer): cap grid charging at the demand-window target

### DIFF
--- a/custom_components/localshift/engine/constraints.py
+++ b/custom_components/localshift/engine/constraints.py
@@ -120,7 +120,22 @@ def feasible_actions(
 
     actions = []
 
-    can_charge = soc_pct < config.max_soc_pct
+    # Grid charging is capped at the demand-window target in self-consumption
+    # mode, not at the physical 100% ceiling. The target (battery_target plus any
+    # learned drain/headroom margin) is the SOC the planner is trying to reach for
+    # demand-window readiness; grid should fill the battery up to it and no further.
+    # Without this cap, any cheap slot below 100% invites a marginal above-target
+    # top-up (e.g. grid-charging at 98% just before the demand window) that the
+    # full-retail self-consumption credit makes look profitable but which only
+    # cycles the battery for negligible gain. Solar can still fill above the target
+    # for free (export actions are handled separately), and arbitrage mode keeps the
+    # physical ceiling so it can still chase price spreads.
+    charge_ceiling = (
+        config.demand_window_target_soc_pct
+        if config.optimization_mode == "self_consumption"
+        else config.max_soc_pct
+    )
+    can_charge = soc_pct < charge_ceiling
 
     actions.append(PlannerAction.HOLD)
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -147,25 +147,34 @@ is_reservation_valid() {
     local res_agent=""
     local res_branch=""
     local res_timestamp=""
+    local res_epoch=""
     local res_pid=""
-    
+
     while IFS='=' read -r key value; do
         case $key in
             AGENT) res_agent="$value" ;;
             BRANCH) res_branch="$value" ;;
             TIMESTAMP) res_timestamp="$value" ;;
+            EPOCH) res_epoch="$value" ;;
             PID) res_pid="$value" ;;
         esac
     done < "$reserve_file"
-    
-    # Check expiration (30 minutes of inactivity)
+
+    # Check expiration (30 minutes of inactivity).
+    # Prefer the stored epoch (portable); fall back to parsing the ISO timestamp
+    # with GNU date. NOTE: BSD/macOS `date -d` cannot parse ISO timestamps, so
+    # without the EPOCH field a reservation would always read as expired here
+    # (which silently defeats the multi-agent guard on macOS).
     local now=$(date +%s)
-    local reserve_time=$(date -d "$res_timestamp" +%s 2>/dev/null || echo "0")
-    
+    local reserve_time="$res_epoch"
+    if [ -z "$reserve_time" ]; then
+        reserve_time=$(date -d "$res_timestamp" +%s 2>/dev/null || echo "0")
+    fi
+
     if [ $((now - reserve_time)) -gt $RESERVE_TIMEOUT ]; then
         return 1
     fi
-    
+
     return 0
 }
 
@@ -192,15 +201,17 @@ create_reservation() {
     local agent_id=$(get_agent_id)
     local branch=$(git -C "$SCRIPT_DIR" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
     local timestamp=$(date -Iseconds)
+    local epoch=$(date +%s)
     local pid=$$
-    
+
     # Ensure directory exists
     mkdir -p "$(dirname "$RESERVE_FILE")"
-    
+
     cat > "$RESERVE_FILE" << EOF
 AGENT=$agent_id
 BRANCH=$branch
 TIMESTAMP=$timestamp
+EPOCH=$epoch
 PID=$pid
 EOF
     
@@ -501,21 +512,14 @@ if [ -d "$DEST_DIR" ]; then
     BACKUP_DIR="$BACKUP_BASE/${COMPONENT_NAME}.backup.$(date +%Y%m%d_%H%M%S)"
     log_info "Backing up existing installation to: $BACKUP_DIR"
     mv "$DEST_DIR" "$BACKUP_DIR"
-    
-    # Cleanup backups older than 7 days
-    log_info "Cleaning up backups older than 7 days..."
-    OLD_BACKUPS=$(find "$BACKUP_BASE" -name "${COMPONENT_NAME}.backup.*" -type d -mtime +7 2>/dev/null || true)
-    if [ -n "$OLD_BACKUPS" ]; then
-        echo "$OLD_BACKUPS" | while read -r old_backup; do
-            log_info "Removing old backup: $old_backup"
-            rm -rf "$old_backup"
-        done
-    else
-        log_info "No old backups to remove"
-    fi
 fi
 
 # Copy current worktree state to HA
+# IMPORTANT: this must run immediately after the backup mv. The backup step has
+# already moved the live integration out of DEST_DIR, so if anything between the
+# mv and this copy fails under `set -e`, HA is left with no integration on disk
+# (a reload/restart would then fail to load it). Keep this copy adjacent to the
+# mv, and push all best-effort/janitorial work (backup cleanup) to AFTER it.
 log_info "Copying files from worktree to HA config..."
 mkdir -p "$HA_CONFIG/custom_components"
 cp -r "$SOURCE_DIR" "$HA_CONFIG/custom_components/"
@@ -524,6 +528,16 @@ log_success "Files copied successfully"
 # Set appropriate permissions
 log_info "Setting permissions..."
 chmod -R 755 "$DEST_DIR" 2>/dev/null || log_warning "Could not set permissions"
+
+# Cleanup backups older than 7 days (best-effort; never abort the deploy).
+# Backups can contain root-owned *.pyc written by the HA container, so rm may hit
+# permission errors. This runs AFTER the copy and is fully non-fatal so a cleanup
+# failure can never strand the integration (see the IMPORTANT note above).
+if [ -d "$HA_CONFIG/backups" ]; then
+    log_info "Cleaning up backups older than 7 days..."
+    find "$HA_CONFIG/backups" -maxdepth 1 -name "${COMPONENT_NAME}.backup.*" \
+        -type d -mtime +7 -exec rm -rf {} + 2>/dev/null || true
+fi
 
 # Reload integration via HA API (skip if restart mode - full restart handles it)
 if [ "$RESTART_MODE" = true ]; then

--- a/tests/engine/test_constraints.py
+++ b/tests/engine/test_constraints.py
@@ -99,6 +99,74 @@ class TestFeasibleActions:
         actions = feasible_actions(50.0, slot, config)
         assert PlannerAction.CHARGE_GRID_NORMAL in actions
 
+    def test_no_grid_charge_above_target_self_consumption(self):
+        """Grid charging is capped at the demand-window target, not 100%.
+
+        Regression for the above-target top-up: at 98% SOC with a cheap price just
+        before the demand window, the optimizer used to grid-charge to ~100% because
+        the gate was soc < max_soc_pct. Grid charging must stop at the target.
+        """
+        config = OptimizerConfig(
+            optimization_mode="self_consumption",
+            effective_cheap_price=20.0,
+            demand_window_target_soc_pct=95.0,
+        )
+        slot = SlotContext(
+            slot_index=0,
+            slot_interval_minutes=30,
+            timestamp_iso="2024-01-01T00:00:00+00:00",
+            buy_price=15.0,  # cheap AND very-cheap (would otherwise add NORMAL+BOOST)
+            sell_price=10.0,
+            solar_kwh=1.0,
+            consumption_kwh=1.0,
+            is_demand_window_slot=False,
+        )
+
+        actions = feasible_actions(98.0, slot, config)  # above the 95% target
+        assert PlannerAction.CHARGE_GRID_NORMAL not in actions
+        assert PlannerAction.CHARGE_GRID_BOOST not in actions
+
+    def test_grid_charge_allowed_below_target_self_consumption(self):
+        """The target cap must not block legitimate pre-charge below target."""
+        config = OptimizerConfig(
+            optimization_mode="self_consumption",
+            effective_cheap_price=20.0,
+            demand_window_target_soc_pct=95.0,
+        )
+        slot = SlotContext(
+            slot_index=0,
+            slot_interval_minutes=30,
+            timestamp_iso="2024-01-01T00:00:00+00:00",
+            buy_price=15.0,
+            sell_price=10.0,
+            solar_kwh=1.0,
+            consumption_kwh=1.0,
+            is_demand_window_slot=False,
+        )
+
+        actions = feasible_actions(90.0, slot, config)  # below the 95% target
+        assert PlannerAction.CHARGE_GRID_NORMAL in actions
+
+    def test_arbitrage_charges_above_target(self):
+        """Arbitrage mode keeps the physical ceiling so it can chase spreads."""
+        config = OptimizerConfig(
+            optimization_mode="arbitrage",
+            demand_window_target_soc_pct=95.0,
+        )
+        slot = SlotContext(
+            slot_index=0,
+            slot_interval_minutes=30,
+            timestamp_iso="2024-01-01T00:00:00+00:00",
+            buy_price=15.0,
+            sell_price=10.0,
+            solar_kwh=1.0,
+            consumption_kwh=1.0,
+            is_demand_window_slot=False,
+        )
+
+        actions = feasible_actions(98.0, slot, config)  # above target, but arbitrage
+        assert PlannerAction.CHARGE_GRID_NORMAL in actions
+
     def test_expensive_price_blocks_charge_self_consumption(self):
         """Expensive import price blocks charging in self_consumption mode."""
         config = OptimizerConfig(

--- a/tests/test_optimizer_dp_solve.py
+++ b/tests/test_optimizer_dp_solve.py
@@ -1132,9 +1132,17 @@ def test_feasible_actions_gate_disabled_in_arbitrage_mode():
     assert PlannerAction.CHARGE_GRID_BOOST in actions
 
 
-def test_feasible_actions_gate_not_fired_when_soc_already_at_target():
-    """When SOC >= target (no deficit), gate should not suppress grid charging."""
-    # SOC=85 >= target=80 → deficit=0 → gate does not fire
+def test_feasible_actions_grid_charge_capped_at_target():
+    """At/above the demand-window target, grid charging is capped (not offered).
+
+    Previously, with SOC >= target the solar-sufficiency gate did not fire and a
+    cheap price would still offer grid charge — producing marginal above-target
+    top-ups (e.g. grid-charging at 98% just before the demand window). Grid
+    charging is now capped at ``demand_window_target_soc_pct`` in self-consumption
+    mode, so only HOLD remains. (The solar gate still does not fire here; the
+    target cap is the operative brake. Solar may still fill above target for free.)
+    """
+    # SOC=85 >= target=80 → above the grid-charge ceiling
     slots = [
         _make_slot(slot_index=i, buy_price=0.08, solar_kwh=0.0, consumption_kwh=0.3)
         for i in range(4)
@@ -1156,9 +1164,9 @@ def test_feasible_actions_gate_not_fired_when_soc_already_at_target():
         terminal_penalty_idx=4,
     )
 
-    # No deficit → gate does not fire → price-gated grid charge offered
+    # Above target → grid charge capped even though price is cheap and gate is idle
     assert PlannerAction.HOLD in actions
-    assert PlannerAction.CHARGE_GRID_NORMAL in actions
+    assert PlannerAction.CHARGE_GRID_NORMAL not in actions
 
 
 def test_projected_solar_soc_gain_pct_positive_surplus():


### PR DESCRIPTION
## Problem

Investigating a grid charge at **14:55 (just before the 3pm demand window)** while SOC was **98% — above the 95% battery target**. The charge moved ~0 kWh (battery near-full, Tesla throttles >~95%) yet cycled the battery and burned a mode switch.

## Root cause

In `feasible_actions` (`engine/constraints.py`), grid charging was gated **only** by `soc_pct < config.max_soc_pct` (100%) — the target was never a ceiling. So whenever a slot was cheap (`buy ≤ cheap_threshold`) and SOC < 100%, `CHARGE_GRID_NORMAL` was offered, and the live cost model (full-retail self-consumption credit, **no cycle penalty** on `test`) made banking cheap energy for the evening peak look profitable, even a couple of % above the effective target (~95%).

This is the live-code mechanism. (The `#811/#816` DW-entry hard constraint is parked at the horizon boundary on this system because `allow_dw_entry_under_target=true`, so it was *not* the driver.)

## Fix

Cap grid charging at `demand_window_target_soc_pct` in self-consumption mode; arbitrage keeps the physical 100% ceiling so it can still chase spreads. Solar may still fill above target for free; export actions are unaffected.

```python
charge_ceiling = (
    config.demand_window_target_soc_pct
    if config.optimization_mode == "self_consumption"
    else config.max_soc_pct
)
can_charge = soc_pct < charge_ceiling
```

## Tests

- New gate tests: above-target blocked, below-target still allowed, arbitrage unaffected.
- Updated `test_feasible_actions_gate_not_fired_when_soc_already_at_target` → `..._grid_charge_capped_at_target`: it encoded the **old** above-target-charging behaviour (the exact thing being fixed). No other test depended on it.
- **Full suite: 2977 passed, 1 xfailed.**

## Also: `deploy.sh` hardening (separate commit)

A live deploy exposed two footguns, fixed here:
1. The "cleanup old backups" `rm` ran **between** the backup `mv` and the copy; root-owned `*.pyc` caused permission-denied → under `set -e` it aborted **before the copy**, briefly leaving HA with no integration on disk. Copy now runs immediately after the backup; cleanup moved to the end and made non-fatal.
2. Reservation expiry used GNU `date -d` (unparseable on BSD/macOS → always "expired"). Now stores/uses an `EPOCH` field.

## Deployment status

Already deployed to the live HA (Unraid container) and the integration reloaded clean (`integration_status: ok`, optimizer `success`). This PR brings `test` in line so live can return to tracking mainline.