### PR TITLE
fix(optimizer): robust daily reset of pre-charge target latch

### DIFF
--- a/custom_components/localshift/computation_engine.py
+++ b/custom_components/localshift/computation_engine.py
@@ -236,6 +236,16 @@ class ComputationEngine:
         """
         now_dt = dt_util.now()
 
+        # Robust daily reset of the demand-window pre-charge latch. ``target_reached_today``
+        # is otherwise only cleared by a single midnight ``async_track_time_change`` event;
+        # if that event is ever missed (restart/reload spanning local midnight, DST), the
+        # latch stays True for up to 24h and silently disables all pre-charge. A date-change
+        # check here is immune to missed events.
+        today = now_dt.date()
+        if data.last_target_reset_date != today:
+            data.target_reached_today = False
+            data.last_target_reset_date = today
+
         # Pass adaptive parameters to load forecaster (Issue #170 Phase 2)
         self._load_forecaster.set_adaptive_params(data.adaptive_params)
 
@@ -392,6 +402,7 @@ class ComputationEngine:
             now_dt=now_dt,
             before_dw=before_dw,
             target_hour=target_hour,
+            target_pct=target_pct,
         )
 
         # ---- Step 8: cheap_charge_stop_price ----

--- a/custom_components/localshift/coordinator/data.py
+++ b/custom_components/localshift/coordinator/data.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import date, datetime
 from typing import TYPE_CHECKING, Any
 
 from ..const import BatteryMode
@@ -293,6 +293,10 @@ class CoordinatorData:
     # Internal state flags (managed by state machine / buttons)
     manual_override: bool = False
     target_reached_today: bool = False
+    # Local date the target latch was last reset. Drives a date-change reset in the
+    # compute cycle that is immune to a missed midnight event (the latch's only other
+    # live reset), preventing a stuck latch from silently disabling pre-charge.
+    last_target_reset_date: date | None = None
     allow_dw_entry_under_target: bool = (
         False  # Allow DW entry when solar can reach target
     )

--- a/custom_components/localshift/engine/price_calculator.py
+++ b/custom_components/localshift/engine/price_calculator.py
@@ -21,6 +21,27 @@ from ..coordinator.data import CoordinatorData
 from ..pricing.types import ForecastSlot
 from .utils import parse_forecast_dt
 
+# A stale ``target_reached_today`` latch (e.g. from a missed midnight reset) must not
+# suppress demand-window pre-charge when the battery is actually well below target.
+# Honor the latch only within this SOC deadband of the target — wide enough to avoid
+# a re-charging sawtooth after legitimately reaching target, narrow enough to re-engage
+# urgency once the battery has clearly drained far below target before the DW.
+_STALE_TARGET_REACHED_SOC_DEADBAND_PCT = 20.0
+
+
+def _target_reached_blocks_urgency(data: CoordinatorData, target_pct: float) -> bool:
+    """Whether the daily target-reached latch should suppress urgency pre-charge.
+
+    Guards against a stale ``target_reached_today`` starving a battery that sits far
+    below target before the demand window. The latch's only live reset is a single
+    midnight event, so a missed reset would otherwise disable all pre-charge for ~24h.
+    """
+    if not data.target_reached_today:
+        return False
+    if target_pct <= 0.0:
+        return True  # No target context (legacy callers) — preserve prior behaviour.
+    return data.soc >= target_pct - _STALE_TARGET_REACHED_SOC_DEADBAND_PCT
+
 
 def _parse_price_entry(
     entry: Any, slot_start: datetime, slot_end: datetime
@@ -403,7 +424,11 @@ class PriceCalculator:
         preliminary_solar_can_reach = data.soc >= target_pct or net_solar >= deficit_kwh
         solar_gap = not preliminary_solar_can_reach
 
-        if not solar_gap or not before_dw or data.target_reached_today:
+        if (
+            not solar_gap
+            or not before_dw
+            or _target_reached_blocks_urgency(data, target_pct)
+        ):
             data.effective_cheap_price = base
         else:
             data.effective_cheap_price = self._calculate_urgency_adjusted_price(
@@ -463,6 +488,7 @@ class PriceCalculator:
         now_dt: datetime,
         before_dw: bool,
         target_hour: int,
+        target_pct: float = 0.0,
     ) -> None:
         """Compute final effective cheap price threshold.
 
