### PR TITLE
fix(learning): correct solar backfill attribution, boost, dusk, eviction

### DIFF
--- a/custom_components/localshift/coordinator/tick_scheduler.py
+++ b/custom_components/localshift/coordinator/tick_scheduler.py
@@ -42,6 +42,14 @@ class TickScheduler:
         self._last_solar_power_kw: float | None = None
         self._last_solar_power_timestamp: datetime | None = None
 
+        # Accumulate-and-flush state for solar backfill attribution.
+        # Energy integrated each medium tick is prorated into these wall-clock
+        # 30-min buckets (keyed by ISO period_start) and flushed once the
+        # period's end is in the past — so energy lands on the period it was
+        # produced in, not the period that just started.
+        self._period_energy_accum: dict[str, float] = {}  # ISO period_start -> kWh
+        self._period_boost_flags: dict[str, bool] = {}  # ISO period_start -> boost seen
+
     @callback
     def handle_state_change(self, _event: Event) -> None:
         """Handle a state change from a monitored entity."""
@@ -148,12 +156,11 @@ class TickScheduler:
                 self._coordinator.data
             )
 
-        # Backfill solar forecast accuracy for completed periods (Issue #378)
-        if (
-            hasattr(self._coordinator, "solar_accuracy_tracker")
-            and self._coordinator.solar_accuracy_tracker is not None
-        ):
-            pass
+        # Backfill solar forecast accuracy for completed periods (Issue #378).
+        # Runs on the 5-min cadence: shorter trapezoid integration is far more
+        # accurate for fast-changing solar power and makes boundary proration
+        # nearly exact.
+        self._backfill_solar_actual()
 
         # Update solar bias metrics from tracker (Issue #378)
         if (
@@ -216,9 +223,6 @@ class TickScheduler:
                 ),
                 "localshift_save_accuracy_metrics",
             )
-
-        # Backfill actual solar energy for completed periods (Issue #513)
-        self._backfill_solar_actual()
 
         _LOGGER.debug("Slow tick completed: weather forecast and accuracy metrics")
 
@@ -291,20 +295,25 @@ class TickScheduler:
             self._coordinator.cost_tracker.accumulate_costs(self._coordinator.data)
 
     def _backfill_solar_actual(self) -> None:
-        """Backfill actual solar energy for completed 30-min periods.
+        """Accumulate solar energy into wall-clock periods and flush completed ones.
 
-        Calculates energy produced since last tick using integrated power,
-        then calls backfill_actual() on the tracker for completed periods.
+        Each medium tick integrates solar power since the previous tick
+        (trapezoid) and prorates that energy across every 30-min wall-clock
+        period the interval overlaps. A period is flushed to the tracker once
+        its end is in the past, so energy produced 09:30-10:00 is attributed to
+        the 09:30 period and flushed at the first tick after 10:00 — the
+        attribution fix — instead of to the 10:00 period that just started.
+
+        Boost intervals continue to accumulate (the daily ~3pm boost no longer
+        orphans pending forecasts); their periods are flagged so the tracker
+        excludes them from metrics. The dusk power gate is gone — whether a
+        record is meaningful is decided at flush time by the tracker.
         """
-        if not hasattr(self._coordinator, "solar_accuracy_tracker"):
-            return
-
         tracker = getattr(self._coordinator, "solar_accuracy_tracker", None)
         if tracker is None:
             return
 
-        if getattr(self._coordinator.data, "boost_charge_active", False) is True:
-            return
+        from datetime import timedelta
 
         from homeassistant.util import dt as dt_util
 
@@ -318,21 +327,59 @@ class TickScheduler:
 
         assert self._last_solar_power_kw is not None  # nosec B101 — type narrowing, not assertion
 
-        time_delta_hours = (
-            now - self._last_solar_power_timestamp
-        ).total_seconds() / 3600.0
-        if time_delta_hours < 0.01:
+        last_ts = self._last_solar_power_timestamp
+        interval_seconds = (now - last_ts).total_seconds()
+        if interval_seconds / 3600.0 < 0.01:
+            # Interval too short to integrate; keep the baseline for next tick.
             return
 
-        avg_power_kw = (self._last_solar_power_kw + current_power) / 2.0
-        energy_kwh = avg_power_kw * time_delta_hours
+        boost_active = bool(
+            getattr(self._coordinator.data, "boost_charge_active", False)
+        )
+        energy_kwh = ((self._last_solar_power_kw + current_power) / 2.0) * (
+            interval_seconds / 3600.0
+        )
 
-        if energy_kwh > 0.001 and current_power > 0.01:
-            now_local = now.astimezone()
-            period_start = now_local.replace(
-                minute=(now_local.minute // 30) * 30, second=0, microsecond=0
-            )
-            tracker.backfill_actual(period_start, energy_kwh)
+        # Prorate this interval's energy across every 30-min wall-clock period it
+        # overlaps, so boundary-spanning intervals split proportionally. Keys are
+        # the local :00/:30 floor serialized with .isoformat(), matching the
+        # pending-forecast keys recorded by optimizer_facade.
+        start_local = last_ts.astimezone()
+        end_local = now.astimezone()
+        period_start = start_local.replace(
+            minute=(start_local.minute // 30) * 30, second=0, microsecond=0
+        )
+        while period_start < end_local:
+            period_end = period_start + timedelta(minutes=30)
+            overlap_seconds = (
+                min(end_local, period_end) - max(start_local, period_start)
+            ).total_seconds()
+            if overlap_seconds > 0:
+                key = period_start.isoformat()
+                self._period_energy_accum[key] = self._period_energy_accum.get(
+                    key, 0.0
+                ) + energy_kwh * (overlap_seconds / interval_seconds)
+                if boost_active:
+                    self._period_boost_flags[key] = True
+            period_start = period_end
 
+        # Advance the integration baseline.
         self._last_solar_power_timestamp = now
         self._last_solar_power_kw = current_power
+
+        # Flush every period whose end is now in the past.
+        self._flush_completed_periods(tracker, end_local)
+
+        # Drop pendings that never received an actual (e.g. restart mid-period).
+        tracker.evict_stale_pendings()
+
+    def _flush_completed_periods(self, tracker, now_local: datetime) -> None:
+        """Flush accumulated periods whose end is in the past to the tracker."""
+        from datetime import timedelta
+
+        for key in list(self._period_energy_accum.keys()):
+            period_start = datetime.fromisoformat(key)
+            if period_start + timedelta(minutes=30) <= now_local:
+                kwh = self._period_energy_accum.pop(key)
+                is_boost = self._period_boost_flags.pop(key, False)
+                tracker.backfill_actual(period_start, kwh, is_boost=is_boost)

--- a/custom_components/localshift/coordinator/tick_scheduler.py
+++ b/custom_components/localshift/coordinator/tick_scheduler.py
@@ -26,6 +26,19 @@ _LOGGER = logging.getLogger(__name__)
 class TickScheduler:
     """Manages periodic task execution for coordinator."""
 
+    # Solar backfill period geometry / robustness thresholds.
+    _PERIOD_SECONDS = 1800.0  # 30-min accuracy period
+    # A flushed period must be at least this fraction covered by integration
+    # intervals, else it is discarded rather than recorded as a full actual.
+    # Guards the restart case: the baseline re-establishes mid-period, so that
+    # period only accumulates partial energy (Issue: partial-coverage poisoning).
+    _MIN_COVERAGE_FRACTION = 0.9
+    # Intervals longer than this (e.g. an event-loop stall or a long gap) are
+    # not integrated — one giant trapezoid prorated across many periods would
+    # produce several plausible-looking but garbage samples. We re-baseline and
+    # skip integration; the spanned periods fall below the coverage gate.
+    _MAX_INTEGRATION_SECONDS = 900.0  # 15 min
+
     def __init__(
         self,
         coordinator: LocalShiftCoordinator,
@@ -49,6 +62,7 @@ class TickScheduler:
         # produced in, not the period that just started.
         self._period_energy_accum: dict[str, float] = {}  # ISO period_start -> kWh
         self._period_boost_flags: dict[str, bool] = {}  # ISO period_start -> boost seen
+        self._period_coverage_accum: dict[str, float] = {}  # ISO -> seconds covered
 
     @callback
     def handle_state_change(self, _event: Event) -> None:
@@ -308,6 +322,13 @@ class TickScheduler:
         orphans pending forecasts); their periods are flagged so the tracker
         excludes them from metrics. The dusk power gate is gone — whether a
         record is meaningful is decided at flush time by the tracker.
+
+        Two robustness guards keep partial/garbage samples out of the (now
+        persisted) learning store: a period must be >=90% covered by integration
+        intervals to be recorded (else it is discarded — handles the restart
+        re-baseline mid-period), and intervals longer than 15 min are not
+        integrated at all (an event-loop stall would otherwise smear one
+        trapezoid across many periods as plausible-looking garbage).
         """
         tracker = getattr(self._coordinator, "solar_accuracy_tracker", None)
         if tracker is None:
