### PR TITLE
feat(optimizer): target-first charge eligibility — fund the DW target up to max_precharge_price

### DIFF
--- a/custom_components/localshift/engine/constraints.py
+++ b/custom_components/localshift/engine/constraints.py
@@ -227,7 +227,24 @@ def cheap_threshold_for_slot(
 
     Backward compatible: when ``urgency_window_start_idx`` is None (e.g. direct unit calls),
     the inflated price applies to all pre-DW slots (legacy: base only at/after the DW entry).
+
+    Target-first eligibility (2026-06-12): when ``config.pre_dw_charge_thresholds`` is
+    present (computed by ``compute_pre_dw_charge_thresholds``), pre-DW slots return their
+    precomputed per-slot threshold instead — sized so the demand-window target is fundable
+    from the cheapest sufficient slots up to ``max_precharge_price``, and time-consistent
+    (each slot gated at the urgency the live controller will have when it arrives). Slots
+    at/after the DW entry never use the list, so post-DW gating is byte-for-byte the
+    legacy base-price behaviour (#800 protection).
     """
+    pre_dw = config.pre_dw_charge_thresholds
+    if (
+        pre_dw is not None
+        and terminal_penalty_idx is not None
+        and slot_idx < terminal_penalty_idx
+        and slot_idx < len(pre_dw)
+    ):
+        return pre_dw[slot_idx]
+
     threshold = config.effective_cheap_price
     if config.base_cheap_price is None or terminal_penalty_idx is None:
         return threshold
@@ -241,6 +258,159 @@ def cheap_threshold_for_slot(
     if not in_urgency_window:
         threshold = min(threshold, config.base_cheap_price)
     return threshold
+
+
+def compute_pre_dw_charge_thresholds(
+    slots: list[SlotContext],
+    config: OptimizerConfig,
+    terminal_penalty_idx: int | None,
+    initial_soc_pct: float,
+) -> list[float] | None:
+    """Per-slot charge-price thresholds that make the DW target fundable (2026-06-12).
+
+    The hard cheap-price gate in ``feasible_actions`` is the load-bearing anti-sawtooth
+    lever (soft penalties get paid through — #800/#804/#816), but gating *pre-DW* slots at
+    the cheap percentile made the demand-window target structurally unreachable on days
+    with few cheap slots: 2026-06-12 live, a 12.7 kWh deficit met ~1.2 h of eligible slot
+    time, the plan entered the DW at 48.5% vs a 95% target, and held at 11–13 ¢ midday
+    while scheduling 13–15.7 ¢ imports all evening. The #624 hard target constraint and
+    the shortfall penalty could not fix it: no penalty can buy an action that is not in
+    the feasible set.
+
+    For each slot before the DW entry this returns the max of:
+
+    - the legacy ``cheap_threshold_for_slot`` value (never tightens the gate),
+    - the urgency ramp (``dp_math.urgency_ramp_price``) evaluated at that slot's OWN time,
+      so a morning plan sees the same near-DW unlocks the live controller's re-plans will
+      apply when those slots arrive (fixes the now-scalar time-inconsistency that made
+      plans procrastinate and lie), and
+    - the "water level": the marginal buy price of the cheapest set of pre-DW slots whose
+      combined boost-rate charge capacity closes the SOC deficit to target (net of
+      accuracy-discounted solar, mirroring ``check_global_solar_sufficiency``). Eligibility
+      by price ≤ water level IS the cheapest-sufficient-set: the DP funds the target from
+      the cheapest slots first and pricier slots unlock only when genuinely needed.
+
+    Everything is clamped to ``config.max_precharge_price`` — the operator's existing
+    pre-charge authorization ceiling. Slots at/after the DW entry keep their legacy
+    thresholds untouched (post-DW/overnight gating on ``base_cheap_price`` is the #800
+    protection and this function never widens it).
+
+    Water-level capacity sizing uses the boost rate and ignores the >80% charge taper
+    (slightly optimistic, i.e. the water level errs low); the ramp term guarantees
+    eligibility keeps widening toward the ceiling as the DW approaches, so taper optimism
+    cannot strand the target.
+
+    Returns None (feature inert, legacy behaviour) when there is no demand window, the
+    mode is not self-consumption, ``max_precharge_price`` is unset, or the ceiling does
+    not exceed the ramp base. Callers must reset ``config.pre_dw_charge_thresholds`` to
+    None before invoking (this function reads legacy thresholds via
+    ``cheap_threshold_for_slot``, which consults that field).
+    """
+    if (
+        terminal_penalty_idx is None
+        or terminal_penalty_idx <= 0
+        or config.optimization_mode != "self_consumption"
+        or config.max_precharge_price is None
+        or not slots
+        or terminal_penalty_idx >= len(slots)
+    ):
+        return None
+
+    from datetime import datetime
+
+    from custom_components.localshift.engine.dp_math import (
+        _simulate_solar_only_terminal_soc,
+        urgency_ramp_price,
+        urgency_window_hours,
+    )
+
+    ramp_base = (
+        config.base_cheap_price
+        if config.base_cheap_price is not None
+        else config.effective_cheap_price
+    )
+    max_price = config.max_precharge_price
+    if max_price <= ramp_base:
+        return None
+
+    legacy = [
+        cheap_threshold_for_slot(config, j, terminal_penalty_idx)
+        for j in range(len(slots))
+    ]
+
+    try:
+        dw_time = datetime.fromisoformat(slots[terminal_penalty_idx].timestamp_iso)
+    except (ValueError, TypeError):
+        return None
+
+    window_hours = urgency_window_hours(
+        initial_soc_pct,
+        config.demand_window_target_soc_pct,
+        config.battery_capacity_kwh,
+        config.charge_rate_kw,
+        config.charge_efficiency,
+    )
+
+    # Expected SOC at DW entry on solar alone, discounting only the positive gain by
+    # forecast accuracy — the same shape as check_global_solar_sufficiency, so the
+    # required grid charge is no more optimistic than the solar feasibility gate
+    # (the raw-vs-discounted asymmetry behind the 2026-06-09 undercharge / #816).
+    sim_soc = _simulate_solar_only_terminal_soc(
+        initial_soc_pct, slots, terminal_penalty_idx, config
+    )
+    accuracy = max(0.0, min(1.0, config.solar_forecast_accuracy))
+    if sim_soc >= initial_soc_pct:
+        expected_soc_at_dw = initial_soc_pct + (sim_soc - initial_soc_pct) * accuracy
+    else:
+        expected_soc_at_dw = sim_soc
+    required_stored_kwh = max(
+        0.0,
+        (config.demand_window_target_soc_pct - expected_soc_at_dw)
+        / 100.0
+        * config.battery_capacity_kwh,
+    )
+
+    water = ramp_base
+    if required_stored_kwh > 0.0:
+        candidates: list[tuple[float, float]] = []
+        for j in range(terminal_penalty_idx):
+            slot = slots[j]
+            if slot.is_demand_window_slot:
+                continue
+            stored_kwh = (
+                config.boost_charge_rate_kw
+                * (slot.slot_interval_minutes / 60.0)
+                * config.charge_efficiency
+            )
+            if stored_kwh > 0.0:
+                candidates.append((slot.buy_price, stored_kwh))
+        candidates.sort(key=lambda c: c[0])
+        # Insufficient capacity even using every pre-DW slot: authorize the ceiling.
+        water = max_price
+        cumulative = 0.0
+        for price, stored_kwh in candidates:
+            cumulative += stored_kwh
+            if cumulative >= required_stored_kwh:
+                water = price
+                break
+        water = max(ramp_base, min(water, max_price))
+
+    thresholds: list[float] = []
+    for j, slot in enumerate(slots):
+        if j >= terminal_penalty_idx:
+            thresholds.append(legacy[j])
+            continue
+        try:
+            slot_time = datetime.fromisoformat(slot.timestamp_iso)
+            hours_to_dw = max(0.0, (dw_time - slot_time).total_seconds() / 3600.0)
+            ramp_j = urgency_ramp_price(ramp_base, max_price, hours_to_dw, window_hours)
+        except (ValueError, TypeError):
+            ramp_j = ramp_base
+        # ramp_j and water are ≤ max_price by construction; legacy is deliberately NOT
+        # clamped to the ceiling — on a spike day whose percentile base exceeds
+        # max_precharge_price this function must never tighten the existing gate.
+        thresholds.append(max(legacy[j], ramp_j, water))
+    return thresholds
 
 
 def compute_max_normal_gain_pct_to_terminal(

--- a/custom_components/localshift/engine/constraints.py
+++ b/custom_components/localshift/engine/constraints.py
@@ -319,7 +319,6 @@ def compute_pre_dw_charge_thresholds(
     from datetime import datetime
 
     from custom_components.localshift.engine.dp_math import (
-        _simulate_solar_only_terminal_soc,
         urgency_ramp_price,
         urgency_window_hours,
     )
@@ -351,49 +350,12 @@ def compute_pre_dw_charge_thresholds(
         config.charge_efficiency,
     )
 
-    # Expected SOC at DW entry on solar alone, discounting only the positive gain by
-    # forecast accuracy — the same shape as check_global_solar_sufficiency, so the
-    # required grid charge is no more optimistic than the solar feasibility gate
-    # (the raw-vs-discounted asymmetry behind the 2026-06-09 undercharge / #816).
-    sim_soc = _simulate_solar_only_terminal_soc(
-        initial_soc_pct, slots, terminal_penalty_idx, config
+    required_stored_kwh = _required_stored_kwh_to_target(
+        slots, config, terminal_penalty_idx, initial_soc_pct
     )
-    accuracy = max(0.0, min(1.0, config.solar_forecast_accuracy))
-    if sim_soc >= initial_soc_pct:
-        expected_soc_at_dw = initial_soc_pct + (sim_soc - initial_soc_pct) * accuracy
-    else:
-        expected_soc_at_dw = sim_soc
-    required_stored_kwh = max(
-        0.0,
-        (config.demand_window_target_soc_pct - expected_soc_at_dw)
-        / 100.0
-        * config.battery_capacity_kwh,
+    water = _target_funding_water_level(
+        slots, config, terminal_penalty_idx, required_stored_kwh, ramp_base, max_price
     )
-
-    water = ramp_base
-    if required_stored_kwh > 0.0:
-        candidates: list[tuple[float, float]] = []
-        for j in range(terminal_penalty_idx):
-            slot = slots[j]
-            if slot.is_demand_window_slot:
-                continue
-            stored_kwh = (
-                config.boost_charge_rate_kw
-                * (slot.slot_interval_minutes / 60.0)
-                * config.charge_efficiency
-            )
-            if stored_kwh > 0.0:
-                candidates.append((slot.buy_price, stored_kwh))
-        candidates.sort(key=lambda c: c[0])
-        # Insufficient capacity even using every pre-DW slot: authorize the ceiling.
-        water = max_price
-        cumulative = 0.0
-        for price, stored_kwh in candidates:
-            cumulative += stored_kwh
-            if cumulative >= required_stored_kwh:
-                water = price
-                break
-        water = max(ramp_base, min(water, max_price))
 
     thresholds: list[float] = []
     for j, slot in enumerate(slots):
@@ -411,6 +373,81 @@ def compute_pre_dw_charge_thresholds(
         # max_precharge_price this function must never tighten the existing gate.
         thresholds.append(max(legacy[j], ramp_j, water))
     return thresholds
+
+
+def _required_stored_kwh_to_target(
+    slots: list[SlotContext],
+    config: OptimizerConfig,
+    terminal_penalty_idx: int,
+    initial_soc_pct: float,
+) -> float:
+    """Grid charge (stored kWh) needed to reach the DW target, net of expected solar.
+
+    Expected SOC at DW entry on solar alone, discounting only the positive gain by
+    forecast accuracy — the same shape as ``check_global_solar_sufficiency``, so the
+    required grid charge is no more optimistic than the solar feasibility gate
+    (the raw-vs-discounted asymmetry behind the 2026-06-09 undercharge / #816).
+    """
+    from custom_components.localshift.engine.dp_math import (
+        _simulate_solar_only_terminal_soc,
+    )
+
+    sim_soc = _simulate_solar_only_terminal_soc(
+        initial_soc_pct, slots, terminal_penalty_idx, config
+    )
+    accuracy = max(0.0, min(1.0, config.solar_forecast_accuracy))
+    if sim_soc >= initial_soc_pct:
+        expected_soc_at_dw = initial_soc_pct + (sim_soc - initial_soc_pct) * accuracy
+    else:
+        expected_soc_at_dw = sim_soc
+    return max(
+        0.0,
+        (config.demand_window_target_soc_pct - expected_soc_at_dw)
+        / 100.0
+        * config.battery_capacity_kwh,
+    )
+
+
+def _target_funding_water_level(
+    slots: list[SlotContext],
+    config: OptimizerConfig,
+    terminal_penalty_idx: int,
+    required_stored_kwh: float,
+    ramp_base: float,
+    max_price: float,
+) -> float:
+    """Marginal buy price of the cheapest pre-DW slot set that closes the deficit.
+
+    Eligibility by ``price <= water level`` IS cheapest-sufficient-set funding: the DP
+    funds the target from the cheapest slots first and pricier slots unlock only when
+    genuinely needed. When even every pre-DW slot together cannot close the deficit,
+    the operator's full ``max_precharge_price`` ceiling is authorized.
+    """
+    if required_stored_kwh <= 0.0:
+        return ramp_base
+
+    candidates: list[tuple[float, float]] = []
+    for j in range(terminal_penalty_idx):
+        slot = slots[j]
+        if slot.is_demand_window_slot:
+            continue
+        stored_kwh = (
+            config.boost_charge_rate_kw
+            * (slot.slot_interval_minutes / 60.0)
+            * config.charge_efficiency
+        )
+        if stored_kwh > 0.0:
+            candidates.append((slot.buy_price, stored_kwh))
+    candidates.sort(key=lambda c: c[0])
+
+    water = max_price
+    cumulative = 0.0
+    for price, stored_kwh in candidates:
+        cumulative += stored_kwh
+        if cumulative >= required_stored_kwh:
+            water = price
+            break
+    return max(ramp_base, min(water, max_price))
 
 
 def compute_max_normal_gain_pct_to_terminal(

--- a/custom_components/localshift/engine/core.py
+++ b/custom_components/localshift/engine/core.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from custom_components.localshift.engine.constraints import (
     compute_max_normal_gain_pct_to_terminal,
+    compute_pre_dw_charge_thresholds,
 )
 from custom_components.localshift.engine.constraints import (
     feasible_actions as _constraints_feasible_actions,
@@ -162,24 +163,36 @@ class DPPlanner:
             slots, terminal_penalty_idx, inputs.initial_soc_pct, config
         )
 
-        # Shortfall-aware boost (2026-06-11 incident): precompute, per slot, the most SOC
-        # normal-rate grid charging could add from that slot to the demand-window entry, so
-        # the boost gate can unlock boost when normal alone cannot reach target. Must come
-        # after urgency_window_start_idx (the precompute calls cheap_threshold_for_slot,
-        # which reads it) and before _initialize_dp_tables. Follows the existing
-        # config-attach precedent (urgency_window_start_idx / solar_forecast_accuracy);
-        # per-call cost in the DP inner loop is one index + compare.
-        config.max_normal_gain_pct_to_terminal = (
-            compute_max_normal_gain_pct_to_terminal(slots, config, terminal_penalty_idx)
-        )
-
         # Feed live forecast accuracy into the pre-charge feasibility gate so it
         # discounts projected solar the same way the shortfall cost model does
         # (check_global_solar_sufficiency / _is_target_shortfall_risk). Prevents the
         # gate over-trusting an inaccurate forecast and blocking grid pre-charge
-        # (2026-06-09 demand-window undercharge; recurrence of #816).
+        # (2026-06-09 demand-window undercharge; recurrence of #816). Must come before
+        # compute_pre_dw_charge_thresholds, whose required-charge estimate applies the
+        # same discount.
         config.solar_forecast_accuracy = get_forecast_accuracy(
             inputs.solar_accuracy_tracker
+        )
+
+        # Target-first eligibility (2026-06-12): per-slot pre-DW charge thresholds sized
+        # so the demand-window target is fundable from the cheapest sufficient slots up
+        # to max_precharge_price, and time-consistent (each slot gated at the urgency it
+        # will have when it arrives, not today's now-scalar). Reset first: the precompute
+        # reads legacy thresholds via cheap_threshold_for_slot, which consults this field.
+        config.pre_dw_charge_thresholds = None
+        config.pre_dw_charge_thresholds = compute_pre_dw_charge_thresholds(
+            slots, config, terminal_penalty_idx, inputs.initial_soc_pct
+        )
+
+        # Shortfall-aware boost (2026-06-11 incident): precompute, per slot, the most SOC
+        # normal-rate grid charging could add from that slot to the demand-window entry, so
+        # the boost gate can unlock boost when normal alone cannot reach target. Must come
+        # after urgency_window_start_idx and pre_dw_charge_thresholds (the precompute calls
+        # cheap_threshold_for_slot, which reads both) and before _initialize_dp_tables.
+        # Follows the existing config-attach precedent (urgency_window_start_idx /
+        # solar_forecast_accuracy); per-call cost in the DP inner loop is one index + compare.
+        config.max_normal_gain_pct_to_terminal = (
+            compute_max_normal_gain_pct_to_terminal(slots, config, terminal_penalty_idx)
         )
 
         dp, terminal_penalty_by_bin = self._initialize_dp_tables(
@@ -784,11 +797,26 @@ class DPPlanner:
             # Mirrors the SOC-floor anti-sawtooth guard's urgency-window exemption below.
             # Safe vs the #800 overnight sawtooth: those slots are post-DW / far pre-DW and
             # never inside an urgency window, so the gate stays fully active there.
+            #
+            # Target-first eligibility (2026-06-12): when pre_dw_charge_thresholds is
+            # active, ANY pre-DW charge below target is target-driven — feasible_actions
+            # only offers it at/below that slot's target-funded threshold — so the
+            # exemption covers the whole pre-DW range, not just the 4-8h urgency window.
+            # Without this, min-cycle-saving re-introduces the procrastination the
+            # thresholds exist to fix (each early slot's margin over deferring is thin,
+            # the deferrals compound, and the plan undershoots — the #860 incident shape).
+            # Post-DW slots are never exempted by either branch.
             is_urgency_precharge = (
                 terminal_penalty_idx is not None
-                and config.urgency_window_start_idx is not None
-                and config.urgency_window_start_idx <= slot_idx < terminal_penalty_idx
+                and slot_idx < terminal_penalty_idx
                 and soc < config.demand_window_target_soc_pct
+                and (
+                    config.pre_dw_charge_thresholds is not None
+                    or (
+                        config.urgency_window_start_idx is not None
+                        and config.urgency_window_start_idx <= slot_idx
+                    )
+                )
             )
 
             if action == PlannerAction.HOLD:

--- a/custom_components/localshift/engine/dp_math.py
+++ b/custom_components/localshift/engine/dp_math.py
@@ -57,6 +57,33 @@ def urgency_window_hours(
     return max(min_hours, min(max_hours, hours))
 
 
+def urgency_ramp_price(
+    base_price: float,
+    max_price: float,
+    hours_to_dw: float,
+    window_hours: float,
+) -> float:
+    """Charge-price threshold at a moment ``hours_to_dw`` before the demand window.
+
+    The single source of truth for the urgency ramp: the threshold rises linearly from
+    ``base_price`` at the window's outer edge to ``max_price`` at the demand-window entry.
+    ``price_calculator._calculate_urgency_adjusted_price`` uses it for the live "now"
+    threshold and ``constraints.compute_pre_dw_charge_thresholds`` evaluates it at each
+    future slot's own time, so the plan the DP produces in the morning agrees with what
+    the live controller will be willing to pay when those slots arrive (the
+    time-inconsistency behind the 2026-06-12 undercharge: a now-scalar threshold gated
+    afternoon slots a morning plan could never use).
+
+    Outside the window (``hours_to_dw >= window_hours``) the ramp contributes nothing
+    (returns ``base_price``); a degenerate window or an inverted ``max_price < base_price``
+    also collapses to ``base_price`` so a misconfigured ceiling can never *tighten* the gate.
+    """
+    if window_hours <= 0.0 or max_price <= base_price:
+        return base_price
+    urgency = max(min(1.0 - (hours_to_dw / window_hours), 1.0), 0.0)
+    return base_price + (max_price - base_price) * urgency
+
+
 def _build_soc_grid(config: OptimizerConfig) -> list[float]:
     """Build SOC discretization grid from min_soc_pct to max_soc_pct."""
     if config.soc_bins <= 1:

--- a/custom_components/localshift/engine/optimizer_runner.py
+++ b/custom_components/localshift/engine/optimizer_runner.py
@@ -247,6 +247,7 @@ def _build_optimizer_config(
         CONF_ALLOW_DW_ENTRY_UNDER_TARGET,
         CONF_BATTERY_TARGET,
         CONF_EXPORT_PRICE_MARGIN,
+        CONF_MAX_PRECHARGE_PRICE,
         CONF_MIN_CYCLE_SAVING,
         CONF_MINIMUM_TARGET_SOC,
         CONF_OPTIMIZATION_MODE,
@@ -257,6 +258,7 @@ def _build_optimizer_config(
         DEFAULT_ALLOW_DW_ENTRY_UNDER_TARGET,
         DEFAULT_BATTERY_TARGET,
         DEFAULT_EXPORT_PRICE_MARGIN,
+        DEFAULT_MAX_PRECHARGE_PRICE,
         DEFAULT_MIN_CYCLE_SAVING,
         DEFAULT_MINIMUM_TARGET_SOC,
         DEFAULT_OPTIMIZATION_MODE,
@@ -315,6 +317,13 @@ def _build_optimizer_config(
 
     min_cycle_saving = float(
         config_options.get(CONF_MIN_CYCLE_SAVING, DEFAULT_MIN_CYCLE_SAVING)
+    )
+
+    # Target-first eligibility (2026-06-12): the operator's pre-charge price ceiling.
+    # Already governs the live urgency ramp in price_calculator; plumbed into the engine
+    # so compute_pre_dw_charge_thresholds can size the pre-DW charge gate to the target.
+    max_precharge_price = float(
+        config_options.get(CONF_MAX_PRECHARGE_PRICE, DEFAULT_MAX_PRECHARGE_PRICE)
     )
 
     # Apply adaptive parameter transforms (Issue #444 Phase 2)
@@ -380,6 +389,7 @@ def _build_optimizer_config(
         self_consumption_value_per_kwh=self_consumption_value_per_kwh,
         effective_cheap_price=effective_cheap_price,
         base_cheap_price=base_cheap_price,
+        max_precharge_price=max_precharge_price,
         switching_penalty=switching_penalty,
         export_price_margin=export_price_margin,
         forecast_horizon_hours=float(getattr(data, "forecast_horizon_hours", 24.0)),

--- a/custom_components/localshift/engine/price_calculator.py
+++ b/custom_components/localshift/engine/price_calculator.py
@@ -20,7 +20,7 @@ from ..const import (
 )
 from ..coordinator.data import CoordinatorData
 from ..pricing.types import ForecastSlot
-from .dp_math import urgency_window_hours
+from .dp_math import urgency_ramp_price, urgency_window_hours
 from .utils import parse_forecast_dt
 
 # A stale ``target_reached_today`` latch (e.g. from a missed midnight reset) must not
@@ -374,8 +374,10 @@ class PriceCalculator:
             CHARGE_RATE_GRID_KW,
             0.92,
         )
-        urgency = max(min(1 - (hours_left / total_window), 1.0), 0.0)
-        urgency_price = base + (max_price - base) * urgency
+        # Shared with the optimizer's per-slot pre-DW thresholds
+        # (constraints.compute_pre_dw_charge_thresholds) so the live "now" threshold and
+        # the value the DP assumes each future slot will be gated at cannot drift apart.
+        urgency_price = urgency_ramp_price(base, max_price, hours_left, total_window)
 
         min_forecast = max_price
         now_dt_local = dt_util.as_local(now_dt) if now_dt.tzinfo else now_dt

--- a/custom_components/localshift/engine/types.py
+++ b/custom_components/localshift/engine/types.py
@@ -251,6 +251,31 @@ class OptimizerConfig:
     shortfall penalty. None ⇒ legacy behavior (boost only at very-cheap prices) for existing
     tests and direct callers."""
 
+    max_precharge_price: float | None = None
+    """Operator price ceiling for target-driven pre-charge ($/kWh), from
+    ``CONF_MAX_PRECHARGE_PRICE`` (default 0.20).
+
+    Target-first eligibility (2026-06-12): reaching the demand-window target is a
+    constraint the operator has authorized paying up to this price for — the same ceiling
+    the live urgency ramp in ``price_calculator`` already uses. Plumbed into the engine so
+    ``compute_pre_dw_charge_thresholds`` can size the pre-DW charge gate to the target
+    instead of leaving the target structurally unreachable on days with few cheap slots.
+    None ⇒ feature inert (legacy gate behaviour) for unit tests and direct callers."""
+
+    pre_dw_charge_thresholds: list[float] | None = None
+    """Solver-derived (set by ``DPPlanner._solve``): per-slot charge-price threshold for
+    slots before the demand-window entry (target-first eligibility, 2026-06-12).
+
+    Computed by ``constraints.compute_pre_dw_charge_thresholds`` as the max of (a) the
+    legacy cheap threshold, (b) the urgency ramp evaluated at that slot's own time
+    (time-consistent — a morning plan sees the same unlocks afternoon re-plans will), and
+    (c) the "water level": the marginal price of the cheapest set of pre-DW slots whose
+    combined charge capacity closes the SOC deficit to target, clamped to
+    ``max_precharge_price``. ``cheap_threshold_for_slot`` returns these for pre-DW slots
+    when present; slots at/after the DW entry are unaffected (still gated on
+    ``base_cheap_price`` — the #800 overnight-sawtooth protection is untouched).
+    None ⇒ legacy behaviour."""
+
     base_cheap_price: float | None = None
     """Un-inflated "genuinely cheap" threshold (percentile-derived), $/kWh.
 

--- a/tests/engine/test_target_first_eligibility.py
+++ b/tests/engine/test_target_first_eligibility.py
@@ -1,0 +1,265 @@
+"""Tests for target-first charge eligibility (2026-06-12).
+
+Live incident 2026-06-12: with the 3pm force-charge guardrail removed, a plan computed
+at 09:02 with SOC 16% and the demand window at 17:00 (target 95%) projected DW entry at
+48.5%. Root cause: grid charging was feasible ONLY in slots at/below the cheap-percentile
+threshold ($0.11), and only ~1.2h of such slot-time preceded the DW — so the #624 hard
+target constraint and the shortfall penalty had no feasible path to buy. The plan held at
+11.2–13 ¢ midday, then scheduled 13–15.7 ¢ imports all evening off an empty battery. A
+0.3 ¢ price wobble around the threshold moved projected DW entry by ~19 SOC points
+between two runs 16 minutes apart.
+
+``compute_pre_dw_charge_thresholds`` makes the target fundable: per-slot pre-DW
+thresholds = max(legacy cheap threshold, urgency ramp at the slot's own time, the
+"water level" — the marginal price of the cheapest sufficient set of pre-DW slots),
+clamped to the operator's ``max_precharge_price`` ceiling. Post-DW slots are untouched
+(#800 overnight-sawtooth protection).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+from custom_components.localshift.engine.constraints import (
+    cheap_threshold_for_slot,
+    compute_pre_dw_charge_thresholds,
+    feasible_actions,
+)
+from custom_components.localshift.engine.core import DPPlanner
+from custom_components.localshift.engine.dp_math import urgency_ramp_price
+from custom_components.localshift.engine.types import (
+    OptimizerConfig,
+    OptimizerInputs,
+    PlannerAction,
+    SlotContext,
+)
+
+INTERVAL = 30
+_CHARGE_ACTIONS = (PlannerAction.CHARGE_GRID_NORMAL, PlannerAction.CHARGE_GRID_BOOST)
+
+
+def _slots(pre_dw_prices: list[float], dw_prices: list[float]) -> list[SlotContext]:
+    """30-min slots: ``pre_dw_prices`` then the demand window at ``len(pre_dw_prices)``."""
+    base = datetime(2026, 6, 12, 9, 0)
+    n_pre = len(pre_dw_prices)
+    out: list[SlotContext] = []
+    for i, price in enumerate([*pre_dw_prices, *dw_prices]):
+        t = base + timedelta(minutes=INTERVAL * i)
+        is_dw = i >= n_pre
+        out.append(
+            SlotContext(
+                slot_index=i,
+                timestamp_iso=t.isoformat(),
+                slot_interval_minutes=INTERVAL,
+                buy_price=price,
+                sell_price=0.04,
+                solar_kwh=0.0,
+                consumption_kwh=0.25,
+                is_demand_window_entry=(i == n_pre),
+                is_demand_window_slot=is_dw,
+            )
+        )
+    return out
+
+
+def _config(**overrides) -> OptimizerConfig:
+    defaults = dict(
+        optimization_mode="self_consumption",
+        demand_window_target_soc_pct=95.0,
+        battery_capacity_kwh=13.5,
+        charge_rate_kw=3.3,
+        boost_charge_rate_kw=5.0,
+        charge_efficiency=0.92,
+        effective_cheap_price=0.10,
+        base_cheap_price=0.10,
+        max_precharge_price=0.20,
+        max_soc_pct=100.0,
+        min_soc_pct=10.0,
+    )
+    defaults.update(overrides)
+    return OptimizerConfig(**defaults)
+
+
+class TestComputePreDwChargeThresholds:
+    """Unit coverage for the per-slot threshold precompute."""
+
+    def test_water_level_is_marginal_price_of_cheapest_sufficient_set(self):
+        """Deficit needs 5 of 12 pre-DW slots; the 5th cheapest price sets the water level.
+
+        SOC 20 → 95 on 13.5 kWh needs 10.125 kWh stored; boost stores 2.3 kWh per 30-min
+        slot, so 5 slots suffice: four at $0.10 plus one at $0.12 → water level $0.12.
+        Slots 0–3 sit 6–4.5h before the DW — outside the deficit-derived urgency window
+        (~4h) where the ramp contributes nothing — so their threshold IS the water level.
+        """
+        slots = _slots([0.10] * 4 + [0.12] * 4 + [0.16] * 4, [0.30] * 2)
+        config = _config()
+        thresholds = compute_pre_dw_charge_thresholds(slots, config, 12, 20.0)
+        assert thresholds is not None
+        for j in range(4):
+            assert thresholds[j] == 0.12
+
+    def test_thresholds_never_below_legacy_and_ramp_rises_toward_dw(self):
+        slots = _slots([0.10] * 4 + [0.12] * 4 + [0.16] * 4, [0.30] * 2)
+        config = _config()
+        thresholds = compute_pre_dw_charge_thresholds(slots, config, 12, 20.0)
+        assert thresholds is not None
+        for j in range(12):
+            legacy = cheap_threshold_for_slot(config, j, 12)
+            assert thresholds[j] >= legacy
+        # Inside the window the ramp lifts later slots above the flat water level.
+        assert thresholds[11] > thresholds[0]
+        assert thresholds[11] <= config.max_precharge_price
+
+    def test_insufficient_capacity_authorizes_the_full_ceiling(self):
+        """When every pre-DW slot together cannot close the deficit, water = ceiling."""
+        slots = _slots([0.13, 0.14], [0.30] * 2)  # 2 slots = 4.6 kWh < 11.5 kWh needed
+        config = _config()
+        thresholds = compute_pre_dw_charge_thresholds(slots, config, 2, 10.0)
+        assert thresholds is not None
+        assert thresholds[0] == 0.20
+        assert thresholds[1] == 0.20
+
+    def test_post_dw_slots_keep_legacy_thresholds(self):
+        """#800 protection: slots at/after the DW entry are byte-for-byte legacy."""
+        slots = _slots([0.10] * 4, [0.30] * 3)
+        config = _config(effective_cheap_price=0.15, base_cheap_price=0.10)
+        thresholds = compute_pre_dw_charge_thresholds(slots, config, 4, 10.0)
+        assert thresholds is not None
+        for j in range(4, 7):
+            assert thresholds[j] == cheap_threshold_for_slot(config, j, 4)
+
+    def test_no_deficit_means_no_water_level(self):
+        """At/above target only the ramp term remains; far slots stay legacy."""
+        slots = _slots([0.10] * 4 + [0.12] * 8, [0.30] * 2)
+        config = _config()
+        thresholds = compute_pre_dw_charge_thresholds(slots, config, 12, 96.0)
+        assert thresholds is not None
+        # Slot 0 is 6h out — outside any urgency window — so legacy applies untouched.
+        assert thresholds[0] == cheap_threshold_for_slot(config, 0, 12)
+
+    def test_inert_without_dw_mode_or_ceiling(self):
+        slots = _slots([0.10] * 4, [0.30] * 2)
+        assert compute_pre_dw_charge_thresholds(slots, _config(), None, 20.0) is None
+        assert (
+            compute_pre_dw_charge_thresholds(
+                slots, _config(max_precharge_price=None), 4, 20.0
+            )
+            is None
+        )
+        assert (
+            compute_pre_dw_charge_thresholds(
+                slots, _config(optimization_mode="arbitrage"), 4, 20.0
+            )
+            is None
+        )
+        # A ceiling at/below the ramp base can only be inert, never tighten the gate.
+        assert (
+            compute_pre_dw_charge_thresholds(
+                slots, _config(max_precharge_price=0.10), 4, 20.0
+            )
+            is None
+        )
+
+    def test_solar_reduces_required_charge(self):
+        """Expected solar gain (accuracy-discounted) shrinks the funded slot set."""
+        slots = _slots([0.10] * 4 + [0.12] * 4 + [0.16] * 4, [0.30] * 2)
+        for s in slots[:12]:
+            s.solar_kwh = 1.5
+        config = _config(solar_forecast_accuracy=1.0)
+        thresholds = compute_pre_dw_charge_thresholds(slots, config, 12, 20.0)
+        assert thresholds is not None
+        # 12 × (1.5 − 0.25) kWh ≈ 13.8 kWh stored-equivalent of solar wipes the deficit:
+        # no water level, slot 0 (outside the ramp window) stays at legacy.
+        assert thresholds[0] == cheap_threshold_for_slot(config, 0, 12)
+
+
+class TestGateIntegration:
+    """The thresholds actually unlock charge actions in feasible_actions."""
+
+    def _attached_config_and_slots(self):
+        slots = _slots([0.10] * 4 + [0.12] * 4 + [0.16] * 4, [0.30] * 2)
+        config = _config()
+        config.pre_dw_charge_thresholds = compute_pre_dw_charge_thresholds(
+            slots, config, 12, 20.0
+        )
+        return config, slots
+
+    def test_water_level_slot_becomes_chargeable(self):
+        config, slots = self._attached_config_and_slots()
+        # Slot 5 at $0.12 is above the legacy $0.10 gate but at the water level.
+        actions = feasible_actions(
+            20.0, slots[5], config, slot_idx=5, slots=slots, terminal_penalty_idx=12
+        )
+        assert any(a in _CHARGE_ACTIONS for a in actions)
+
+    def test_legacy_gate_without_thresholds_still_blocks(self):
+        config, slots = self._attached_config_and_slots()
+        config.pre_dw_charge_thresholds = None
+        actions = feasible_actions(
+            20.0, slots[5], config, slot_idx=5, slots=slots, terminal_penalty_idx=12
+        )
+        assert not any(a in _CHARGE_ACTIONS for a in actions)
+
+
+class TestEndToEndPlan:
+    """DP-level replay of the 2026-06-12 shape: thin spreads, few cheap slots."""
+
+    # Live 09:02 pre-DW buy prices (thinned): only 4 slots at/below the $0.11 gate.
+    PRE_DW = [
+        0.110,
+        0.110,
+        0.114,
+        0.117,
+        0.118,
+        0.122,
+        0.124,
+        0.130,
+        0.121,
+        0.111,
+        0.106,
+        0.108,
+        0.112,
+        0.123,
+        0.134,
+        0.142,
+    ]
+    DW = [0.150, 0.156, 0.154, 0.151]
+
+    def _plan(self, max_precharge_price: float | None):
+        slots = _slots(self.PRE_DW, self.DW)
+        config = _config(
+            effective_cheap_price=0.11,
+            base_cheap_price=0.11,
+            max_precharge_price=max_precharge_price,
+            min_cycle_saving=0.25,
+            target_shortfall_penalty_per_pct=0.08,
+            switching_penalty=0.08,
+            soc_bins=100,
+        )
+        inputs = OptimizerInputs(
+            cycle_id="undercharge-2026-06-12",
+            initial_soc_pct=10.0,
+            slots=slots,
+            config=config,
+            all_solcast=[],
+        )
+        return DPPlanner(config).plan(inputs)
+
+    def test_without_ceiling_the_target_is_structurally_unreachable(self):
+        """Pin the broken shape so the fix assertion below is meaningful."""
+        result = self._plan(max_precharge_price=None)
+        assert result.success
+        # Only ~4 cheap slots × ~17 pts/slot from 10% → far short of 95%.
+        assert result.decisions[16].predicted_soc_pct < 85.0
+
+    def test_with_ceiling_the_plan_funds_the_target(self):
+        result = self._plan(max_precharge_price=0.20)
+        assert result.success
+        # 16 pre-DW slots offer ~37 kWh of boost capacity against a 11.5 kWh deficit;
+        # the charge taper above 80% is the only physical drag, so the plan should
+        # come within a few points of the 95% target instead of stalling in the 60s.
+        assert result.decisions[16].predicted_soc_pct >= 90.0
+        # And it must still be funded cheapest-first: no charging in the DW itself.
+        assert not any(
+            d.action in _CHARGE_ACTIONS for d in result.decisions if d.slot_index >= 16
+        )


### PR DESCRIPTION
## Why

Ratified objectives (2026-06-12, after the 3pm guardrail was removed):

1. **Target is a constraint, not a fee** — reach 95% by demand-window entry whenever physically possible, authorized up to `max_precharge_price` ($0.20).
2. **Cost-minimize within that** — fund the target from the cheapest eligible slots first.
3. **Keep anti-sawtooth protections** — post-DW gating and `min_cycle_saving` for discretionary arbitrage are untouched.
4. **Honest plan** — the morning plan must show what the rolling system will actually do.

Live 2026-06-12 09:02: SOC 16%, target 95%, DW 17:00 — plan projected **48.5% entry** (terminal shortfall 46.5%). Grid charging was feasible only in $0.11-and-below slots (~1.2h of them), so the #624 hard target constraint had no feasible path to buy; the plan held at 11.2–13¢ midday then scheduled ~10.7 kWh of 13–15.7¢ evening/overnight imports. A 0.3¢ price wobble at the threshold moved projected entry SOC by ~19 points between runs 16 minutes apart.

## What

`compute_pre_dw_charge_thresholds` (constraints.py): per-slot pre-DW charge thresholds =
**max(legacy threshold, urgency ramp at the slot's own time, water level)**, where the water level is the marginal price of the cheapest set of pre-DW slots whose boost capacity closes the (accuracy-discounted, solar-netted) deficit — clamped to the operator's existing `max_pre_charge_price` option.

- `dp_math.urgency_ramp_price`: single source of truth for the ramp, now shared by `price_calculator` (live threshold) and the DP (per-slot), eliminating the time-inconsistency that made morning plans procrastinate and under-report.
- `max_precharge_price` plumbed into `OptimizerConfig`; `None` ⇒ fully legacy-inert.
- `min_cycle_saving` exemption widened to any pre-DW below-target charge while thresholds are active (target-driven ≠ speculative arbitrage). Post-DW never exempted.
- **Post-DW slots are byte-for-byte legacy** — #800 overnight-sawtooth protection untouched.

## Tests

- 11 new tests incl. a 2026-06-12 replay A/B: without the ceiling the DP stalls **<85%** at entry; with it **≥90%** (taper is the only drag) and no charging inside the DW.
- Full suite: **3094 passed, 1 xfailed** — sawtooth (#800/#853), shortfall-boost (#859/#860), mid-DW (#854), floor-guard, horizon-invariance, price-calculator suites all green.

## Not in this PR

- Mode-flap hysteresis (PR B in the plan) — water-level eligibility removes most of the binary price cliff; re-measure after this lands.
- **No deploy**: live rollout is a separate, explicit step.