### PR TITLE
fix(learning): schedule pattern analysis by persisted timestamp + restart survival

### DIFF
--- a/custom_components/localshift/coordinator/coordinator.py
+++ b/custom_components/localshift/coordinator/coordinator.py
@@ -298,6 +298,11 @@ class LocalShiftCoordinator:
             self._learning_orchestrator.optimization_controller
         )
 
+        # Re-derive ephemeral learning state from persisted data before sensors
+        # first render: learning_status from the decision deque, and the last
+        # pattern report / bias corrections (which only lived in memory).
+        self._learning_orchestrator.restore_runtime_state(self.data)
+
         # Initialize solar forecast accuracy tracker (Issue #378)
         from ..forecast.solar_accuracy import SolarAccuracyTracker
 

--- a/custom_components/localshift/coordinator/data.py
+++ b/custom_components/localshift/coordinator/data.py
@@ -423,6 +423,9 @@ class CoordinatorData:
     active_bias_corrections: list[dict[str, Any]] = field(
         default_factory=list
     )  # Currently active corrections
+    last_pattern_analysis: str | None = (
+        None  # ISO timestamp of the last pattern-analysis run
+    )
     solar_bias_metrics: dict[str, Any] = field(
         default_factory=dict
     )  # Solar forecast bias metrics and correction factors

--- a/custom_components/localshift/engine/pattern_analyzer.py
+++ b/custom_components/localshift/engine/pattern_analyzer.py
@@ -713,6 +713,11 @@ class PatternAnalyzer:
         """
         return self._last_report
 
+    @property
+    def last_analysis_time(self) -> datetime | None:
+        """Return the timestamp of the last analysis (persisted across restarts)."""
+        return self._last_analysis_time
+
     def should_run_analysis(self, days_since_last: int, new_decisions: int) -> bool:
         """Check if pattern analysis should run.
 

--- a/custom_components/localshift/learning/orchestrator.py
+++ b/custom_components/localshift/learning/orchestrator.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 
 import logging
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.storage import Store
+from homeassistant.util import dt as dt_util
 
 from ..const import SWITCH_ENABLE_LEARNING
 from ..engine.counterfactual import CounterfactualEvaluator
@@ -42,8 +43,12 @@ class LearningOrchestrator:
         self.pattern_analyzer: Any | None = None
         self.optimization_controller: Any | None = None
 
-        self._last_pattern_analysis: datetime | None = None
-        self._days_since_pattern_analysis = 0
+        # Throttle for pattern-analysis scheduling. In-memory only: prevents
+        # double-scheduling while the task runs and re-attempting every 5 min on
+        # a fresh install with too few decisions. Due-ness itself is driven by
+        # the pattern analyzer's persisted last_analysis_time, so this resetting
+        # to None on restart is harmless.
+        self._next_analysis_attempt: datetime | None = None
         self._forecast_corrections: ForecastCorrectionProvider | None = None
         self._forecast_corrections_store = Store(
             hass,
@@ -188,21 +193,11 @@ class LearningOrchestrator:
                 "localshift_save_param_optimizer",
             )
 
