### PR TITLE
fix(state): one mode decision per decision-context change — decision-token architecture

### DIFF
--- a/custom_components/localshift/coordinator/coordinator.py
+++ b/custom_components/localshift/coordinator/coordinator.py
@@ -740,12 +740,26 @@ class LocalShiftCoordinator:
         """
         await self._evaluate_state_machine()
 
-    async def async_recompute_and_evaluate(self) -> None:
+    async def async_recompute_and_evaluate(
+        self, invalidate_decision: bool = True
+    ) -> None:
         """Public method for triggering recomputation and state evaluation.
 
         Called by switch and number platforms when configuration changes.
         Encapsulates the pattern: compute derived values → notify listeners → evaluate state machine.
+
+        Args:
+            invalidate_decision: When True (the default), force the next state
+                machine evaluation to be an allowed re-decision (#622 gate
+                replacement) — used for deliberate config-change re-decision
+                points. The load-deviation / solar-event reoptimizers pass False:
+                they may update the plan but must NOT grant a mode change.
+
         """
+        if invalidate_decision and self._state_machine is not None:
+            self._state_machine.invalidate_decision_fingerprint(
+                "async_recompute_and_evaluate (config change)"
+            )
         self._compute_derived_values()
         self.notify_listeners()
         await self.async_evaluate_state_machine()

--- a/custom_components/localshift/coordinator/data.py
+++ b/custom_components/localshift/coordinator/data.py
@@ -546,3 +546,20 @@ class CoordinatorData:
     Each entry: {from_mode, to_mode, lag_seconds, decision_time, implementation_time}.
     Max 50 entries.
     """
+
+    # ---------------------------------------------------------------------------
+    # --- Decision-token gating (#622 gate replacement) ---
+    # ---------------------------------------------------------------------------
+    # Transient per-evaluation flag set by the state machine BEFORE
+    # compute_derived_values runs. When False the optimizer facade must NOT
+    # re-decide active_mode (it pins the previously-decided mode); the would-be
+    # plan mode is surfaced via debug_plan_mode_pending instead. Default False so
+    # any code path that forgets to set it freezes rather than thrashes.
+
+    mode_decision_allowed: bool = False
+    """True only on evaluations where the decision context changed (one decision
+    per price/spike/DW-boundary/SOC-floor change). Transient; not persisted."""
+
+    debug_plan_mode_pending: str | None = None
+    """When the decision is frozen, the mode the plan would have selected
+    ("plan wants X, decision held at Y"). None when no decision is pending."""

--- a/custom_components/localshift/engine/optimizer_facade.py
+++ b/custom_components/localshift/engine/optimizer_facade.py
@@ -309,6 +309,13 @@ class OptimizerFacade:
         data.debug_first_forecast_slot_time = first_hhmm
         data.debug_time_gap_seconds = gap_seconds
 
+        # #622 gate replacement: the mode may be (re-)decided only on an allowed
+        # evaluation. When frozen, every branch below records its block-status /
+        # debug observability but must NOT touch active_mode, decision_timestamp
+        # or decision_mode — the previously-decided mode is pinned. The would-be
+        # plan mode is surfaced via debug_plan_mode_pending instead.
+        decision_allowed = data.mode_decision_allowed
+
         safety_gate = OptimizerSafetyGate(config_options)
         gate_result = safety_gate.check_admission(data, result, alignment)
 
@@ -318,10 +325,14 @@ class OptimizerFacade:
                 gate_result.block_reason,
             )
 
-            data.active_mode = _BatteryMode.SELF_CONSUMPTION
             data.optimizer_last_apply_status = "blocked"
             data.optimizer_safety_block_reason = gate_result.block_reason or ""
-            data.debug_mode_source = "fallback"
+            self._commit_or_hold_mode(
+                data,
+                _BatteryMode.SELF_CONSUMPTION,
+                decision_allowed,
+                mode_source="fallback",
+            )
             _LOGGER.warning(
                 "Optimizer safety gate failed — defaulting to SELF_CONSUMPTION"
             )
@@ -335,26 +346,17 @@ class OptimizerFacade:
         battery_mode_str = apply_plan.get("battery_mode", "")
         try:
             new_mode = _BatteryMode(battery_mode_str)
-            if new_mode != data.active_mode:
-                decision_time = dt_util.now()
-                if decision_time is not None:
-                    data.decision_timestamp = decision_time
-                    data.decision_mode = new_mode
-                    _LOGGER.info(
-                        "Decision lag tracking: mode change %s → %s at %s",
-                        data.active_mode.value,
-                        new_mode.value,
-                        decision_time.isoformat(),
-                    )
-            data.active_mode = new_mode
             data.optimizer_last_apply_status = "ready_to_apply"
             data.optimizer_safety_block_reason = ""
-            data.debug_mode_source = "optimizer"
+            self._commit_or_hold_mode(
+                data, new_mode, decision_allowed, mode_source="optimizer"
+            )
             _LOGGER.info(
-                "DP optimizer: selected %s (action=%s, slot=%d)",
+                "DP optimizer: selected %s (action=%s, slot=%d, decision_allowed=%s)",
                 battery_mode_str,
                 apply_plan.get("action"),
                 current_slot_idx,
+                decision_allowed,
             )
         except ValueError:
             _LOGGER.warning(
@@ -362,9 +364,51 @@ class OptimizerFacade:
                 battery_mode_str,
             )
 
-            data.active_mode = _BatteryMode.SELF_CONSUMPTION
             data.optimizer_last_apply_status = "fallback"
-            data.debug_mode_source = "fallback"
+            self._commit_or_hold_mode(
+                data,
+                _BatteryMode.SELF_CONSUMPTION,
+                decision_allowed,
+                mode_source="fallback",
+            )
+
+    @staticmethod
+    def _commit_or_hold_mode(
+        data: CoordinatorData,
+        new_mode: Any,
+        decision_allowed: bool,
+        mode_source: str,
+    ) -> None:
+        """Commit a freshly-decided mode, or hold the pinned mode when frozen.
+
+        #622 gate replacement. On an allowed evaluation this commits ``new_mode``
+        to ``data.active_mode`` (with decision-lag tracking) exactly as before.
+        On a frozen evaluation it leaves ``active_mode`` / ``decision_timestamp``
+        / ``decision_mode`` untouched and records the would-be mode in
+        ``debug_plan_mode_pending`` so the dashboard can show "plan wants X,
+        decision held at Y".
+        """
+        if not decision_allowed:
+            # Frozen: pin the previously-decided mode, surface the pending plan.
+            data.debug_plan_mode_pending = (
+                new_mode.value if new_mode != data.active_mode else None
+            )
+            return
+
+        if new_mode != data.active_mode:
+            decision_time = dt_util.now()
+            if decision_time is not None:
+                data.decision_timestamp = decision_time
+                data.decision_mode = new_mode
+                _LOGGER.info(
+                    "Decision lag tracking: mode change %s → %s at %s",
+                    data.active_mode.value,
+                    new_mode.value,
+                    decision_time.isoformat(),
+                )
+        data.active_mode = new_mode
+        data.debug_mode_source = mode_source
+        data.debug_plan_mode_pending = None
 
     @staticmethod
     def _mark_mode_debug_fallback(data: CoordinatorData) -> None:

--- a/custom_components/localshift/services/evaluation_dispatcher.py
+++ b/custom_components/localshift/services/evaluation_dispatcher.py
@@ -204,8 +204,11 @@ class EvaluationDispatcher:
         if not self._load_deviation_detector.evaluate(coordinator.data, now):
             return False
 
+        # #622 gate replacement: a load-deviation reoptimization may update the
+        # plan but must NOT grant a mode re-decision — pass invalidate_decision
+        # False so the once-per-context invariant holds.
         self.hass.async_create_task(
-            coordinator.async_recompute_and_evaluate(),
+            coordinator.async_recompute_and_evaluate(invalidate_decision=False),
             "localshift_reoptimize_load_deviation",
         )
         return True
@@ -218,8 +221,10 @@ class EvaluationDispatcher:
         if not self._solar_event_detector.evaluate(coordinator.data, now):
             return False
 
