### PR TITLE
fix(forecast): robust short-window load statistic replaces spike clamp (#826)

### DIFF
--- a/custom_components/localshift/computation_engine.py
+++ b/custom_components/localshift/computation_engine.py
@@ -356,6 +356,7 @@ class ComputationEngine:
 
         # Bridge recent load data
         data.recent_load_1hr_kw = self._history_fetcher._recent_load_1hr_kw
+        data.recent_load_short_kw = self._history_fetcher._recent_load_short_kw
         data.recent_load_1hr_statistic_id = (
             self._history_fetcher._recent_load_1hr_statistic_id
         )
@@ -688,6 +689,11 @@ class ComputationEngine:
     def _recent_load_1hr_kw(self) -> float:
         """Get recent 1hr load from history fetcher."""
         return self._history_fetcher._recent_load_1hr_kw
+
+    @property
+    def _recent_load_short_kw(self) -> float:
+        """Get recent short-window load from history fetcher."""
+        return self._history_fetcher._recent_load_short_kw
 
     @property
     def _recent_load_1hr_statistic_id(self) -> str:

--- a/custom_components/localshift/const.py
+++ b/custom_components/localshift/const.py
@@ -223,15 +223,8 @@ DEFAULT_CURRENT_HOUR_INSTANTANEOUS_WEIGHT = (
 DEFAULT_CURRENT_HOUR_RECENT_WEIGHT = (
     0.7  # 70% recent 1-hour average for current hour blend (Issue #728)
 )
-# Issue #826: Physical sanity bounds on the load forecast. A transient
-# instantaneous reading (e.g. compressor inrush, EV start) must not propagate
-# into the whole-hour consumption forecast. The home's real sustained load has
-# never exceeded ~10 kW, so these bounds sit comfortably above normal operation
-# and only reject implausible spikes.
-MAX_PLAUSIBLE_LOAD_KW = 15.0  # absolute ceiling on any per-slot load forecast (kW)
-LOAD_SPIKE_MULTIPLIER = (
-    4.0  # instantaneous load may exceed the recent 1-hr avg by at most this factor
-)
+RECENT_LOAD_SHORT_WINDOW_SAMPLES = 3  # trailing 5-min stat means for the robust short-window median (~15 min) (Issue #826)
+LOAD_FORECAST_CEILING_FACTOR = 3.0  # per-slot forecast may not exceed this multiple of the home's historical peak hourly average (Issue #826)
 DEFAULT_MINIMUM_TARGET_SOC = 20  # % minimum SOC for discharge modes
 DEFAULT_ALLOW_DW_ENTRY_UNDER_TARGET = (
     False  # Allow DW entry under target when solar can reach target

--- a/custom_components/localshift/coordinator/data.py
+++ b/custom_components/localshift/coordinator/data.py
@@ -269,6 +269,7 @@ class CoordinatorData:
     weekend_hourly_profile_kw: dict[int, float] = field(default_factory=dict)
     forecast_consumption_source_counts: dict[str, int] = field(default_factory=dict)
     recent_load_1hr_kw: float = 0.0
+    recent_load_short_kw: float = 0.0
     recent_load_1hr_statistic_id: str = ""
     recent_load_1hr_samples: int = 0
     recent_load_1hr_last_error: str = ""

--- a/custom_components/localshift/forecast/history.py
+++ b/custom_components/localshift/forecast/history.py
@@ -15,6 +15,7 @@ New in this patch (Issue #151):
 from __future__ import annotations
 
 import logging
+import statistics
 from datetime import UTC, datetime, timedelta
 from typing import Any, cast
 
@@ -78,7 +79,11 @@ except Exception:  # pragma: no cover
 
     dt_util = _DTUtilStub()  # pragma: no cover
 
-from ..const import HISTORY_WINDOW_DAYS, MIN_SAMPLES_PER_HOUR
+from ..const import (
+    HISTORY_WINDOW_DAYS,
+    MIN_SAMPLES_PER_HOUR,
+    RECENT_LOAD_SHORT_WINDOW_SAMPLES,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -122,6 +127,7 @@ class HistoryFetcher:
 
         # Recent load cache (1-hour average)
         self._recent_load_1hr_kw: float = 0.0
+        self._recent_load_short_kw: float = 0.0
         self._recent_load_cache_time: datetime | None = None
         self._recent_load_1hr_statistic_id: str = ""
         self._recent_load_1hr_samples: int = 0
@@ -674,6 +680,9 @@ class HistoryFetcher:
                 self._fetch_recent_load_sync, entity_id, now
             )
             self._recent_load_1hr_kw = float(result.get("recent_avg_kw", 0.0) or 0.0)
+            self._recent_load_short_kw = float(
+                result.get("recent_load_short_kw", 0.0) or 0.0
+            )
             self._recent_load_1hr_statistic_id = str(result.get("statistic_id", ""))
             self._recent_load_1hr_samples = int(result.get("samples", 0) or 0)
             self._recent_load_1hr_last_error = str(result.get("error", ""))
@@ -682,6 +691,7 @@ class HistoryFetcher:
         except Exception as e:
             _LOGGER.warning("Failed to fetch recent load: %s", e)
             self._recent_load_1hr_kw = 0.0
+            self._recent_load_short_kw = 0.0
             self._recent_load_1hr_statistic_id = ""
             self._recent_load_1hr_samples = 0
             self._recent_load_1hr_last_error = str(e)
@@ -837,6 +847,7 @@ class HistoryFetcher:
         """
         rows = data.get("rows", [])
         values: list[float] = []
+        pairs: list[tuple[Any, float]] = []
 
         for row in rows:
             if not isinstance(row, dict):
@@ -845,19 +856,39 @@ class HistoryFetcher:
             if mean_val in (None, "unknown", "unavailable"):
                 continue
             try:
-                values.append(float(mean_val))
+                fval = float(mean_val)
             except (TypeError, ValueError):
                 continue
+            values.append(fval)
+            pairs.append((row.get("start"), fval))
 
         if not values:
             return self._error_result("no numeric mean values", resolved_entity_id)
 
+        recent_avg = sum(values) / len(values)
+        short_kw = self._compute_short_window_median(
+            pairs, RECENT_LOAD_SHORT_WINDOW_SAMPLES
+        )
+
         return {
-            "recent_avg_kw": sum(values) / len(values),
+            "recent_avg_kw": recent_avg,
+            "recent_load_short_kw": short_kw,
             "samples": len(values),
             "statistic_id": resolved_entity_id,
             "error": "",
         }
+
+    def _compute_short_window_median(
+        self, pairs: list[tuple[Any, float]], k: int
+    ) -> float:
+        """Return the median of the k most-recent 5-min stat means (by start timestamp).
+
+        Rows without a start key are treated as oldest so they sort to the end only
+        among their own bucket; rows with real starts always rank ahead of them.
+        """
+        pairs_sorted = sorted(pairs, key=lambda p: (p[0] is None, p[0]))
+        window = [m for _, m in pairs_sorted[-k:]]
+        return statistics.median(window) if window else 0.0
 
     def _error_result(self, error: str, statistic_id: str = "") -> dict[str, Any]:
         """Create standardized error result.
@@ -872,6 +903,7 @@ class HistoryFetcher:
         """
         return {
             "recent_avg_kw": 0.0,
+            "recent_load_short_kw": 0.0,
             "samples": 0,
             "statistic_id": statistic_id,
             "error": error,

--- a/custom_components/localshift/forecast/load.py
+++ b/custom_components/localshift/forecast/load.py
@@ -13,8 +13,7 @@ from ..const import (
     DEFAULT_CURRENT_HOUR_RECENT_WEIGHT,
     DEFAULT_LOAD_DECAY_FACTOR,
     DEFAULT_LOAD_INITIAL_WEIGHT,
-    LOAD_SPIKE_MULTIPLIER,
-    MAX_PLAUSIBLE_LOAD_KW,
+    LOAD_FORECAST_CEILING_FACTOR,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -124,9 +123,6 @@ class LoadForecaster:
         Returns tuple of (kW, source_tag).
 
         """
-        current_load_kw = self._clamp_instantaneous_load(
-            current_load_kw, recent_load_kw
-        )
         historical_kw = self._get_historical(hourly_avg_kw, slot_hour)
         base_load_kw, base_source = self._calculate_base_load(
             historical_kw,
@@ -148,43 +144,18 @@ class LoadForecaster:
                 slot_hour,
                 season,
             )
-        if final_load_kw > MAX_PLAUSIBLE_LOAD_KW:
-            _LOGGER.warning(
-                "LOAD_FORECAST_CEILING (Issue #826): forecast %.3f kW for hour %d "
-                "exceeds ceiling %.3f kW; clamping",
-                final_load_kw,
-                slot_hour,
-                MAX_PLAUSIBLE_LOAD_KW,
-            )
-            final_load_kw = MAX_PLAUSIBLE_LOAD_KW
+        if hourly_avg_kw:
+            ceiling = max(hourly_avg_kw.values()) * LOAD_FORECAST_CEILING_FACTOR
+            if ceiling > 0 and final_load_kw > ceiling:
+                _LOGGER.warning(
+                    "LOAD_FORECAST_CEILING (Issue #826): forecast %.3f kW for hour %d "
+                    "exceeds data-driven ceiling %.3f kW; clamping",
+                    final_load_kw,
+                    slot_hour,
+                    ceiling,
+                )
+                final_load_kw = ceiling
         return round(final_load_kw, 3), adjusted_source
-
-    def _clamp_instantaneous_load(
-        self, current_load_kw: float, recent_load_kw: float
-    ) -> float:
-        """Reject transient instantaneous load spikes (Issue #826).
-
-        A single live reading must not exceed a generous multiple of the recent
-        1-hour rolling average, nor an absolute plausible ceiling. This prevents a
-        sub-minute appliance/EV/compressor inrush spike from propagating into the
-        whole-hour consumption forecast. Bounds are generous enough never to affect
-        normal operation (real sustained load is < 10 kW).
-        """
-        if current_load_kw <= 0:
-            return current_load_kw
-        ceiling = MAX_PLAUSIBLE_LOAD_KW
-        if recent_load_kw > 0:
-            ceiling = min(ceiling, recent_load_kw * LOAD_SPIKE_MULTIPLIER)
-        if current_load_kw > ceiling:
-            _LOGGER.warning(
-                "LOAD_SPIKE_CLAMP (Issue #826): instantaneous load %.3f kW exceeds "
-                "ceiling %.3f kW (recent_avg=%.3f kW); clamping to ceiling",
-                current_load_kw,
-                ceiling,
-                recent_load_kw,
-            )
-            return ceiling
-        return current_load_kw
 
     def _get_historical(self, hourly_avg_kw: dict[int, float], slot_hour: int) -> float:
         """Get historical load for a specific hour.

--- a/custom_components/localshift/forecast/pipeline.py
+++ b/custom_components/localshift/forecast/pipeline.py
@@ -52,6 +52,12 @@ class ForecastPipeline:
 
         self._load_forecaster.reset_weather_adjustment_applied()
 
+        robust_current_kw = (
+            data.recent_load_short_kw
+            if data.recent_load_short_kw > 0
+            else data.load_power_kw
+        )
+
         slots: list[float] = []
         for i in range(total_slots):
             slot_start = base_slot + timedelta(minutes=15 * i)
@@ -64,7 +70,7 @@ class ForecastPipeline:
                 hourly_avg_kw=historical_avg_kw,
                 slot_hour=slot_hour,
                 current_hour=current_hour,
-                current_load_kw=data.load_power_kw,
+                current_load_kw=robust_current_kw,
                 recent_load_kw=recent_load_kw,
                 temperature=temperature,
                 hours_ahead=hours_ahead,
@@ -78,11 +84,12 @@ class ForecastPipeline:
             self._load_forecaster.get_weather_adjustment_applied()
         )
         _LOGGER.info(
-            "ISSUE_500 load_forecast_slots: %d slots, indices 4-8 = %s, recent_load=%.3f, hourly_avg_12=%.3f",
+            "ISSUE_500 load_forecast_slots: %d slots, indices 4-8 = %s, recent_load=%.3f, hourly_avg_12=%.3f, robust_current=%.3f",
             len(slots),
             [round(slots[i], 3) for i in range(4, min(9, len(slots)))],
             recent_load_kw,
             historical_avg_kw.get(12, -1),
+            robust_current_kw,
         )
 
     def compute_solar_battery_forecast(

--- a/tests/forecast/test_history.py
+++ b/tests/forecast/test_history.py
@@ -740,6 +740,66 @@ class TestComputeRecentAverage:
 
         assert "error" in result
 
+    def test_short_window_median_attenuates_spike(self, history_fetcher):
+        """Spike in the most-recent row inflates 1hr avg but median stays at middle value."""
+        data = {
+            "rows": [
+                {"start": 100, "mean": 2.4},
+                {"start": 200, "mean": 2.6},
+                {"start": 300, "mean": 20.6},
+            ]
+        }
+        result = history_fetcher._compute_recent_average(data, "sensor.test")
+        assert result["recent_load_short_kw"] == pytest.approx(2.6)
+        assert result["recent_avg_kw"] == pytest.approx((2.4 + 2.6 + 20.6) / 3)
+
+    def test_short_window_takes_trailing_k_by_start(self, history_fetcher):
+        """With 5 out-of-order rows, median is taken from the 3 largest-start rows."""
+        data = {
+            "rows": [
+                {"start": 500, "mean": 5.0},
+                {"start": 100, "mean": 1.0},
+                {"start": 400, "mean": 4.0},
+                {"start": 300, "mean": 3.0},
+                {"start": 200, "mean": 2.0},
+            ]
+        }
+        result = history_fetcher._compute_recent_average(data, "sensor.test")
+        # trailing 3 by start: 300->3.0, 400->4.0, 500->5.0; median=4.0
+        assert result["recent_load_short_kw"] == pytest.approx(4.0)
+
+    def test_short_window_fewer_than_k_rows(self, history_fetcher):
+        """With only 2 rows, median of those 2 rows is returned."""
+        data = {
+            "rows": [
+                {"start": 100, "mean": 2.0},
+                {"start": 200, "mean": 4.0},
+            ]
+        }
+        result = history_fetcher._compute_recent_average(data, "sensor.test")
+        assert result["recent_load_short_kw"] == pytest.approx(3.0)
+
+    def test_short_window_missing_start_uses_source_order(self, history_fetcher):
+        """Rows without a start key sort to the end; median uses last 3 in source order."""
+        data = {
+            "rows": [
+                {"mean": 1.0},
+                {"mean": 2.0},
+                {"mean": 3.0},
+                {"mean": 4.0},
+                {"mean": 5.0},
+            ]
+        }
+        result = history_fetcher._compute_recent_average(data, "sensor.test")
+        # All no-start rows; stable sort → source order preserved; last 3: 3.0, 4.0, 5.0
+        assert result["recent_load_short_kw"] == pytest.approx(4.0)
+
+    def test_short_window_zero_when_no_values(self, history_fetcher):
+        """When no numeric values exist the short-window key is 0.0 (from error result)."""
+        data = {"rows": [{"mean": None}]}
+        result = history_fetcher._compute_recent_average(data, "sensor.test")
+        assert result.get("recent_load_short_kw") == 0.0
+
 
 class TestFetchStatisticsDataEdgeCases:
     """Tests for _fetch_statistics_data edge cases."""

--- a/tests/forecast/test_load.py
+++ b/tests/forecast/test_load.py
@@ -542,28 +542,12 @@ class TestLoadForecasterExponentialDecay:
         assert source == "blended_live"
 
 
-class TestLoadForecasterSpikeGuardrail:
-    """Issue #826: physical sanity bounds reject transient load spikes."""
+class TestLoadForecasterOutputCeiling:
+    """Issue #826: data-driven output ceiling and no input clamp."""
 
-    def test_instantaneous_spike_clamped_to_recent_multiple(self):
-        """A 20.671 kW spike with 2.587 kW recent avg must not inflate the forecast."""
+    def test_no_input_clamp_passes_current_through(self):
+        """Without the clamp, current_load_kw is passed directly; blend = 0.3*3.0 + 0.7*2.5 = 2.65."""
         forecaster = _create_load_forecaster()
-        # current clamped to recent*4 = 10.348; blend = 0.3*10.348 + 0.7*2.587 = 4.915
-        kw, _ = forecaster.estimate_hourly_consumption_kw(
-            hourly_avg_kw={12: 2.399},
-            slot_hour=12,
-            current_hour=12,
-            current_load_kw=20.671,
-            recent_load_kw=2.587,
-            hours_ahead=0.0,
-        )
-        assert kw < 6.0  # far below the 20.671 inflation
-        assert kw == pytest.approx(4.915, abs=0.05)
-
-    def test_normal_load_not_clamped(self):
-        """Normal load within 4x of recent avg is unaffected by the guardrail."""
-        forecaster = _create_load_forecaster()
-        # current 3.0 < recent*4 = 10.0, so blend = 0.3*3.0 + 0.7*2.5 = 2.65
         kw, _ = forecaster.estimate_hourly_consumption_kw(
             hourly_avg_kw={12: 2.5},
             slot_hour=12,
@@ -572,34 +556,34 @@ class TestLoadForecasterSpikeGuardrail:
             recent_load_kw=2.5,
             hours_ahead=0.0,
         )
+        # No clamp; data-driven ceiling = 2.5*3=7.5 > 2.65 so no ceiling hit either
         assert kw == pytest.approx(2.65, abs=0.01)
 
-    def test_spike_with_no_recent_avg_clamped_to_absolute_ceiling(self):
-        """With no recent rolling avg, a spike is clamped to the absolute ceiling."""
+    def test_output_ceiling_is_data_driven(self):
+        """Per-slot ceiling = max(hourly_avg_kw)*3; low-peak home clamps, high-peak home does not."""
         forecaster = _create_load_forecaster()
-        # recent=0 -> live_load path returns clamped current = MAX_PLAUSIBLE_LOAD_KW (15.0)
-        kw, source = forecaster.estimate_hourly_consumption_kw(
-            hourly_avg_kw={},
+
+        # Case 1: peak avg = 2.0 kW, ceiling = 6.0 kW; live-load path returns 50.0 → clamped
+        kw, _ = forecaster.estimate_hourly_consumption_kw(
+            hourly_avg_kw={12: 2.0},
             slot_hour=12,
             current_hour=12,
-            current_load_kw=100.0,
+            current_load_kw=50.0,
             recent_load_kw=0.0,
             hours_ahead=0.0,
         )
-        assert kw <= 15.0
+        assert kw == pytest.approx(6.0)
 
-    def test_final_output_never_exceeds_ceiling(self):
-        """No forecast path may emit a value above MAX_PLAUSIBLE_LOAD_KW."""
-        forecaster = _create_load_forecaster()
-        kw, _ = forecaster.estimate_hourly_consumption_kw(
-            hourly_avg_kw={12: 50.0},  # absurd historical to probe the output ceiling
+        # Case 2: peak avg = 10.0 kW, ceiling = 30.0 kW; 20.0 kW is below ceiling, not clamped
+        kw2, _ = forecaster.estimate_hourly_consumption_kw(
+            hourly_avg_kw={12: 10.0},
             slot_hour=12,
-            current_hour=None,  # skip blending -> falls back to historical/profile
-            current_load_kw=0.0,
+            current_hour=12,
+            current_load_kw=20.0,
             recent_load_kw=0.0,
-            hours_ahead=None,
+            hours_ahead=0.0,
         )
-        assert kw <= 15.0
+        assert kw2 == pytest.approx(20.0)
 
 
 @pytest.fixture

--- a/tests/forecast/test_pipeline.py
+++ b/tests/forecast/test_pipeline.py
@@ -415,3 +415,60 @@ def test_get_dp_decision_when_target_hour_already_passed():
         decision = pipeline._get_dp_decision_at_demand_window(data, target_hour=18)
 
     assert decision is not None
+
+
+def test_uses_robust_short_window_when_available():
+    """When recent_load_short_kw > 0, pipeline feeds it as current_load_kw; load_power_kw is unchanged."""
+    data = CoordinatorData()
+    data.weather_temperature_forecast = {}
+    data.load_power_kw = 20.671
+    data.recent_load_short_kw = 2.6
+
+    load_forecaster = _StubLoadForecaster(1.0)
+    pipeline = ForecastPipeline(
+        load_forecaster=load_forecaster,
+        price_signals=_StubPriceSignals(),
+        forecast_history_store=_StubForecastHistoryStore(),
+        get_switch_state=lambda _key: False,
+        excess_solar_signals=MagicMock(),
+    )
+
+    now_dt = datetime(2026, 6, 1, 10, 0, 0, tzinfo=UTC)
+    pipeline.compute_load_forecast_slots(
+        data=data,
+        now_dt=now_dt,
+        historical_avg_kw={10: 2.5},
+        recent_load_kw=2.5,
+        total_slots=4,
+    )
+
+    assert all(call["current_load_kw"] == 2.6 for call in load_forecaster.calls)
+    assert data.load_power_kw == 20.671
+
+
+def test_falls_back_to_instantaneous_when_short_zero():
+    """When recent_load_short_kw is 0.0, pipeline falls back to load_power_kw."""
+    data = CoordinatorData()
+    data.weather_temperature_forecast = {}
+    data.load_power_kw = 1.4
+    data.recent_load_short_kw = 0.0
+
+    load_forecaster = _StubLoadForecaster(1.0)
+    pipeline = ForecastPipeline(
+        load_forecaster=load_forecaster,
+        price_signals=_StubPriceSignals(),
+        forecast_history_store=_StubForecastHistoryStore(),
+        get_switch_state=lambda _key: False,
+        excess_solar_signals=MagicMock(),
+    )
+
+    now_dt = datetime(2026, 6, 1, 10, 0, 0, tzinfo=UTC)
+    pipeline.compute_load_forecast_slots(
+        data=data,
+        now_dt=now_dt,
+        historical_avg_kw={10: 1.4},
+        recent_load_kw=1.4,
+        total_slots=4,
+    )
+
+    assert all(call["current_load_kw"] == 1.4 for call in load_forecaster.calls)


### PR DESCRIPTION
## Follow-up to #857 — pivots the #826 fix from a magic-number clamp to a structural fix

PR #857 (merged) guarded against the load-forecast spike inflation in #826 with an **input clamp** using magic constants (`MAX_PLAUSIBLE_LOAD_KW=15`, `LOAD_SPIKE_MULTIPLIER=4`). That clamp was clunky and **not portable across homes** — a household with legitimate high load (EV charging, 3-phase, large HVAC) would be wrongly clamped. This PR replaces it with a structural fix.

### Root cause (validated)
The forecaster's "current load" channel was fed a **raw instantaneous sensor reading** (`data.load_power_kw`, a point sample). A sub-minute appliance/EV/compressor-inrush spike the sample happened to land on then propagated as the whole-hour forecast (`load_forecast_slots` → `consumption_kwh`). The unit-mismatch hypotheses in the issue were ruled out (those would be 1000×, not ~5.7×); weather (3×) and context (±50%) paths were already bounded.

### The fix
1. **Robust short-window statistic.** Feed the forecaster the **median of the last 3 five-minute statistic means** (~15 min) instead of the raw instantaneous point. This reuses the existing 5-minute recorder fetch that already backs `recent_load_1hr_kw` — no new recorder call. A 5-minute mean structurally attenuates a sub-minute spike, and the median rejects an anomalous window outright. Spikes can no longer enter the forecast.
2. **Cold-start fallback.** When no 5-minute statistics exist yet (e.g. just after a recorder restart), fall back to the raw instantaneous reading — same behavior as before, no regression. `data.load_power_kw` itself is left untouched for its real-time consumers (spike analyzer, price signals, excess-solar, deviation, diagnostics).
3. **Removed** PR #857's input clamp and both magic constants.
4. **Data-driven output ceiling** (defense-in-depth) replaces the fixed 15 kW one: per-slot forecast may not exceed `max(historical hourly average) × 3.0`. This **self-scales per home** (a high-load home's ceiling rises with its own profile) and never clamps legitimate load, while still netting the cold-start path.

### Tests
- `test_history.py`: median attenuates a spike window, trailing-K-by-start ordering, <K rows, missing-`start` source-order fallback, zero-when-empty.
- `test_pipeline.py`: robust value substituted when available; falls back to instantaneous when unavailable; `data.load_power_kw` left unchanged.
- `test_load.py`: removed the input-clamp tests; added no-input-clamp pass-through and data-driven-ceiling tests (incl. a high-load home that is correctly NOT clamped).

Full suite green locally (3040 passed); ruff + vulture clean.

Closes #826.
