### PR TITLE
fix(learning): persist solar accuracy samples across restarts

### DIFF
--- a/custom_components/localshift/coordinator/coordinator.py
+++ b/custom_components/localshift/coordinator/coordinator.py
@@ -477,15 +477,30 @@ class LocalShiftCoordinator:
         if self._learning_orchestrator is not None:
             await self._learning_orchestrator.async_save_all()
 
+        # Persist solar accuracy samples. The tracker is owned by the
+        # coordinator (not the orchestrator), so async_save_all() misses it.
+        # async_save() early-returns unless there are pending changes and
+        # swallows its own exceptions, so this is a cheap, safe no-op most
+        # ticks and cannot block the orchestrator save above (which runs first
+        # to preserve existing behavior). The getattr guard matters because the
+        # attribute is only created in async_start and this can run on a
+        # failed-startup teardown.
+        tracker = getattr(self, "solar_accuracy_tracker", None)
+        if tracker is not None:
+            await tracker.async_save()
+
     @callback
     def _handle_learning_save(self, now: datetime) -> None:
         """Periodic save of learning data to prevent data loss on restart.
 
         Fires every 5 minutes to ensure data is persisted even if HA
-        restarts unexpectedly.
+        restarts unexpectedly. Shares the same path as the shutdown save so
+        the solar accuracy tracker is covered by both.
         """
-        if self._learning_orchestrator is not None:
-            self._learning_orchestrator.handle_periodic_save()
+        self.hass.async_create_task(
+            self._save_learning_data(),
+            "localshift_periodic_learning_save",
+        )
 
     # ------------------------------------------------------------------
     # Entity update subscription (for sensor/binary_sensor entities)

--- a/custom_components/localshift/learning/orchestrator.py
+++ b/custom_components/localshift/learning/orchestrator.py
@@ -174,13 +174,6 @@ class LearningOrchestrator:
             self._forecast_corrections.to_dict()
         )
 
-    def handle_periodic_save(self) -> None:
-        """Schedule a periodic save of learning data."""
-        self.hass.async_create_task(
-            self.async_save_all(),
-            "localshift_periodic_learning_save",
-        )
-
     def handle_midnight_reset(self, data) -> None:
         """Handle learning-specific midnight reset tasks."""
         if self.decision_tracker is not None:

--- a/tests/coordinator/test_coordinator.py
+++ b/tests/coordinator/test_coordinator.py
@@ -1098,28 +1098,81 @@ class TestCoordinatorBootstrapperAndLearning:
         # Verify orchestrator was called
         mock_orchestrator.async_save_all.assert_called_once()
 
-    def test_handle_learning_save_calls_orchestrator_when_present(self, coordinator):
-        """Test _handle_learning_save calls orchestrator when present."""
+    def test_save_learning_data_calls_solar_tracker(self, coordinator):
+        """Test _save_learning_data persists the solar accuracy tracker."""
+        import asyncio
+        from unittest.mock import AsyncMock
+
+        coordinator._learning_orchestrator = AsyncMock()
+        tracker = AsyncMock()
+        coordinator.solar_accuracy_tracker = tracker
+
+        asyncio.run(coordinator._save_learning_data())
+
+        tracker.async_save.assert_called_once()
+
+    def test_save_learning_data_no_tracker_attribute(self, coordinator):
+        """Test _save_learning_data tolerates a missing tracker (failed startup)."""
+        import asyncio
+        from unittest.mock import AsyncMock
+
+        coordinator._learning_orchestrator = AsyncMock()
+        # Ensure the attribute is absent (getattr guard path)
+        if hasattr(coordinator, "solar_accuracy_tracker"):
+            del coordinator.solar_accuracy_tracker
+
+        # Should not raise
+        asyncio.run(coordinator._save_learning_data())
+
+    def test_save_learning_data_tracker_save_does_not_block_orchestrator(
+        self, coordinator
+    ):
+        """Tracker save runs after the orchestrator save; ordering is preserved."""
+        import asyncio
+        from unittest.mock import AsyncMock
+
+        calls = []
+        orchestrator = AsyncMock()
+        orchestrator.async_save_all.side_effect = lambda: calls.append("orchestrator")
+        tracker = AsyncMock()
+        tracker.async_save.side_effect = lambda: calls.append("tracker")
+        coordinator._learning_orchestrator = orchestrator
+        coordinator.solar_accuracy_tracker = tracker
+
+        asyncio.run(coordinator._save_learning_data())
+
+        assert calls == ["orchestrator", "tracker"]
+
+    def test_handle_learning_save_schedules_save_learning_data(self, coordinator):
+        """Test _handle_learning_save schedules the shared _save_learning_data path."""
         from datetime import UTC, datetime
         from unittest.mock import MagicMock
 
-        mock_orchestrator = MagicMock()
-        coordinator._learning_orchestrator = mock_orchestrator
+        coordinator.hass.async_create_task = MagicMock()
 
         # Call the method
         coordinator._handle_learning_save(datetime.now(UTC))
 
-        # Verify orchestrator was called
-        mock_orchestrator.handle_periodic_save.assert_called_once()
+        # Verify it scheduled _save_learning_data (the one shared save path that
+        # also covers the solar accuracy tracker)
+        coordinator.hass.async_create_task.assert_called_once()
+        call_args = coordinator.hass.async_create_task.call_args
+        assert call_args[0][1] == "localshift_periodic_learning_save"
+        # Close the un-awaited coroutine to avoid a RuntimeWarning
+        call_args[0][0].close()
 
     def test_handle_learning_save_when_orchestrator_is_none(self, coordinator):