+        # #622 gate replacement: a solar-event reoptimization may update the plan
+        # but must NOT grant a mode re-decision — pass invalidate_decision False.
         self.hass.async_create_task(
-            coordinator.async_recompute_and_evaluate(),
+            coordinator.async_recompute_and_evaluate(invalidate_decision=False),
             "localshift_reoptimize_solar_event",
         )
         return True

--- a/custom_components/localshift/state/machine.py
+++ b/custom_components/localshift/state/machine.py
@@ -14,8 +14,10 @@ from ..const import (
     BACKUP_RESERVE_MAX_VALID,
     CONF_BATTERY_TARGET,
     CONF_MANUAL_OVERRIDE_TIMEOUT,
+    CONF_MINIMUM_TARGET_SOC,
     DEFAULT_BATTERY_TARGET,
     DEFAULT_MANUAL_OVERRIDE_TIMEOUT,
+    DEFAULT_MINIMUM_TARGET_SOC,
     PROACTIVE_EXPORT_MIN_RESERVE_PERCENT,
     PROACTIVE_EXPORT_SOC_BUFFER_PERCENT,
     STATE_MACHINE_MIN_CORRECTION_INTERVAL_MINUTES,
@@ -87,8 +89,12 @@ class StateMachine:
         # Cooldown for health-check corrections (prevents command spam when
         # Teslemetry cloud lags in reflecting a legitimate transition)
         self._last_health_correction: datetime | None = None
-        # Issue #622: Fingerprint for gating mode transitions on price changes
-        self._last_decision_fingerprint: str | None = None
+        # Decision-token gating (#622 gate replacement): the mode may be
+        # re-decided at most once per discrete decision-context change. The
+        # fingerprint is consumed by the *evaluation* that observes the change
+        # (not by a transition), which kills the old deferred-redemption bug
+        # where a stale token was redeemed minutes later by a non-price input.
+        self._last_evaluated_fingerprint: str | None = None
         self._MIN_CORRECTION_INTERVAL = timedelta(
             minutes=STATE_MACHINE_MIN_CORRECTION_INTERVAL_MINUTES
         )
@@ -143,16 +149,31 @@ class StateMachine:
         return self._tesla_override_detected
 
     def _get_decision_fingerprint(self, data: CoordinatorData) -> str | None:
-        """Generate fingerprint from price data for gating mode transitions.
+        """Generate the discrete decision-context fingerprint.
 
-        Issue #622: Mode transitions are gated on price changes. This fingerprint
-        captures the price state that affects mode decisions.
+        #622 gate replacement: the mode may be re-decided only when the discrete
+        decision context changes. This fingerprint enumerates every legitimate
+        re-decision trigger so the once-per-context invariant holds by
+        construction — no timers, no dwell:
+
+        - buy/sell price (Amber's 5-min interval is the primary trigger)
+        - spike: price-spike onset
+        - dw_active: demand-window boundary crossing
+        - soc_floor_breached: SOC dropped below the optimizer's minimum target
+
+        ``dw_active`` and ``soc_floor_breached`` are read from ``data`` *before*
+        compute_derived_values refreshes them this tick. The resulting 1-tick
+        detection lag is acceptable and intended: the very next evaluation (≤1
+        min away) carries the refreshed values, and treating the pre-refresh
+        snapshot as the decision context keeps the fingerprint consistent with
+        the prices read at the same instant.
 
         Args:
-            data: Coordinator data with current prices.
+            data: Coordinator data with current prices and state.
 
         Returns:
-            Fingerprint string "{buy}|{sell}|{spike}" or None if prices unavailable.
+            Fingerprint string or None if prices are unavailable. None must NOT
+            count as a context change (the caller freezes on None).
 
         """
         buy = data.general_price
@@ -162,7 +183,13 @@ class StateMachine:
         if buy is None or sell is None:
             return None
 
-        return f"{buy:.4f}|{sell:.4f}|{spike}"
+        dw_active = data.demand_window_active
+        min_target_soc = float(
+            self._get_option(CONF_MINIMUM_TARGET_SOC, DEFAULT_MINIMUM_TARGET_SOC)
+        )
+        soc_floor_breached = data.soc is not None and data.soc < min_target_soc
+
+        return f"{buy:.4f}|{sell:.4f}|{spike}|{dw_active}|{soc_floor_breached}"
 
     def _get_mode_config(
         self, target: BatteryMode, data: CoordinatorData
@@ -317,6 +344,15 @@ class StateMachine:
 
         self._startup_grace_until = None
 
+        # #622 gate replacement: grace-end is the startup-settle re-decision
+        # point (enumerated exception). A token may already have been burned by
+        # an evaluation during grace while the safety gate was still blocking
+        # (e.g. optimizer slots absent pre-Solcast), committing the SC fallback;
+        # without invalidation the first real decision would stay frozen until
+        # the next price change (~5 min). Invalidate so the first post-grace
+        # evaluation re-decides from the now-populated inputs.
+        self.invalidate_decision_fingerprint("startup grace ended")
+
         # Issue #349: Check if automation is ready before inferring mode
         # At startup, entities may not be populated, leading to incorrect mode inference
         if not data.automation_ready:
@@ -380,6 +416,12 @@ class StateMachine:
         )
         data.manual_override = False
         self._manual_override_set_at = None
+        # #622 gate replacement: the timeout is a deliberate re-decision point.
+        # Without invalidating the fingerprint the facade would keep pinning
+        # active_mode at MANUAL until the next genuine price change (up to ~5
+        # min away), because an unchanged decision context grants no token.
+        # Invalidate so the very next evaluation is decision-allowed.
+        self.invalidate_decision_fingerprint("manual override timeout")
         # Send notification about manual override timeout
         await self._notification_service.send_manual_override_timeout_notification(
             data, timeout_hours
@@ -388,7 +430,9 @@ class StateMachine:
         # A full recompute already ran at the top of this lock
         # (Item 5 fix).
         # desired remains MANUAL this cycle; the next periodic tick
-        # (at most 1 minute away) will recompute the correct mode.
+        # (at most 1 minute away) will recompute the correct mode — now that the
+        # fingerprint is invalidated, that tick is decision-allowed and the
+        # optimizer mode commits instead of staying pinned at MANUAL.
 
     async def _handle_soc_monitoring(self, data: CoordinatorData) -> bool:
         """Handle SOC-based charge target enforcement.
@@ -512,20 +556,60 @@ class StateMachine:
             if not data.automation_ready and check_automation_ready_func is not None:
                 in_grace = self._startup_grace_until is not None
                 check_automation_ready_func(data, suppress_warning=in_grace)
+
+            # #622 gate replacement: consume the decision token at evaluation
+            # time, from fresh post-read_state data, BEFORE compute_derived_values
+            # runs the optimizer facade. The facade reads data.mode_decision_allowed
+            # to decide whether it may re-select active_mode this tick.
+            self._apply_decision_token(data)
+
             computation_engine.compute_derived_values(data)
 
             try:
                 await self._evaluate_core(data, computation_engine)
             finally:
+                # #622 gate replacement (transience guarantee): the decision
+                # token is valid ONLY within this in-lock window, from
+                # _apply_decision_token above to here. Resetting it (even on
+                # exception) guarantees the flag is never True for the
+                # OUT-OF-LOCK compute_derived_values call at the top of
+                # coordinator.async_recompute_and_evaluate — so a load-deviation
+                # or solar reoptimize can never commit an ungated mode decision.
+                data.mode_decision_allowed = False
                 if notify_func is not None:
                     notify_func()
+
+    def _apply_decision_token(self, data: CoordinatorData) -> None:
+        """Consume the decision token for this evaluation (#622 gate replacement).
+
+        Computes the discrete decision-context fingerprint from fresh data and
+        sets ``data.mode_decision_allowed`` accordingly. The token is consumed by
+        the evaluation that *observes* a context change — not by a later
+        transition — so a stale token can never be redeemed by a non-price input
+        on a subsequent tick (the original deferred-redemption bug).
+
+        A None fingerprint (price sensor unavailable) never grants a decision and
+        never overwrites the stored fingerprint: we stay frozen on the last known
+        context until a genuinely new value arrives.
+        """
+        fingerprint = self._get_decision_fingerprint(data)
+        decision_allowed = (
+            fingerprint is not None and fingerprint != self._last_evaluated_fingerprint
+        )
+        if decision_allowed:
+            # Consume immediately: the evaluation, not the transition, spends the
+            # token. Covers every downstream path (including debounce-in-progress).
+            self._last_evaluated_fingerprint = fingerprint
+            _LOGGER.debug(
+                "Decision token granted (fingerprint=%s)", fingerprint
+            )
+        data.mode_decision_allowed = decision_allowed
 
     async def _evaluate_core(
         self, data: CoordinatorData, computation_engine: ComputationEngine
     ) -> None:
         """Core evaluation logic extracted from evaluate_state_machine."""
         now = dt_util.now()
-        desired = data.active_mode
 
         if self._handle_startup_grace_period(data, now):
             return
@@ -533,6 +617,16 @@ class StateMachine:
             return
 
         await self._handle_manual_override_timeout(data, now)
+
+        # #622 gate replacement: the convergence-while-frozen guarantee rests on
+        # the optimizer facade (_commit_or_hold_mode), not on any local state
+        # here. While frozen the facade holds data.active_mode at the last
+        # committed decision, so ``desired`` below cannot name a new mode; a
+        # frozen evaluation can only converge hardware toward that held decision
+        # (debounce progression, failed/blocked-command retry, health checks).
+        # On an allowed evaluation the facade has just (re-)selected
+        # data.active_mode and the transition logic drives toward the new mode.
+        desired = data.active_mode
 
         if desired == self._commanded_mode:
             await self._handle_stable_mode(data)
@@ -559,8 +653,15 @@ class StateMachine:
         debounce = self._get_debounce_duration(desired)
         debounce_in_progress = desired in self._mode_desired_since
 
+        # #622 gate replacement: the "decide only on context change" gate now
+        # lives at the facade (active_mode is pinned when frozen), so this path
+        # is only reached when converging toward the already-decided mode —
+        # either a fresh decision this tick, or an in-flight debounce / retry.
+        # No price-fingerprint check here: starting/continuing the debounce and
+        # retrying a failed or validator-blocked command are convergence, not
+        # new decisions.
         if not debounce_in_progress:
-            if await self._handle_new_desired_mode(data, desired, now, debounce):
+            if self._start_debounce(desired, now, debounce):
                 return
 
         if not await self._check_debounce_and_transition(data, desired, now, debounce):
@@ -573,23 +674,6 @@ class StateMachine:
         for mode in list(self._mode_desired_since.keys()):
             if mode != desired:
                 self._mode_desired_since.pop(mode, None)
-
-    async def _handle_new_desired_mode(
-        self,
-        data: CoordinatorData,
-        desired: BatteryMode,
-        now: datetime,
-        debounce: timedelta,
-    ) -> bool:
-        """Handle new desired mode (debounce not in progress).
-
-        Returns True if caller should return, False to continue.
-        """
-        if self._should_skip_price_unchanged(data, desired):
-            if not self._get_switch_state("dry_run"):
-                await self._perform_health_check(data)
-            return True
-        return self._start_debounce(data, desired, now, debounce)
 
     async def _execute_transition_with_validation(
         self, data: CoordinatorData, desired: BatteryMode, now: datetime
@@ -646,29 +730,8 @@ class StateMachine:
             old_mode, desired, data
         )
 
-    def _should_skip_price_unchanged(
-        self, data: CoordinatorData, desired: BatteryMode
-    ) -> bool:
-        """Check if transition should be skipped due to unchanged price."""
-        fingerprint = self._get_decision_fingerprint(data)
-        price_changed = (
-            fingerprint != self._last_decision_fingerprint
-            or self._last_decision_fingerprint is None
-        )
-
-        if not price_changed:
-            _LOGGER.debug(
-                "Price unchanged (fingerprint=%s), skipping new mode transition %s → %s",
-                fingerprint,
-                self._commanded_mode.value,
-                desired.value,
-            )
-            return True
-        return False
-
     def _start_debounce(
         self,
-        data: CoordinatorData,
         desired: BatteryMode,
         now: datetime,
         debounce: timedelta,
@@ -676,9 +739,11 @@ class StateMachine:
         """Start debounce timer for new desired mode.
 
         Returns True if caller should return (wait for debounce), False if debounce is 0.
+
+        #622 gate replacement: the decision token is consumed in
+        _apply_decision_token at evaluation time, not here — a debounce start is
+        convergence toward the decided mode, never a fresh decision.
         """
-        fingerprint = self._get_decision_fingerprint(data)
-        self._last_decision_fingerprint = fingerprint
         self._mode_desired_since[desired] = now
         if debounce > timedelta(0):
             _LOGGER.info(
@@ -1172,6 +1237,24 @@ class StateMachine:
             "Commanded mode set directly to %s (manual button press)",
             mode.value,
         )
+
+    def invalidate_decision_fingerprint(self, reason: str) -> None:
+        """Force the next evaluation to be an allowed decision (#622 gate replacement).
+
+        Clears the stored decision-context fingerprint so the next evaluation
+        sees a "changed" context and may re-select the mode. Used for deliberate
+        re-decision points (user config changes, automation re-enable) where the
+        plan genuinely needs to take effect now, independent of price movement.
+
+        NOT called by the load-deviation / solar-event reoptimizers: those may
+        update the plan but must not grant a mode change (the invariant holds).
+
+        Args:
+            reason: Human-readable reason for the invalidation (logged at INFO).
+
+        """
+        _LOGGER.info("Decision fingerprint invalidated: %s", reason)
+        self._last_evaluated_fingerprint = None
 
     @property
     def in_mode_transition(self) -> bool:

--- a/custom_components/localshift/state/machine.py
+++ b/custom_components/localshift/state/machine.py
@@ -600,9 +600,7 @@ class StateMachine:
             # Consume immediately: the evaluation, not the transition, spends the
             # token. Covers every downstream path (including debounce-in-progress).
             self._last_evaluated_fingerprint = fingerprint
-            _LOGGER.debug(
-                "Decision token granted (fingerprint=%s)", fingerprint
-            )
+            _LOGGER.debug("Decision token granted (fingerprint=%s)", fingerprint)
         data.mode_decision_allowed = decision_allowed
 
     async def _evaluate_core(

--- a/tests/services/test_evaluation_dispatcher.py
+++ b/tests/services/test_evaluation_dispatcher.py
@@ -383,6 +383,43 @@ def test_fast_tick_triggers_load_deviation_reoptimization():
         hass.async_create_task.call_args.args[1]
         == "localshift_reoptimize_load_deviation"
     )
+    # #622 gate replacement: a reoptimization may update the plan but must NOT
+    # grant a mode re-decision.
+    coordinator.async_recompute_and_evaluate.assert_called_once_with(
+        invalidate_decision=False
+    )
+
+
+def test_load_deviation_reoptimization_does_not_invalidate_decision():
+    """#622 gate replacement: load-deviation reoptimizer passes invalidate_decision=False."""
+    hass = MagicMock()
+    hass.async_create_task = MagicMock()
+
+    coordinator = StubCoordinator()
+
+    dispatcher = EvaluationDispatcher(
+        hass,
+        lambda _key: "sensor.price",
+        coordinator.read_state,
+        MagicMock(),
+        AsyncMock(),
+        MagicMock(in_mode_transition=False),
+        timedelta(minutes=10),
+    )
+    # Load-deviation does not fire; solar-event does.
+    dispatcher._load_deviation_detector = MagicMock()
+    dispatcher._load_deviation_detector.evaluate.return_value = False
+    dispatcher._solar_event_detector = MagicMock()
+    dispatcher._solar_event_detector.evaluate.return_value = True
+
+    dispatcher.on_fast_tick(dt_util.now())
+
+    assert (
+        hass.async_create_task.call_args.args[1] == "localshift_reoptimize_solar_event"
+    )
+    coordinator.async_recompute_and_evaluate.assert_called_once_with(
+        invalidate_decision=False
+    )
 
 
 def test_fast_tick_uses_periodic_evaluation_when_no_load_deviation_trigger():

--- a/tests/state/test_state_machine.py
+++ b/tests/state/test_state_machine.py
@@ -1456,24 +1456,28 @@ class TestDecisionFingerprint:
         fp2 = state_machine._get_decision_fingerprint(coordinator_data)
 
         assert fp1 == fp2
-        assert fp1 == "0.2500|0.0800|False"
+        # #622 gate replacement: fingerprint now enumerates the full discrete
+        # decision context: buy|sell|spike|dw_active|soc_floor_breached.
+        assert fp1 == "0.2500|0.0800|False|False|False"
 
 
 class TestModeTransitionGating:
-    """Test that mode transitions are gated on fingerprint.
+    """Test that mode decisions are gated on the decision-context fingerprint.
 
-    Issue #622: Mode transitions only occur when price fingerprint changes.
-    Optimizer always runs to update plan data.
+    #622 gate replacement: the decision token is consumed at evaluation time
+    (in _apply_decision_token), and the facade pins active_mode when frozen.
+    The state machine no longer gates transitions itself — it only converges
+    toward the decided mode.
     """
 
     @pytest.mark.asyncio
-    async def test_optimizer_runs_even_if_price_unchanged(
+    async def test_token_consumed_at_evaluation(
         self,
         state_machine,
         coordinator_data,
         computation_engine,
     ):
-        """Optimizer always runs even if price unchanged."""
+        """First evaluation with a price consumes the token (stores fingerprint)."""
         # Set up data with prices and a different desired mode
         coordinator_data.general_price = 0.25
         coordinator_data.feed_in_price = 0.08
@@ -1481,57 +1485,57 @@ class TestModeTransitionGating:
         # Set desired mode different from commanded mode (which is SELF_CONSUMPTION)
         coordinator_data.active_mode = BatteryMode.GRID_CHARGING
 
-        # First evaluation sets fingerprint and transitions
+        # First evaluation: decision allowed, fingerprint stored
         await state_machine.evaluate_state_machine(
             coordinator_data,
             computation_engine,
         )
 
-        # Verify fingerprint was set
+        # The token was consumed by the evaluation itself: the fingerprint is
+        # now stored (this only happens on a decision-allowed evaluation).
         fingerprint = state_machine._get_decision_fingerprint(coordinator_data)
         assert fingerprint is not None
-        assert state_machine._last_decision_fingerprint is not None
+        assert state_machine._last_evaluated_fingerprint == fingerprint
+        # FIX 1 (transience guarantee): even though this evaluation GRANTED a
+        # token, the flag is reset to False in the evaluate finally block so it
+        # cannot leak True into the out-of-lock recompute.
+        assert coordinator_data.mode_decision_allowed is False
 
     @pytest.mark.asyncio
-    async def test_mode_transition_skipped_if_price_unchanged(
+    async def test_second_eval_same_price_is_frozen(
         self,
         state_machine,
         coordinator_data,
         computation_engine,
-        mock_battery_controller,
     ):
-        """Mode transition is skipped when fingerprint unchanged."""
-        # Set up data with prices and different desired mode
+        """A second evaluation with unchanged context is frozen (no new token).
+
+        This is the deferred-redemption kill: the first eval consumes the token,
+        and the second eval on the same context yields mode_decision_allowed=False
+        regardless of what the plan would do.
+        """
         coordinator_data.general_price = 0.25
         coordinator_data.feed_in_price = 0.08
         coordinator_data.price_spike = False
         coordinator_data.active_mode = BatteryMode.GRID_CHARGING
 
-        # First evaluation to set fingerprint and transition
         await state_machine.evaluate_state_machine(
             coordinator_data,
             computation_engine,
         )
+        # First eval granted a token (it stored a non-None fingerprint). The
+        # flag itself is transient (FIX 1) and already reset to False here.
+        first_fp = state_machine._last_evaluated_fingerprint
+        assert first_fp is not None
+        assert coordinator_data.mode_decision_allowed is False
 
-        # Verify fingerprint was set
-        fingerprint = state_machine._get_decision_fingerprint(coordinator_data)
-        assert fingerprint is not None
-        assert state_machine._last_decision_fingerprint is not None
-
-        # Reset mock to track second call
-        mock_battery_controller.set_force_charge.reset_mock()
-
-        # Change desired mode but keep same prices
-        coordinator_data.active_mode = BatteryMode.BOOST_CHARGING
-
-        # Second evaluation should skip transition due to same prices
+        # Second evaluation, same prices: frozen, fingerprint unchanged.
         await state_machine.evaluate_state_machine(
             coordinator_data,
             computation_engine,
         )
-
-        # Mode transition should be skipped (no new calls)
-        mock_battery_controller.set_force_charge.assert_not_called()
+        assert coordinator_data.mode_decision_allowed is False
+        assert state_machine._last_evaluated_fingerprint == first_fp
 
     @pytest.mark.asyncio
     async def test_first_evaluation_allows_transition(
@@ -1663,3 +1667,469 @@ class TestModeTransitionGating:
 
         # NOW transition should have happened despite unchanged prices
         mock_battery_controller.set_proactive_export.assert_called_once()
+
+
+# =============================================================================
+# #622 GATE REPLACEMENT — DECISION-TOKEN ARCHITECTURE
+# =============================================================================
+# These tests exercise the once-per-decision-context invariant: the optimizer
+# may select a *new* mode only when the discrete decision context changes; the
+# state machine always converges hardware toward the already-decided mode.
+
+
+class FakeFacadeEngine:
+    """Computation-engine stub that mimics the real optimizer-facade contract.
+
+    Real flow: compute_derived_values() → facade._assign_active_mode() pins
+    data.active_mode when data.mode_decision_allowed is False, and re-decides it
+    (to whatever the plan wants) only when True. This stub reproduces exactly
+    that pin/commit behaviour so the state machine can be driven through the
+    knife-edge without the full optimizer.
+    """
+
+    def __init__(self, plan_mode: BatteryMode) -> None:
+        # The mode the "plan" currently wants (the oscillating knife-edge value).
+        self.plan_mode = plan_mode
+        # The value of data.mode_decision_allowed observed on the LAST call.
+        # The flag is transient (reset in the evaluate finally block), so a test
+        # cannot read it after evaluate_state_machine returns — it captures the
+        # in-lock value here instead.
+        self.last_decision_allowed: bool | None = None
+
+    def compute_derived_values(self, data) -> None:
+        self.last_decision_allowed = data.mode_decision_allowed
+        if data.mode_decision_allowed:
+            # Allowed: the facade commits the fresh plan mode.
+            if self.plan_mode != data.active_mode:
+                data.decision_timestamp = dt_aware(2026, 2, 16, 16, 0, 0)
+                data.decision_mode = self.plan_mode
+            data.active_mode = self.plan_mode
+            data.debug_plan_mode_pending = None
+        else:
+            # Frozen: pin active_mode, surface the would-be plan mode.
+            data.debug_plan_mode_pending = (
+                self.plan_mode.value if self.plan_mode != data.active_mode else None
+            )
+
+
+class TestDecisionTokenInvariant:
+    """THE INVARIANT TEST plus the exception/bypass coverage (#622 replacement)."""
+
+    def _run(self, state_machine, data, engine):
+        asyncio.run(state_machine.evaluate_state_machine(data, engine))
+
+    def test_invariant_transitions_le_distinct_fingerprints(
+        self, state_machine, coordinator_data, mock_battery_controller
+    ):
+        """Knife-edge: many evals across price intervals, plan oscillating every
+        eval; executed transitions must be ≤ distinct fingerprint values.
+        """
+        coordinator_data.active_mode = BatteryMode.SELF_CONSUMPTION
+        state_machine._commanded_mode = BatteryMode.SELF_CONSUMPTION
+        # Real engine decisions are immediate-debounce modes so a granted token
+        # transitions on the same tick.
+        engine = FakeFacadeEngine(BatteryMode.GRID_CHARGING)
+
+        transitions = []
+        original = state_machine._execute_mode_transition
+
+        async def _counting(data, target):
+            result = await original(data, target)
+            if result:
+                transitions.append(target)
+            return result
+
+        state_machine._execute_mode_transition = _counting
+
+        # 4 price intervals, ~6 evals each (tick + coalesce cadence). Each eval
+        # the plan oscillates between two immediate modes.
+        prices = [0.25, 0.25, 0.25, 0.30, 0.30, 0.30, 0.20, 0.20, 0.20, 0.40, 0.40, 0.40]
+        oscillate = [BatteryMode.GRID_CHARGING, BatteryMode.SPIKE_DISCHARGE]
+        distinct_fps = set()
+        for i, price in enumerate(prices):
+            coordinator_data.general_price = price
+            coordinator_data.price_spike = False
+            engine.plan_mode = oscillate[i % 2]
+            distinct_fps.add(
+                state_machine._get_decision_fingerprint(coordinator_data)
+            )
+            self._run(state_machine, coordinator_data, engine)
+
+        # The crown jewel: at most one transition per distinct decision context.
+        assert len(transitions) <= len(distinct_fps)
+        # And concretely: 4 distinct prices → ≤ 4 transitions, not ~12.
+        assert len(distinct_fps) == 4
+        # Guard against a vacuous pass: the knife-edge MUST have driven some
+        # transitions (otherwise the invariant is trivially satisfied).
+        assert len(transitions) >= 1
+
+    def test_token_flag_reset_after_granting_evaluation(
+        self, state_machine, coordinator_data, mock_battery_controller
+    ):
+        """FIX 1 test (a): after an evaluation that GRANTED a token, the
+        transient flag is reset to False (it cannot leak True)."""
+        coordinator_data.active_mode = BatteryMode.SELF_CONSUMPTION
+        state_machine._commanded_mode = BatteryMode.SELF_CONSUMPTION
+        coordinator_data.general_price = 0.25
+        engine = FakeFacadeEngine(BatteryMode.GRID_CHARGING)
+
+        self._run(state_machine, coordinator_data, engine)
+
+        # The evaluation observed an allowed decision in-lock...
+        assert engine.last_decision_allowed is True
+        # ...but the flag is reset to False once the evaluation completes.
+        assert coordinator_data.mode_decision_allowed is False
+
+    def test_out_of_lock_recompute_cannot_commit_ungated_mode(
+        self, state_machine, coordinator_data, mock_battery_controller
+    ):
+        """FIX 1 test (b) — the invariant-leak scenario: an evaluation grants a
+        token (price change), then the OUT-OF-LOCK recompute runs the engine's
+        compute_derived_values(data) directly with the plan now preferring a
+        different mode. Because the flag was reset, active_mode is held (pinned)
+        and decision_timestamp is not written.
+        """
+        coordinator_data.active_mode = BatteryMode.SELF_CONSUMPTION
+        state_machine._commanded_mode = BatteryMode.SELF_CONSUMPTION
+        coordinator_data.general_price = 0.25
+        engine = FakeFacadeEngine(BatteryMode.SELF_CONSUMPTION)
+
+        # In-lock evaluation grants a token; plan == current so no mode change.
+        self._run(state_machine, coordinator_data, engine)
+        assert coordinator_data.mode_decision_allowed is False
+        coordinator_data.decision_timestamp = None
+
+        # Out-of-lock recompute: the plan now prefers a DIFFERENT mode. This
+        # mirrors coordinator.async_recompute_and_evaluate's pre-lock
+        # _compute_derived_values call, which must see the flag frozen at False.
+        engine.plan_mode = BatteryMode.GRID_CHARGING
+        engine.compute_derived_values(coordinator_data)
+
+        assert coordinator_data.active_mode == BatteryMode.SELF_CONSUMPTION
+        assert coordinator_data.decision_timestamp is None
+        assert (
+            coordinator_data.debug_plan_mode_pending
+            == BatteryMode.GRID_CHARGING.value
+        )
+
+    def test_frozen_eval_pins_mode_no_decision_timestamp(
+        self, state_machine, coordinator_data, mock_battery_controller
+    ):
+        """Same fingerprint, plan flips → no transition, active_mode pinned, no
+        decision_timestamp write."""
+        coordinator_data.active_mode = BatteryMode.SELF_CONSUMPTION
+        state_machine._commanded_mode = BatteryMode.SELF_CONSUMPTION
+        coordinator_data.general_price = 0.25
+        engine = FakeFacadeEngine(BatteryMode.SELF_CONSUMPTION)
+
+        # First eval: decision allowed, mode stays SELF_CONSUMPTION (plan == current).
+        self._run(state_machine, coordinator_data, engine)
+        coordinator_data.decision_timestamp = None
+
+        # Plan flips on the SAME price — must be frozen.
+        engine.plan_mode = BatteryMode.GRID_CHARGING
+        mock_battery_controller.set_force_charge.reset_mock()
+        self._run(state_machine, coordinator_data, engine)
+
+        assert coordinator_data.active_mode == BatteryMode.SELF_CONSUMPTION
+        assert coordinator_data.decision_timestamp is None
+        assert coordinator_data.debug_plan_mode_pending == BatteryMode.GRID_CHARGING.value
+        mock_battery_controller.set_force_charge.assert_not_called()
+
+    def test_deferred_token_kill(
+        self, state_machine, coordinator_data, mock_battery_controller
+    ):
+        """Price change with a stable plan, then plan flips at next tick with the
+        same price → NO transition (the original deferred-redemption bug)."""
+        coordinator_data.active_mode = BatteryMode.SELF_CONSUMPTION
+        state_machine._commanded_mode = BatteryMode.SELF_CONSUMPTION
+
+        # Tick 1: price changes, plan stable (stays SELF_CONSUMPTION). Token spent
+        # by the evaluation, no transition.
+        coordinator_data.general_price = 0.25
+        engine = FakeFacadeEngine(BatteryMode.SELF_CONSUMPTION)
+        self._run(state_machine, coordinator_data, engine)
+        mock_battery_controller.set_force_charge.reset_mock()
+
+        # Tick 2: SAME price, plan now flips to GRID_CHARGING. Under the old gate
+        # the stale token would be redeemed here. Now: frozen, no transition.
+        engine.plan_mode = BatteryMode.GRID_CHARGING
+        self._run(state_machine, coordinator_data, engine)
+
+        assert coordinator_data.active_mode == BatteryMode.SELF_CONSUMPTION
+        mock_battery_controller.set_force_charge.assert_not_called()
+
+    def test_none_price_never_grants_transition(
+        self, state_machine, coordinator_data, mock_battery_controller
+    ):
+        """price → None → same price restores → still frozen; new price → one
+        decision. None must never grant a transition."""
+        coordinator_data.active_mode = BatteryMode.SELF_CONSUMPTION
+        state_machine._commanded_mode = BatteryMode.SELF_CONSUMPTION
+        coordinator_data.general_price = 0.25
+        engine = FakeFacadeEngine(BatteryMode.SELF_CONSUMPTION)
+
+        # Tick 1: establish context, plan stable.
+        self._run(state_machine, coordinator_data, engine)
+        stored_fp = state_machine._last_evaluated_fingerprint
+
+        # Tick 2: price unavailable (None) + plan flips. None must freeze and must
+        # NOT overwrite the stored fingerprint.
+        coordinator_data.general_price = None
+        engine.plan_mode = BatteryMode.GRID_CHARGING
+        self._run(state_machine, coordinator_data, engine)
+        assert coordinator_data.mode_decision_allowed is False
+        assert state_machine._last_evaluated_fingerprint == stored_fp
+        mock_battery_controller.set_force_charge.assert_not_called()
+
+        # Tick 3: same price returns — still frozen (no context change).
+        coordinator_data.general_price = 0.25
+        self._run(state_machine, coordinator_data, engine)
+        assert coordinator_data.mode_decision_allowed is False
+        mock_battery_controller.set_force_charge.assert_not_called()
+
+        # Tick 4: genuinely new price — exactly one decision.
+        coordinator_data.general_price = 0.40
+        self._run(state_machine, coordinator_data, engine)
+        assert engine.last_decision_allowed is True
+        assert coordinator_data.active_mode == BatteryMode.GRID_CHARGING
+        mock_battery_controller.set_force_charge.assert_called_once()
+
+    def test_spike_onset_grants_one_decision(
+        self, state_machine, coordinator_data
+    ):
+        """price_spike False→True is a context change → one decision."""
+        coordinator_data.general_price = 0.25
+        coordinator_data.price_spike = False
+        engine = FakeFacadeEngine(BatteryMode.SELF_CONSUMPTION)
+        self._run(state_machine, coordinator_data, engine)
+
+        coordinator_data.price_spike = True
+        self._run(state_machine, coordinator_data, engine)
+        assert engine.last_decision_allowed is True
+
+        # Same spike state → frozen.
+        self._run(state_machine, coordinator_data, engine)
+        assert engine.last_decision_allowed is False
+
+    def test_dw_active_flip_grants_one_decision(
+        self, state_machine, coordinator_data
+    ):
+        """demand_window_active flip is a context change → one decision."""
+        coordinator_data.general_price = 0.25
+        coordinator_data.demand_window_active = False
+        engine = FakeFacadeEngine(BatteryMode.SELF_CONSUMPTION)
+        self._run(state_machine, coordinator_data, engine)
+
+        coordinator_data.demand_window_active = True
+        self._run(state_machine, coordinator_data, engine)
+        assert engine.last_decision_allowed is True
+
+        self._run(state_machine, coordinator_data, engine)
+        assert engine.last_decision_allowed is False
+
+    def test_soc_floor_breach_flip_grants_one_decision(
+        self, state_machine, coordinator_data, mock_get_option
+    ):
+        """soc < minimum_target_soc flip is a context change → one decision."""
+        # mock_get_option returns the default for minimum_target_soc, which is
+        # the canonical DEFAULT_MINIMUM_TARGET_SOC (= 20). We cross the floor
+        # inside the 10-20 band (25 → 15) so this test would catch a regression
+        # to the old hardcoded default of 10.0.
+        coordinator_data.general_price = 0.25
+        coordinator_data.soc = 25.0
+        engine = FakeFacadeEngine(BatteryMode.SELF_CONSUMPTION)
+        self._run(state_machine, coordinator_data, engine)
+
+        # Drop SOC below the floor (20) but above the old wrong default (10).
+        coordinator_data.soc = 15.0
+        self._run(state_machine, coordinator_data, engine)
+        assert engine.last_decision_allowed is True
+
+        # Still below floor, same context → frozen.
+        self._run(state_machine, coordinator_data, engine)
+        assert engine.last_decision_allowed is False
+
+
+class TestConvergeWhileFrozen:
+    """Frozen evaluations still converge hardware toward the decided mode."""
+
+    def _run(self, state_machine, data, engine, now):
+        with patch(
+            "custom_components.localshift.state.machine.dt_util.now"
+        ) as mock_now:
+            mock_now.return_value = now
+            asyncio.run(state_machine.evaluate_state_machine(data, engine))
+
+    def test_proactive_export_debounce_completes_across_frozen_evals(
+        self, state_machine, coordinator_data, mock_battery_controller
+    ):
+        """A PROACTIVE_EXPORT debounce started on an allowed eval completes across
+        subsequent frozen evals (debounce progression is convergence)."""
+        coordinator_data.active_mode = BatteryMode.SELF_CONSUMPTION
+        state_machine._commanded_mode = BatteryMode.SELF_CONSUMPTION
+        coordinator_data.general_price = 0.25
+        engine = FakeFacadeEngine(BatteryMode.PROACTIVE_EXPORT)
+
+        # Tick 1 (allowed): decision = PROACTIVE_EXPORT, debounce starts.
+        self._run(
+            state_machine, coordinator_data, engine, dt_aware(2026, 2, 16, 16, 0, 0)
+        )
+        mock_battery_controller.set_proactive_export.assert_not_called()
+        assert BatteryMode.PROACTIVE_EXPORT in state_machine._mode_desired_since
+
+        # Tick 2 (frozen, same price): still converging toward decided mode.
+        self._run(
+            state_machine, coordinator_data, engine, dt_aware(2026, 2, 16, 16, 1, 0)
+        )
+        assert coordinator_data.mode_decision_allowed is False
+        mock_battery_controller.set_proactive_export.assert_not_called()
+
+        # Tick 3 (frozen): debounce satisfied → transition completes.
+        self._run(
+            state_machine, coordinator_data, engine, dt_aware(2026, 2, 16, 16, 2, 1)
+        )
+        mock_battery_controller.set_proactive_export.assert_called_once()
+        assert state_machine._commanded_mode == BatteryMode.PROACTIVE_EXPORT
+
+    def test_failed_transition_retries_across_frozen_evals(
+        self, state_machine, coordinator_data, mock_battery_controller
+    ):
+        """A failed command retries toward the decided mode on later frozen evals."""
+        coordinator_data.active_mode = BatteryMode.SELF_CONSUMPTION
+        state_machine._commanded_mode = BatteryMode.SELF_CONSUMPTION
+        coordinator_data.general_price = 0.25
+        engine = FakeFacadeEngine(BatteryMode.GRID_CHARGING)
+
+        # First the command fails.
+        mock_battery_controller.set_force_charge = AsyncMock(return_value=False)
+        self._run(
+            state_machine, coordinator_data, engine, dt_aware(2026, 2, 16, 16, 0, 0)
+        )
+        assert state_machine._commanded_mode == BatteryMode.SELF_CONSUMPTION
+
+        # Next eval is frozen (same price), but the command now succeeds — the
+        # state machine retries toward the decided mode without a fresh token.
+        mock_battery_controller.set_force_charge = AsyncMock(return_value=True)
+        self._run(
+            state_machine, coordinator_data, engine, dt_aware(2026, 2, 16, 16, 1, 0)
+        )
+        assert coordinator_data.mode_decision_allowed is False
+        assert state_machine._commanded_mode == BatteryMode.GRID_CHARGING
+
+    def test_validator_blocked_then_unblocked_retries_without_fresh_token(
+        self, state_machine, coordinator_data, mock_battery_controller, mock_entity_validator
+    ):
+        """A validator-blocked transition retries on a later frozen eval once the
+        validator allows it — and a DIFFERENT desired mode while frozen does NOT
+        execute (active_mode is pinned to the decided mode)."""
+        coordinator_data.active_mode = BatteryMode.SELF_CONSUMPTION
+        state_machine._commanded_mode = BatteryMode.SELF_CONSUMPTION
+        coordinator_data.general_price = 0.25
+        engine = FakeFacadeEngine(BatteryMode.GRID_CHARGING)
+
+        # Validator blocks the first (allowed) transition.
+        mock_entity_validator.should_allow_automation.return_value = False
+        self._run(
+            state_machine, coordinator_data, engine, dt_aware(2026, 2, 16, 16, 0, 0)
+        )
+        assert state_machine._commanded_mode == BatteryMode.SELF_CONSUMPTION
+
+        # While still frozen, the plan tries to flip to a DIFFERENT mode. Because
+        # active_mode is pinned to the decided GRID_CHARGING, the machine never
+        # converges toward SPIKE_DISCHARGE.
+        engine.plan_mode = BatteryMode.SPIKE_DISCHARGE
+        mock_entity_validator.should_allow_automation.return_value = True
+        self._run(
+            state_machine, coordinator_data, engine, dt_aware(2026, 2, 16, 16, 1, 0)
+        )
+        assert coordinator_data.mode_decision_allowed is False
+        # Converged toward the DECIDED mode (GRID_CHARGING), not the frozen plan.
+        assert state_machine._commanded_mode == BatteryMode.GRID_CHARGING
+        mock_battery_controller.set_force_discharge.assert_not_called()
+
+
+class TestInvalidateDecisionFingerprint:
+    """Deliberate re-decision points (#622 gate replacement)."""
+
+    def test_invalidate_grants_next_decision(
+        self, state_machine, coordinator_data
+    ):
+        """After invalidate_decision_fingerprint, the next eval decides even with
+        an unchanged price."""
+        coordinator_data.general_price = 0.25
+        engine = FakeFacadeEngine(BatteryMode.SELF_CONSUMPTION)
+        asyncio.run(state_machine.evaluate_state_machine(coordinator_data, engine))
+
+        # Same price → would normally be frozen.
+        asyncio.run(state_machine.evaluate_state_machine(coordinator_data, engine))
+        assert engine.last_decision_allowed is False
+
+        # Invalidate → next eval is an allowed decision.
+        state_machine.invalidate_decision_fingerprint("config change")
+        assert state_machine._last_evaluated_fingerprint is None
+        asyncio.run(state_machine.evaluate_state_machine(coordinator_data, engine))
+        assert engine.last_decision_allowed is True
+
+    def test_manual_override_timeout_invalidates_fingerprint(
+        self, state_machine, coordinator_data
+    ):
+        """FIX 2: after the manual-override auto-timeout clears the override, the
+        NEXT evaluation with UNCHANGED prices is decision-allowed and the
+        optimizer mode commits — not pinned at MANUAL until the next price
+        change.
+        """
+        state_machine._commanded_mode = BatteryMode.MANUAL
+        coordinator_data.active_mode = BatteryMode.MANUAL
+        coordinator_data.manual_override = True
+        coordinator_data.general_price = 0.25
+        # Override set long ago → beyond the default 24h timeout.
+        state_machine._manual_override_set_at = dt_aware(2020, 1, 1, 0, 0, 0)
+
+        engine = FakeFacadeEngine(BatteryMode.SELF_CONSUMPTION)
+
+        # Eval 1: timeout fires, clears the override AND invalidates the
+        # fingerprint. (The token for this eval was already spent before the
+        # timeout handler ran, so the invalidation takes effect next tick.)
+        asyncio.run(state_machine.evaluate_state_machine(coordinator_data, engine))
+        assert coordinator_data.manual_override is False
+        assert state_machine._last_evaluated_fingerprint is None
+
+        # Eval 2: prices UNCHANGED, yet the optimizer mode commits because the
+        # fingerprint was invalidated — without FIX 2 this would stay frozen
+        # (pinned at MANUAL) until a genuine price change.
+        asyncio.run(state_machine.evaluate_state_machine(coordinator_data, engine))
+        assert engine.last_decision_allowed is True
+        assert coordinator_data.active_mode == BatteryMode.SELF_CONSUMPTION
+
+    def test_startup_grace_end_invalidates_fingerprint(
+        self, state_machine, coordinator_data
+    ):
+        """A token burned during startup grace (e.g. while the safety gate was
+        still blocking, committing the SC fallback) must not pin that fallback
+        after grace ends: grace-end invalidates the fingerprint so the next
+        evaluation re-decides from the now-populated inputs.
+        """
+        coordinator_data.general_price = 0.25
+        coordinator_data.automation_ready = True
+        engine = FakeFacadeEngine(BatteryMode.SELF_CONSUMPTION)
+
+        # Eval 1 DURING grace: the token is consumed (decision allowed) even
+        # though _evaluate_core returns early on the grace check.
+        state_machine.set_startup_grace(grace_seconds=60)
+        asyncio.run(state_machine.evaluate_state_machine(coordinator_data, engine))
+        assert engine.last_decision_allowed is True
+        assert state_machine._last_evaluated_fingerprint is not None
+
+        # Grace expires → eval 2 hits the grace-end branch, which invalidates.
+        state_machine._startup_grace_until = dt_aware(2020, 1, 1, 0, 0, 0)
+        asyncio.run(state_machine.evaluate_state_machine(coordinator_data, engine))
+        assert state_machine._last_evaluated_fingerprint is None
+
+        # Eval 3: prices UNCHANGED, yet decision-allowed — the plan can replace
+        # the fallback committed during grace instead of staying frozen until
+        # the next genuine price change.
+        engine.plan_mode = BatteryMode.GRID_CHARGING
+        asyncio.run(state_machine.evaluate_state_machine(coordinator_data, engine))
+        assert engine.last_decision_allowed is True
+        assert coordinator_data.active_mode == BatteryMode.GRID_CHARGING

--- a/tests/test_optimizer_facade.py
+++ b/tests/test_optimizer_facade.py
@@ -335,6 +335,8 @@ def test_assign_active_mode_sets_mode_and_apply_status():
     facade = OptimizerFacade(slot_builder_cls=_StubSlotBuilder)
     data = CoordinatorData()
     data.active_mode = BatteryMode.SELF_CONSUMPTION
+    # #622 gate replacement: an allowed evaluation may commit a fresh mode.
+    data.mode_decision_allowed = True
     # A decision whose window brackets "now" (huge interval) so the current-slot
     # lookup reports a real match and the debug_* fields are populated.
     data.optimizer_decisions = [
@@ -392,6 +394,8 @@ def test_assign_active_mode_falls_back_on_invalid_battery_mode():
     facade = OptimizerFacade(slot_builder_cls=_StubSlotBuilder)
     data = CoordinatorData()
     data.active_mode = BatteryMode.GRID_CHARGING
+    # #622 gate replacement: an allowed evaluation may commit a fresh mode.
+    data.mode_decision_allowed = True
     data.optimizer_decisions = [{"action": "hold"}]
     result = MagicMock()
     optimizer_config = MagicMock()
@@ -414,6 +418,105 @@ def test_assign_active_mode_falls_back_on_invalid_battery_mode():
     assert data.active_mode == BatteryMode.SELF_CONSUMPTION
     assert data.optimizer_last_apply_status == "fallback"
     assert data.debug_mode_source == "fallback"
+
+
+def _frozen_data_with_decided_mode(decided: BatteryMode) -> CoordinatorData:
+    """A frozen evaluation: active_mode already decided, decision NOT allowed."""
+    data = CoordinatorData()
+    data.active_mode = decided
+    data.mode_decision_allowed = False
+    data.debug_mode_source = "optimizer"  # source of the held decision
+    return data
+
+
+def test_assign_active_mode_frozen_optimizer_branch_pins_mode():
+    """#622 gate replacement: frozen + normal optimizer branch holds active_mode
+    and records debug_plan_mode_pending instead."""
+    facade = OptimizerFacade(slot_builder_cls=_StubSlotBuilder)
+    data = _frozen_data_with_decided_mode(BatteryMode.SELF_CONSUMPTION)
+    data.optimizer_decisions = [
+        {
+            "action": "charge_grid_normal",
+            "timestamp_iso": "2020-01-01T00:00:00+00:00",
+            "slot_interval_minutes": 9_999_999,
+        }
+    ]
+
+    with (
+        patch(
+            "custom_components.localshift.engine.optimizer_facade.OptimizerSafetyGate"
+        ) as mock_gate,
+        patch(
+            "custom_components.localshift.engine.optimizer_facade._derive_runtime_apply_plan",
+            return_value={
+                "battery_mode": BatteryMode.GRID_CHARGING.value,
+                "action": "charge_grid_normal",
+            },
+        ),
+    ):
+        mock_gate.return_value.check_admission.return_value = SimpleNamespace(
+            allowed=True, block_reason=None
+        )
+        facade._assign_active_mode(data, MagicMock(), MagicMock(), {})
+
+    # Mode held, no decision-lag write, plan surfaced as pending.
+    assert data.active_mode == BatteryMode.SELF_CONSUMPTION
+    assert data.decision_timestamp is None
+    assert data.decision_mode is None
+    assert data.debug_plan_mode_pending == BatteryMode.GRID_CHARGING.value
+    # debug_mode_source reflects the HELD decision, not the frozen plan.
+    assert data.debug_mode_source == "optimizer"
+    # Observability (apply status) still refreshes.
+    assert data.optimizer_last_apply_status == "ready_to_apply"
+
+
+def test_assign_active_mode_frozen_safety_block_pins_mode():
+    """#622 gate replacement: frozen + safety-gate block holds active_mode."""
+    facade = OptimizerFacade(slot_builder_cls=_StubSlotBuilder)
+    data = _frozen_data_with_decided_mode(BatteryMode.GRID_CHARGING)
+
+    with patch(
+        "custom_components.localshift.engine.optimizer_facade.OptimizerSafetyGate"
+    ) as mock_gate:
+        mock_gate.return_value.check_admission.return_value = SimpleNamespace(
+            allowed=False, block_reason="stale forecast"
+        )
+        facade._assign_active_mode(data, MagicMock(), MagicMock(), {})
+
+    # Block would default to SELF_CONSUMPTION, but frozen → hold GRID_CHARGING.
+    assert data.active_mode == BatteryMode.GRID_CHARGING
+    assert data.decision_timestamp is None
+    assert data.debug_plan_mode_pending == BatteryMode.SELF_CONSUMPTION.value
+    # Block status is observability and still recorded.
+    assert data.optimizer_last_apply_status == "blocked"
+    assert data.optimizer_safety_block_reason == "stale forecast"
+
+
+def test_assign_active_mode_frozen_valueerror_pins_mode():
+    """#622 gate replacement: frozen + invalid-mode fallback holds active_mode."""
+    facade = OptimizerFacade(slot_builder_cls=_StubSlotBuilder)
+    data = _frozen_data_with_decided_mode(BatteryMode.GRID_CHARGING)
+    data.optimizer_decisions = [{"action": "hold"}]
+
+    with (
+        patch(
+            "custom_components.localshift.engine.optimizer_facade.OptimizerSafetyGate"
+        ) as mock_gate,
+        patch(
+            "custom_components.localshift.engine.optimizer_facade._derive_runtime_apply_plan",
+            return_value={"battery_mode": "not-a-mode", "action": "hold"},
+        ),
+    ):
+        mock_gate.return_value.check_admission.return_value = SimpleNamespace(
+            allowed=True, block_reason=None
+        )
+        facade._assign_active_mode(data, MagicMock(), MagicMock(), {})
+
+    # Fallback would default to SELF_CONSUMPTION, but frozen → hold GRID_CHARGING.
+    assert data.active_mode == BatteryMode.GRID_CHARGING
+    assert data.decision_timestamp is None
+    assert data.debug_plan_mode_pending == BatteryMode.SELF_CONSUMPTION.value
+    assert data.optimizer_last_apply_status == "fallback"
 
 
 def test_current_slot_debug_info_matched():


### PR DESCRIPTION
## Root cause (evidence-validated live, 2026-06-12 06:00–13:00 AEST)

**The mode flapping is real hardware flapping**: 48 `select.localshift_battery_mode` transitions in 7h, **32 reaching the physical Powerwall** (Teslemetry history), including sub-minute full hardware round-trips (09:25:01→09:25:14, 11:55:17→11:55:43, 12:25:17→12:25:45, 12:50:17→12:50:47).

Three generators, all confirmed from HA history + Teslemetry history + `home-assistant.log`:

1. **Deferred token redemption.** The #622 gate stored its fingerprint only when a transition fired (`_start_debounce`). A price change with a stable plan stored nothing; minutes later the 1-min tick (which evaluates **unconditionally**) flipped a knife-edge plan on a non-price input (SOC drift, slot roll) and redeemed the stale token — then the correction redeemed the next interval's token → minute-scale A→B→A.
2. **Boundary-roll stale-price decisions.** The forecast-array roll at each 5-min boundary triggers a coalesced evaluation at ~:14.5 that decides on the **previous** interval's price; the real Amber price lands ~:24 (+15s coalesce → ~:39) and grants a fresh token → two hardware transitions ~25s apart inside one interval.
3. **Gate bypasses**: the `debounce_in_progress` path skipped the fingerprint check entirely (validator-blocked transitions left `_mode_desired_since` populated), and a `None` fingerprint (price sensor blip) counted as "changed" in both directions → two free transitions per blip.

(The handoff's mystery ":00-aligned writer" was the pre-restart phase of the 1-min tick — its second-offset follows each restart time.)

## The fix — invariant by construction, no dwell, no hysteresis

**The mode may be re-decided at most once per discrete decision-context change:**

- **Fingerprint = full discrete decision context**: `buy|sell|spike|dw_active|soc_floor_breached`. The enumerated exceptions (price-spike onset, demand-window boundary, SOC-floor protection) are fingerprint *components* — each grants exactly one decision when it flips.
- **Token consumed at evaluation time** (in-lock, before `compute_derived_values`), covering every path including the old `debounce_in_progress` bypass. `None` freezes — never grants, never overwrites the stored fingerprint.
- **The facade pins `data.active_mode` when frozen** (all branches incl. safety-gate block and ValueError fallback). The would-be plan mode is surfaced as `debug_plan_mode_pending` ("plan wants X, decision held at Y").
- **Frozen evaluations converge only**: debounce progression, failed/blocked-command retry, and health checks still run every minute toward the held decision — the 1-min tick remains a health/SOC/plan-freshness channel, no longer a mode-decision channel.
- **`mode_decision_allowed` is transient** (reset in the evaluate `finally`), so the out-of-lock recompute in `async_recompute_and_evaluate` can never commit an ungated decision.
- **Deliberate re-decision points invalidate the fingerprint**: config changes (default for `async_recompute_and_evaluate`), manual-override timeout, startup grace end. The load-deviation / solar-event reoptimizers pass `invalidate_decision=False` — they may update the plan, never the mode.

Predicted live effect on today's pattern: the :14.5 boundary-roll leg is frozen (price unchanged), the :39 price-landing evaluation decides once → at most one transition per interval, exactly at the price change (~9 reversals/hour → ≈0 on a threshold-pinned morning; a genuine threshold-crossing price move still changes the mode — once).

## Review process

Implemented by a dev agent against a written design doc, then verified and adversarially reviewed by three independent reviewers (safety-exceptions / token-logic / regressions lenses). All four review findings fixed:
- **critical**: `mode_decision_allowed` leak into the out-of-lock recompute (transience reset)
- **major**: manual-override timeout left the mode pinned at MANUAL (now invalidates)
- **major**: SOC-floor fingerprint used hardcoded default 10.0 vs canonical `DEFAULT_MINIMUM_TARGET_SOC=20` (now uses the canonical constants; the masking test now crosses the floor inside the 10–20 band)
- **minor**: dead `_decided_mode` state removed; comments state the real mechanism

Plus one gap found in final review: a token burned during startup grace while the safety gate still blocked would pin the SC fallback for up to a price interval — grace-end now invalidates (startup settle is an enumerated exception).

## Tests

- Full suite: **3123 passed, 1 xfailed** (baseline ~3,100). `ruff check` clean on all touched production files.
- New coverage: knife-edge invariant test (transitions ≤ distinct fingerprints), frozen-pin, deferred-token-kill, None-price freeze, spike/DW/SOC-floor exception paths (one decision each), converge-while-frozen (PROACTIVE_EXPORT debounce, failed retry, validator-block recovery, different-mode-not-executed), out-of-lock recompute leak, invalidation paths (config change, manual-override timeout, startup grace end), facade pinning in all three branches, reoptimizers pass `invalidate_decision=False`.

## Verification steps after deploy (for Jack)

1. Watch `select.localshift_battery_mode` against `sensor.amber_express_100h_general_price`: transitions should land only ~:30–:45 after 5-min boundaries (price arrival + coalesce), never at the :16 tick phase, never twice per interval.
2. `debug_plan_mode_pending` should show knife-edge pressure (plan wants X while decision holds Y) without mode movement.
3. Confirm spike onset / DW entry still transition promptly (≤ coalesce window).
4. After restart: automation re-arms (known gotcha) and the first decision lands within ~1 min of grace end.

**Do not deploy without explicit go-ahead.** Note #871 is merged-but-not-deployed — the next deploy carries #871 + this together.