@@ -333,53 +354,76 @@ class TickScheduler:
             # Interval too short to integrate; keep the baseline for next tick.
             return
 
-        boost_active = bool(
-            getattr(self._coordinator.data, "boost_charge_active", False)
-        )
-        energy_kwh = ((self._last_solar_power_kw + current_power) / 2.0) * (
-            interval_seconds / 3600.0
-        )
+        # Pathological gap (stall / long pause): re-baseline without integrating.
+        # The periods spanned by the gap stay below the coverage gate and are
+        # discarded at flush, rather than recording a smeared trapezoid.
+        if interval_seconds <= self._MAX_INTEGRATION_SECONDS:
+            boost_active = bool(
+                getattr(self._coordinator.data, "boost_charge_active", False)
+            )
+            energy_kwh = ((self._last_solar_power_kw + current_power) / 2.0) * (
+                interval_seconds / 3600.0
+            )
 
-        # Prorate this interval's energy across every 30-min wall-clock period it
-        # overlaps, so boundary-spanning intervals split proportionally. Keys are
-        # the local :00/:30 floor serialized with .isoformat(), matching the
-        # pending-forecast keys recorded by optimizer_facade.
-        start_local = last_ts.astimezone()
-        end_local = now.astimezone()
-        period_start = start_local.replace(
-            minute=(start_local.minute // 30) * 30, second=0, microsecond=0
-        )
-        while period_start < end_local:
-            period_end = period_start + timedelta(minutes=30)
-            overlap_seconds = (
-                min(end_local, period_end) - max(start_local, period_start)
-            ).total_seconds()
-            if overlap_seconds > 0:
-                key = period_start.isoformat()
-                self._period_energy_accum[key] = self._period_energy_accum.get(
-                    key, 0.0
-                ) + energy_kwh * (overlap_seconds / interval_seconds)
-                if boost_active:
-                    self._period_boost_flags[key] = True
-            period_start = period_end
+            # Prorate this interval's energy across every 30-min wall-clock period
+            # it overlaps, accumulating both energy and covered seconds. Keys are
+            # the local :00/:30 floor serialized with .isoformat(), matching the
+            # pending-forecast keys recorded by optimizer_facade.
+            start_local = last_ts.astimezone()
+            end_local = now.astimezone()
+            period_start = start_local.replace(
+                minute=(start_local.minute // 30) * 30, second=0, microsecond=0
+            )
+            while period_start < end_local:
+                period_end = period_start + timedelta(minutes=30)
+                overlap_seconds = (
+                    min(end_local, period_end) - max(start_local, period_start)
+                ).total_seconds()
+                if overlap_seconds > 0:
+                    key = period_start.isoformat()
+                    self._period_energy_accum[key] = self._period_energy_accum.get(
+                        key, 0.0
+                    ) + energy_kwh * (overlap_seconds / interval_seconds)
+                    self._period_coverage_accum[key] = (
+                        self._period_coverage_accum.get(key, 0.0) + overlap_seconds
+                    )
+                    if boost_active:
+                        self._period_boost_flags[key] = True
+                period_start = period_end
 
         # Advance the integration baseline.
         self._last_solar_power_timestamp = now
         self._last_solar_power_kw = current_power
 
-        # Flush every period whose end is now in the past.
-        self._flush_completed_periods(tracker, end_local)
+        # Flush every period whose end is now in the past (record or discard).
+        self._flush_completed_periods(tracker, now.astimezone())
 
         # Drop pendings that never received an actual (e.g. restart mid-period).
         tracker.evict_stale_pendings()
 
     def _flush_completed_periods(self, tracker, now_local: datetime) -> None:
-        """Flush accumulated periods whose end is in the past to the tracker."""
+        """Flush accumulated periods whose end is in the past.
+
+        A period is recorded only if it is at least _MIN_COVERAGE_FRACTION
+        covered by integration intervals; otherwise it is discarded (its
+        pending forecast is later cleaned by evict_stale_pendings) so a
+        partially-observed period is not recorded as a full-period actual.
+        """
         from datetime import timedelta
 
+        min_coverage = self._MIN_COVERAGE_FRACTION * self._PERIOD_SECONDS
         for key in list(self._period_energy_accum.keys()):
             period_start = datetime.fromisoformat(key)
-            if period_start + timedelta(minutes=30) <= now_local:
-                kwh = self._period_energy_accum.pop(key)
-                is_boost = self._period_boost_flags.pop(key, False)
-                tracker.backfill_actual(period_start, kwh, is_boost=is_boost)
+            if period_start + timedelta(minutes=30) > now_local:
+                continue
+            kwh = self._period_energy_accum.pop(key)
+            coverage = self._period_coverage_accum.pop(key, 0.0)
+            is_boost = self._period_boost_flags.pop(key, False)
+            if coverage < min_coverage:
+                _LOGGER.debug(
+                    "Discarding partially-covered solar period %s (%.0f%% covered)",
+                    period_start.strftime("%H:%M"),
+                    100.0 * coverage / self._PERIOD_SECONDS,
+                )
+                continue
+            tracker.backfill_actual(period_start, kwh, is_boost=is_boost)

--- a/custom_components/localshift/forecast/solar_accuracy.py
+++ b/custom_components/localshift/forecast/solar_accuracy.py
@@ -297,11 +297,20 @@ class SolarAccuracyTracker:
         self,
         period_start: datetime,
         actual_kwh: float,
+        is_boost: bool | None = None,
     ) -> None:
         """Backfill actual solar energy for a completed period.
 
         Called by coordinator after a period ends. Calculates bias and stores
         the completed record.
+
+        Args:
+            period_start: Start of the completed 30-min period.
+            actual_kwh: Measured solar energy for the period.
+            is_boost: Override the pending's boost flag at flush time. The boost
+                state recorded when the forecast was made may differ from the
+                state during the period itself. ``None`` (default) preserves the
+                pending's existing flag — backward compatible with old callers.
         """
         key = period_start.isoformat()
         pending = self._pending_forecasts.pop(key, None)
@@ -313,6 +322,15 @@ class SolarAccuracyTracker:
             )
             return
 