@@ -480,7 +506,11 @@ class PriceCalculator:
 
         solar_gap = not data.solar_can_reach_target
 
-        if not solar_gap or not before_dw or data.target_reached_today:
+        if (
+            not solar_gap
+            or not before_dw
+            or _target_reached_blocks_urgency(data, target_pct)
+        ):
             raw_threshold = base
         else:
             raw_threshold = self._calculate_urgency_adjusted_price(

--- a/custom_components/localshift/engine/price_signal_engine.py
+++ b/custom_components/localshift/engine/price_signal_engine.py
@@ -104,7 +104,12 @@ class PriceSignalEngine:
         )
 
     def compute_effective_cheap_price(
-        self, data: CoordinatorData, now_dt: datetime, before_dw: bool, target_hour: int
+        self,
+        data: CoordinatorData,
+        now_dt: datetime,
+        before_dw: bool,
+        target_hour: int,
+        target_pct: float = 0.0,
     ) -> None:
         """Compute final effective cheap price threshold."""
         self._price_calculator.compute_effective_cheap_price(
@@ -112,6 +117,7 @@ class PriceSignalEngine:
             now_dt=now_dt,
             before_dw=before_dw,
             target_hour=target_hour,
+            target_pct=target_pct,
         )
 
     def compute_solar_weighted_avg_fit(

--- a/tests/engine/test_price_calculator.py
+++ b/tests/engine/test_price_calculator.py
@@ -6,9 +6,11 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from custom_components.localshift.engine.price_calculator import (
+    _STALE_TARGET_REACHED_SOC_DEADBAND_PCT,
     _collect_prices_by_source,
     _compute_price_slot_data,
     _parse_price_entry,
+    _target_reached_blocks_urgency,
     get_price_for_slot,
     get_price_for_slot_or_none,
     get_price_for_slot_with_source,
@@ -19,6 +21,28 @@ from custom_components.localshift.engine.price_calculator import PriceCalculator
 def _make_utc_datetime(offset_minutes: int = 0) -> datetime:
     """Create a timezone-aware UTC datetime."""
     return datetime.now(timezone.utc) + timedelta(minutes=offset_minutes)
+
+
+def _make_price_calculator() -> PriceCalculator:
+    """Fresh PriceCalculator with deterministic base=0.10 and max_pre_charge_price=0.50."""
+
+    def parse_dt(val):
+        if val is None:
+            return None
+        try:
+            return datetime.fromisoformat(val.replace("Z", "+00:00"))
+        except Exception:
+            return None
+
+    entry = MagicMock()
+    entry.options = {"max_pre_charge_price": 0.50}
+    return PriceCalculator(
+        entry=entry,
+        parse_forecast_dt=parse_dt,
+        percentile_func=lambda x, y: 0.10,
+        sum_solar_before_target=lambda x, y, z: 10.0,
+        get_expected_load_kw=lambda x, y: 1.0,
+    )
 
 
 class TestParsePriceEntry:
@@ -1033,12 +1057,18 @@ class TestComputeEffectiveCheapPricePreliminary:
         assert data.effective_cheap_price is not None
 
     def test_base_price_when_target_reached(self, calculator):
-        """Test base price when target already reached today."""
+        """Base price when target reached today AND battery still near target.
+
+        The target-reached latch only suppresses urgency within a SOC deadband of the
+        target (a stale latch with a low SOC must NOT suppress pre-charge — see
+        TestComputeEffectiveCheapPriceStaleLatch). Here SOC is within the deadband, so
+        the latch is honored and the threshold stays at base.
+        """
         now = _make_utc_datetime()
         data = MagicMock()
         data.general_forecast = [{"start_time": now.isoformat(), "per_kwh": 0.15}]
         data.forecast_horizon_hours = 12.0
-        data.soc = 30.0
+        data.soc = 75.0  # within deadband of target_pct=80 (80 - 20 = 60)
         data.target_reached_today = True
         data.solcast_today = []
         data.solcast_tomorrow = []
@@ -1132,6 +1162,95 @@ class TestComputeEffectiveCheapPrice:
             data, now, target_hour=18, before_dw=False
         )
         assert data.effective_cheap_price == 0.10
+
+
+class TestTargetReachedBlocksUrgency:
+    """Tests for the stale-latch SOC guard (_target_reached_blocks_urgency).
+
+    Regression for the demand-window pre-charge failure: target_reached_today is a daily
+    latch whose only live reset is a single midnight event. A stale latch must not suppress
+    urgency pre-charge while the battery sits far below target before the demand window.
+    """
+
+    def test_latch_clear_never_blocks(self):
+        data = MagicMock()
+        data.target_reached_today = False
+        data.soc = 12.0
+        assert _target_reached_blocks_urgency(data, target_pct=95.0) is False
+
+    def test_stale_latch_with_low_soc_does_not_block(self):
+        # The bug: latch True but battery far below target before the DW must NOT
+        # suppress urgency pre-charge.
+        data = MagicMock()
+        data.target_reached_today = True
+        data.soc = 12.0
+        assert _target_reached_blocks_urgency(data, target_pct=95.0) is False
+
+    def test_latch_honored_within_deadband(self):
+        # Near target: honor the latch so we don't re-charge (sawtooth avoidance).
+        data = MagicMock()
+        data.target_reached_today = True
+        data.soc = 95.0
+        assert _target_reached_blocks_urgency(data, target_pct=95.0) is True
+
+    def test_deadband_boundary(self):
+        data = MagicMock()
+        data.target_reached_today = True
+        boundary = 95.0 - _STALE_TARGET_REACHED_SOC_DEADBAND_PCT
+        data.soc = boundary
+        assert _target_reached_blocks_urgency(data, target_pct=95.0) is True
+        data.soc = boundary - 0.1
+        assert _target_reached_blocks_urgency(data, target_pct=95.0) is False
+
+    def test_no_target_context_preserves_legacy(self):
+        # target_pct<=0 (legacy callers) -> latch alone suppresses, as before.
+        data = MagicMock()
+        data.target_reached_today = True
+        data.soc = 12.0
+        assert _target_reached_blocks_urgency(data, target_pct=0.0) is True
+
+
+class TestComputeEffectiveCheapPriceStaleLatch:
+    """End-to-end: a stale latch + low SOC before the DW still funds pre-charge."""
+
+    def _data(self, now, soc, latched):
+        data = MagicMock()
+        data.general_forecast = [{"start_time": now.isoformat(), "per_kwh": 0.10}]
+        data.forecast_horizon_hours = 12.0
+        data.solar_can_reach_target = False  # solar_gap -> urgency eligible
+        data.target_reached_today = latched
+        data.soc = soc
+        return data
+
+    def test_stale_latch_low_soc_still_inflates_threshold(self):
+        # Fixed time 2h before target so the urgency path yields a value above base
+        # (urgency = 1 - 2/4 = 0.5 -> 0.10 + (0.50-0.10)*0.5 = 0.30).
+        now = datetime(2026, 6, 4, 16, 0, tzinfo=timezone.utc)
+
+        ref = _make_price_calculator()
+        d_ref = self._data(now, soc=12.0, latched=False)
+        ref.compute_effective_cheap_price(
+            d_ref, now, before_dw=True, target_hour=18, target_pct=95.0
+        )
+
+        stuck = _make_price_calculator()
+        d_stuck = self._data(now, soc=12.0, latched=True)
+        stuck.compute_effective_cheap_price(
+            d_stuck, now, before_dw=True, target_hour=18, target_pct=95.0
+        )
+
+        honored = _make_price_calculator()
+        d_hon = self._data(now, soc=95.0, latched=True)
+        honored.compute_effective_cheap_price(
+            d_hon, now, before_dw=True, target_hour=18, target_pct=95.0
+        )
+
+        # Urgency path produces a threshold strictly above base (test is meaningful).
+        assert d_ref.effective_cheap_price > 0.10
+        # Stuck latch + low SOC behaves like no latch at all -> pre-charge funded.
+        assert d_stuck.effective_cheap_price == d_ref.effective_cheap_price
+        # Latch honored only when SOC is within the deadband -> base, no pre-charge.
+        assert d_hon.effective_cheap_price == 0.10
 
 
 class TestGetFitPriceForPeriod:


### PR DESCRIPTION
## Problem

On 2026-06-04 the live optimizer produced an economically broken plan: the battery rode the 10% SOC floor straight into the evening demand window (DW entry **10.8%** vs the **95%** target), importing at peak rates (~**+\$1.05**). It self-healed ~2.5h later on a control-mode cycle — i.e. a **transient**, not a code/config fault at the time.

### Root cause (confirmed via live diagnostics)

`sensor.localshift_price_cheap_effective` was pinned at the un-inflated **base (0.09)** for the whole broken window, *below* the day's ~0.093–0.097 midday prices. So **no slot read as "cheap"**, the DP was never offered a `CHARGE_GRID` action (`engine/constraints.py`), and it could only HOLD → floor.

The urgency-inflation gate (`price_calculator.py`) is:
```python
if not solar_gap or not before_dw or data.target_reached_today:
    raw_threshold = base          # no pre-charge funding
```
`solar_can_reach_target` was `off` (solar_gap True) and it was before the DW — so by elimination, **`target_reached_today` was latched `True`**.

`target_reached_today` is a **daily latch** whose **only live reset is a single `async_track_time_change(hour=0)` midnight event** (`subscription_manager.py` → `tick_scheduler.py`). There's no storage-restore (reload defaults `False`), and the intended *backup* reset `reset_daily_accumulators` (`costs.py`) is **dead code with no production caller**. So a single missed midnight event (restart/reload spanning local midnight, DST) leaves the latch `True` for up to 24h, silently disabling **all** pre-charge.

## Fix (two parts, defense-in-depth)

1. **Robust daily reset (root cause)** — a date-change check at the top of every compute cycle clears `target_reached_today` when the local date rolls over, tracked via a new `CoordinatorData.last_target_reset_date`. Immune to missed midnight events.
2. **SOC guard (symptom defense)** — `_target_reached_blocks_urgency` only lets the latch suppress pre-charge while SOC is within a **20% deadband** of target. A battery far below target before the DW always pre-charges; the deadband preserves post-target sawtooth avoidance (#800).

## Tests

- Unit: `_target_reached_blocks_urgency` (latch clear / stale-low-SOC / honored / deadband boundary / legacy no-target).
- End-to-end: stuck latch + low SOC funds pre-charge identically to no-latch; honored + high SOC stays at base.
- Updated the one pre-existing test that encoded the old "latch alone → base" rule.
- Full `tests/engine` + `tests/forecast` green; no sawtooth regression.

## Notes

- `reset_daily_accumulators` (`costs.py`) is left untouched (dead in production but covered by `tests/utils/test_costs.py`); the new date-based reset supersedes its role. Wiring it up or removing it is a reasonable follow-up.
- The pre-existing `test_config_flow.py` failure (HA-version `OptionsFlow.config_entry` API drift) is unrelated to this change and reproduces on `main`.