### PR TITLE
fix(health): align Solcast staleness threshold with its 4.8h poll cadence

### DIFF
--- a/custom_components/localshift/utils/entity_configs.py
+++ b/custom_components/localshift/utils/entity_configs.py
@@ -133,7 +133,11 @@ STALENESS_THRESHOLDS: dict[str, timedelta] = {
     CONF_TESLEMETRY_OPERATION_MODE: timedelta(minutes=5),
     CONF_PRICING_GENERAL_PRICE: timedelta(minutes=10),
     CONF_PRICING_FEED_IN_PRICE: timedelta(minutes=10),
-    CONF_SOLCAST_FORECAST_TODAY: timedelta(hours=2),
+    # Solcast auto-polls 5x/day on a fixed 4.8h cadence (00:00, 04:48, 09:36,
+    # 14:24, 19:12 local); thresholds must exceed that interval or the entity
+    # is flagged stale for ~2.8h of every poll window, falsely degrading
+    # health and engaging the stale-solar confidence ceiling.
+    CONF_SOLCAST_FORECAST_TODAY: timedelta(hours=5),
     CONF_SOLCAST_FORECAST_TOMORROW: timedelta(hours=6),
 }
 


### PR DESCRIPTION
## Problem

Solcast auto-polls 5x/day on a fixed 4.8h cadence (00:00, 04:48, 09:36, 14:24, 19:12 local — confirmed from the integration's startup log and 48h of `api_last_polled` history). LocalShift's staleness threshold for today's forecast was **2h**, so for ~2.8h of *every* poll window the entity was flagged stale — deterministically, more than half of every day.

## Impact of the false-stale flag

- `integration_status` reports **degraded** (cosmetic — the decision path doesn't read it)
- The stale-solar conservative confidence ceiling (0.3, PR #849) **engages mid-window**, discounting solar the optimizer should trust. Observed live 2026-06-12: sunny day, 100% solar forecast accuracy, 3.7 kWh solar remaining — but "Solar Can Reach Target: off" and midday grid boost-charging at $0.15/kWh because solar trust was capped at 30%.

## Fix

Raise the today-forecast threshold to **5h** (poll interval + 12min margin). A genuinely missed poll still trips staleness shortly after the expected poll time, so PR #849's protection against truly stale data is preserved. Tomorrow's threshold (6h) already clears the cadence and is unchanged.

## Testing

`pytest -k 'staleness or stale'` + `tests/forecast/test_solcast_analysis.py`: 37 passed.