### PR TITLE
fix(learning): honest weather-correlation confidence reporting

### DIFF
--- a/custom_components/localshift/coordinator/data.py
+++ b/custom_components/localshift/coordinator/data.py
@@ -371,6 +371,8 @@ class CoordinatorData:
     weather_avg_heating_slope: float = 0.0  # Average kW per °C below heating threshold
     weather_avg_r_squared: float = 0.0  # Average regression fit quality
     weather_sample_count: int = 0  # Number of samples used for learning
+    weather_usable_hours: int = 0  # Hours whose label is medium or high
+    weather_hours_with_data: int = 0  # Hours with any regression result
     weather_anomaly_weight: float = 1.0  # Issue #681: Weight for rollback evaluation
 
     # Forecast accuracy tracking fields (Issue #37 Phase 2)

--- a/custom_components/localshift/engine/weather_diagnostics.py
+++ b/custom_components/localshift/engine/weather_diagnostics.py
@@ -52,17 +52,25 @@ class WeatherDiagnosticsEngine:
         data.weather_avg_heating_slope = diagnostics.get("average_heating_slope", 0.0)
         data.weather_avg_r_squared = diagnostics.get("average_r_squared", 0.0)
 
+        # Majority rule: the old "high if ANY hour is high" let a single good
+        # hour brand the whole forecast "high". Report the label the bulk of
+        # hours actually support, and surface the usable/total counts so the
+        # number behind the label is visible.
         hourly_results = diagnostics.get("hourly_regression", {})
-        has_high_confidence = any(
-            coef.get("confidence") == "high" for coef in hourly_results.values()
-        )
-        has_medium_confidence = any(
-            coef.get("confidence") == "medium" for coef in hourly_results.values()
-        )
-        if has_high_confidence:
+        confidences = [
+            coef.get("confidence", "low") for coef in hourly_results.values()
+        ]
+        n_hours = len(confidences)
+        n_high = confidences.count("high")
+        n_usable = n_high + confidences.count("medium")
+        if n_hours and n_high * 2 >= n_hours:
             data.weather_correlation_confidence = "high"
-        elif has_medium_confidence:
+        elif n_hours and n_usable * 2 >= n_hours:
             data.weather_correlation_confidence = "medium"
+        else:
+            data.weather_correlation_confidence = "low"
+        data.weather_usable_hours = n_usable
+        data.weather_hours_with_data = n_hours
 
         # Issue #681: Weather anomaly detection for rollback protection
         current_temp = weather_correlation.get_current_temperature()

--- a/custom_components/localshift/forecast/load.py
+++ b/custom_components/localshift/forecast/load.py
@@ -42,7 +42,9 @@ class LoadForecaster:
         self._weather_correlation = weather_correlation
         self._adaptive_params = None  # Issue #170 Phase 2: Adaptive parameters
         self._forecast_corrections: ForecastCorrectionProvider | None = None
-        self._weather_adjustment_applied = False  # Track if weather adjustment was used
+        # True if ≥1 slot was weather-adjusted in the most recent forecast run;
+        # reset every run at pipeline.py:53, published at pipeline.py:77-79.
+        self._weather_adjustment_applied = False
 
     def set_weather_correlation(self, weather_correlation: Any | None) -> None:
         """Set or clear WeatherCorrelation dependency at runtime."""
@@ -392,7 +394,14 @@ class LoadForecaster:
             return adjusted_load_kw, adjusted_source
 
         coef = self._weather_correlation.get_coefficients_for_hour(slot_hour)
