### PR TITLE
fix(optimizer): target the next real demand window when re-planning mid-DW

### DIFF
--- a/custom_components/localshift/engine/core.py
+++ b/custom_components/localshift/engine/core.py
@@ -300,7 +300,23 @@ class DPPlanner:
         end_idx = None
         in_demand_window = False
 
+        # When the plan is computed mid-demand-window, slot 0 is already inside the DW and
+        # slots.py flags it as an entry (prev_in_demand_window is seeded False). That
+        # in-progress DW is not a future deadline the optimizer can pre-charge for — taking
+        # it as terminal_penalty_idx pins the target penalty at the present instant and
+        # leaves the next REAL DW entry (e.g. tomorrow's) with no pre-charge incentive. So
+        # ignore entries until we have exited that initial in-progress block.
+        started_in_dw = bool(slots) and slots[0].is_demand_window_slot
+        exited_initial_dw = not started_in_dw
+
         for i, slot in enumerate(slots):
+            if not exited_initial_dw:
+                if not slot.is_demand_window_slot:
+                    exited_initial_dw = True
+                else:
+                    # Still inside the initial in-progress DW block: skip its (false) entry.
+                    continue
+
             if slot.is_demand_window_entry:
                 if entry_idx is None:
                     entry_idx = i

--- a/simulations/scenarios/hot-day-spike.json
+++ b/simulations/scenarios/hot-day-spike.json
@@ -175,7 +175,7 @@
   },
   "expected": {
     "price_spike": true,
-    "solar_can_reach_target": false,
+    "solar_can_reach_target": true,
     "optimizer_result_success": true
   }
 }