+        # Drop information-free overnight samples (zero forecast AND zero actual)
+        # so they don't inflate sample_count toward the 20-sample threshold.
+        # Dusk periods (forecast > 0, tiny actual) are kept — that bias matters.
+        if pending.forecast_kwh <= 0.01 and actual_kwh <= 0.01:
+            return
+
+        if is_boost is not None:
+            pending.is_boost_period = is_boost
+
         pending.actual_kwh = actual_kwh
         pending.__post_init__()
 
@@ -322,12 +340,33 @@ class SolarAccuracyTracker:
         self._recompute_metrics()
 
         _LOGGER.info(
-            "Solar period %s: forecast=%.3f kWh, actual=%.3f kWh, bias=%.1f%%",
+            "Solar period %s: forecast=%.3f kWh, actual=%.3f kWh, bias=%.1f%%%s",
             period_start.strftime("%H:%M"),
             pending.forecast_kwh,
             actual_kwh,
             pending.bias * 100,
+            " (boost, excluded from metrics)" if pending.is_boost_period else "",
         )
+
+    def evict_stale_pendings(self, max_age_hours: float = 4.0) -> None:
+        """Drop past-dated pending forecasts that never received an actual.
+
+        Safety net for periods that never got a backfill (e.g. a restart
+        mid-period). Only past-dated entries are dropped; future horizon slots
+        are legitimately pending.
+        """
+        from datetime import timedelta
+
+        cutoff = dt_util.now() - timedelta(hours=max_age_hours)
+        stale = [
+            key
+            for key, record in self._pending_forecasts.items()
+            if record.period_start < cutoff
+        ]
+        for key in stale:
+            del self._pending_forecasts[key]
+        if stale:
+            _LOGGER.debug("Evicted %d stale pending solar forecasts", len(stale))
 
     def _recompute_metrics(self) -> None:
         """Recompute aggregated metrics from all period records."""

--- a/tests/coordinator/test_tick_scheduler.py
+++ b/tests/coordinator/test_tick_scheduler.py
@@ -140,6 +140,28 @@ async def test_handle_medium_tick(coordinator):
 
 
 @pytest.mark.asyncio
+async def test_handle_medium_tick_drives_solar_backfill(coordinator):
+    """Solar backfill now runs on the medium (5-min) tick, not the slow tick."""
+    scheduler = TickScheduler(coordinator)
+    now = datetime.now()
+
+    coordinator._entity_monitor = MagicMock()
+    coordinator._entity_monitor.read_all_external_state = MagicMock()
+    coordinator._entity_monitor.check_entity_health = MagicMock()
+    coordinator._state_machine = MagicMock()
+    coordinator._state_machine.startup_grace_until = None
+    coordinator._learning_orchestrator = None
+    coordinator._computation_engine = None
+    coordinator.data = MagicMock()
+
+    scheduler._backfill_solar_actual = MagicMock()
+
+    scheduler.handle_medium_tick(now)
+
+    scheduler._backfill_solar_actual.assert_called_once()
+
+
+@pytest.mark.asyncio
 async def test_handle_medium_tick_startup_grace(coordinator):
     """Test handle_medium_tick skips operations during startup grace period."""
     scheduler = TickScheduler(coordinator)
@@ -177,15 +199,15 @@ async def test_handle_slow_tick(coordinator):
         )
     )
 
-    # Mock backfill method
+    # Backfill now runs on the medium tick, not the slow tick.
     scheduler._backfill_solar_actual = MagicMock()
 
     scheduler.handle_slow_tick(now)
 
     # Should schedule async task for weather refresh
     assert coordinator.hass.async_create_task.call_count >= 1
-    # Should schedule backfill
-    scheduler._backfill_solar_actual.assert_called_once()
+    # Slow tick no longer backfills solar accuracy (moved to medium tick)
+    scheduler._backfill_solar_actual.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -356,9 +378,6 @@ async def test_handle_slow_tick_with_computation_engine(coordinator):
     )
     coordinator.data = MagicMock()
 
-    # Mock backfill method
-    scheduler._backfill_solar_actual = MagicMock()
-
     scheduler.handle_slow_tick(now)
 
     # Should create async tasks for forecast accuracy and history
@@ -460,80 +479,176 @@ async def test_backfill_solar_actual_small_time_delta(coordinator):
     coordinator.solar_accuracy_tracker.backfill_actual.assert_not_called()
 
 
-@pytest.mark.asyncio
-async def test_backfill_solar_actual_zero_energy(coordinator):
-    """Test _backfill_solar_actual skips backfill for zero energy."""
+def _aligned_times(base_hour, base_min, tick_hour, tick_min):
+    """Build two tz-aware datetimes in the HA default timezone for backfill tests."""
     from homeassistant.util import dt as dt_util
 
