### PR TITLE
fix(cards): unfreeze actual-SOC line — expire history pending lock, extend to live state

### DIFF
--- a/custom_components/localshift/www/localshift-cards.js
+++ b/custom_components/localshift/www/localshift-cards.js
@@ -142,8 +142,11 @@ async function lsFetchHistory(hass, cache, key, entityId, startMs, endMs, ttlMs)
   const now = Date.now();
   const hit = cache[key];
   if (hit && now - hit.at < ttlMs) return hit.data;
-  if (hit && hit.pending) return hit.data || [];
-  cache[key] = { at: hit ? hit.at : 0, data: hit ? hit.data : [], pending: true };
+  // The pending lock must expire: a request that never settles (e.g. a tab
+  // left open across an HA restart) would otherwise freeze history forever.
+  if (hit && hit.pending && now - hit.pendingAt < 30e3) return hit.data || [];
+  const mine = { at: hit ? hit.at : 0, data: hit ? hit.data : [], pending: true, pendingAt: now };
+  cache[key] = mine;
   try {
     const url =
       `history/period/${new Date(startMs).toISOString()}` +
@@ -156,11 +159,11 @@ async function lsFetchHistory(hass, cache, key, entityId, startMs, endMs, ttlMs)
       .map((r) => ({ t: new Date(r.last_changed || r.last_updated).getTime(), v: parseFloat(r.state) }))
       .filter((p) => Number.isFinite(p.t) && Number.isFinite(p.v))
       .sort((a, b) => a.t - b.t);
-    cache[key] = { at: Date.now(), data, pending: false };
+    if (cache[key] === mine) cache[key] = { at: Date.now(), data, pending: false };
     return data;
   } catch (e) {
-    cache[key] = { at: Date.now(), data: (hit && hit.data) || [], pending: false };
-    return cache[key].data;
+    if (cache[key] === mine) cache[key] = { at: Date.now(), data: (hit && hit.data) || [], pending: false };
+    return (hit && hit.data) || [];
   }
 }
 
@@ -436,13 +439,14 @@ class LocalShiftCommandCard extends HTMLElement {
       i = j + 1;
     }
 
-    // actual SOC (history)
-    if (socHist && socHist.length > 1) {
-      const pts = socHist
-        .filter((p) => p.t >= t0 && p.t <= now)
-        .map((p) => `${x(p.t).toFixed(1)},${y(p.v).toFixed(1)}`)
-        .join(" ");
-      if (pts) svg += `<polyline points="${pts}" fill="none" stroke="var(--primary-text-color)" stroke-width="2.5" stroke-linejoin="round" stroke-linecap="round"/>`;
+    // actual SOC (history, extended to the live state so the line keeps
+    // tracking current SOC even when the history fetch lags or fails)
+    const liveSoc = lsNum(hass, this._e.soc, NaN);
+    const actual = (socHist || []).filter((p) => p.t >= t0 && p.t <= now);
+    if (Number.isFinite(liveSoc)) actual.push({ t: now, v: liveSoc });
+    if (actual.length > 1) {
+      const pts = actual.map((p) => `${x(p.t).toFixed(1)},${y(p.v).toFixed(1)}`).join(" ");
+      svg += `<polyline points="${pts}" fill="none" stroke="var(--primary-text-color)" stroke-width="2.5" stroke-linejoin="round" stroke-linecap="round"/>`;
     }
 
     // planned SOC (dashed, future)


### PR DESCRIPTION
## Problem

The command card's actual-SOC line (and the money card's 7-day bars) stopped updating. Live diagnosis 2026-06-12: recorder data and the deployed JS were both fine — the freeze is client-side. `lsFetchHistory` sets `pending: true` before fetching and every later call returns early while pending. A request that never settles (observed trigger: dashboard tab left open across the 09:36 HA restart) leaves the lock stuck **forever** — the plot freezes until the page is reloaded.

## Fix

- **Expire the pending lock after 30s** so a wedged request can't block refreshes; cache writes are guarded (`cache[key] === mine`) so a late straggler can't clobber a newer result.
- **Extend the actual-SOC polyline to the live SOC state** — the line now tracks current SOC between history refreshes even when a fetch lags or fails, and degrades gracefully instead of silently freezing.

## Testing

`node --check` passes; deployed to the live www share for visual verification (card renders, actual line reaches the now-marker).