### PR TITLE
feat(learning): surface solar-accuracy + pattern-analysis progress on sensors

### DIFF
--- a/custom_components/localshift/coordinator/coordinator.py
+++ b/custom_components/localshift/coordinator/coordinator.py
@@ -604,7 +604,7 @@ class LocalShiftCoordinator:
             hasattr(self, "solar_accuracy_tracker")
             and self.solar_accuracy_tracker is not None
         ):
-            self.data.solar_bias_metrics = self.solar_accuracy_tracker.metrics.to_dict()
+            self.data.solar_bias_metrics = self.solar_accuracy_tracker.get_status_dict()
             self.data.solar_forecast_accuracy = (
                 self.solar_accuracy_tracker.metrics.accuracy
             )

--- a/custom_components/localshift/coordinator/tick_scheduler.py
+++ b/custom_components/localshift/coordinator/tick_scheduler.py
@@ -161,7 +161,7 @@ class TickScheduler:
             and self._coordinator.solar_accuracy_tracker is not None
         ):
             self._coordinator.data.solar_bias_metrics = (
-                self._coordinator.solar_accuracy_tracker.metrics.to_dict()
+                self._coordinator.solar_accuracy_tracker.get_status_dict()
             )
             self._coordinator.data.solar_forecast_accuracy = (
                 self._coordinator.solar_accuracy_tracker.metrics.accuracy

--- a/custom_components/localshift/forecast/solar_accuracy.py
+++ b/custom_components/localshift/forecast/solar_accuracy.py
@@ -501,6 +501,28 @@ class SolarAccuracyTracker:
         """
         return self._metrics.sample_count >= MIN_SOLAR_CORRECTION_SAMPLES
 
+    def get_status_dict(self) -> dict[str, Any]:
+        """Return metrics plus operational status for sensor observability.
+
+        Surfaces how close the tracker is to activating bias correction
+        (sample_count vs MIN_SOLAR_CORRECTION_SAMPLES) and how many pending /
+        boost-excluded records there are — so progress is visible without
+        log-diving.
+        """
+        status = self._metrics.to_dict()
+        status.update({
+            "pending_forecasts": len(self._pending_forecasts),
+            "samples_until_active": max(
+                0, MIN_SOLAR_CORRECTION_SAMPLES - self._metrics.sample_count
+            ),
+            "min_samples_required": MIN_SOLAR_CORRECTION_SAMPLES,
+            "correction_active": self.has_sufficient_samples(),
+            "boost_records_excluded": sum(
+                1 for r in self._period_records if r.is_boost_period
+            ),
+        })
+        return status
+
     def accuracy_confidence_ceiling(self, low: float = 0.3, high: float = 1.0) -> float:
         """Return a confidence ceiling derived from realized forecast accuracy.
 

--- a/custom_components/localshift/sensors/learning.py
+++ b/custom_components/localshift/sensors/learning.py
@@ -33,6 +33,8 @@ class LearningStatusSensor(LocalShiftSensorBase):
             },
             "optimization_weights": d.optimization_weights,
             "contextual_adjustments_active": d.contextual_adjustments_active,
+            "last_pattern_analysis": getattr(d, "last_pattern_analysis", None),
+            "active_bias_corrections": len(d.active_bias_corrections),
         }
 
     @property

--- a/tests/coordinator/test_tick_scheduler.py
+++ b/tests/coordinator/test_tick_scheduler.py
@@ -548,12 +548,13 @@ async def test_handle_medium_tick_with_solar_tracker(coordinator):
     coordinator._state_machine = MagicMock()
     coordinator._state_machine.startup_grace_until = None  # No grace period
 
-    # Mock solar accuracy tracker
+    # Mock solar accuracy tracker. The medium tick now publishes the richer
+    # get_status_dict() payload (metrics + activation/pending/boost status).
     coordinator.solar_accuracy_tracker = MagicMock()
