### PR TITLE
fix(optimizer): discount pre-charge gate solar by forecast accuracy

### DIFF
--- a/custom_components/localshift/engine/constraints.py
+++ b/custom_components/localshift/engine/constraints.py
@@ -262,7 +262,17 @@ def check_global_solar_sufficiency(
     simulated_terminal_soc = _simulate_solar_only_terminal_soc(
         soc_pct, remaining_slots, relative_terminal_idx, config
     )
-    return simulated_terminal_soc >= config.demand_window_target_soc_pct
+
+    # Discount the projected solar gain by forecast accuracy so this hard
+    # feasibility gate is no more optimistic than the shortfall cost model
+    # (reason_codes._is_target_shortfall_risk, which applies the same discount).
+    # Without it, a low-accuracy forecast that over-projects pre-DW solar makes the
+    # gate conclude "solar reaches target" and strips grid pre-charge from the
+    # feasible set, causing demand-window undercharge (2026-06-09 incident; #816).
+    # Mirrors the classifier: discount only the positive gain over current SOC.
+    accuracy = max(0.0, min(1.0, config.solar_forecast_accuracy))
+    discounted_gain = max(0.0, simulated_terminal_soc - soc_pct) * accuracy
+    return (soc_pct + discounted_gain) >= config.demand_window_target_soc_pct
 
 
 def is_cheap_import_window(

--- a/custom_components/localshift/engine/core.py
+++ b/custom_components/localshift/engine/core.py
@@ -164,6 +164,15 @@ class DPPlanner:
             slots, terminal_penalty_idx
         )
 
+        # Feed live forecast accuracy into the pre-charge feasibility gate so it
+        # discounts projected solar the same way the shortfall cost model does
+        # (check_global_solar_sufficiency / _is_target_shortfall_risk). Prevents the
+        # gate over-trusting an inaccurate forecast and blocking grid pre-charge
+        # (2026-06-09 demand-window undercharge; recurrence of #816).
+        config.solar_forecast_accuracy = get_forecast_accuracy(
+            inputs.solar_accuracy_tracker
+        )
+
         dp, terminal_penalty_by_bin = self._initialize_dp_tables(
             n_slots, soc_grid, config, terminal_penalty_idx, solar_capable, inputs
         )

--- a/custom_components/localshift/engine/types.py
+++ b/custom_components/localshift/engine/types.py
@@ -176,6 +176,16 @@ class OptimizerConfig:
     stale_solar_confidence_ceiling: float = 0.3
     """Confidence ceiling applied when stale_solar_conservative and data is stale."""
 
+    solar_forecast_accuracy: float = 1.0
+    """Forecast accuracy (0-1) used to discount projected solar in the pre-charge
+    feasibility gate (``check_global_solar_sufficiency``).
+
+    Set per-plan from ``get_forecast_accuracy(inputs.solar_accuracy_tracker)`` so the
+    hard gate is no more optimistic than the shortfall cost model
+    (``reason_codes._is_target_shortfall_risk``), which already discounts projected
+    solar by the same accuracy. Default 1.0 (full trust) preserves legacy behavior
+    for unit tests and standalone use. See the 2026-06-09 DW undercharge / #816."""
+
     # --- Objective weights ---
     target_shortfall_penalty_per_pct: float = 0.030
     """Penalty applied per % SOC below target at demand-window entry ($/%-point).

--- a/tests/engine/test_constraints.py
+++ b/tests/engine/test_constraints.py
@@ -429,6 +429,90 @@ class TestCheckGlobalSolarSufficiency:
         result = check_global_solar_sufficiency(50.0, 0, [], config)
         assert result is False
 
+    def test_low_forecast_accuracy_discounts_solar_gain(self):
+        """Gate must not over-trust forecast solar in a low-accuracy regime.
+
+        Regression for the 2026-06-09 demand-window undercharge (recurrence of
+        #816). The hard feasibility gate simulates solar-only SOC from the *raw*
+        forecast. When forecast accuracy is poor, that raw projection over-states
+        pre-DW solar, the gate concludes "solar will reach target" and strips grid
+        pre-charge from the feasible set, and the battery enters the DW undercharged.
+
+        The shortfall *cost* classifier (reason_codes._is_target_shortfall_risk)
+        already discounts projected solar by forecast accuracy; this gate must be
+        no more optimistic than that classifier.
+        """
+        from custom_components.localshift.engine.constraints import (
+            check_global_solar_sufficiency,
+        )
+
+        # Raw solar comfortably reaches target: from 50% SOC, two rate-limited
+        # slots add ~2.3 kWh each (23%/slot on a 10 kWh battery) -> ~96% raw.
+        slots = [
+            SlotContext(
+                slot_index=i,
+                slot_interval_minutes=30,
+                timestamp_iso="2024-01-01T00:00:00+00:00",
+                buy_price=30.0,
+                sell_price=10.0,
+                solar_kwh=5.0,
+                consumption_kwh=0.0,
+                is_demand_window_slot=False,
+            )
+            for i in range(2)
+        ]
+
+        # Full trust (accuracy=1.0): raw projection reaches target -> covered.
+        config_trusted = OptimizerConfig(
+            battery_capacity_kwh=10.0,
+            demand_window_target_soc_pct=80.0,
+            solar_charge_rate_kw=5.0,
+            charge_efficiency=0.92,
+            solar_forecast_accuracy=1.0,
+        )
+        assert check_global_solar_sufficiency(50.0, 0, slots, config_trusted) is True
+
+        # Low accuracy (0.2): discounted gain ~ (96-50)*0.2 = ~9% -> ~59% < 80%,
+        # so solar does NOT cover and grid pre-charge stays feasible.
+        config_unreliable = OptimizerConfig(
+            battery_capacity_kwh=10.0,
+            demand_window_target_soc_pct=80.0,
+            solar_charge_rate_kw=5.0,
+            charge_efficiency=0.92,
+            solar_forecast_accuracy=0.2,
+        )
+        assert (
+            check_global_solar_sufficiency(50.0, 0, slots, config_unreliable) is False
+        )
+
+    def test_default_forecast_accuracy_preserves_behavior(self):
+        """A config with no accuracy set (default 1.0) keeps the legacy gate result."""
+        from custom_components.localshift.engine.constraints import (
+            check_global_solar_sufficiency,
+        )
+
+        config = OptimizerConfig(
+            battery_capacity_kwh=10.0,
+            demand_window_target_soc_pct=80.0,
+            solar_charge_rate_kw=5.0,
+            charge_efficiency=0.92,
+        )
+        slots = [
+            SlotContext(
+                slot_index=i,
+                slot_interval_minutes=30,
+                timestamp_iso="2024-01-01T00:00:00+00:00",
+                buy_price=30.0,
+                sell_price=10.0,
+                solar_kwh=5.0,
+                consumption_kwh=0.0,
+                is_demand_window_slot=False,
+            )
+            for i in range(2)
+        ]
+        assert config.solar_forecast_accuracy == 1.0
+        assert check_global_solar_sufficiency(50.0, 0, slots, config) is True
+
     def test_rate_limited_solar_returns_false(self):
         """Returns False when charge rate limit prevents capturing all solar.
 


### PR DESCRIPTION
## Problem

The pre-charge feasibility gate `check_global_solar_sufficiency()` simulates solar-only SOC from the **raw** forecast. If that projection reaches the demand-window target, it strips **all** grid-charge actions from the feasible set (`constraints.py:149-153`) — before the DP ever prices them.

The shortfall cost model (`reason_codes._is_target_shortfall_risk`) **already** discounts projected solar by forecast accuracy. So in a low-accuracy regime the hard gate was strictly *more optimistic* than the cost model: it blocked grid pre-charge on a forecast the cost model itself didn't trust, and the battery entered the demand window undercharged.

**Observed 2026-06-09** (solar forecast accuracy 13.3%): plan reached only **58%** vs the **95%** target at DW entry. Recurrence of #816.

## Fix

- Add `OptimizerConfig.solar_forecast_accuracy` (default `1.0`).
- Set it per-plan in `core._solve` from `get_forecast_accuracy(inputs.solar_accuracy_tracker)`.
- `check_global_solar_sufficiency` discounts the simulated solar-only gain by it, mirroring the classifier (discount only the positive gain over current SOC).

The gate only ever *removes a false block* — the DP cost model (terminal penalty + import cost) still governs whether to actually charge, so this cannot force compulsive charging. Symmetric with the #849 stale-solar confidence ceiling.

## Tests

- Failing-first regression in `TestCheckGlobalSolarSufficiency` (gate returned `True` at 0.2 accuracy pre-fix).
- Backward-compat test (default accuracy → legacy result).
- Full engine + DP suite: **675 passed**, including adjacent `test_sawtooth_gate`, `test_stale_solar_precharge_gate`, `test_mid_dw_target_undercharge`. Ruff lint + format clean.