-        if coef is None or coef.confidence not in ("medium", "high"):
+        # No confidence pre-gate here: predict_load (correlation.py:507/520) is
+        # the authoritative per-zone gate, refusing the adjustment (returning
+        # "low_confidence") when the relevant zone fails samples/r². The old
+        # `confidence not in ("medium","high")` check was strictly redundant
+        # with that — the hour label is the max of zone confidences, so a passing
+        # zone always passed it — and reading the now-stricter hour label here
+        # would wrongly suppress a usable zone in a mixed hour. Behavior-neutral.
+        if coef is None:
             return adjusted_load_kw, adjusted_source
 
         weather_adjusted, adjustment_source = self._weather_correlation.predict_load(

--- a/custom_components/localshift/learning/correlation.py
+++ b/custom_components/localshift/learning/correlation.py
@@ -595,11 +595,23 @@ class WeatherCorrelation:
         heating_conf = self._calculate_confidence(aggregated.heating.n, heating_r2)
         cooling_conf = self._calculate_confidence(aggregated.cooling.n, cooling_r2)
 
-        confidence = "low"
-        if "high" in (heating_conf, cooling_conf):
-            confidence = "high"
-        elif "medium" in (heating_conf, cooling_conf):
-            confidence = "medium"
+        zone_pairs = (
+            (heating_conf, aggregated.heating.n, heating_r2),
+            (cooling_conf, aggregated.cooling.n, cooling_r2),
+        )
+        # Zones with enough samples are "reportable"; a reportable zone failing
+        # the r² gate is a junk fit and caps the hour label (the old max-rule let
+        # a passable cooling fit mask a junk heating fit, reporting "high" at
+        # r²≈0.07). Under-sampled zones do not cap.
+        reportable = [(c, r2) for c, n, r2 in zone_pairs if n >= MIN_SAMPLES_PER_ZONE]
+        passing = [c for c, r2 in reportable if r2 >= MIN_R_SQUARED]
+
+        if not passing:
+            confidence = "low"
+        elif len(passing) < len(reportable):
+            confidence = "medium"  # mixed hour: usable fit + a junk reportable zone
+        else:
+            confidence = "high" if "high" in passing else "medium"
 
         r_squared_values = [
             value

--- a/custom_components/localshift/sensors/forecast.py
+++ b/custom_components/localshift/sensors/forecast.py
@@ -327,6 +327,8 @@ class ForecastDiagnosticsSensor(LocalShiftSensorBase):
             },
             "weather_condition": self.coordinator.data.weather_condition,
             "weather_correlation_confidence": self.coordinator.data.weather_correlation_confidence,
+            "weather_usable_hours": self.coordinator.data.weather_usable_hours,
+            "weather_hours_with_data": self.coordinator.data.weather_hours_with_data,
             "weather_adjustment_applied": self.coordinator.data.weather_adjustment_applied,
             "weather_learning_enabled": self.coordinator.data.weather_learning_enabled,
             "weather_avg_cooling_slope": round(

--- a/tests/engine/test_weather_diagnostics.py
+++ b/tests/engine/test_weather_diagnostics.py
@@ -152,9 +152,10 @@ class TestWeatherDiagnosticsAnomalyPopulation:
         assert data.weather_avg_heating_slope == pytest.approx(0.25)
         assert data.weather_avg_r_squared == pytest.approx(0.35)
 
-    def test_sets_high_confidence_when_any_hour_is_high(
+    def test_sets_high_confidence_by_majority(
         self, mock_entry_enabled, mock_weather_correlation
     ):
+        """Majority of hours high -> "high", and counts are surfaced."""
         mock_weather_correlation.get_diagnostics.return_value = {
             "total_samples": 60,
             "average_cooling_slope": 0.18,
@@ -162,7 +163,9 @@ class TestWeatherDiagnosticsAnomalyPopulation:
             "average_r_squared": 0.35,
             "hourly_regression": {
                 8: {"confidence": "high"},
-                9: {"confidence": "medium"},
+                9: {"confidence": "high"},
+                10: {"confidence": "medium"},
+                11: {"confidence": "low"},
             },
         }
         mock_weather_correlation.get_current_temperature.return_value = None
@@ -171,4 +174,30 @@ class TestWeatherDiagnosticsAnomalyPopulation:
 
         engine.populate_weather_diagnostics(data, mock_weather_correlation)
 
+        # 2 of 4 high -> n_high*2 >= n_hours -> "high"
         assert data.weather_correlation_confidence == "high"
+        assert data.weather_hours_with_data == 4
+        assert data.weather_usable_hours == 3  # 2 high + 1 medium
+
+    def test_single_high_hour_does_not_brand_forecast_high(
+        self, mock_entry_enabled, mock_weather_correlation
+    ):
+        """1 high hour out of 10 must not label the whole forecast "high"."""
+        hourly = {h: {"confidence": "low"} for h in range(10)}
+        hourly[0] = {"confidence": "high"}
+        mock_weather_correlation.get_diagnostics.return_value = {
+            "total_samples": 60,
+            "average_cooling_slope": 0.18,
+            "average_heating_slope": 0.25,
+            "average_r_squared": 0.35,
+            "hourly_regression": hourly,
+        }
+        mock_weather_correlation.get_current_temperature.return_value = None
+        engine = WeatherDiagnosticsEngine(mock_entry_enabled)
+        data = CoordinatorData()
+
+        engine.populate_weather_diagnostics(data, mock_weather_correlation)
+
+        assert data.weather_correlation_confidence == "low"
+        assert data.weather_hours_with_data == 10
+        assert data.weather_usable_hours == 1

--- a/tests/forecast/test_load.py
+++ b/tests/forecast/test_load.py
@@ -283,11 +283,19 @@ class TestLoadForecasterExponentialDecay:
         assert kw == 0.75
 
     def test_weather_correlation_skipped_low_confidence(self, mock_weather_correlation):
-        """Test weather correlation skipped when confidence is low."""
+        """predict_load is the authority: a "low_confidence" result keeps base.
+
+        The pre-gate on the hour's max-of-zones label was removed (it was
+        strictly redundant with predict_load's per-zone gate and would wrongly
+        suppress a usable zone in a mixed hour). Here predict_load itself refuses
+        the adjustment by returning "low_confidence" even though it returned a
+        candidate value, so the blended-live base must be kept.
+        """
         mock_entry = _create_mock_entry()
         mock_weather_correlation.get_coefficients_for_hour.return_value = MagicMock(
             confidence="low"
         )
+        mock_weather_correlation.predict_load.return_value = (0.99, "low_confidence")
 
         forecaster = LoadForecaster(
             mock_entry, weather_correlation=mock_weather_correlation
@@ -651,10 +659,13 @@ class TestWeatherAdjustmentTracking:
         assert forecaster.get_weather_adjustment_applied() is True
 
     def test_weather_adjustment_flag_not_set_for_low_confidence(self):
+        # Authority moved to predict_load: it refuses by returning a
+        # "low_confidence" source, so the flag stays unset even though a coef
+        # exists for the hour. (Previously a "low" hour label pre-gated this.)
         mock_entry = _create_mock_entry()
         weather = MagicMock()
         weather.get_coefficients_for_hour.return_value = MagicMock(confidence="low")
-        weather.predict_load.return_value = (1.5, "weather_adjusted")
+        weather.predict_load.return_value = (1.5, "low_confidence")
 
         forecaster = LoadForecaster(mock_entry, weather_correlation=weather)
         forecaster.reset_weather_adjustment_applied()

--- a/tests/learning/test_correlation.py
+++ b/tests/learning/test_correlation.py
@@ -39,6 +39,25 @@ def _linear_stats(n: int, slope: float) -> ZoneStats:
     )
 
 
+def _stats_from_points(xs: list[float], ys: list[float]) -> ZoneStats:
+    """Build ZoneStats from explicit (x, y) points (for low-r² junk fits)."""
+    return ZoneStats(
+        n=len(xs),
+        sum_x=float(sum(xs)),
+        sum_y=float(sum(ys)),
+        sum_xx=float(sum(x * x for x in xs)),
+        sum_xy=float(sum(x * y for x, y in zip(xs, ys, strict=False))),
+        sum_yy=float(sum(y * y for y in ys)),
+    )
+
+
+def _junk_stats(n: int) -> ZoneStats:
+    """A zone with n>=samples but a near-zero r² (a "junk" fit)."""
+    xs = [float(i) for i in range(1, n + 1)]
+    ys = [10.0 if x <= 2 else 0.05 for x in xs]  # r^2 ~ 0.003, well below 0.10
+    return _stats_from_points(xs, ys)
+
+
 class TestZoneStats:
     def test_roundtrip(self):
         stats = ZoneStats(n=2, sum_x=3.0, sum_y=4.0, sum_xx=5.0, sum_xy=6.0, sum_yy=7.0)
@@ -584,6 +603,51 @@ class TestDelegationsAndDiagnostics:
                     data=HourlyRegressionData(
                         mild=ZoneStats(),
                         heating=_linear_stats(30, 2.0),
+                        cooling=_linear_stats(30, 1.0),
+                    ),
+                )
+            ]
+        }
+        diagnostics = correlation.get_diagnostics()
+        assert diagnostics["hourly_regression"][8]["confidence"] == "high"
+
+    def test_build_hourly_result_mixed_zone_caps_confidence_at_medium(
+        self, correlation
+    ):
+        """A reportable junk zone caps the hour label below the good zone.
+
+        Heating has enough samples (n=20) but a near-zero r² (junk fit); cooling
+        is a clean n=30 high fit. The old max-rule reported "high"; the hour must
+        now be "medium" because a reportable zone failed the r² gate.
+        """
+        correlation._data.daily_regression_stats = {
+            8: [
+                DailySnapshot(
+                    date_key="2026-03-26",
+                    data=HourlyRegressionData(
+                        mild=ZoneStats(),
+                        heating=_junk_stats(20),
+                        cooling=_linear_stats(30, 1.0),
+                    ),
+                )
+            ]
+        }
+        diagnostics = correlation.get_diagnostics()
+        assert diagnostics["hourly_regression"][8]["confidence"] == "medium"
+
+    def test_build_hourly_result_undersampled_zone_does_not_cap(self, correlation):
+        """An under-sampled second zone is not reportable and does not cap.
+
+        Heating has only n=10 samples (below MIN_SAMPLES_PER_ZONE) so it is not
+        reportable; cooling is a clean n=30 high fit. The hour stays "high".
+        """
+        correlation._data.daily_regression_stats = {
+            8: [
+                DailySnapshot(
+                    date_key="2026-03-26",
+                    data=HourlyRegressionData(
+                        mild=ZoneStats(),
+                        heating=_junk_stats(10),
                         cooling=_linear_stats(30, 1.0),
                     ),
                 )


### PR DESCRIPTION
## Summary

The weather-correlation confidence label over-reported. Live snapshot (2026-06-11 23:28 +10) showed **Confidence: high** with **Average R² 0.0701** (no correlation). Two compounding bugs:

1. **Hour label** (`correlation.py:598-602`) took the **MAX** of zone confidences — a junk heating fit (r²≈0.07) was masked by a passable cooling fit.
2. **Global label** (`weather_diagnostics.py:55-65`) was "high" if **ANY** hour was high.

Actual forecast adjustments are mostly protected by `predict_load`'s independent per-zone gates (`correlation.py:507/520`), so this is **primarily an honesty fix** — but a marginal-r² *reportable* zone still drove real adjustments, and the label was dishonest.

## Changes

- **Hour aggregation** (`correlation.py`): replace max-rule with cap-on-junk-zone — a zone with ≥`MIN_SAMPLES_PER_ZONE` that fails the r² gate is a junk fit and caps the hour at "medium"; under-sampled zones don't cap. Snapshot case (heating r²=0.07 n≥20 + good cooling) → "medium".
- **Drop redundant pre-gate** (`forecast/load.py`): the `confidence not in ("medium","high")` check was strictly redundant with `predict_load`'s per-zone gate (hour label is max-of-zones, so a passing zone always passed it) and would now wrongly suppress a usable zone in a mixed hour. Removed — `predict_load` is the authority. Provably behavior-neutral; pinned by rewritten tests. Also clarified the `_weather_adjustment_applied` comment.
- **Global diagnostic** (`weather_diagnostics.py`): majority rule (`n_high*2 >= n_hours` → high, else `n_usable*2 >= n_hours` → medium, else low) + two new count fields.
- **New fields** `weather_usable_hours` / `weather_hours_with_data` on `CoordinatorData`, exposed in the forecast diagnostics sensor.

## Behavior note (expected, not a regression)
The weather section will flip to "low"/"medium" with X/Y usable-hours counts — honest, and adjustment behavior is unchanged (`weather_correlation_confidence` is display-only; sole consumer is `sensors/forecast.py`).

## Tests
- `correlation.py`: reportable junk zone caps at "medium"; under-sampled zone does not cap.
- `weather_diagnostics.py`: majority-rule → "high"; 1-of-10-high → "low"; both assert the new count fields.
- `load.py`: authority moved — `predict_load` returning "low_confidence" keeps base / leaves the flag unset.

```
pytest tests/learning/ tests/engine/test_weather_diagnostics.py tests/forecast/test_load.py -v   # 181 passed
pytest tests/ -x -q                                                                                # 3077 passed, 1 xfailed
```