### PR TITLE
fix(diagnostics): repopulate mode-decision debug fields + debug-surface cleanup

### DIFF
--- a/custom_components/localshift/computation_engine.py
+++ b/custom_components/localshift/computation_engine.py
@@ -286,6 +286,13 @@ class ComputationEngine:
         if data.manual_override:
             data.active_mode = _BatteryMode.MANUAL
             data.debug_mode_source = "manual_override"
+            # The optimizer's current-slot lookup never runs on the manual path
+            # (we return below), so reset the slot fields to avoid showing a
+            # stale match from a prior optimizer tick.
+            data.debug_forecast_slot_found = False
+            data.debug_forecast_slot_time = ""
+            data.debug_first_forecast_slot_time = ""
+            data.debug_time_gap_seconds = 0.0
             # Skip DP optimizer and other mode decisions when in manual mode
             return
 

--- a/custom_components/localshift/coordinator/data.py
+++ b/custom_components/localshift/coordinator/data.py
@@ -322,7 +322,9 @@ class CoordinatorData:
     debug_forecast_slot_time: str = ""  # Time of matched forecast slot (HH:MM)
     debug_first_forecast_slot_time: str = ""  # Time of first forecast slot (HH:MM)
     debug_time_gap_seconds: float = 0.0  # Seconds between now and first forecast slot
-    debug_mode_source: str = "unknown"  # "forecast" or "fallback"
+    debug_mode_source: str = (
+        "unknown"  # "manual_override" | "optimizer" | "fallback" | "unknown"
+    )
     debug_dry_run: bool = False  # Dry run mode active
     debug_commanded_mode: str = ""  # State machine's commanded mode
     debug_pending_transition: str = ""  # Pending mode transition (if any)

--- a/custom_components/localshift/dashboard.yaml
+++ b/custom_components/localshift/dashboard.yaml
@@ -468,6 +468,8 @@ views:
               Forecast Status: {{ states('sensor.localshift_forecast_status') }}
 
               {% set entities = state_attr('sensor.localshift_entity_health', 'entities') | default({}) %}
+              {% set ls_entities = state_attr('sensor.localshift_entity_health', 'localshift_entities') | default({}) %}
+              {% set all_entities = dict((entities.items() | list) + (ls_entities.items() | list)) %}
               {% set errors = state_attr('sensor.localshift_entity_health', 'errors') | default([]) %}
               {% set warnings = state_attr('sensor.localshift_entity_health', 'warnings') | default([]) %}
 
@@ -481,17 +483,10 @@ views:
                 - {{ warning }}
               {% endfor %}
 
-              Stale Entities:
-              {% for name, info in entities.items() %}
-              {%- if info.status == 'stale' %}
-                - {{ info.entity_id }}: {{ info.error_message | default('stale') }}
-              {%- endif %}
-              {%- endfor %}
-
-              Missing Entities:
-              {% for name, info in entities.items() %}
-              {%- if info.status == 'missing' %}
-                - {{ info.entity_id }}: {{ info.error_message | default('missing') }}
+              Unhealthy Entities:
+              {% for name, info in all_entities.items() %}
+              {%- if info.status != 'ok' %}
+                - {{ info.entity_id }}: {{ info.status }}{% if info.error_message %} ({{ info.error_message }}){% endif %}
               {%- endif %}
               {%- endfor %}
 
@@ -519,7 +514,7 @@ views:
 
               Excess Solar Available: {{ states('binary_sensor.localshift_excess_solar_available') }}
 
-              Excess Solar Forecast: {{ states('sensor.localshift_excess_solar_kwh') }} kWh
+              Excess Solar Forecast: {{ states('sensor.localshift_excess_solar') }} kWh
 
               Load Shift Signal: {{ states('sensor.localshift_load_shift_signal') }}
 
@@ -705,11 +700,11 @@ views:
 
               Cost Trend: {{ state_attr('sensor.localshift_learning_status', 'cost_trend') | default('stable') }}
 
-              Grid Charge Efficiency: {{ state_attr('sensor.localshift_decision_quality', 'grid_charge_efficiency') | default(0) }}%
+              Grid Charge Efficiency (not yet computed): {{ state_attr('sensor.localshift_decision_quality', 'grid_charge_efficiency') | default(0) }}%
 