-    coordinator.solar_accuracy_tracker.metrics = MagicMock()
-    coordinator.solar_accuracy_tracker.metrics.to_dict = MagicMock(
-        return_value={"bias": 0.1}
+    coordinator.solar_accuracy_tracker.get_status_dict = MagicMock(
+        return_value={"bias": 0.1, "correction_active": False}
     )
+    coordinator.solar_accuracy_tracker.metrics = MagicMock()
     coordinator.solar_accuracy_tracker.metrics.accuracy = 0.95
 
     coordinator.data = MagicMock()
@@ -562,8 +563,11 @@ async def test_handle_medium_tick_with_solar_tracker(coordinator):
 
     scheduler.handle_medium_tick(now)
 
-    # Should update solar bias metrics
-    assert coordinator.data.solar_bias_metrics == {"bias": 0.1}
+    # Should publish the status dict and the accuracy scalar.
+    assert coordinator.data.solar_bias_metrics == {
+        "bias": 0.1,
+        "correction_active": False,
+    }
     assert coordinator.data.solar_forecast_accuracy == 0.95
 
 

--- a/tests/forecast/test_solar_accuracy.py
+++ b/tests/forecast/test_solar_accuracy.py
@@ -441,6 +441,49 @@ class TestSolarAccuracyTracker:
 
         assert tracker.has_sufficient_samples() is True
 
+    def test_get_status_dict_below_threshold(self, tracker):
+        """get_status_dict reports progress toward activation while dormant."""
+        from custom_components.localshift.forecast.solar_accuracy import (
+            MIN_SOLAR_CORRECTION_SAMPLES,
+        )
+
+        for i in range(5):
+            period_start = datetime(2026, 1, 1 + i, 10, 0, tzinfo=UTC)
+            tracker.record_forecast(period_start, 2.0, "sunny")
+            tracker.backfill_actual(period_start, 1.0)
+        # A still-pending forecast for a future slot.
+        tracker.record_forecast(datetime(2026, 2, 1, 10, 0, tzinfo=UTC), 2.0, "sunny")
+        # A boost record (excluded from sample_count). The boost flag is set at
+        # record time and preserved through backfill.
+        boost = datetime(2026, 1, 20, 14, 0, tzinfo=UTC)
+        tracker.record_forecast(boost, 5.0, "sunny", is_boost=True)
+        tracker.backfill_actual(boost, 1.0)
+
+        status = tracker.get_status_dict()
+
+        assert status["sample_count"] == 5
+        assert status["min_samples_required"] == MIN_SOLAR_CORRECTION_SAMPLES
+        assert status["samples_until_active"] == MIN_SOLAR_CORRECTION_SAMPLES - 5
+        assert status["correction_active"] is False
+        assert status["pending_forecasts"] == 1
+        assert status["boost_records_excluded"] == 1
+        # Still carries the underlying metrics fields.
+        assert "overall_bias" in status
+        assert "accuracy" in status
+
+    def test_get_status_dict_active_clamps_samples_until_active(self, tracker):
+        """Once enough samples exist, correction is active and the gap is 0."""
+        for i in range(20):
+            period_start = datetime(2026, 1, 1 + i, 10, 0, tzinfo=UTC)
+            tracker.record_forecast(period_start, 2.0, "sunny")
+            tracker.backfill_actual(period_start, 1.0)
+
+        status = tracker.get_status_dict()
+
+        assert status["sample_count"] == 20
+        assert status["samples_until_active"] == 0
+        assert status["correction_active"] is True
+
     def test_get_bias_correction_with_data(self, tracker):
         """Test get_bias_correction with historical data."""
         # Add historical data with known bias (need 20+ samples for correction)

--- a/tests/sensors/test_learning.py
+++ b/tests/sensors/test_learning.py
@@ -36,6 +36,8 @@ def _make_coordinator(overrides: dict | None = None) -> Mock:
     data.optimization_weights = {"cost": 0.7, "comfort": 0.3}
     data.contextual_adjustments_active = True
     data.recent_decision_log = [{"mode": "grid_charging"} for _ in range(25)]
+    data.last_pattern_analysis = "2026-06-11T00:05:00+00:00"
+    data.active_bias_corrections = [{"bias": 1}, {"bias": 2}]
 
     coordinator = Mock()
     coordinator.data = data
@@ -65,6 +67,19 @@ class TestLearningStatusSensor:
         assert "mode_cost_attribution" in attrs
         assert "optimization_weights" in attrs
         assert attrs["contextual_adjustments_active"] is True
+        assert attrs["last_pattern_analysis"] == "2026-06-11T00:05:00+00:00"
+        assert attrs["active_bias_corrections"] == 2
+
+    def test_extra_state_attributes_handles_missing_last_pattern_analysis(self):
+        """last_pattern_analysis falls back to None when the field is absent."""
+        sensor = _make_sensor(LearningStatusSensor)
+        # Simulate an older data object without the field (defensive getattr).
+        del sensor.coordinator.data.last_pattern_analysis
+        sensor.coordinator.data.active_bias_corrections = []
+        sensor._update_from_coordinator()
+        attrs = sensor.extra_state_attributes
+        assert attrs["last_pattern_analysis"] is None
+        assert attrs["active_bias_corrections"] == 0
 
     def test_icon_optimizing(self):
         sensor = _make_sensor(LearningStatusSensor, status="optimizing")


### PR DESCRIPTION
## Why

PRs 1–3 fix the learning subsystems but their progress is invisible without log-diving. This adds observability so you can watch samples accumulate toward activation and confirm pattern analysis ran.

## Changes

- **`SolarAccuracyTracker.get_status_dict()`**: `metrics.to_dict()` merged with
  - `pending_forecasts` — `len(self._pending_forecasts)`
  - `samples_until_active` — `max(0, MIN_SOLAR_CORRECTION_SAMPLES - sample_count)`
  - `min_samples_required` — 20
  - `correction_active` — `has_sufficient_samples()`
  - `boost_records_excluded` — count of `is_boost_period` records (excluded from metrics)
- Both the medium-tick (`tick_scheduler.py`) and the legacy coordinator medium-tick now publish `get_status_dict()` into `data.solar_bias_metrics` instead of the bare `metrics.to_dict()`. `SolarForecastAccuracySensor.extra_state_attributes` already passes `solar_bias_metrics` through, so the new fields surface automatically — no sensor change there.
- **`LearningStatusSensor`** gains `last_pattern_analysis` and `active_bias_corrections` (count) attributes.

## Dependencies / merge order

Conceptually depends on **PR #862** (boost-record semantics make `boost_records_excluded` meaningful) and **PR #863** (`data.last_pattern_analysis`). To keep this PR landable in any order, the new sensor attribute uses `getattr(d, "last_pattern_analysis", None)`, and `get_status_dict` is fully self-contained. Recommended landing order is 1 → 2 → 3 → 4; the non-overlapping hunks in `solar_accuracy.py` / `tick_scheduler.py` should auto-merge.

## Tests
- `get_status_dict` below the threshold (pending + boost counts, `samples_until_active` gap) and above it (clamped to 0, `correction_active` true).
- `LearningStatusSensor` attribute assertions incl. the missing-field fallback.
- Medium tick publishes the status payload (not the bare metrics dict).

Part of the learning-mode fix series (PR 4 of 4).