-        """Test _handle_learning_save returns early when orchestrator is None."""
+        """Test _handle_learning_save does not raise when orchestrator is None."""
         from datetime import UTC, datetime
+        from unittest.mock import MagicMock
 
+        coordinator.hass.async_create_task = MagicMock()
         coordinator._learning_orchestrator = None
 
         # Should not raise
         coordinator._handle_learning_save(datetime.now(UTC))
+        call_args = coordinator.hass.async_create_task.call_args
+        call_args[0][0].close()
 
 
 class TestCoordinatorEntityHealthLogging:

--- a/tests/forecast/test_solar_accuracy.py
+++ b/tests/forecast/test_solar_accuracy.py
@@ -652,6 +652,51 @@ class TestSolarAccuracyTracker:
         # save_pending should be reset
         assert tracker._save_pending is False
 
+    @pytest.mark.asyncio
+    async def test_save_load_round_trip_survives_fresh_tracker(self, mock_hass):
+        """record_forecast -> backfill_actual -> async_save -> fresh tracker load.
+
+        Regression for root cause B: samples must survive a process restart.
+        """
+        # Use a single in-memory store shared between the two trackers to
+        # simulate the .storage file persisting across a restart.
+        saved_payload = {}
+
+        store = MagicMock()
+
+        async def _save(data):
+            saved_payload.clear()
+            saved_payload.update(data)
+
+        async def _load():
+            return saved_payload or None
+
+        store.async_save = AsyncMock(side_effect=_save)
+        store.async_load = AsyncMock(side_effect=_load)
+
+        tracker = SolarAccuracyTracker(mock_hass, "test_entry")
+        tracker._store = store
+
+        period_start = datetime(2026, 1, 15, 10, 0, tzinfo=UTC)
+        tracker.record_forecast(period_start, 2.0, "sunny")
+        tracker.backfill_actual(period_start, 1.5)
+
+        assert tracker._save_pending is True
+        await tracker.async_save()
+        store.async_save.assert_called_once()
+        assert tracker._save_pending is False
+
+        # Fresh tracker on the same store == a restart.
+        reloaded = SolarAccuracyTracker(mock_hass, "test_entry")
+        reloaded._store = store
+        await reloaded.async_load()
+
+        assert reloaded.metrics.sample_count == 1
+        assert len(reloaded._period_records) == 1
+        assert reloaded._period_records[0].forecast_kwh == 2.0
+        assert reloaded._period_records[0].actual_kwh == 1.5
+        assert reloaded.metrics.overall_bias == tracker.metrics.overall_bias
+
 
 class TestGetTimeOfDay:
     """Tests for _get_time_of_day static method."""

--- a/tests/learning/test_learning_integration.py
+++ b/tests/learning/test_learning_integration.py
@@ -338,15 +338,6 @@ class TestLearningOrchestratorForecastCorrections:
 
         assert state_machine._decision_tracker is tracker
 
-    def test_handle_periodic_save_schedules_task(self, mock_hass, mock_entry):
-        orchestrator = LearningOrchestrator(mock_hass, mock_entry, lambda _key: False)
-        orchestrator.handle_periodic_save()
-
-        assert mock_hass.async_create_task.call_count == 1
-        coro = mock_hass.async_create_task.call_args.args[0]
-        if hasattr(coro, "close"):
-            coro.close()
-
     @pytest.mark.parametrize(
         ("learning_status", "starting_days", "expects_analysis", "expected_days"),
         [


### PR DESCRIPTION
## Problem (root cause B)

`SolarAccuracyTracker.async_save()` has **zero call sites** anywhere in the codebase. The tracker is owned by the **coordinator**, not the `LearningOrchestrator`, so `async_save_all()` (which saves the decision tracker, param optimizer, pattern analyzer, optimization controller, and forecast corrections) misses it entirely.

Because the system redeploys/restarts every 1–2 days and deploys don't touch `.storage/`, solar accuracy samples are wiped every restart. They never reach `MIN_SOLAR_CORRECTION_SAMPLES = 20`, so neither solar bias correction (`slots.py`) nor the accuracy-based confidence ceiling has **ever** activated. Live confirmation: there is no `localshift.solar_accuracy.*` file in `.storage/` at all.

## Fix

- `coordinator._save_learning_data()` now also calls `solar_accuracy_tracker.async_save()` **after** the orchestrator save. The `getattr` guard matters because the attribute is only created in `async_start` and this method can run on a failed-startup teardown. `async_save()` already early-returns unless `_save_pending` is set (cheap no-op most ticks) and catches its own exceptions (cannot block the orchestrator save).
- `_handle_learning_save()` (the 5-min timer) now schedules the shared `_save_learning_data` path instead of `orchestrator.handle_periodic_save()`, so both the periodic timer and `async_stop()` cover the tracker.
- Deleted the now-dead `LearningOrchestrator.handle_periodic_save()` — required in the same PR because of the dead-code CI guardrail (#837).

No storage schema/version change (solar_accuracy v1 has no live file yet).

## Tests
- `test_solar_accuracy.py`: `record_forecast → backfill_actual → async_save → fresh tracker → async_load` round-trip survives a simulated restart; existing no-op (`_save_pending` False) test retained.
- `test_coordinator.py`: `_save_learning_data` calls the tracker, tolerates a missing attribute, and preserves orchestrator-first ordering; `_handle_learning_save` schedules the shared path.
- Removed the obsolete `handle_periodic_save` test.

Part of the learning-mode fix series (PR 1 of 4). PRs 1–3 are independent; this one lands first so real samples start persisting while the others are in review.