-    scheduler = TickScheduler(coordinator)
+    tz = dt_util.now().tzinfo
+    baseline = datetime(2026, 6, 11, base_hour, base_min, tzinfo=tz)
+    tick_now = datetime(2026, 6, 11, tick_hour, tick_min, tzinfo=tz)
+    return baseline, tick_now
 
-    # Mock tracker
-    coordinator.solar_accuracy_tracker = MagicMock()
-    coordinator.solar_accuracy_tracker.backfill_actual = MagicMock()
 
-    # Set timestamp 1 hour ago with zero power
-    now = dt_util.now()
-    scheduler._last_solar_power_timestamp = now - timedelta(hours=1)
-    scheduler._last_solar_power_kw = 0.0
-    coordinator.data = MagicMock()
-    coordinator.data.solar_power_kw = 0.0
-
-    scheduler._backfill_solar_actual()
-
-    # Should NOT call backfill_actual due to zero energy
-    coordinator.solar_accuracy_tracker.backfill_actual.assert_not_called()
+def _expected_period(ts):
+    """Floor a timestamp to its local :00/:30 period, matching the scheduler."""
+    local = ts.astimezone()
+    return local.replace(minute=(local.minute // 30) * 30, second=0, microsecond=0)
 
 
 @pytest.mark.asyncio
-async def test_backfill_solar_actual_success(coordinator):
-    """Test _backfill_solar_actual successfully backfills energy."""
-    from homeassistant.util import dt as dt_util
+async def test_backfill_attribution_lands_on_producing_period(coordinator):
+    """Energy produced 09:35-10:00 lands on the 09:30 period, flushed after 10:00.
+
+    Headline regression: the just-started 10:00 period must NOT be backfilled at
+    the 10:05 tick — it lands on the period the energy was actually produced in.
+    """
+    from unittest.mock import patch
 
     scheduler = TickScheduler(coordinator)
-
-    # Mock tracker
     coordinator.solar_accuracy_tracker = MagicMock()
     coordinator.solar_accuracy_tracker.backfill_actual = MagicMock()
-
-    # Set timestamp 30 minutes ago with solar power
-    now = dt_util.now()
-    scheduler._last_solar_power_timestamp = now - timedelta(minutes=30)
-    scheduler._last_solar_power_kw = 4.0
+    coordinator.solar_accuracy_tracker.evict_stale_pendings = MagicMock()
     coordinator.data = MagicMock()
     coordinator.data.solar_power_kw = 6.0
+    coordinator.data.boost_charge_active = False
 
-    scheduler._backfill_solar_actual()
+    baseline, tick_now = _aligned_times(9, 35, 10, 5)
+    scheduler._last_solar_power_timestamp = baseline
+    scheduler._last_solar_power_kw = 4.0
 
-    # Should call backfill_actual with calculated energy
+    with patch("homeassistant.util.dt.now", return_value=tick_now):
+        scheduler._backfill_solar_actual()
+
+    # Exactly one completed period flushed: the 09:30 period.
     coordinator.solar_accuracy_tracker.backfill_actual.assert_called_once()
-    # Verify energy calculation: avg_power * time = (4+6)/2 * 0.5 = 2.5 kWh
-    args = coordinator.solar_accuracy_tracker.backfill_actual.call_args[0]
-    assert args[1] > 2.0  # Energy should be around 2.5 kWh
-
-    # Verify timestamp updated
-    assert scheduler._last_solar_power_kw == 6.0
+    call = coordinator.solar_accuracy_tracker.backfill_actual.call_args
+    expected = _expected_period(baseline)
+    assert call.args[0] == expected
+    # The 10:00 period has not completed at 10:05 -> still pending in the accumulator.
+    later = expected + timedelta(minutes=30)
+    assert later.isoformat() in scheduler._period_energy_accum
+    # Energy split 25/30 to the completed period; total = (4+6)/2 * 0.5 = 2.5 kWh.
+    assert call.args[1] == pytest.approx(2.5 * (25 / 30), rel=1e-3)
+    assert call.kwargs["is_boost"] is False
 
 
 @pytest.mark.asyncio
-async def test_backfill_solar_actual_skips_during_boost(coordinator):
-    """Boost charging periods should not contaminate solar accuracy backfill."""
-    from homeassistant.util import dt as dt_util
+async def test_backfill_proration_splits_across_boundary(coordinator):
+    """An interval spanning a :00 boundary splits energy proportionally."""
+    from unittest.mock import patch
 
     scheduler = TickScheduler(coordinator)
-
     coordinator.solar_accuracy_tracker = MagicMock()
     coordinator.solar_accuracy_tracker.backfill_actual = MagicMock()
+    coordinator.solar_accuracy_tracker.evict_stale_pendings = MagicMock()
+    coordinator.data = MagicMock()
+    coordinator.data.solar_power_kw = 6.0
+    coordinator.data.boost_charge_active = False
 
-    now = dt_util.now()
-    scheduler._last_solar_power_timestamp = now - timedelta(minutes=30)
+    # 09:45 -> 10:15: 15 min in the 09:30 period, 15 min in the 10:00 period.
+    baseline, tick_now = _aligned_times(9, 45, 10, 15)
+    scheduler._last_solar_power_timestamp = baseline
     scheduler._last_solar_power_kw = 4.0
+
+    with patch("homeassistant.util.dt.now", return_value=tick_now):
+        scheduler._backfill_solar_actual()
+
+    # total = (4+6)/2 * 0.5h = 2.5 kWh, split 50/50 across the two periods.
+    expected = _expected_period(baseline)
+    call = coordinator.solar_accuracy_tracker.backfill_actual.call_args
+    assert call.args[0] == expected  # 09:30, the completed period
+    assert call.args[1] == pytest.approx(1.25, rel=1e-3)
+    # The 10:00 period is still accumulating with its half.
+    later = expected + timedelta(minutes=30)
+    assert scheduler._period_energy_accum[later.isoformat()] == pytest.approx(
+        1.25, rel=1e-3
+    )
+
+
+@pytest.mark.asyncio
+async def test_backfill_during_boost_flags_and_consumes_pending(coordinator):
+    """Boost intervals keep accumulating; the flush tags the period as boost.
+
+    Regression for the pending-forecast orphan leak: the pending IS consumed
+    (backfill_actual called) even during the daily ~3pm boost.
+    """
+    from unittest.mock import patch
+
+    scheduler = TickScheduler(coordinator)
+    coordinator.solar_accuracy_tracker = MagicMock()
+    coordinator.solar_accuracy_tracker.backfill_actual = MagicMock()
+    coordinator.solar_accuracy_tracker.evict_stale_pendings = MagicMock()
     coordinator.data = MagicMock()
     coordinator.data.solar_power_kw = 6.0
     coordinator.data.boost_charge_active = True
 
-    scheduler._backfill_solar_actual()
+    baseline, tick_now = _aligned_times(9, 35, 10, 5)
+    scheduler._last_solar_power_timestamp = baseline
+    scheduler._last_solar_power_kw = 4.0
 
-    coordinator.solar_accuracy_tracker.backfill_actual.assert_not_called()
+    with patch("homeassistant.util.dt.now", return_value=tick_now):
+        scheduler._backfill_solar_actual()
+
+    coordinator.solar_accuracy_tracker.backfill_actual.assert_called_once()
+    assert (
+        coordinator.solar_accuracy_tracker.backfill_actual.call_args.kwargs["is_boost"]
+        is True
+    )
+
+
+@pytest.mark.asyncio
+async def test_backfill_zero_power_still_flushes(coordinator):
+    """Zero-power completed periods still flush; the tracker decides meaningfulness.
+
+    Regression for the removed `current_power > 0.01` gate — declining-to-zero
+    dusk periods are no longer dropped at the scheduler level.
+    """
+    from unittest.mock import patch
+
+    scheduler = TickScheduler(coordinator)
+    coordinator.solar_accuracy_tracker = MagicMock()
+    coordinator.solar_accuracy_tracker.backfill_actual = MagicMock()
+    coordinator.solar_accuracy_tracker.evict_stale_pendings = MagicMock()
+    coordinator.data = MagicMock()
+    coordinator.data.solar_power_kw = 0.0
+    coordinator.data.boost_charge_active = False
+
+    baseline, tick_now = _aligned_times(18, 35, 19, 5)
+    scheduler._last_solar_power_timestamp = baseline
+    scheduler._last_solar_power_kw = 0.0
+
+    with patch("homeassistant.util.dt.now", return_value=tick_now):
+        scheduler._backfill_solar_actual()
+
+    # The completed dusk period is flushed with ~0 energy (tracker gate decides).
+    coordinator.solar_accuracy_tracker.backfill_actual.assert_called_once()
+    assert (
+        coordinator.solar_accuracy_tracker.backfill_actual.call_args.args[1]
+        == pytest.approx(0.0)
+    )
+
+
+@pytest.mark.asyncio
+async def test_backfill_evicts_stale_pendings(coordinator):
+    """evict_stale_pendings runs after the flush."""
+    from unittest.mock import patch
+
+    scheduler = TickScheduler(coordinator)
+    coordinator.solar_accuracy_tracker = MagicMock()
+    coordinator.solar_accuracy_tracker.backfill_actual = MagicMock()
+    coordinator.solar_accuracy_tracker.evict_stale_pendings = MagicMock()
+    coordinator.data = MagicMock()
+    coordinator.data.solar_power_kw = 6.0
+    coordinator.data.boost_charge_active = False
+
+    baseline, tick_now = _aligned_times(9, 35, 10, 5)
+    scheduler._last_solar_power_timestamp = baseline
+    scheduler._last_solar_power_kw = 4.0
+
+    with patch("homeassistant.util.dt.now", return_value=tick_now):
+        scheduler._backfill_solar_actual()
+
+    coordinator.solar_accuracy_tracker.evict_stale_pendings.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -576,9 +691,6 @@ async def test_handle_slow_tick_no_entity_monitor(coordinator):
     # Mock dependencies
     coordinator._entity_monitor = None
     coordinator._computation_engine = None
-
-    # Mock backfill method
-    scheduler._backfill_solar_actual = MagicMock()
 
     # Should not raise
     scheduler.handle_slow_tick(now)

--- a/tests/coordinator/test_tick_scheduler.py
+++ b/tests/coordinator/test_tick_scheduler.py
@@ -479,14 +479,15 @@ async def test_backfill_solar_actual_small_time_delta(coordinator):
     coordinator.solar_accuracy_tracker.backfill_actual.assert_not_called()
 
 
-def _aligned_times(base_hour, base_min, tick_hour, tick_min):
-    """Build two tz-aware datetimes in the HA default timezone for backfill tests."""
+def _ha_tz():
     from homeassistant.util import dt as dt_util
 
-    tz = dt_util.now().tzinfo
-    baseline = datetime(2026, 6, 11, base_hour, base_min, tzinfo=tz)
-    tick_now = datetime(2026, 6, 11, tick_hour, tick_min, tzinfo=tz)
-    return baseline, tick_now
+    return dt_util.now().tzinfo
+
+
+def _t(hour, minute, second=0):
+    """A tz-aware datetime in the HA default timezone."""
+    return datetime(2026, 6, 11, hour, minute, second, tzinfo=_ha_tz())
 
 
 def _expected_period(ts):
@@ -495,74 +496,114 @@ def _expected_period(ts):
     return local.replace(minute=(local.minute // 30) * 30, second=0, microsecond=0)
 
 
-@pytest.mark.asyncio
-async def test_backfill_attribution_lands_on_producing_period(coordinator):
-    """Energy produced 09:35-10:00 lands on the 09:30 period, flushed after 10:00.
+def _setup_tracker(coordinator, *, power=5.0, boost=False):
+    """Wire a mock solar accuracy tracker + data onto the coordinator."""
+    tracker = MagicMock()
+    tracker.backfill_actual = MagicMock()
+    tracker.evict_stale_pendings = MagicMock()
+    coordinator.solar_accuracy_tracker = tracker
+    coordinator.data = MagicMock()
+    coordinator.data.solar_power_kw = power
+    coordinator.data.boost_charge_active = boost
+    return tracker
 
-    Headline regression: the just-started 10:00 period must NOT be backfilled at
-    the 10:05 tick — it lands on the period the energy was actually produced in.
+
+def _drive(scheduler, coordinator, ticks):
+    """Drive _backfill_solar_actual across a sequence of (time, power[, boost]) ticks.
+
+    Mirrors real 5-min medium-tick cadence so a period accumulates full coverage
+    over several ticks (the coverage gate requires >=90% of the 30 min).
     """
     from unittest.mock import patch
 
+    for tick in ticks:
+        now = tick[0]
+        coordinator.data.solar_power_kw = tick[1]
+        if len(tick) > 2:
+            coordinator.data.boost_charge_active = tick[2]
+        with patch("homeassistant.util.dt.now", return_value=now):
+            scheduler._backfill_solar_actual()
+
+
+def _five_min_ticks(start_h, start_m, end_h, end_m, power):
+    """Baseline tick at start, then 5-min ticks through end (inclusive)."""
+    ticks = [(_t(start_h, start_m), power)]
+    minute = start_m
+    hour = start_h
+    while (hour, minute) < (end_h, end_m):
+        minute += 5
+        if minute >= 60:
+            minute -= 60
+            hour += 1
+        ticks.append((_t(hour, minute), power))
+    return ticks
+
+
+@pytest.mark.asyncio
+async def test_backfill_attribution_lands_on_producing_period(coordinator):
+    """Energy produced 09:30-10:00 lands on the 09:30 period, not the 10:00 one.
+
+    Headline regression: driven at the real 5-min cadence, the fully-covered
+    09:30 period is flushed at the first tick after 10:00; the just-started
+    10:00 period is NOT.
+    """
     scheduler = TickScheduler(coordinator)
-    coordinator.solar_accuracy_tracker = MagicMock()
-    coordinator.solar_accuracy_tracker.backfill_actual = MagicMock()
-    coordinator.solar_accuracy_tracker.evict_stale_pendings = MagicMock()
-    coordinator.data = MagicMock()
-    coordinator.data.solar_power_kw = 6.0
-    coordinator.data.boost_charge_active = False
+    tracker = _setup_tracker(coordinator, power=5.0)
 
-    baseline, tick_now = _aligned_times(9, 35, 10, 5)
-    scheduler._last_solar_power_timestamp = baseline
-    scheduler._last_solar_power_kw = 4.0
+    # Baseline 09:30, then 5-min ticks through 10:00 -> 09:30 period fully covered.
+    _drive(scheduler, coordinator, _five_min_ticks(9, 30, 10, 0, 5.0))
 
-    with patch("homeassistant.util.dt.now", return_value=tick_now):
-        scheduler._backfill_solar_actual()
-
-    # Exactly one completed period flushed: the 09:30 period.
-    coordinator.solar_accuracy_tracker.backfill_actual.assert_called_once()
-    call = coordinator.solar_accuracy_tracker.backfill_actual.call_args
-    expected = _expected_period(baseline)
-    assert call.args[0] == expected
-    # The 10:00 period has not completed at 10:05 -> still pending in the accumulator.
-    later = expected + timedelta(minutes=30)
-    assert later.isoformat() in scheduler._period_energy_accum
-    # Energy split 25/30 to the completed period; total = (4+6)/2 * 0.5 = 2.5 kWh.
-    assert call.args[1] == pytest.approx(2.5 * (25 / 30), rel=1e-3)
+    tracker.backfill_actual.assert_called_once()
+    call = tracker.backfill_actual.call_args
+    assert call.args[0] == _expected_period(_t(9, 30))
+    # 5 kW for 30 min = 2.5 kWh.
+    assert call.args[1] == pytest.approx(2.5, rel=1e-3)
     assert call.kwargs["is_boost"] is False
+    # The 10:00 period has not started accumulating yet.
+    assert _expected_period(_t(10, 0)).isoformat() not in scheduler._period_energy_accum
+
+
+@pytest.mark.asyncio
+async def test_backfill_partial_coverage_after_restart_discarded(coordinator):
+    """A period whose baseline re-establishes mid-period is discarded, not recorded.
+
+    Headline regression for the partial-coverage poisoning fix: a restart leaves
+    the 10:00 period only ~33% covered, so it must NOT be recorded as a full
+    actual (which would persist understated into the learning store).
+    """
+    scheduler = TickScheduler(coordinator)
+    tracker = _setup_tracker(coordinator, power=5.0)
+
+    # Baseline lands at 10:20 (post-restart grace), then ticks to past 10:30.
+    _drive(
+        scheduler,
+        coordinator,
+        [(_t(10, 20), 5.0), (_t(10, 25), 5.0), (_t(10, 30), 5.0)],
+    )
+
+    # The 10:00 period (only 10:20-10:30 covered = 33%) is discarded.
+    tracker.backfill_actual.assert_not_called()
+    assert _expected_period(_t(10, 0)).isoformat() not in scheduler._period_energy_accum
 
 
 @pytest.mark.asyncio
 async def test_backfill_proration_splits_across_boundary(coordinator):
-    """An interval spanning a :00 boundary splits energy proportionally."""
-    from unittest.mock import patch
+    """A boundary-spanning interval splits energy/coverage proportionally.
 
+    Baseline 09:56 -> tick 10:02 (6 min): 4 min in the 09:30 period, 2 min in the
+    10:00 period. The 10:00 period (still pending) keeps its 1/3 share.
+    """
     scheduler = TickScheduler(coordinator)
-    coordinator.solar_accuracy_tracker = MagicMock()
-    coordinator.solar_accuracy_tracker.backfill_actual = MagicMock()
-    coordinator.solar_accuracy_tracker.evict_stale_pendings = MagicMock()
-    coordinator.data = MagicMock()
-    coordinator.data.solar_power_kw = 6.0
-    coordinator.data.boost_charge_active = False
+    tracker = _setup_tracker(coordinator, power=5.0)
 
-    # 09:45 -> 10:15: 15 min in the 09:30 period, 15 min in the 10:00 period.
-    baseline, tick_now = _aligned_times(9, 45, 10, 15)
-    scheduler._last_solar_power_timestamp = baseline
-    scheduler._last_solar_power_kw = 4.0
+    _drive(scheduler, coordinator, [(_t(9, 56), 5.0), (_t(10, 2), 5.0)])
 
-    with patch("homeassistant.util.dt.now", return_value=tick_now):
-        scheduler._backfill_solar_actual()
-
-    # total = (4+6)/2 * 0.5h = 2.5 kWh, split 50/50 across the two periods.
-    expected = _expected_period(baseline)
-    call = coordinator.solar_accuracy_tracker.backfill_actual.call_args
-    assert call.args[0] == expected  # 09:30, the completed period
-    assert call.args[1] == pytest.approx(1.25, rel=1e-3)
-    # The 10:00 period is still accumulating with its half.
-    later = expected + timedelta(minutes=30)
-    assert scheduler._period_energy_accum[later.isoformat()] == pytest.approx(
-        1.25, rel=1e-3
-    )
+    # total = 5 kW * (6/60)h = 0.5 kWh; 10:00 period overlap = 2 of 6 min -> 1/3.
+    later_key = _expected_period(_t(10, 0)).isoformat()
+    assert scheduler._period_energy_accum[later_key] == pytest.approx(0.5 / 3, rel=1e-3)
+    assert scheduler._period_coverage_accum[later_key] == pytest.approx(120.0, rel=1e-3)
+    # The 09:30 period (only 4 min covered) is discarded, not recorded.
+    tracker.backfill_actual.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -572,28 +613,13 @@ async def test_backfill_during_boost_flags_and_consumes_pending(coordinator):
     Regression for the pending-forecast orphan leak: the pending IS consumed
     (backfill_actual called) even during the daily ~3pm boost.
     """
-    from unittest.mock import patch
-
     scheduler = TickScheduler(coordinator)
-    coordinator.solar_accuracy_tracker = MagicMock()
-    coordinator.solar_accuracy_tracker.backfill_actual = MagicMock()
-    coordinator.solar_accuracy_tracker.evict_stale_pendings = MagicMock()
-    coordinator.data = MagicMock()
-    coordinator.data.solar_power_kw = 6.0
-    coordinator.data.boost_charge_active = True
+    tracker = _setup_tracker(coordinator, power=5.0, boost=True)
 
-    baseline, tick_now = _aligned_times(9, 35, 10, 5)
-    scheduler._last_solar_power_timestamp = baseline
-    scheduler._last_solar_power_kw = 4.0
+    _drive(scheduler, coordinator, _five_min_ticks(14, 0, 14, 30, 5.0))
 
-    with patch("homeassistant.util.dt.now", return_value=tick_now):
-        scheduler._backfill_solar_actual()
-
-    coordinator.solar_accuracy_tracker.backfill_actual.assert_called_once()
-    assert (
-        coordinator.solar_accuracy_tracker.backfill_actual.call_args.kwargs["is_boost"]
-        is True
-    )
+    tracker.backfill_actual.assert_called_once()
+    assert tracker.backfill_actual.call_args.kwargs["is_boost"] is True
 
 
 @pytest.mark.asyncio
@@ -603,52 +629,46 @@ async def test_backfill_zero_power_still_flushes(coordinator):
     Regression for the removed `current_power > 0.01` gate — declining-to-zero
     dusk periods are no longer dropped at the scheduler level.
     """
-    from unittest.mock import patch
-
     scheduler = TickScheduler(coordinator)
-    coordinator.solar_accuracy_tracker = MagicMock()
-    coordinator.solar_accuracy_tracker.backfill_actual = MagicMock()
-    coordinator.solar_accuracy_tracker.evict_stale_pendings = MagicMock()
-    coordinator.data = MagicMock()
-    coordinator.data.solar_power_kw = 0.0
-    coordinator.data.boost_charge_active = False
+    tracker = _setup_tracker(coordinator, power=0.0)
 
-    baseline, tick_now = _aligned_times(18, 35, 19, 5)
-    scheduler._last_solar_power_timestamp = baseline
-    scheduler._last_solar_power_kw = 0.0
+    _drive(scheduler, coordinator, _five_min_ticks(18, 30, 19, 0, 0.0))
 
-    with patch("homeassistant.util.dt.now", return_value=tick_now):
-        scheduler._backfill_solar_actual()
+    # The fully-covered dusk period is flushed with ~0 energy (tracker gate decides).
+    tracker.backfill_actual.assert_called_once()
+    assert tracker.backfill_actual.call_args.args[1] == pytest.approx(0.0)
 
-    # The completed dusk period is flushed with ~0 energy (tracker gate decides).
-    coordinator.solar_accuracy_tracker.backfill_actual.assert_called_once()
-    assert (
-        coordinator.solar_accuracy_tracker.backfill_actual.call_args.args[1]
-        == pytest.approx(0.0)
-    )
+
+@pytest.mark.asyncio
+async def test_backfill_long_interval_rebaselines_without_integrating(coordinator):
+    """An interval longer than the cap (15 min) re-baselines without integrating.
+
+    Guards against an event-loop stall smearing one trapezoid across many periods.
+    """
+    scheduler = TickScheduler(coordinator)
+    tracker = _setup_tracker(coordinator, power=5.0)
+    scheduler._last_solar_power_timestamp = _t(10, 0)
+    scheduler._last_solar_power_kw = 5.0
+
+    _drive(scheduler, coordinator, [(_t(10, 20), 5.0)])  # 20-min gap > 15-min cap
+
+    tracker.backfill_actual.assert_not_called()
+    assert scheduler._period_energy_accum == {}
+    # Baseline is advanced so the next normal interval integrates cleanly.
+    assert scheduler._last_solar_power_timestamp == _t(10, 20)
 
 
 @pytest.mark.asyncio
 async def test_backfill_evicts_stale_pendings(coordinator):
-    """evict_stale_pendings runs after the flush."""
-    from unittest.mock import patch
-
+    """evict_stale_pendings runs on each integrating tick."""
     scheduler = TickScheduler(coordinator)
-    coordinator.solar_accuracy_tracker = MagicMock()
-    coordinator.solar_accuracy_tracker.backfill_actual = MagicMock()
-    coordinator.solar_accuracy_tracker.evict_stale_pendings = MagicMock()
-    coordinator.data = MagicMock()
-    coordinator.data.solar_power_kw = 6.0
-    coordinator.data.boost_charge_active = False
+    tracker = _setup_tracker(coordinator, power=5.0)
+    scheduler._last_solar_power_timestamp = _t(10, 0)
+    scheduler._last_solar_power_kw = 5.0
 
-    baseline, tick_now = _aligned_times(9, 35, 10, 5)
-    scheduler._last_solar_power_timestamp = baseline
-    scheduler._last_solar_power_kw = 4.0
+    _drive(scheduler, coordinator, [(_t(10, 5), 5.0)])
 
-    with patch("homeassistant.util.dt.now", return_value=tick_now):
-        scheduler._backfill_solar_actual()
-
-    coordinator.solar_accuracy_tracker.evict_stale_pendings.assert_called_once()
+    tracker.evict_stale_pendings.assert_called_once()
 
 
 @pytest.mark.asyncio

--- a/tests/forecast/test_solar_accuracy.py
+++ b/tests/forecast/test_solar_accuracy.py
@@ -1,9 +1,10 @@
 """Tests for forecast/solar_accuracy.py - Solar forecast accuracy tracking."""
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from homeassistant.util import dt as dt_util
 
 from custom_components.localshift.forecast.solar_accuracy import (
     BIAS_HALF_LIFE_DAYS,
@@ -377,6 +378,70 @@ class TestSolarAccuracyTracker:
         assert len(tracker._period_records) == 2
         assert tracker._metrics.sample_count == 1
         assert tracker._period_records[-1].is_boost_period is True
+
+    def test_backfill_is_boost_override_true(self, tracker):
+        """is_boost=True at flush time overrides a non-boost pending."""
+        period_start = datetime(2026, 1, 15, 10, 0, tzinfo=UTC)
+        tracker.record_forecast(period_start, 2.0, "sunny", is_boost=False)
+        tracker.backfill_actual(period_start, 1.0, is_boost=True)
+
+        assert tracker._period_records[-1].is_boost_period is True
+        # Boost records are excluded from metrics.
+        assert tracker._metrics.sample_count == 0
+
+    def test_backfill_is_boost_override_false(self, tracker):
+        """is_boost=False at flush time overrides a boost-tagged pending."""
+        period_start = datetime(2026, 1, 15, 10, 0, tzinfo=UTC)
+        tracker.record_forecast(period_start, 2.0, "sunny", is_boost=True)
+        tracker.backfill_actual(period_start, 1.0, is_boost=False)
+
+        assert tracker._period_records[-1].is_boost_period is False
+        assert tracker._metrics.sample_count == 1
+
+    def test_backfill_is_boost_none_preserves_pending_flag(self, tracker):
+        """is_boost=None (default) preserves the pending's recorded flag."""
+        period_start = datetime(2026, 1, 15, 10, 0, tzinfo=UTC)
+        tracker.record_forecast(period_start, 2.0, "sunny", is_boost=True)
+        tracker.backfill_actual(period_start, 1.0)  # no is_boost arg
+
+        assert tracker._period_records[-1].is_boost_period is True
+
+    def test_backfill_zero_forecast_zero_actual_dropped(self, tracker):
+        """Information-free overnight samples are dropped, not counted."""
+        period_start = datetime(2026, 1, 15, 2, 0, tzinfo=UTC)
+        tracker.record_forecast(period_start, 0.0, "clear")
+        tracker.backfill_actual(period_start, 0.0)
+
+        # Pending consumed, but no record appended and sample_count unchanged.
+        assert period_start.isoformat() not in tracker._pending_forecasts
+        assert len(tracker._period_records) == 0
+        assert tracker._metrics.sample_count == 0
+
+    def test_backfill_dusk_forecast_positive_tiny_actual_kept(self, tracker):
+        """Dusk periods (forecast > 0, ~0 actual) ARE kept — that bias matters."""
+        period_start = datetime(2026, 1, 15, 19, 0, tzinfo=UTC)
+        tracker.record_forecast(period_start, 0.5, "clear")
+        tracker.backfill_actual(period_start, 0.0)
+
+        assert len(tracker._period_records) == 1
+        assert tracker._metrics.sample_count == 1
+
+    def test_evict_stale_pendings_drops_past_keeps_future(self, tracker):
+        """Past-dated pendings are evicted; future horizon slots are retained."""
+        now = dt_util.now()
+        stale = (now - timedelta(hours=6)).replace(minute=0, second=0, microsecond=0)
+        recent = (now - timedelta(hours=1)).replace(minute=0, second=0, microsecond=0)
+        future = (now + timedelta(hours=2)).replace(minute=0, second=0, microsecond=0)
+
+        tracker.record_forecast(stale, 2.0, "sunny")
+        tracker.record_forecast(recent, 2.0, "sunny")
+        tracker.record_forecast(future, 2.0, "sunny")
+
+        tracker.evict_stale_pendings(max_age_hours=4.0)
+
+        assert stale.isoformat() not in tracker._pending_forecasts
+        assert recent.isoformat() in tracker._pending_forecasts
+        assert future.isoformat() in tracker._pending_forecasts
 
     def test_get_bias_correction_no_data(self, tracker):
         """Test get_bias_correction with no historical data returns 1.0."""


### PR DESCRIPTION
## Problem (root cause C)

Even in-session, solar accuracy samples were slow, mis-attributed, and lossy. Live: accuracy = 10.0%, overall_bias = −2.78.

- **Off-by-one-period attribution**: the 30-min trapezoid energy was attributed to `period_start = now floored to :00/:30` — the period that just *started*, not the one(s) the energy was produced in. Forecast vs actual compared one period out of phase → garbage bias.
- **Ticks aren't wall-aligned** (`async_track_time_interval` anchors at startup), so an interval almost always spans a :00/:30 boundary; energy must be prorated, not dumped on one period.
- **Boost early-return orphaned pendings**: the daily ~3pm boost-charge made `_backfill_solar_actual` return, silently skipping midday periods. Their pending forecasts were never consumed and `_pending_forecasts` had no eviction → slow leak + lost samples.
- **Dusk gate**: `current_power > 0.01` dropped declining-to-zero dusk periods — exactly where forecast bias matters.

## Fix

Rewrote `_backfill_solar_actual` as **accumulate-and-flush**, moved from the slow (30-min) tick to the **medium (5-min) tick** (shorter trapezoid integration is far more accurate for fast-changing solar; makes proration nearly exact):

1. Each medium tick integrates power since the last tick and **prorates** the energy across every 30-min wall-clock period the interval overlaps (keys = local `:00/:30` floor `.isoformat()`, matching `optimizer_facade._record_forecasts_for_slots` pending keys).
2. **Flush** every period whose end is in the past → `backfill_actual(period_start, kwh, is_boost=...)`. Energy produced 09:30–10:00 lands on 09:30 and flushes at the first tick after 10:00.
3. **Boost** intervals keep accumulating; the period is flagged and the pending is consumed (orphan-leak fix). Boost records stay excluded from metrics.
4. **Dusk gate removed**; meaningfulness is decided at flush time.
5. `evict_stale_pendings(max_age_hours=4.0)` drops past-dated pendings that never got an actual (restart mid-period safety net).
6. Deleted the vestigial dead `pass` block in `handle_medium_tick`.

### `solar_accuracy.py`
- `backfill_actual` gains `is_boost: bool | None = None` — overrides the pending's flag at flush time (the boost state when the forecast was recorded may differ from the period itself); `None` (default) preserves the existing flag → backward compatible.
- Meaningfulness gate: zero-forecast **and** zero-actual → pop pending, no record (don't inflate `sample_count` with information-free overnight samples). Dusk (forecast > 0, ~0 actual) is kept.
- New `evict_stale_pendings`.

No storage schema/version change. **Accepted trade-off**: pendings + accumulators are in-memory, so a restart mid-period loses that one period's sample.

## Tests
- **Attribution regression (headline)**: baseline 09:35 → tick 10:05 prorates 25/5 min; the 09:30 period is flushed, the just-started 10:00 period is NOT.
- Boundary proration (09:45→10:15 splits 50/50).
- Boost: accumulation continues, flush calls `is_boost=True`, pending consumed (replaces the old skip test).
- Dusk: forecast > 0 with ~0 actual still produces a record.
- Zero/zero drop; `is_boost` override True/False/None; `evict_stale_pendings` past-dropped/future-kept.
- Tick cadence: medium tick drives backfill, slow tick no longer does.

Part of the learning-mode fix series (PR 2 of 4). Independent of PRs 1 and 3.