-        self._days_since_pattern_analysis += 1
-        analysis_interval = self._get_pattern_analysis_interval(
-            getattr(data, "learning_status", "observing")
-        )
-        if (
-            self.pattern_analyzer is not None
-            and self.decision_tracker is not None
-            and self._days_since_pattern_analysis >= analysis_interval
-        ):
-            self._days_since_pattern_analysis = 0
-            self.hass.async_create_task(
-                self._run_pattern_analysis(data),
-                "localshift_pattern_analysis",
-            )
-
+        # Pattern analysis is no longer triggered here. The old in-memory day
+        # counter reset on every restart (the system restarts every 1-2 days),
+        # so it never reached the 7-day interval and analysis never ran. It is
+        # now scheduled from update_medium_tick based on the persisted
+        # last_analysis_time (see maybe_run_pattern_analysis).
         if self.pattern_analyzer is not None:
             self.hass.async_create_task(
                 self.pattern_analyzer.async_save(),
@@ -211,6 +206,83 @@ class LearningOrchestrator:
 
     def _get_pattern_analysis_interval(self, learning_status: str) -> int:
         return self._PATTERN_ANALYSIS_INTERVALS.get(learning_status, 7)
+
+    @staticmethod
+    def _derive_learning_status(decision_count: int) -> str:
+        """Derive learning status from how many decisions are available.
+
+        Equivalent to the thresholds applied inside _run_pattern_analysis:
+        report.data_points_analyzed == len(decisions) and the same 720h decision
+        window is used, so deriving from the count at startup is identical.
+        """
+        if decision_count >= 100:
+            return "optimizing"
+        if decision_count >= 50:
+            return "tuning"
+        return "observing"
+
+    def maybe_run_pattern_analysis(self, data) -> None:
+        """Schedule pattern analysis when it is due, based on persisted state.
+
+        Due when the analyzer has never run, or when more than the
+        status-dependent interval (7/5/3 days) has elapsed since the persisted
+        last_analysis_time. A short in-memory throttle prevents double-scheduling
+        while the task runs and stops a too-few-decisions install from retrying
+        every 5 minutes.
+        """
+        if self.pattern_analyzer is None or self.decision_tracker is None:
+            return
+
+        now = dt_util.now()
+        if (
+            self._next_analysis_attempt is not None
+            and now < self._next_analysis_attempt
+        ):
+            return
+
+        last = self.pattern_analyzer.last_analysis_time
+        interval_days = self._get_pattern_analysis_interval(
+            getattr(data, "learning_status", "observing")
+        )
+        due = last is None or (now - last) >= timedelta(days=interval_days)
+        if not due:
+            return
+
+        # Reserve a 1h window so the running task is not re-scheduled. If the run
+        # skips for too few decisions it pushes this out to 24h itself.
+        self._next_analysis_attempt = now + timedelta(hours=1)
+        self.hass.async_create_task(
+            self._run_pattern_analysis(data),
+            "localshift_pattern_analysis",
+        )
+
+    def restore_runtime_state(self, data) -> None:
+        """Re-derive ephemeral learning state after a restart.
+
+        learning_status, the last pattern report summary, and active bias
+        corrections are not persisted as such — but everything needed to
+        reconstruct them is. This re-derives them from the persisted decision
+        deque and pattern report so sensors render correctly and bias
+        corrections (which only lived in memory) survive a restart.
+        """
+        if self.decision_tracker is not None:
+            recent = self.decision_tracker.get_recent_decisions(hours=720)
+            data.learning_status = self._derive_learning_status(len(recent))
+
+        if self.pattern_analyzer is None:
+            return
+
+        report = self.pattern_analyzer.get_last_report()
+        if report is not None:
+            data.pattern_report_summary = report.get_summary()
+            data.active_bias_corrections = [
+                bc.to_dict() for bc in report.biases_detected
+            ]
+            if self.param_optimizer is not None and report.biases_detected:
+                self.param_optimizer.set_bias_corrections(report.biases_detected)
+
+        last = self.pattern_analyzer.last_analysis_time
+        data.last_pattern_analysis = last.isoformat() if last is not None else None
 
     def update_medium_tick(self, data) -> None:
         """Run learning and monitoring tasks on medium tick."""
@@ -260,6 +332,11 @@ class LearningOrchestrator:
                     len(active_adjustments),
                 )
 
+        # Schedule pattern analysis if it is due. handle_medium_tick skips during
+        # the startup grace period, so the first post-grace tick (~5-35 min after
+        # a restart) runs any overdue analysis — startup catch-up for free.
+        self.maybe_run_pattern_analysis(data)
+
     async def _run_pattern_analysis(self, data) -> None:
         """Run weekly pattern analysis to generate bias corrections."""
         if self.pattern_analyzer is None or self.decision_tracker is None:
@@ -272,29 +349,29 @@ class LearningOrchestrator:
                 "Pattern analysis skipped: only %d decisions (need 50+)",
                 len(decisions),
             )