-              Export Loss Ratio: {{ state_attr('sensor.localshift_decision_quality', 'export_loss_ratio') | default(0) }}%
+              Export Loss Ratio (not yet computed): {{ state_attr('sensor.localshift_decision_quality', 'export_loss_ratio') | default(0) }}%
 
-              Unnecessary Grid Charge: {{ state_attr('sensor.localshift_decision_quality', 'unnecessary_grid_charge_kwh') | default(0) }} kWh
+              Unnecessary Grid Charge (not yet computed): {{ state_attr('sensor.localshift_decision_quality', 'unnecessary_grid_charge_kwh') | default(0) }} kWh
 
               Mode Durations Today: {{ state_attr('sensor.localshift_learning_status', 'mode_durations_today') | default({}) }}
 

--- a/custom_components/localshift/engine/optimizer_facade.py
+++ b/custom_components/localshift/engine/optimizer_facade.py
@@ -16,6 +16,7 @@ from .optimizer_runner import (
     OptimizerSafetyGate,
     _build_optimizer_config,
     _build_summary,
+    _current_slot_debug_info,
     _derive_runtime_apply_plan,
     _find_current_slot_index,
     _normalize_initial_soc,
@@ -195,6 +196,7 @@ class OptimizerFacade:
 
             if not slots:
                 _LOGGER.warning("DP optimizer: no slots available, skipping")
+                self._mark_mode_debug_fallback(data)
                 return
 
             optimizer_config = _build_optimizer_config(data, config_options)
@@ -204,6 +206,7 @@ class OptimizerFacade:
                 _LOGGER.warning(
                     "DP optimizer: invalid SOC %s, skipping", soc_info.get("error")
                 )
+                self._mark_mode_debug_fallback(data)
                 return
 
             cycle_id = uuid.uuid4().hex[:12]
@@ -235,6 +238,7 @@ class OptimizerFacade:
             _LOGGER.warning(
                 "Inline DP optimizer failed (non-blocking): %s", exc, exc_info=True
             )
+            self._mark_mode_debug_fallback(data)
 
     def _write_optimizer_fields(
         self,
@@ -294,6 +298,17 @@ class OptimizerFacade:
             "warnings": [],
         }
 
+        # Surface the current-slot lookup that drives the apply plan. found=False
+        # means the silent idx=0 fallback is in effect — exactly what these
+        # debug fields exist to expose (Mode Source / Forecast Slot Found).
+        current_slot_idx, slot_found, slot_hhmm, first_hhmm, gap_seconds = (
+            _current_slot_debug_info(data)
+        )
+        data.debug_forecast_slot_found = slot_found
+        data.debug_forecast_slot_time = slot_hhmm
+        data.debug_first_forecast_slot_time = first_hhmm
+        data.debug_time_gap_seconds = gap_seconds
+
         safety_gate = OptimizerSafetyGate(config_options)
         gate_result = safety_gate.check_admission(data, result, alignment)
 
@@ -306,12 +321,12 @@ class OptimizerFacade:
             data.active_mode = _BatteryMode.SELF_CONSUMPTION
             data.optimizer_last_apply_status = "blocked"
             data.optimizer_safety_block_reason = gate_result.block_reason or ""
+            data.debug_mode_source = "fallback"
             _LOGGER.warning(
                 "Optimizer safety gate failed — defaulting to SELF_CONSUMPTION"
             )
             return
 
-        current_slot_idx = _find_current_slot_index(data)
         apply_plan = _derive_runtime_apply_plan(
             data.optimizer_decisions, current_slot_idx, optimizer_config
         )
@@ -334,6 +349,7 @@ class OptimizerFacade:
             data.active_mode = new_mode
             data.optimizer_last_apply_status = "ready_to_apply"
             data.optimizer_safety_block_reason = ""
+            data.debug_mode_source = "optimizer"
             _LOGGER.info(
                 "DP optimizer: selected %s (action=%s, slot=%d)",
                 battery_mode_str,
@@ -348,6 +364,18 @@ class OptimizerFacade:
 
             data.active_mode = _BatteryMode.SELF_CONSUMPTION
             data.optimizer_last_apply_status = "fallback"
+            data.debug_mode_source = "fallback"
+
+    @staticmethod
+    def _mark_mode_debug_fallback(data: CoordinatorData) -> None:
+        """Mark the mode-decision debug fields as a non-optimizer fallback.
+
+        Called from run_inline early exits so the debug_* fields never go stale
+        when the optimizer did not produce a decision this tick.
+        """
+        data.debug_mode_source = "fallback"
+        data.debug_forecast_slot_found = False
+        data.debug_forecast_slot_time = ""
 
     def _run_shadow_comparison(
         self,

--- a/custom_components/localshift/engine/optimizer_runner.py
+++ b/custom_components/localshift/engine/optimizer_runner.py
@@ -873,6 +873,57 @@ def _derive_runtime_apply_plan(
     }
 
 
+def _current_slot_debug_info(
+    data: Any,
+) -> tuple[int, bool, str, str, float]:
+    """Locate the current optimizer slot and expose diagnostics about the match.
+
+    Returns:
+        (idx, found, matched_slot_hhmm, first_slot_hhmm, gap_seconds)
+
+        - idx: index of the matched slot, or 0 as fallback.
+        - found: True only on a real ``slot_time <= now < slot_end`` match;
+          False means the silent ``idx=0`` fallback is in effect (exactly what
+          the debug fields exist to surface).
+        - matched_slot_hhmm: HH:MM of the matched slot ("" when not found).
+        - first_slot_hhmm: HH:MM of the first parsable slot ("" when none).
+        - gap_seconds: now minus the first parsable slot timestamp (0.0 when
+          none parses).
+
+    """
+    now = datetime.now(UTC)
+
+    decisions = data.optimizer_decisions
+    if not decisions:
+        return 0, False, "", "", 0.0
+
+    first_slot_hhmm = ""
+    gap_seconds = 0.0
+
+    for idx, decision in enumerate(decisions):
+        timestamp_str = decision.get("timestamp_iso", "")
+        if not timestamp_str:
+            continue
+
+        try:
+            slot_time = datetime.fromisoformat(timestamp_str.replace("Z", "+00:00"))
+        except (ValueError, TypeError):
+            continue
+
+        if not first_slot_hhmm:
+            first_slot_hhmm = slot_time.strftime("%H:%M")
+            gap_seconds = (now - slot_time).total_seconds()
+
+        slot_end = slot_time + timedelta(
+            minutes=decision.get("slot_interval_minutes", 30)
+        )
+        if slot_time <= now < slot_end:
+            return idx, True, slot_time.strftime("%H:%M"), first_slot_hhmm, gap_seconds
+
+    # No slot brackets now: fall back to the first slot (idx 0).
+    return 0, False, "", first_slot_hhmm, gap_seconds
+
+
 def _find_current_slot_index(data: Any) -> int:
     """
     Find the index of the current slot in the optimizer decisions.
@@ -884,28 +935,5 @@ def _find_current_slot_index(data: Any) -> int:
         Index of current slot, or 0 as fallback
 
     """
-    now = datetime.now(UTC)
-
-    decisions = data.optimizer_decisions
-    if not decisions:
-        return 0
-
-    # Find the first slot where timestamp_iso is >= now
-    for idx, decision in enumerate(decisions):
-        timestamp_str = decision.get("timestamp_iso", "")
-        if not timestamp_str:
-            continue
-
-        try:
-            slot_time = datetime.fromisoformat(timestamp_str.replace("Z", "+00:00"))
-            slot_end = slot_time + timedelta(
-                minutes=decision.get("slot_interval_minutes", 30)
-            )
-
-            if slot_time <= now < slot_end:
-                return idx
-        except (ValueError, TypeError):
-            continue
-
-    # Default: use first slot
-    return 0
+    idx, _found, _matched, _first, _gap = _current_slot_debug_info(data)
+    return idx

--- a/custom_components/localshift/forecast/pipeline.py
+++ b/custom_components/localshift/forecast/pipeline.py
@@ -53,6 +53,7 @@ class ForecastPipeline:
         self._load_forecaster.reset_weather_adjustment_applied()
 
         slots: list[float] = []
+        source_counts: dict[str, int] = {}
         for i in range(total_slots):
             slot_start = base_slot + timedelta(minutes=15 * i)
             slot_hour = slot_start.hour
@@ -60,7 +61,7 @@ class ForecastPipeline:
             season = SolarAccuracyTracker._get_season(slot_start)
             hours_ahead = i / 4.0
             temperature = data.weather_temperature_forecast.get(slot_hour)
-            load_kw, _ = self._load_forecaster.estimate_hourly_consumption_kw(
+            load_kw, source = self._load_forecaster.estimate_hourly_consumption_kw(
                 hourly_avg_kw=historical_avg_kw,
                 slot_hour=slot_hour,
                 current_hour=current_hour,
@@ -72,8 +73,10 @@ class ForecastPipeline:
                 season=season,
             )
             slots.append(load_kw)
+            source_counts[source] = source_counts.get(source, 0) + 1
 
         data.load_forecast_slots = slots
+        data.forecast_consumption_source_counts = source_counts
         data.weather_adjustment_applied = (
             self._load_forecaster.get_weather_adjustment_applied()
         )

--- a/scripts/snapshot_charging_plan.py
+++ b/scripts/snapshot_charging_plan.py
@@ -210,25 +210,28 @@ class SnapshotGenerator:
     def _entity_health(self) -> str:
         integration_status = self.state("sensor.localshift_integration_status")
         entity_health = self.state("sensor.localshift_entity_health")
+        # The sensor state counts both dependency entities and localshift
+        # entities; the unhealthy ones often live in localshift_entities, so
+        # merge both and report every non-"ok" status (stale, missing,
+        # unavailable, unknown, invalid_value).
         entities = self.attr("sensor.localshift_entity_health", "entities", {})
+        ls_entities = self.attr(
+            "sensor.localshift_entity_health", "localshift_entities", {}
+        )
+        all_entities = {**(entities or {}), **(ls_entities or {})}
         errors = self.attr("sensor.localshift_entity_health", "errors", [])
         warnings = self.attr("sensor.localshift_entity_health", "warnings", [])
 
-        # Find stale and missing entities
-        stale = []
-        missing = []
-        for name, info in (entities or {}).items():
-            if info.get("status") == "stale":
-                stale.append(
-                    f"- {info.get('entity_id')}: {info.get('error_message', 'stale')}"
-                )
-            elif info.get("status") == "missing":
-                missing.append(
-                    f"- {info.get('entity_id')}: {info.get('error_message', 'missing')}"
+        unhealthy = []
+        for _name, info in all_entities.items():
+            if info.get("status") != "ok":
+                error_message = info.get("error_message")
+                suffix = f" ({error_message})" if error_message else ""
+                unhealthy.append(
+                    f"- {info.get('entity_id')}: {info.get('status')}{suffix}"
                 )
 
-        stale_str = "\n".join(stale) if stale else "None"
-        missing_str = "\n".join(missing) if missing else "None"
+        unhealthy_str = "\n".join(unhealthy) if unhealthy else "None"
         errors_str = "\n".join(f"- {e}" for e in (errors or [])) if errors else "None"
         warnings_str = (
             "\n".join(f"- {w}" for w in (warnings or [])) if warnings else "None"
@@ -248,11 +251,8 @@ class SnapshotGenerator:
 **Warnings:** {len(warnings or [])}
 {warnings_str}
 
-**Stale Entities:**
-{stale_str}
-
-**Missing Entities:**
-{missing_str}"""
+**Unhealthy Entities:**
+{unhealthy_str}"""
 
     def _internal_state_flags(self) -> str:
         automation = self.state("switch.localshift_automation_enabled")
@@ -686,8 +686,8 @@ class SnapshotGenerator:
 | **Avg Score Today** | {avg_today} |
 | **Avg Score 7d** | {avg_7d} |
 | **Cost Trend** | {trend} |
-| **Grid Charge Efficiency** | {grid_eff}% |
-| **Export Loss Ratio** | {export_loss}% |"""
+| **Grid Charge Efficiency** (not yet computed) | {grid_eff}% |
+| **Export Loss Ratio** (not yet computed) | {export_loss}% |"""
 
     def _binary_sensors(self) -> str:
         sensors = [

--- a/tests/forecast/test_pipeline.py
+++ b/tests/forecast/test_pipeline.py
@@ -3,10 +3,10 @@
 from datetime import UTC, datetime
 from unittest.mock import MagicMock, patch
 
+from custom_components.localshift.coordinator import CoordinatorData
 from custom_components.localshift.forecast.pipeline import (
     ForecastPipeline,
 )
-from custom_components.localshift.coordinator import CoordinatorData
 
 
 class _StubLoadForecaster:
@@ -17,6 +17,25 @@ class _StubLoadForecaster:
     def estimate_hourly_consumption_kw(self, **_kwargs):
         self.calls.append(_kwargs)
         return self._value, "stub"
+
+    def reset_weather_adjustment_applied(self) -> None:
+        pass
+
+    def get_weather_adjustment_applied(self) -> bool:
+        return False
+
+
+class _VaryingSourceLoadForecaster:
+    """Returns a source that cycles through a fixed list, slot by slot."""
+
+    def __init__(self, sources: list[str]) -> None:
+        self._sources = sources
+        self._i = 0
+
+    def estimate_hourly_consumption_kw(self, **_kwargs):
+        source = self._sources[self._i % len(self._sources)]
+        self._i += 1
+        return 1.0, source
 
     def reset_weather_adjustment_applied(self) -> None:
         pass
@@ -68,6 +87,38 @@ def test_compute_load_forecast_slots_populates_slots():
 
     assert len(data.load_forecast_slots) == 8
     assert all(slot == 1.2 for slot in data.load_forecast_slots)
+    # Source counts are tallied across every slot.
+    assert data.forecast_consumption_source_counts == {"stub": 8}
+
+
+def test_compute_load_forecast_slots_tallies_source_counts():
+    """forecast_consumption_source_counts sums to total_slots, keys = sources."""
+    data = CoordinatorData()
+    data.weather_temperature_forecast = {}
+    data.load_power_kw = 0.5
+
+    sources = ["statistics", "blended_live", "weather_heating"]
+    pipeline = ForecastPipeline(
+        load_forecaster=_VaryingSourceLoadForecaster(sources),
+        price_signals=_StubPriceSignals(),
+        forecast_history_store=_StubForecastHistoryStore(),
+        get_switch_state=lambda _key: False,
+        excess_solar_signals=MagicMock(),
+    )
+
+    total_slots = 9
+    pipeline.compute_load_forecast_slots(
+        data=data,
+        now_dt=datetime(2026, 2, 16, 10, 0, 0, tzinfo=UTC),
+        historical_avg_kw={10: 0.5},
+        recent_load_kw=0.5,
+        total_slots=total_slots,
+    )
+
+    counts = data.forecast_consumption_source_counts
+    assert sum(counts.values()) == total_slots
+    assert set(counts) == set(sources)
+    assert counts == {"statistics": 3, "blended_live": 3, "weather_heating": 3}
 
 
 def test_compute_load_forecast_slots_passes_context():

--- a/tests/sensors/test_forecast.py
+++ b/tests/sensors/test_forecast.py
@@ -540,7 +540,7 @@ class TestForecastDiagnosticsSensor:
             debug_forecast_slot_time="10:00",
             debug_first_forecast_slot_time="09:00",
             debug_time_gap_seconds=120.5,
-            debug_mode_source="forecast",
+            debug_mode_source="optimizer",
             allow_export="yes",
             weather_entity_id="weather.home",
             weather_temperature_current=25.0,

--- a/tests/sensors/test_sensors.py
+++ b/tests/sensors/test_sensors.py
@@ -120,7 +120,7 @@ class Fixtures:
         data.debug_forecast_slot_time = "2024-01-01T14:00:00"
         data.debug_first_forecast_slot_time = "2024-01-01T10:00:00"
         data.debug_time_gap_seconds = 300
-        data.debug_mode_source = "automatic"
+        data.debug_mode_source = "optimizer"
         data.allow_export = True
         data.weather_entity_id = "weather.home"
         data.weather_temperature_current = 25.0

--- a/tests/sensors/test_status.py
+++ b/tests/sensors/test_status.py
@@ -175,7 +175,7 @@ class TestForecastStatusSensor:
             forecast_ready=True,
             solcast_today=[1, 2, 3],
             solcast_tomorrow=[4, 5],
-            debug_mode_source="live",
+            debug_mode_source="optimizer",
         )
         attrs = sensor.extra_state_attributes
         assert attrs["solcast_today_entries"] == 3

--- a/tests/test_optimizer_facade.py
+++ b/tests/test_optimizer_facade.py
@@ -12,6 +12,9 @@ from custom_components.localshift.coordinator import CoordinatorData
 from custom_components.localshift.engine.optimizer_facade import (
     OptimizerFacade,
 )
+from custom_components.localshift.engine.optimizer_runner import (
+    _current_slot_debug_info,
+)
 
 
 class _StubSlotBuilder:
@@ -50,6 +53,10 @@ def test_run_inline_no_slots_leaves_optimizer_fields():
     facade.run_inline(data=data, now_dt=now_dt, config_options={})
 
     assert data.optimizer_decisions == [{"action": "hold"}]
+    # Mode-decision debug fields (PR C): the early exit marks a non-optimizer
+    # fallback so the fields never go stale.
+    assert data.debug_mode_source == "fallback"
+    assert data.debug_forecast_slot_found is False
 
 
 def test_facade_wires_solar_can_reach_target_in_dw_correctly():
@@ -328,7 +335,15 @@ def test_assign_active_mode_sets_mode_and_apply_status():
     facade = OptimizerFacade(slot_builder_cls=_StubSlotBuilder)
     data = CoordinatorData()
     data.active_mode = BatteryMode.SELF_CONSUMPTION
-    data.optimizer_decisions = [{"action": "charge_grid_normal"}]
+    # A decision whose window brackets "now" (huge interval) so the current-slot
+    # lookup reports a real match and the debug_* fields are populated.
+    data.optimizer_decisions = [
+        {
+            "action": "charge_grid_normal",
+            "timestamp_iso": "2020-01-01T00:00:00+00:00",
+            "slot_interval_minutes": 9_999_999,
+        }
+    ]
     result = MagicMock()
     optimizer_config = MagicMock()
     decision_time = datetime(2026, 1, 15, 10, 0, tzinfo=UTC)
@@ -337,10 +352,6 @@ def test_assign_active_mode_sets_mode_and_apply_status():
         patch(
             "custom_components.localshift.engine.optimizer_facade.OptimizerSafetyGate"
         ) as mock_gate,
-        patch(
-            "custom_components.localshift.engine.optimizer_facade._find_current_slot_index",
-            return_value=2,
-        ),
         patch(
             "custom_components.localshift.engine.optimizer_facade._derive_runtime_apply_plan",
             return_value={
@@ -368,6 +379,13 @@ def test_assign_active_mode_sets_mode_and_apply_status():
     assert data.optimizer_safety_block_reason == ""
     assert data.decision_timestamp == decision_time
     assert data.decision_mode == BatteryMode.GRID_CHARGING
+    # Mode-decision debug fields (PR C): a real slot match attributed to the
+    # optimizer.
+    assert data.debug_mode_source == "optimizer"
+    assert data.debug_forecast_slot_found is True
+    assert data.debug_forecast_slot_time == "00:00"
+    assert data.debug_first_forecast_slot_time == "00:00"
+    assert data.debug_time_gap_seconds > 0
 
 
 def test_assign_active_mode_falls_back_on_invalid_battery_mode():
@@ -383,10 +401,6 @@ def test_assign_active_mode_falls_back_on_invalid_battery_mode():
             "custom_components.localshift.engine.optimizer_facade.OptimizerSafetyGate"
         ) as mock_gate,
         patch(
-            "custom_components.localshift.engine.optimizer_facade._find_current_slot_index",
-            return_value=0,
-        ),
-        patch(
             "custom_components.localshift.engine.optimizer_facade._derive_runtime_apply_plan",
             return_value={"battery_mode": "not-a-mode", "action": "hold"},
         ),
@@ -399,6 +413,53 @@ def test_assign_active_mode_falls_back_on_invalid_battery_mode():
 
     assert data.active_mode == BatteryMode.SELF_CONSUMPTION
     assert data.optimizer_last_apply_status == "fallback"
+    assert data.debug_mode_source == "fallback"
+
+
+def test_current_slot_debug_info_matched():
+    """A decision whose window brackets now reports a real match."""
+    data = CoordinatorData()
+    data.optimizer_decisions = [
+        {
+            "timestamp_iso": "2020-01-01T00:00:00+00:00",
+            "slot_interval_minutes": 9_999_999,
+        }
+    ]
+    idx, found, matched, first, gap = _current_slot_debug_info(data)
+    assert idx == 0
+    assert found is True
+    assert matched == "00:00"
+    assert first == "00:00"
+    assert gap > 0
+
+
+def test_current_slot_debug_info_past_window_no_match():
+    """A past slot whose window has closed reports found=False with the
+    first-slot diagnostics still populated (the silent idx=0 fallback)."""
+    data = CoordinatorData()
+    data.optimizer_decisions = [
+        {"timestamp_iso": "2020-01-01T00:00:00+00:00", "slot_interval_minutes": 30}
+    ]
+    idx, found, matched, first, gap = _current_slot_debug_info(data)
+    assert idx == 0
+    assert found is False
+    assert matched == ""
+    assert first == "00:00"
+    assert gap > 0
+
+
+def test_current_slot_debug_info_empty_decisions():
+    """No decisions -> no match and no diagnostics."""
+    data = CoordinatorData()
+    data.optimizer_decisions = []
+    assert _current_slot_debug_info(data) == (0, False, "", "", 0.0)
+
+
+def test_current_slot_debug_info_malformed_timestamp():
+    """An unparsable timestamp is skipped; with no parsable slot, no match."""
+    data = CoordinatorData()
+    data.optimizer_decisions = [{"timestamp_iso": "not-a-timestamp"}]
+    assert _current_slot_debug_info(data) == (0, False, "", "", 0.0)
 
 
 class _ShadowSlotBuilderWithOneSlot:


### PR DESCRIPTION
## Summary

Repopulates the dead mode-decision debug fields and cleans up the debug snapshot / dashboard surface. Three commits.

### 1. Repopulate the 5 mode-decision `debug_*` fields
After the Phase-4 refactor (commit 8d64870 removed `ForecastComputer`), only `manual_override` was ever written — the live snapshot showed **Mode Source: unknown** / **Forecast Slot Found: False** permanently.

Mode decisions still flow through a current-slot lookup, so this repopulates rather than removes:
- New `_current_slot_debug_info()` next to `_find_current_slot_index()` in `optimizer_runner.py` (the latter now delegates, preserving its shared behavior with `computation_engine` / `boost_charge_needed`).
- `_assign_active_mode` writes `debug_forecast_slot_found` / `slot_time` / `first_slot_time` / `time_gap_seconds` (`found=True` only on a real `slot_time <= now < slot_end` match — the silent `idx=0` fallback is exactly what these fields exist to expose) and `debug_mode_source = "optimizer"` on success / `"fallback"` on the safety-gate block + invalid-mode fallback.
- `run_inline` early exits (no slots, invalid SOC, swallowed exception) mark `"fallback"` + `slot_found=False` so fields never go stale; the manual path sets `"manual_override"` and resets the slot fields.

### 2. Populate `forecast_consumption_source_counts`
`compute_load_forecast_slots` discarded the per-slot source (`load_kw, _ = ...`), so this field was permanently empty. Now tallies a `dict[str, int]` across all slots.

### 3. Debug-surface cleanup (renderer-only)
- **Excess Solar Forecast "unknown"** → renderer used the unique_id `sensor.localshift_excess_solar_kwh`; entity registers as `sensor.localshift_excess_solar` (`has_entity_name`). Fixed.
- **Entity health "68/71" with no listed unhealthy entities** → renderers iterated only the `entities` (deps, all healthy) attribute and matched only `stale`/`missing`, while the 3 unhealthy entities live in `localshift_entities` with `unavailable`/`unknown`/`invalid_value`. Merge both dicts, list every `status != 'ok'` under one "Unhealthy Entities" heading (dashboard + snapshot script).
- **Relabel** `grid_charge_efficiency` / `export_loss_ratio` / `unnecessary_grid_charge_kwh` **"(not yet computed)"** — never computed (always 0.0). Fields intentionally **not** removed (load-bearing across persistence/sensors/tests). Computation + the dormant export-leak protection it gates → **#868**.

## Tests
- `test_optimizer_facade.py`: optimizer/fallback mode-source attribution, run_inline no-slots fallback, direct `_current_slot_debug_info` unit test (matched / past-window no-match / empty / malformed timestamp).
- `test_pipeline.py`: source counts sum to total_slots, keys match returned sources.

```
pytest tests/test_optimizer_facade.py tests/sensors/ tests/forecast/ -q   # 666 passed
pytest tests/ -x -q                                                        # 3079 passed, 1 xfailed
```

Companion issue: #868