--- a/tests/engine/test_mid_dw_target_undercharge.py
+++ b/tests/engine/test_mid_dw_target_undercharge.py
@@ -1,0 +1,207 @@
+"""Mid-demand-window target under-charge (in-progress DW false-positive).
+
+When the optimizer re-plans *during* the daily demand window (e.g. 19:00, inside a
+15:00-21:00 DW), the DW-entry flag false-positives on slot 0: ``slots.py`` computes
+``is_demand_window_entry = in_demand_window and not prev_in_demand_window`` with
+``prev_in_demand_window`` seeded ``False``, so the very first slot — already inside the DW —
+is wrongly flagged as a demand-window *entry*.
+
+``DPPlanner._find_demand_window_bounds`` takes the FIRST entry, so ``terminal_penalty_idx``
+becomes 0. The hard target penalty then lands on the present instant (nothing earlier to
+charge in) and TOMORROW's real DW entry gets no penalty at all — so the plan exerts zero
+pre-charge pressure, holds all the way, and accepts a large terminal shortfall, relying on an
+external guardrail to reach target.
+
+These tests reproduce that under-charge deterministically and assert the fix: an in-progress
+DW at slot 0 is ignored, the terminal penalty targets tomorrow's real DW entry, and the plan
+reaches target by grid-charging in the cheapest (midday) hours.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, time, timedelta
+
+from custom_components.localshift.engine.core import DPPlanner
+from custom_components.localshift.engine.types import (
+    OptimizerConfig,
+    OptimizerInputs,
+    PlannerAction,
+    SlotContext,
+)
+
+_CHARGE = (PlannerAction.CHARGE_GRID_NORMAL, PlannerAction.CHARGE_GRID_BOOST)
+_INTERVAL = 30
+# Plan computed at 19:00, INSIDE today's 15:00-21:00 demand window.
+_START = datetime(2026, 6, 8, 19, 0)
+_DW_START = time(15, 0)
+_DW_END = time(21, 0)
+
+# Price bands ($/kWh)
+_EVENING_PEAK = 0.30  # today's + tomorrow's DW peak
+_OVERNIGHT = 0.13  # above the base percentile -> not "cheap" outside the urgency window
+_MIDDAY_CHEAP = 0.11  # the cheapest hours, when the sun is up
+_BASE_CHEAP = 0.117
+_EFFECTIVE_CHEAP = 0.15
+
+
+def _price_for(t: datetime) -> float:
+    h = t.hour + t.minute / 60.0
+    in_dw = _DW_START <= t.time() < _DW_END
+    if in_dw:
+        return _EVENING_PEAK
+    if t.day == 9 and 9.0 <= h < 15.0:
+        # Tomorrow daytime: cheapest around midday.
+        return _MIDDAY_CHEAP if 10.5 <= h < 13.5 else 0.125
+    return _OVERNIGHT
+
+
+def _solar_for(t: datetime) -> float:
+    """Modest tomorrow solar that does NOT reach target on its own."""
+    if t.day != 9:
+        return 0.0
+    h = t.hour + t.minute / 60.0
+    if 9.0 <= h < 15.0:
+        return 0.45  # ~0.45 kWh/30min across 6h ~= 5.4 kWh -> well under target
+    return 0.0
+
+
+def _build_slots(n: int, solar_fn=_solar_for) -> list[SlotContext]:
+    """Build slots computing the DW flags exactly as slots.py does (prev seeded False)."""
+    slots: list[SlotContext] = []
+    prev_in_dw = False
+    for i in range(n):
+        t = _START + timedelta(minutes=_INTERVAL * i)
+        in_dw = _DW_START <= t.time() < _DW_END
+        slots.append(
+            SlotContext(
+                slot_index=i,
+                timestamp_iso=t.isoformat(),
+                slot_interval_minutes=_INTERVAL,
+                buy_price=_price_for(t),
+                sell_price=0.05,
+                solar_kwh=solar_fn(t),
+                consumption_kwh=0.3,
+                is_demand_window_entry=(in_dw and not prev_in_dw),
+                is_demand_window_slot=in_dw,
+            )
+        )
+        prev_in_dw = in_dw
+    return slots
+
+
+# 19:00 day-8 -> 16:30 day-9 (43 slots). Tomorrow's real DW entry (15:00) is slot 40.
+_N_SLOTS = 43
+_TOMORROW_DW_ENTRY_IDX = 40
+
+
+def _config() -> OptimizerConfig:
+    return OptimizerConfig(
+        min_soc_pct=10.0,
+        max_soc_pct=100.0,
+        demand_window_target_soc_pct=95.0,
+        allow_dw_entry_under_target=False,
+        optimization_mode="self_consumption",
+        effective_cheap_price=_EFFECTIVE_CHEAP,
+        base_cheap_price=_BASE_CHEAP,
+        target_shortfall_penalty_per_pct=0.08,
+        soc_bins=100,
+    )
+
+
+def _plan():
+    slots = _build_slots(_N_SLOTS)
+    config = _config()
+    return DPPlanner(config).plan(
+        OptimizerInputs(
+            cycle_id="mid-dw-undercharge",
+            initial_soc_pct=70.0,
+            slots=slots,
+            config=config,
+            all_solcast=[],
+        )
+    )
+
+
+class TestMidDwEntryDetection:
+    def test_slot0_in_progress_dw_is_not_the_target_entry(self):
+        """An in-progress DW at slot 0 must not be treated as the terminal-penalty entry."""
+        slots = _build_slots(_N_SLOTS)
+        # Sanity: the scenario really does false-positive slot 0 and have a real entry later.
+        assert slots[0].is_demand_window_slot and slots[0].is_demand_window_entry
+        assert slots[_TOMORROW_DW_ENTRY_IDX].is_demand_window_entry
+
+        bounds = DPPlanner(_config())._find_demand_window_bounds(slots)
+        assert bounds["entry_idx"] == _TOMORROW_DW_ENTRY_IDX, (
+            "demand-window entry must resolve to tomorrow's real 15:00 entry, not the "
+            f"in-progress slot 0; got {bounds['entry_idx']}"
+        )
+
+
+class TestMidDwPlanReachesTarget:
+    def test_plan_reaches_target(self):
+        """With the entry fixed, the optimizer must (nearly) reach the 95% target."""
+        result = _plan()
+        assert result.success
+        assert result.terminal_shortfall_pct < 2.0, (
+            "plan computed inside the demand window must still pre-charge for tomorrow's "
+            f"DW and reach target; got shortfall {result.terminal_shortfall_pct}%"
+        )
+
+    def test_reaches_target_via_cheap_midday_grid_charge(self):
+        """Charging must happen, concentrated in the cheapest (midday) hours."""
+        result = _plan()
+        charges = [d for d in result.decisions if d.action in _CHARGE]
+        assert charges, "expected grid charging to reach target (was all-HOLD)"
+        # Every grid charge should be in a genuinely-cheap slot, never the evening peak.
+        assert all(c.buy_price <= _EFFECTIVE_CHEAP for c in charges), (
+            f"charges must be in cheap slots; got prices {[c.buy_price for c in charges]}"
+        )
+        # The bulk of charging should land in the cheapest midday band (10:30-13:30 tomorrow).
+        midday = [c for c in charges if c.buy_price <= _MIDDAY_CHEAP + 1e-9]
+        assert midday, "expected charging in the cheapest midday band"
+
+
+def _strong_solar(t: datetime) -> float:
+    """Tomorrow solar strong enough to reach target on its own."""
+    if t.day != 9:
+        return 0.0
+    h = t.hour + t.minute / 60.0
+    return 2.0 if 8.0 <= h < 15.0 else 0.0
+
+
+class TestSolarSufficientDayNoOverCharge:
+    """Regression: the fix must not cause grid charging when solar reaches target alone."""
+
+    def _plan_strong_solar(self):
+        slots = _build_slots(_N_SLOTS, solar_fn=_strong_solar)
+        config = _config()
+        return DPPlanner(config).plan(
+            OptimizerInputs(
+                cycle_id="mid-dw-solar-sufficient",
+                initial_soc_pct=70.0,
+                slots=slots,
+                config=config,
+                all_solcast=[],
+            )
+        )
+
+    def test_no_grid_charge_when_solar_reaches_target(self):
+        result = self._plan_strong_solar()
+        assert result.success
+        charges = [d for d in result.decisions if d.action in _CHARGE]
+        assert charges == [], (
+            "solar reaches target on its own — the optimizer must not grid-charge; "
+            f"got charges at {[d.timestamp_iso for d in charges]}"
+        )
+
+    def test_no_overnight_grid_charge(self):
+        """Sawtooth guard intact: no overnight grid charge even with the DW target active."""
+        result = self._plan_strong_solar()
+        overnight = [
+            d
+            for d in result.decisions
+            if d.action in _CHARGE and datetime.fromisoformat(d.timestamp_iso).hour < 8
+        ]
+        assert overnight == [], (
+            f"no overnight grid charging expected; got {[d.timestamp_iso for d in overnight]}"
+        )

--- a/tests/test_optimizer_dp_solve.py
+++ b/tests/test_optimizer_dp_solve.py
@@ -506,9 +506,23 @@ def test_feasible_actions_blocks_grid_charging_in_demand_window(default_config):
 
 def test_terminal_penalty_applied_at_dw_entry_by_default():
     """When switch is off, shortfall is measured at demand window entry."""
+    # Horizon starts BEFORE the demand window so the entry is a genuine transition into
+    # the DW (slot 1), not an in-progress DW at slot 0 (which _find_demand_window_bounds
+    # now correctly ignores — see test_mid_dw_target_undercharge).
     slots = [
         SlotContext(
             slot_index=0,
+            timestamp_iso="2026-01-03T17:30:00",
+            slot_interval_minutes=30,
+            buy_price=0.30,
+            sell_price=0.0,
+            solar_kwh=0.0,
+            consumption_kwh=0.0,
+            is_demand_window_entry=False,
+            is_demand_window_slot=False,
+        ),
+        SlotContext(
+            slot_index=1,
             timestamp_iso="2026-01-03T18:00:00",
             slot_interval_minutes=30,
             buy_price=0.30,
@@ -519,7 +533,7 @@ def test_terminal_penalty_applied_at_dw_entry_by_default():
             is_demand_window_slot=True,
         ),
         SlotContext(
-            slot_index=1,
+            slot_index=2,
             timestamp_iso="2026-01-03T18:30:00",
             slot_interval_minutes=30,
             buy_price=0.30,
@@ -529,7 +543,7 @@ def test_terminal_penalty_applied_at_dw_entry_by_default():
             is_demand_window_slot=True,
         ),
         SlotContext(
-            slot_index=2,
+            slot_index=3,
             timestamp_iso="2026-01-03T19:00:00",
             slot_interval_minutes=30,
             buy_price=0.30,


### PR DESCRIPTION
## Why
On low-solar days the optimizer's plan did **zero grid charging**, rode solar to ~68% SOC, and accepted a **27% shortfall** vs the hard 95% demand-window target — relying entirely on the external 3pm guardrail automation to reach target. User intent: *"It should charge more when the prices are lowest — when the sun is up. It should always reach the target, by charging if necessary (at minimum cost)."*

## Root cause
The plan was computed at ~19:00, **inside** the daily 15:00–21:00 demand window. The DW-entry flag is `is_demand_window_entry = in_demand_window and not prev_in_demand_window` with `prev` seeded `False` (`slots.py`), so **slot 0 false-positives as a DW entry** whenever a plan starts mid-window. `_find_demand_window_bounds` took that first entry → `terminal_penalty_idx = 0`, pinning the hard target penalty on the present instant (nothing earlier to charge in) and leaving tomorrow's real DW entry with **no pre-charge incentive** → all-HOLD.

Fingerprint: `terminal_shortfall = 95 − decisions[0].soc(68%) = 27%`, exactly matching live (`dw_entry_soc=67.97`, `shortfall=27.03`). Corroborated by the morning (outside-DW) plan correctly producing `TARGET_SHORTFALL_RISK` + `charge_grid_boost`.

## Fix
`_find_demand_window_bounds`: when the horizon starts inside a DW, ignore that in-progress block and resolve entry/end to the **next real DW entry**. The hard penalty then lands on tomorrow's 15:00 DW, the urgency window spans the pre-DW hours, and the DP pre-charges in the cheapest (midday) slots to reach target at minimum cost.

**Verified behaviour** (probe): shortfall 27% → **1.5%**; 5 charge slots, all **midday at the cheapest $0.11** (boost through 11:30–13:00) plus a top-off — never overnight, never at peak.

## Tests & fixtures
- New `tests/engine/test_mid_dw_target_undercharge.py`: reproduces the bug (entry_idx=0, 27% shortfall, all-HOLD pre-fix) and asserts the fix (entry → tomorrow, shortfall <2%, charges in cheapest midday band). Plus a **solar-sufficient regression** (no grid charge / no overnight charge when solar reaches target alone).
- `test_terminal_penalty_applied_at_dw_entry_by_default`: start the horizon *before* the DW so the entry is a genuine transition (its old slot-0-in-DW construction was the now-fixed false positive).
- `scenarios/hot-day-spike.json`: `solar_can_reach_target` false→true. That scenario's 24h horizon starts inside the DW with no later DW in range, so the entry is now correctly `None`; the old `false` was an artifact of `terminal_penalty_idx=0`. The behavioural assertion (no grid charge at the $20 peak) is unchanged.

**No production behaviour change from the fixture/test edits:** in production the next daily DW is always within the 24h horizon, so the live evening fix always resolves to tomorrow's DW (the `None` edge only arises in the short-horizon scenario).

Full suite: **3027 passed, 1 xfailed**; ruff + vulture clean. Stacks on the merged #853 (floor guard + taper).