+            # Back off so a fresh install does not retry every medium tick.
+            self._next_analysis_attempt = dt_util.now() + timedelta(hours=24)
             return
 
         report = self.pattern_analyzer.analyze(decisions)
+        # Persist the new last_analysis_time immediately so a crash before the
+        # next 5-min periodic save does not lose the "analysis ran" timestamp.
+        await self.pattern_analyzer.async_save()
 
         data.pattern_report_summary = report.get_summary()
         data.active_bias_corrections = [bc.to_dict() for bc in report.biases_detected]
-
-        total_samples = report.data_points_analyzed
-        if total_samples >= 100:
-            data.learning_status = "optimizing"
-        elif total_samples >= 50:
-            data.learning_status = "tuning"
-        else:
-            data.learning_status = "observing"
+        data.learning_status = self._derive_learning_status(report.data_points_analyzed)
 
         if self.param_optimizer is not None and report.biases_detected:
             self.param_optimizer.set_bias_corrections(report.biases_detected)
-            _LOGGER.info(
-                "Pattern analysis complete: %d bias corrections applied",
-                len(report.biases_detected),
-            )
 
-        self._last_pattern_analysis = datetime.now()
+        last = self.pattern_analyzer.last_analysis_time
+        data.last_pattern_analysis = last.isoformat() if last is not None else None
+        _LOGGER.info(
+            "Pattern analysis complete: %d decisions analyzed, %d biases detected",
+            report.data_points_analyzed,
+            len(report.biases_detected),
+        )
 
         _LOGGER.info(
             "Pattern analysis complete: %d decisions analyzed, %d biases detected",

--- a/tests/learning/test_learning_integration.py
+++ b/tests/learning/test_learning_integration.py
@@ -338,26 +338,14 @@ class TestLearningOrchestratorForecastCorrections:
 
         assert state_machine._decision_tracker is tracker
 
-    @pytest.mark.parametrize(
-        ("learning_status", "starting_days", "expects_analysis", "expected_days"),
-        [
-            ("observing", 5, False, 6),
-            ("observing", 6, True, 0),
-            ("tuning", 3, False, 4),
-            ("tuning", 4, True, 0),
-            ("optimizing", 1, False, 2),
-            ("optimizing", 2, True, 0),
-        ],
-    )
-    def test_handle_midnight_reset_uses_phase_specific_interval(
-        self,
-        mock_hass,
-        mock_entry,
-        learning_status,
-        starting_days,
-        expects_analysis,
-        expected_days,
+    def test_handle_midnight_reset_saves_but_never_runs_analysis(
+        self, mock_hass, mock_entry
     ):
+        """Midnight reset persists learning data but no longer triggers analysis.
+
+        Analysis is now scheduled from the medium tick based on the persisted
+        last_analysis_time, not a per-restart day counter.
+        """
         orchestrator = LearningOrchestrator(mock_hass, mock_entry, lambda _key: False)
         orchestrator.decision_tracker = MagicMock(
             async_save=MagicMock(return_value=None)
@@ -368,10 +356,8 @@ class TestLearningOrchestratorForecastCorrections:
         orchestrator.pattern_analyzer = MagicMock(
             async_save=MagicMock(return_value=None)
         )
-        orchestrator._days_since_pattern_analysis = starting_days
 
         data = CoordinatorData()
-        data.learning_status = learning_status
         orchestrator.handle_midnight_reset(data)
 
         task_names = [
@@ -380,49 +366,7 @@ class TestLearningOrchestratorForecastCorrections:
         assert "localshift_save_decision_outcomes" in task_names
         assert "localshift_save_param_optimizer" in task_names
         assert "localshift_save_pattern_analyzer" in task_names
-        assert ("localshift_pattern_analysis" in task_names) is expects_analysis
-        assert orchestrator._days_since_pattern_analysis == expected_days
-
-        for call in mock_hass.async_create_task.call_args_list:
-            coro = call.args[0]
-            if hasattr(coro, "close"):
-                coro.close()
-        mock_hass.async_create_task.reset_mock()
-
-    def test_handle_midnight_reset_keeps_counter_across_phase_changes(
-        self, mock_hass, mock_entry
-    ):
-        orchestrator = LearningOrchestrator(mock_hass, mock_entry, lambda _key: False)
-        orchestrator.decision_tracker = MagicMock(
-            async_save=MagicMock(return_value=None)
-        )
-        orchestrator.param_optimizer = MagicMock(
-            async_save=MagicMock(return_value=None)
-        )
-        orchestrator.pattern_analyzer = MagicMock(
-            async_save=MagicMock(return_value=None)
-        )
-        orchestrator._days_since_pattern_analysis = 1
-
-        data = CoordinatorData()
-        data.learning_status = "observing"
-        orchestrator.handle_midnight_reset(data)
-        assert orchestrator._days_since_pattern_analysis == 2
-
-        for call in mock_hass.async_create_task.call_args_list:
-            coro = call.args[0]
-            if hasattr(coro, "close"):
-                coro.close()
-        mock_hass.async_create_task.reset_mock()
-
-        data.learning_status = "tuning"
-        orchestrator.handle_midnight_reset(data)
-
-        task_names = [
-            call.args[1] for call in mock_hass.async_create_task.call_args_list
-        ]
         assert "localshift_pattern_analysis" not in task_names
-        assert orchestrator._days_since_pattern_analysis == 3
 
         for call in mock_hass.async_create_task.call_args_list:
             coro = call.args[0]
@@ -513,7 +457,8 @@ class TestLearningOrchestratorForecastCorrections:
         await orchestrator._run_pattern_analysis(data)
 
         orchestrator.pattern_analyzer.analyze.assert_not_called()
-        assert orchestrator._last_pattern_analysis is None
+        # Too few decisions backs off so a fresh install does not retry every tick.
+        assert orchestrator._next_analysis_attempt is not None
 
     @pytest.mark.asyncio
     async def test_run_pattern_analysis_updates_status_and_biases(
@@ -528,11 +473,14 @@ class TestLearningOrchestratorForecastCorrections:
         report.biases_detected = [bias]
         report.data_points_analyzed = 120
 
+        analysis_time = datetime(2026, 6, 11, 0, 0)
         orchestrator.decision_tracker = MagicMock(
             get_recent_decisions=MagicMock(return_value=[1] * 60)
         )
         orchestrator.pattern_analyzer = MagicMock(
-            analyze=MagicMock(return_value=report)
+            analyze=MagicMock(return_value=report),
+            async_save=AsyncMock(),
+            last_analysis_time=analysis_time,
         )
         orchestrator.param_optimizer = MagicMock(set_bias_corrections=MagicMock())
 
@@ -542,7 +490,9 @@ class TestLearningOrchestratorForecastCorrections:
         assert data.pattern_report_summary == {"summary": 1}
         assert data.active_bias_corrections == [{"bias": 1}]
         assert data.learning_status == "optimizing"
-        assert orchestrator._last_pattern_analysis is not None
+        # New last_analysis_time is persisted immediately and surfaced on data.
+        orchestrator.pattern_analyzer.async_save.assert_awaited_once()
+        assert data.last_pattern_analysis == analysis_time.isoformat()
 
     @pytest.mark.asyncio
     async def test_run_pattern_analysis_sets_observing_for_low_sample_report(
@@ -559,7 +509,9 @@ class TestLearningOrchestratorForecastCorrections:
             get_recent_decisions=MagicMock(return_value=[1] * 60)
         )
         orchestrator.pattern_analyzer = MagicMock(
-            analyze=MagicMock(return_value=report)
+            analyze=MagicMock(return_value=report),
+            async_save=AsyncMock(),
+            last_analysis_time=datetime(2026, 6, 11, 0, 0),
         )
         orchestrator.param_optimizer = MagicMock(set_bias_corrections=MagicMock())
 

--- a/tests/learning/test_orchestrator.py
+++ b/tests/learning/test_orchestrator.py
@@ -3,9 +3,11 @@
 This file aggregates tests from test_learning_integration.py for coverage.
 """
 
+from datetime import timedelta
 from unittest.mock import MagicMock
 
 import pytest
+from homeassistant.util import dt as dt_util
 
 from custom_components.localshift.coordinator.data import (
     CoordinatorData,
@@ -81,3 +83,176 @@ class TestOrchestratorWeatherWeightPropagation:
 
         call_kwargs = mock_optimizer.optimize.call_args.kwargs
         assert call_kwargs.get("weather_weight") == pytest.approx(1.0)
+
+
+def _close_scheduled_coros(hass):
+    """Close any un-awaited coroutines passed to the mock async_create_task."""
+    for call in hass.async_create_task.call_args_list:
+        coro = call.args[0]
+        if hasattr(coro, "close"):
+            coro.close()
+
+
+def _scheduled_task_names(hass):
+    return [call.args[1] for call in hass.async_create_task.call_args_list]
+
+
+class TestDeriveLearningStatus:
+    @pytest.mark.parametrize(
+        ("count", "expected"),
+        [
+            (49, "observing"),
+            (50, "tuning"),
+            (99, "tuning"),
+            (100, "optimizing"),
+        ],
+    )
+    def test_boundaries(self, count, expected):
+        from custom_components.localshift.learning.orchestrator import (
+            LearningOrchestrator,
+        )
+
+        assert LearningOrchestrator._derive_learning_status(count) == expected
+
+
+class TestMaybeRunPatternAnalysis:
+    def _wire(self, orchestrator, *, last_analysis_time, decision_count=60):
+        orchestrator.pattern_analyzer = MagicMock(last_analysis_time=last_analysis_time)
+        orchestrator.decision_tracker = MagicMock(
+            get_recent_decisions=MagicMock(return_value=[1] * decision_count)
+        )
+
+    def test_fires_when_never_run(self):
+        orchestrator = _make_orchestrator()
+        self._wire(orchestrator, last_analysis_time=None)
+
+        orchestrator.maybe_run_pattern_analysis(CoordinatorData())
+
+        assert "localshift_pattern_analysis" in _scheduled_task_names(orchestrator.hass)
+        _close_scheduled_coros(orchestrator.hass)
+
+    def test_fires_when_older_than_interval(self):
+        orchestrator = _make_orchestrator()
+        self._wire(
+            orchestrator,
+            last_analysis_time=dt_util.now() - timedelta(days=8),
+        )
+
+        orchestrator.maybe_run_pattern_analysis(CoordinatorData())
+
+        assert "localshift_pattern_analysis" in _scheduled_task_names(orchestrator.hass)
+        _close_scheduled_coros(orchestrator.hass)
+
+    def test_does_not_fire_when_fresh(self):
+        orchestrator = _make_orchestrator()
+        self._wire(orchestrator, last_analysis_time=dt_util.now() - timedelta(days=1))
+
+        orchestrator.maybe_run_pattern_analysis(CoordinatorData())
+
+        assert orchestrator.hass.async_create_task.call_count == 0
+
+    def test_interval_varies_with_status(self):
+        # 4 days elapsed: due while "optimizing" (interval 3), not while "observing" (7).
+        orchestrator = _make_orchestrator()
+        self._wire(orchestrator, last_analysis_time=dt_util.now() - timedelta(days=4))
+
+        observing = CoordinatorData()
+        observing.learning_status = "observing"
+        orchestrator.maybe_run_pattern_analysis(observing)
+        assert orchestrator.hass.async_create_task.call_count == 0
+
+        optimizing = CoordinatorData()
+        optimizing.learning_status = "optimizing"
+        orchestrator.maybe_run_pattern_analysis(optimizing)
+        assert "localshift_pattern_analysis" in _scheduled_task_names(orchestrator.hass)
+        _close_scheduled_coros(orchestrator.hass)
+
+    def test_throttle_blocks_second_attempt(self):
+        orchestrator = _make_orchestrator()
+        self._wire(orchestrator, last_analysis_time=None)
+
+        orchestrator.maybe_run_pattern_analysis(CoordinatorData())
+        first_count = orchestrator.hass.async_create_task.call_count
+        # Immediately try again — the 1h reservation should block re-scheduling.
+        orchestrator.maybe_run_pattern_analysis(CoordinatorData())
+
+        assert orchestrator.hass.async_create_task.call_count == first_count
+        _close_scheduled_coros(orchestrator.hass)
+
+    def test_simulated_restart_schedules_overdue_analysis(self):
+        """Headline: a fresh orchestrator's first medium tick runs overdue analysis.
+
+        Persisted last_analysis_time 8 days old + >=50 persisted decisions means
+        the old per-restart counter would never have triggered — this does.
+        """
+        orchestrator = _make_orchestrator()
+        orchestrator.pattern_analyzer = MagicMock(
+            last_analysis_time=dt_util.now() - timedelta(days=8)
+        )
+        orchestrator.param_optimizer = None
+        orchestrator.optimization_controller = None
+
+        tracker = MagicMock()
+        tracker.backfill_outcomes = MagicMock()
+        tracker.get_daily_summary.return_value = PerformanceMetrics()
+        tracker.get_decision_log.return_value = []
+        tracker.save_pending = False
+        tracker._completed_decisions = [MagicMock() for _ in range(60)]
+        tracker.get_recent_decisions.return_value = [1] * 60
+        orchestrator.decision_tracker = tracker
+
+        data = CoordinatorData()
+        data.performance_metrics = PerformanceMetrics()
+        orchestrator.update_medium_tick(data)
+
+        assert "localshift_pattern_analysis" in _scheduled_task_names(orchestrator.hass)
+        _close_scheduled_coros(orchestrator.hass)
+
+
+class TestRestoreRuntimeState:
+    def test_status_and_report_restored(self):
+        orchestrator = _make_orchestrator()
+
+        orchestrator.decision_tracker = MagicMock(
+            get_recent_decisions=MagicMock(return_value=[1] * 120)
+        )
+
+        bias = MagicMock()
+        bias.to_dict.return_value = {"bias": 1}
+        report = MagicMock()
+        report.get_summary.return_value = {"summary": 1}
+        report.biases_detected = [bias]
+
+        analysis_time = dt_util.now() - timedelta(days=2)
+        orchestrator.pattern_analyzer = MagicMock(
+            get_last_report=MagicMock(return_value=report),
+            last_analysis_time=analysis_time,
+        )
+        orchestrator.param_optimizer = MagicMock(set_bias_corrections=MagicMock())
+
+        data = CoordinatorData()
+        orchestrator.restore_runtime_state(data)
+
+        assert data.learning_status == "optimizing"
+        assert data.pattern_report_summary == {"summary": 1}
+        assert data.active_bias_corrections == [{"bias": 1}]
+        orchestrator.param_optimizer.set_bias_corrections.assert_called_once_with(
+            [bias]
+        )
+        assert data.last_pattern_analysis == analysis_time.isoformat()
+
+    def test_no_report_derives_status_only(self):
+        orchestrator = _make_orchestrator()
+        orchestrator.decision_tracker = MagicMock(
+            get_recent_decisions=MagicMock(return_value=[1] * 10)
+        )
+        orchestrator.pattern_analyzer = MagicMock(
+            get_last_report=MagicMock(return_value=None),
+            last_analysis_time=None,
+        )
+
+        data = CoordinatorData()
+        orchestrator.restore_runtime_state(data)
+
+        assert data.learning_status == "observing"
+        assert data.last_pattern_analysis is None

--- a/tests/test_pattern_analyzer.py
+++ b/tests/test_pattern_analyzer.py
@@ -354,6 +354,26 @@ class TestPatternAnalyzerStorage:
         await analyzer.async_load()
         assert analyzer._last_analysis_time is not None
 
+    @pytest.mark.asyncio
+    async def test_last_analysis_time_property_reflects_persisted_value(
+        self, analyzer
+    ):
+        """The read-only property exposes the persisted _last_analysis_time."""
+        assert analyzer.last_analysis_time is None
+
+        async def mock_async_load():
+            return {"last_analysis_time": "2026-06-03T09:30:00+00:00"}
+
+        mock_store = MagicMock()
+        mock_store.async_load = mock_async_load
+        analyzer._store = mock_store
+
+        await analyzer.async_load()
+
+        assert analyzer.last_analysis_time is analyzer._last_analysis_time
+        assert analyzer.last_analysis_time is not None
+        assert analyzer.last_analysis_time.isoformat() == "2026-06-03T09:30:00+00:00"
+
 
 class TestPatternAnalyzerComputeBucketStats:
     """Tests for _compute_bucket_stats method."""


### PR DESCRIPTION
## Problem (root cause A)

`sensor.localshift_learning_status` has been stuck at "observing" forever. The data pipeline underneath works (decisions are recorded ~13/day and persisted), but the analysis that consumes them never triggers:

- `learning_status` only advances inside `_run_pattern_analysis`.
- `_run_pattern_analysis` was triggered ONLY from `handle_midnight_reset`, when the **in-memory** counter `_days_since_pattern_analysis >= interval` (7 days while "observing").
- The counter starts at 0 in `__init__` and only increments at midnight. **Every restart resets it to 0, and the system restarts every 1–2 days → it never reached 7 → analysis has never run.**
- Even if it had, results died on restart: `learning_status` is ephemeral, and bias corrections only lived in `ParameterOptimizer._pending_bias_corrections` (never persisted).

The fix needs **no storage schema change**: `PatternAnalyzer` already persists `_last_analysis_time` (Store v1 `localshift.pattern_analysis.{entry_id}`) and exposes `get_last_report()`. The orchestrator just never read either.

## Fix

- **`pattern_analyzer.py`**: add read-only `last_analysis_time` property (already persisted/restored).
- **`orchestrator.py`**: replace the day counter with **timestamp-due checks**.
  - New `maybe_run_pattern_analysis(data)`: due when `last_analysis_time is None` or `now - last >= interval` (7/5/3 days by status). Called at the **end of `update_medium_tick`**, so the first post-startup-grace medium tick (~5–35 min after restart) runs any overdue analysis — startup catch-up for free, no new hook, no midnight dependency.
  - Remove the counter trigger from `handle_midnight_reset` (keep the saves).
  - In-memory throttle `_next_analysis_attempt`: 1h reservation when scheduling (no double-schedule); 24h backoff when a run skips for `<50` decisions (no every-5-min retry on a fresh install).
  - `_run_pattern_analysis`: persists the analyzer immediately after `analyze()` (timestamp survives a crash before the next periodic save); derives status via `_derive_learning_status`; sets `data.last_pattern_analysis`; uses `dt_util.now()` (removes a naive `datetime.now()`).
  - `restore_runtime_state(data)`, called from the coordinator right after `async_initialize()`: re-derives `learning_status` from the persisted decision deque and re-applies the persisted report summary + bias corrections to `ParameterOptimizer` (fixes the adjacent bug where corrections died every restart).
- **`data.py`**: new `last_pattern_analysis: str | None`.

On the first restart after deploy, with ~390 decisions/30d live, `learning_status` should flip straight to "optimizing".

## Tests
- `_derive_learning_status` boundaries (49→observing, 50→tuning, 99→tuning, 100→optimizing).
- `maybe_run_pattern_analysis`: fires when never-run / overdue, not when fresh; interval varies 7/5/3 with status; throttle blocks a second attempt.
- **Simulated-restart regression (headline)**: 8-day-old persisted `last_analysis_time` + ≥50 decisions → a fresh orchestrator's first `update_medium_tick` schedules analysis.
- `restore_runtime_state`: status derived, report summary + bias corrections re-applied; `last_pattern_analysis` set.
- `last_analysis_time` property + load round-trip.
- Midnight reset still saves but never schedules analysis.

Part of the learning-mode fix series (PR 3 of 4). Independent of PRs 1 and 2.