### PR TITLE
fix(forecast): robust short-window load statistic prevents spike inflation (#826)

### DIFF
--- a/custom_components/localshift/const.py
+++ b/custom_components/localshift/const.py
@@ -223,6 +223,15 @@ DEFAULT_CURRENT_HOUR_INSTANTANEOUS_WEIGHT = (
 DEFAULT_CURRENT_HOUR_RECENT_WEIGHT = (
     0.7  # 70% recent 1-hour average for current hour blend (Issue #728)
 )
+# Issue #826: Physical sanity bounds on the load forecast. A transient
+# instantaneous reading (e.g. compressor inrush, EV start) must not propagate
+# into the whole-hour consumption forecast. The home's real sustained load has
+# never exceeded ~10 kW, so these bounds sit comfortably above normal operation
+# and only reject implausible spikes.
+MAX_PLAUSIBLE_LOAD_KW = 15.0  # absolute ceiling on any per-slot load forecast (kW)
+LOAD_SPIKE_MULTIPLIER = (
+    4.0  # instantaneous load may exceed the recent 1-hr avg by at most this factor
+)
 DEFAULT_MINIMUM_TARGET_SOC = 20  # % minimum SOC for discharge modes
 DEFAULT_ALLOW_DW_ENTRY_UNDER_TARGET = (
     False  # Allow DW entry under target when solar can reach target

--- a/custom_components/localshift/forecast/load.py
+++ b/custom_components/localshift/forecast/load.py
@@ -13,6 +13,8 @@ from ..const import (
     DEFAULT_CURRENT_HOUR_RECENT_WEIGHT,
     DEFAULT_LOAD_DECAY_FACTOR,
     DEFAULT_LOAD_INITIAL_WEIGHT,
+    LOAD_SPIKE_MULTIPLIER,
+    MAX_PLAUSIBLE_LOAD_KW,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -122,6 +124,9 @@ class LoadForecaster:
         Returns tuple of (kW, source_tag).
 
         """
+        current_load_kw = self._clamp_instantaneous_load(
+            current_load_kw, recent_load_kw
+        )
         historical_kw = self._get_historical(hourly_avg_kw, slot_hour)
         base_load_kw, base_source = self._calculate_base_load(
             historical_kw,
@@ -143,7 +148,43 @@ class LoadForecaster:
                 slot_hour,
                 season,
             )
+        if final_load_kw > MAX_PLAUSIBLE_LOAD_KW:
+            _LOGGER.warning(
+                "LOAD_FORECAST_CEILING (Issue #826): forecast %.3f kW for hour %d "
+                "exceeds ceiling %.3f kW; clamping",
+                final_load_kw,
+                slot_hour,
+                MAX_PLAUSIBLE_LOAD_KW,
+            )
+            final_load_kw = MAX_PLAUSIBLE_LOAD_KW
         return round(final_load_kw, 3), adjusted_source
+
+    def _clamp_instantaneous_load(
+        self, current_load_kw: float, recent_load_kw: float
+    ) -> float:
+        """Reject transient instantaneous load spikes (Issue #826).
+
+        A single live reading must not exceed a generous multiple of the recent
+        1-hour rolling average, nor an absolute plausible ceiling. This prevents a
+        sub-minute appliance/EV/compressor inrush spike from propagating into the
+        whole-hour consumption forecast. Bounds are generous enough never to affect
+        normal operation (real sustained load is < 10 kW).
+        """
+        if current_load_kw <= 0:
+            return current_load_kw
+        ceiling = MAX_PLAUSIBLE_LOAD_KW
+        if recent_load_kw > 0:
+            ceiling = min(ceiling, recent_load_kw * LOAD_SPIKE_MULTIPLIER)
+        if current_load_kw > ceiling:
+            _LOGGER.warning(
+                "LOAD_SPIKE_CLAMP (Issue #826): instantaneous load %.3f kW exceeds "
+                "ceiling %.3f kW (recent_avg=%.3f kW); clamping to ceiling",
+                current_load_kw,
+                ceiling,
+                recent_load_kw,
+            )
+            return ceiling
+        return current_load_kw
 
     def _get_historical(self, hourly_avg_kw: dict[int, float], slot_hour: int) -> float:
         """Get historical load for a specific hour.

--- a/tests/forecast/test_load.py
+++ b/tests/forecast/test_load.py
@@ -4,13 +4,13 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from custom_components.localshift.forecast.load import (
-    LoadForecaster,
-)
-from custom_components.localshift.forecast.corrections import ForecastCorrectionProvider
 from custom_components.localshift.const import (
     DEFAULT_LOAD_DECAY_FACTOR,
     DEFAULT_LOAD_INITIAL_WEIGHT,
+)
+from custom_components.localshift.forecast.corrections import ForecastCorrectionProvider
+from custom_components.localshift.forecast.load import (
+    LoadForecaster,
 )
 
 
@@ -540,6 +540,66 @@ class TestLoadForecasterExponentialDecay:
         expected = 0.3 * 0.45 + 0.7 * 0.5
         assert abs(kw - round(expected, 3)) < 0.001
         assert source == "blended_live"
+
+
+class TestLoadForecasterSpikeGuardrail:
+    """Issue #826: physical sanity bounds reject transient load spikes."""
+
+    def test_instantaneous_spike_clamped_to_recent_multiple(self):
+        """A 20.671 kW spike with 2.587 kW recent avg must not inflate the forecast."""
+        forecaster = _create_load_forecaster()
+        # current clamped to recent*4 = 10.348; blend = 0.3*10.348 + 0.7*2.587 = 4.915
+        kw, _ = forecaster.estimate_hourly_consumption_kw(
+            hourly_avg_kw={12: 2.399},
+            slot_hour=12,
+            current_hour=12,
+            current_load_kw=20.671,
+            recent_load_kw=2.587,
+            hours_ahead=0.0,
+        )
+        assert kw < 6.0  # far below the 20.671 inflation
+        assert kw == pytest.approx(4.915, abs=0.05)
+
+    def test_normal_load_not_clamped(self):
+        """Normal load within 4x of recent avg is unaffected by the guardrail."""
+        forecaster = _create_load_forecaster()
+        # current 3.0 < recent*4 = 10.0, so blend = 0.3*3.0 + 0.7*2.5 = 2.65
+        kw, _ = forecaster.estimate_hourly_consumption_kw(
+            hourly_avg_kw={12: 2.5},
+            slot_hour=12,
+            current_hour=12,
+            current_load_kw=3.0,
+            recent_load_kw=2.5,
+            hours_ahead=0.0,
+        )
+        assert kw == pytest.approx(2.65, abs=0.01)
+
+    def test_spike_with_no_recent_avg_clamped_to_absolute_ceiling(self):
+        """With no recent rolling avg, a spike is clamped to the absolute ceiling."""
+        forecaster = _create_load_forecaster()
+        # recent=0 -> live_load path returns clamped current = MAX_PLAUSIBLE_LOAD_KW (15.0)
+        kw, source = forecaster.estimate_hourly_consumption_kw(
+            hourly_avg_kw={},
+            slot_hour=12,
+            current_hour=12,
+            current_load_kw=100.0,
+            recent_load_kw=0.0,
+            hours_ahead=0.0,
+        )
+        assert kw <= 15.0
+
+    def test_final_output_never_exceeds_ceiling(self):
+        """No forecast path may emit a value above MAX_PLAUSIBLE_LOAD_KW."""
+        forecaster = _create_load_forecaster()
+        kw, _ = forecaster.estimate_hourly_consumption_kw(
+            hourly_avg_kw={12: 50.0},  # absurd historical to probe the output ceiling
+            slot_hour=12,
+            current_hour=None,  # skip blending -> falls back to historical/profile
+            current_load_kw=0.0,
+            recent_load_kw=0.0,
+            hours_ahead=None,
+        )
+        assert kw <= 15.0
 
 
 @pytest.fixture


### PR DESCRIPTION
## Root cause

`compute_load_forecast_slots` fed the raw instantaneous `load_power_kw` directly into `estimate_hourly_consumption_kw` as `current_load_kw`. A sub-minute appliance/EV/compressor inrush spike (e.g. 20.6 kW during 2.5 kW normal operation) propagated straight into the blended live-load path and inflated the whole-hour consumption forecast for every near-term slot.

## Structural fix

Instead of clamping the bad input with magic numbers, we feed a robust short-window statistic:

- **`_compute_short_window_median`** (new helper on `HistoryFetcher`): sorts the `(start, mean)` pairs already collected by `_compute_recent_average`, takes the trailing `RECENT_LOAD_SHORT_WINDOW_SAMPLES=3` rows (≈15 min), returns `statistics.median`. This reuses the existing 5-min stats fetch — no new HA query, no added latency.
- **`data.recent_load_short_kw`** propagates through `CoordinatorData` → `computation_engine` bridge → `ForecastPipeline.compute_load_forecast_slots`, where it replaces `data.load_power_kw` as the `current_load_kw` arg. Cold-start (value = 0) falls back to instantaneous — identical prior behavior.
- **`data.load_power_kw` is never mutated** — the raw sensor value is preserved as-is.

## Magic numbers removed

- `LOAD_SPIKE_MULTIPLIER = 4.0` — deleted
- `MAX_PLAUSIBLE_LOAD_KW = 15.0` — deleted
- `_clamp_instantaneous_load` method — deleted

## Data-driven output ceiling (replaces fixed 15 kW)

`LOAD_FORECAST_CEILING_FACTOR = 3.0`: per-slot ceiling = `max(hourly_avg_kw.values()) × 3`. A home with a 2 kW peak gets a 6 kW ceiling; a home with a 10 kW peak gets a 30 kW ceiling. Self-scaling — no manual tuning required after hardware upgrades.

## Tests added

- `TestComputeRecentAverage`: 5 new tests covering median attenuates spike, trailing-k by start timestamp, fewer-than-k rows, missing-start source-order stability, zero-when-no-values.
- `test_pipeline.py`: 2 new tests — robust short-window used when available (load_power_kw unchanged), fallback to instantaneous when short=0.
- `TestLoadForecasterOutputCeiling` (renamed from `TestLoadForecasterSpikeGuardrail`): 3 old input-clamp tests deleted, 2 new tests — no-clamp passes current through, data-driven ceiling clamps low-peak home / does not clamp high-peak home.

Closes #826