### PR TITLE
refactor: decompose the three grade-D complexity functions (CC 28/23/21 → 8/3/4)

### DIFF
--- a/custom_components/localshift/computation_engine.py
+++ b/custom_components/localshift/computation_engine.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable
-from datetime import datetime, time, timedelta
+from dataclasses import dataclass
+from datetime import date, datetime, time, timedelta
 from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
@@ -82,6 +83,27 @@ from .pricing.types import ForecastSlot
 BatteryMode = _BatteryMode
 
 _LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class _DerivedValuesContext:
+    """Immutable bag of time/window values computed once per orchestrator tick.
+
+    ``target_pct`` is read from options here even though the manual-override
+    early return appears before this context is used in the orchestrator.
+    Hoisting the read is side-effect-free (it only reads a config key) and
+    avoids duplicating the options lookup across the helpers that need it.
+    """
+
+    now_dt: datetime
+    today: date
+    now_t: time
+    dw_start_time: time
+    dw_end_time: time
+    target_hour: int
+    before_dw: bool
+    after_dw: bool
+    target_pct: float
 
 
 class ComputationEngine:
@@ -230,40 +252,51 @@ class ComputationEngine:
     # MAIN ENTRY POINT
     # ========================================================================
 
-    def compute_derived_values(self, data: CoordinatorData) -> None:
-        """Compute all derived sensor/binary_sensor values from raw state.
+    def _build_step_context(self) -> _DerivedValuesContext:
+        """Build the immutable time/window context used across all orchestrator steps.
 
-        Ported from Jinja templates in YAML package. Steps are ordered
-        by dependency — later steps can reference earlier results.
+        ``target_pct`` is read from options here even though the manual-override
+        early return appears before the context is consumed by most helpers.
+        Hoisting the options-dict read is side-effect-free and avoids duplicating
+        the lookup across the step helpers that need it.
         """
         now_dt = dt_util.now()
-
-        # Robust daily reset of the demand-window pre-charge latch. ``target_reached_today``
-        # is otherwise only cleared by a single midnight ``async_track_time_change`` event;
-        # if that event is ever missed (restart/reload spanning local midnight, DST), the
-        # latch stays True for up to 24h and silently disables all pre-charge. A date-change
-        # check here is immune to missed events.
-        today = now_dt.date()
-        if data.last_target_reset_date != today:
-            data.target_reached_today = False
-            data.last_target_reset_date = today
-
-        # Pass adaptive parameters to load forecaster (Issue #170 Phase 2)
-        self._load_forecaster.set_adaptive_params(data.adaptive_params)
-
-        # Common time values used by multiple steps
         dw_start_time = self._parse_time_option(
             CONF_DEMAND_WINDOW_START, DEFAULT_DEMAND_WINDOW_START
         )
         dw_end_time = self._parse_time_option(
             CONF_DEMAND_WINDOW_END, DEFAULT_DEMAND_WINDOW_END
         )
-        target_hour = dw_start_time.hour
         now_t = now_dt.replace(microsecond=0).time()
-        before_dw = now_t < dw_start_time
-        after_dw = now_t >= dw_start_time
+        return _DerivedValuesContext(
+            now_dt=now_dt,
+            today=now_dt.date(),
+            now_t=now_t,
+            dw_start_time=dw_start_time,
+            dw_end_time=dw_end_time,
+            target_hour=dw_start_time.hour,
+            before_dw=now_t < dw_start_time,
+            after_dw=now_t >= dw_start_time,
+            target_pct=float(
+                self.entry.options.get(CONF_BATTERY_TARGET, DEFAULT_BATTERY_TARGET)
+            ),
+        )
 
-        # ---- Step 2: Mode detection from Teslemetry state ----
+    def _reset_daily_precharge_latch(self, data: CoordinatorData, today: date) -> None:
+        """Reset the demand-window pre-charge latch on date change.
+
+        ``target_reached_today`` is otherwise only cleared by a single midnight
+        ``async_track_time_change`` event; if that event is ever missed
+        (restart/reload spanning local midnight, DST), the latch stays True for
+        up to 24 h and silently disables all pre-charge.  A date-change check
+        here is immune to missed events.
+        """
+        if data.last_target_reset_date != today:
+            data.target_reached_today = False
+            data.last_target_reset_date = today
+
+    def _detect_hardware_modes(self, data: CoordinatorData) -> None:
+        """---- Step 2: Mode detection from Teslemetry state ----"""
         data.force_discharge_active = (
             data.operation_mode == "autonomous" and data.backup_reserve < 11
         )
@@ -275,70 +308,46 @@ class ComputationEngine:
             data.operation_mode == "autonomous" and data.backup_reserve > 99
         )
 
-        # ---- Step 3: demand_window_active ----
+    def _compute_demand_window_active(
+        self, data: CoordinatorData, ctx: _DerivedValuesContext
+    ) -> None:
+        """---- Step 3: demand_window_active ----"""
         dw_block_enabled = self._get_switch_state("demand_window_block")
         data.demand_window_active = (
-            dw_block_enabled and now_t >= dw_start_time and now_t < dw_end_time
+            dw_block_enabled
+            and ctx.now_t >= ctx.dw_start_time
+            and ctx.now_t < ctx.dw_end_time
         )
 
-        # ---- Manual override check ----
-        # Always respect manual override first — user is in control
-        if data.manual_override:
-            data.active_mode = _BatteryMode.MANUAL
-            data.debug_mode_source = "manual_override"
-            # The optimizer's current-slot lookup never runs on the manual path
-            # (we return below), so reset the slot fields to avoid showing a
-            # stale match from a prior optimizer tick.
-            data.debug_forecast_slot_found = False
-            data.debug_forecast_slot_time = ""
-            data.debug_first_forecast_slot_time = ""
-            data.debug_time_gap_seconds = 0.0
-            # Skip DP optimizer and other mode decisions when in manual mode
-            return
+    def _enter_manual_override(self, data: CoordinatorData) -> bool:
+        """Handle manual override: set MANUAL mode, clear stale debug fields.
 
-        # Get target percentage for later use
-        target_pct = float(
-            self.entry.options.get(CONF_BATTERY_TARGET, DEFAULT_BATTERY_TARGET)
-        )
+        Always respect manual override first — user is in control.
+        The optimizer's current-slot lookup never runs on the manual path
+        (the orchestrator returns immediately), so reset the slot fields to
+        avoid showing a stale match from a prior optimizer tick.
 
-        # ---- Step 7a: effective_cheap_price (BEFORE forecast to break circular dependency) ----
-        # Compute effective_cheap_price BEFORE forecast using preliminary solar estimate
-        # This breaks the circular dependency where forecast depends on effective_cheap_price
-        # which depends on solar_can_reach_target which depends on forecast
-        self._price_signals.compute_effective_cheap_price_preliminary(
-            data=data,
-            now_dt=now_dt,
-            before_dw=before_dw,
-            target_hour=target_hour,
-            target_pct=target_pct,
-        )
+        Returns True when manual override is active; the orchestrator then
+        performs the early ``return``.
+        """
+        if not data.manual_override:
+            return False
+        data.active_mode = _BatteryMode.MANUAL
+        data.debug_mode_source = "manual_override"
+        data.debug_forecast_slot_found = False
+        data.debug_forecast_slot_time = ""
+        data.debug_first_forecast_slot_time = ""
+        data.debug_time_gap_seconds = 0.0
+        return True
 
-        # Set allow_dw_entry_under_target flag on data for forecast_computer
-        # This allows grid charging decision to simulate to DW END instead of DW START
-        # when solar can reach target within the DW period
-        allow_dw_under_target = self._get_switch_state(
-            SWITCH_ALLOW_DW_ENTRY_UNDER_TARGET
-        )
-        data.allow_dw_entry_under_target = allow_dw_under_target and before_dw
+    def _bridge_history_results(self, data: CoordinatorData, now_dt: datetime) -> None:
+        """Bridge HistoryFetcher results to CoordinatorData (Issue #493).
 
-        # ---- Stamp staleness confidence ceilings on Solcast analysis objects ----
-        self._stamp_confidence_ceilings(data)
-
-        # ---- Phase 1 (#441): Shared load forecast slots ----
-        # Builds data.load_forecast_slots for use by DP optimizer and other helpers.
-        load_entity_id = self._get_entity_id("teslemetry_load_power")
-        hourly_avg_kw = self._get_historical_hourly_averages(load_entity_id)
-        recent_load_kw = self._recent_load_1hr_kw
-        self._forecast_pipeline.compute_load_forecast_slots(
-            data=data,
-            now_dt=now_dt,
-            historical_avg_kw=hourly_avg_kw,
-            recent_load_kw=recent_load_kw,
-            total_slots=TOTAL_SLOTS,
-        )
-
-        # ---- Bridge HistoryFetcher results to CoordinatorData (Issue #493) ----
-        # These fields were never populated, causing diagnostic data to be stuck at defaults
+        These fields were never populated, causing diagnostic data to be stuck
+        at defaults.  Covers weekday/weekend profiles, combined-profile
+        backward-compat fields, recent-load fields, and forecast_profile_selected
+        derivation.
+        """
         (
             data.weekday_hourly_profile_kw,
             data.weekday_sample_counts,
@@ -380,16 +389,11 @@ class ComputationEngine:
         else:
             data.forecast_profile_selected = data.consumption_profile_type
 
-        # ---- Step DP: Inline DP optimizer (Phase 4, #441) ----
-        # Runs before effective_cheap_price final update so solar_can_reach_target
-        # is populated from DP result (not legacy solar-only simulation).
-        config_options = self._build_optimizer_config_options()
-        self._optimizer_facade.run_inline(
-            data=data, now_dt=now_dt, config_options=config_options
-        )
+    def _read_boost_from_plan(self, data: CoordinatorData) -> None:
+        """---- Step 6: boost_charge_needed (Phase 4: derive from DP decision) ----
 
-        # ---- Step 6: boost_charge_needed (Phase 4: derive from DP decision) ----
-        # Read from current-slot DP decision (not forecast_computer).
+        Read from current-slot DP decision (not forecast_computer).
+        """
         current_slot_idx = _find_current_slot_index(data)
         decisions = data.optimizer_decisions or []
         if decisions and 0 <= current_slot_idx < len(decisions):
@@ -399,38 +403,13 @@ class ComputationEngine:
         else:
             data.boost_charge_needed = False
 
-        # ---- Step 7: effective_cheap_price (final update) ----
-        # Update effective_cheap_price with actual solar_can_reach_target from forecast
-        # IMPORTANT: Save the optimizer's threshold BEFORE Step 7 overwrites it.
-        # The optimizer ran with the preliminary threshold from Step 7a. Step 7 recomputes
-        # effective_cheap_price using the optimizer's solar_can_reach_target result.
-        # If the recomputed value differs from the preliminary, we track which was used
-        # so the plan and UI are consistent (Planner Threshold Reconciliation, Fix #xxx).
-        data.planner_threshold_used = data.effective_cheap_price
-        self._price_signals.compute_effective_cheap_price(
-            data=data,
-            now_dt=now_dt,
-            before_dw=before_dw,
-            target_hour=target_hour,
-            target_pct=target_pct,
-        )
+    def _compute_spike_signals(self, data: CoordinatorData, now_dt: datetime) -> None:
+        """---- Steps 9, 10, 10b: spike/price window signals ----
 
-        # ---- Step 8: cheap_charge_stop_price ----
-        # Hardcoded deadband (Issue #214)
-        deadband = DEFAULT_CHEAP_PRICE_DEADBAND
-        data.cheap_charge_stop_price = round(data.effective_cheap_price + deadband, 2)
-
-        # ---- Step 4: solar_battery_forecast (legacy - for backwards compatibility) ----
-        # Kept for API compatibility, but values derived from detailed forecast
-        self._forecast_pipeline.compute_solar_battery_forecast(
-            data=data,
-            now_dt=now_dt,
-            target_hour=target_hour,
-            before_dw=before_dw,
-            after_dw=after_dw,
-            target_pct=target_pct,
-        )
-
+        Covers forecast_spike_within_window (Step 9), max_forecast_price (sell),
+        max_buy_forecast_price with its '(Fix #3)' comment, forecast_expensive_period_coming
+        (Step 10), and the conservative spike analysis (Step 10b).
+        """
         # ---- Step 9: forecast_spike_within_window ----
         # Hardcoded lookahead (Issue #214)
         lookahead = DEFAULT_FORECAST_LOOKAHEAD_HOURS
@@ -459,23 +438,26 @@ class ComputationEngine:
         # ---- Step 10b: spike analysis (conservative mode) ----
         self._price_signals.analyze_spike(data, now_dt)
 
-        # ---- Step 11: solar_weighted_avg_fit ----
-        self._forecast_pipeline.compute_solar_weighted_avg_fit(
-            data=data, now_dt=now_dt, target_hour=target_hour, after_dw=after_dw
-        )
+    def _maybe_log_decision(self, data: CoordinatorData, now_dt: datetime) -> None:
+        """---- Step 12: decision_log ----
 
-        # ---- Step 12: decision_log ----
-        # Phase 4 (#441): active_mode is set by the optimizer facade (Phase 3).
-        # _compute_active_mode is removed in Phase 4.
+        Phase 4 (#441): active_mode is set by the optimizer facade (Phase 3).
+        _compute_active_mode is removed in Phase 4.
 
-        # Add entry when mode changes OR periodically for status updates
+        Add entry when mode changes OR periodically for status updates.
+        Conditions are an elif chain — branch order is load-bearing:
+          1. startup-skip (no log time + zeroed sensors)
+          2. mode_changed
+          3. first evaluation after startup (no log time, data valid)
+          4. 5-minute periodic update
+        """
         mode_changed = (
             data.active_mode != self._previous_active_mode
             and self._previous_active_mode is not None
         )
 
-        # Only skip logging during initial startup when all data is zero
-        # Once we have valid data, always log mode changes and periodic updates
+        # Only skip logging during initial startup when all data is zero.
+        # Once we have valid data, always log mode changes and periodic updates.
         if self._last_decision_log_time is None and (
             data.general_price == 0 or data.feed_in_price == 0 or data.soc == 0
         ):
@@ -489,11 +471,131 @@ class ComputationEngine:
             # Periodic status update every 5 minutes
             self._add_to_decision_log(data, now_dt, mode_change=False)
 
+    def compute_derived_values(self, data: CoordinatorData) -> None:
+        """Compute all derived sensor/binary_sensor values from raw state.
+
+        Ported from Jinja templates in YAML package. Steps are ordered
+        by dependency — later steps can reference earlier results.
+        """
+        ctx = self._build_step_context()
+
+        self._reset_daily_precharge_latch(data, ctx.today)
+
+        # Pass adaptive parameters to load forecaster (Issue #170 Phase 2)
+        self._load_forecaster.set_adaptive_params(data.adaptive_params)
+
+        # ---- Step 2: Mode detection from Teslemetry state ----
+        self._detect_hardware_modes(data)
+
+        # ---- Step 3: demand_window_active ----
+        self._compute_demand_window_active(data, ctx)
+
+        # ---- Manual override check ----
+        if self._enter_manual_override(data):
+            # Skip DP optimizer and other mode decisions when in manual mode
+            return
+
+        # ---- Step 7a: effective_cheap_price (BEFORE forecast to break circular dependency) ----
+        # Compute effective_cheap_price BEFORE forecast using preliminary solar estimate.
+        # This breaks the circular dependency where forecast depends on effective_cheap_price
+        # which depends on solar_can_reach_target which depends on forecast.
+        self._price_signals.compute_effective_cheap_price_preliminary(
+            data=data,
+            now_dt=ctx.now_dt,
+            before_dw=ctx.before_dw,
+            target_hour=ctx.target_hour,
+            target_pct=ctx.target_pct,
+        )
+
+        # Set allow_dw_entry_under_target flag on data for forecast_computer.
+        # This allows grid charging decision to simulate to DW END instead of DW START
+        # when solar can reach target within the DW period.
+        allow_dw_under_target = self._get_switch_state(
+            SWITCH_ALLOW_DW_ENTRY_UNDER_TARGET
+        )
+        data.allow_dw_entry_under_target = allow_dw_under_target and ctx.before_dw
+
+        # ---- Stamp staleness confidence ceilings on Solcast analysis objects ----
+        self._stamp_confidence_ceilings(data)
+
+        # ---- Phase 1 (#441): Shared load forecast slots ----
+        # Builds data.load_forecast_slots for use by DP optimizer and other helpers.
+        load_entity_id = self._get_entity_id("teslemetry_load_power")
+        hourly_avg_kw = self._get_historical_hourly_averages(load_entity_id)
+        recent_load_kw = self._recent_load_1hr_kw
+        self._forecast_pipeline.compute_load_forecast_slots(
+            data=data,
+            now_dt=ctx.now_dt,
+            historical_avg_kw=hourly_avg_kw,
+            recent_load_kw=recent_load_kw,
+            total_slots=TOTAL_SLOTS,
+        )
+
+        self._bridge_history_results(data, ctx.now_dt)
+
+        # ---- Step DP: Inline DP optimizer (Phase 4, #441) ----
+        # Runs before effective_cheap_price final update so solar_can_reach_target
+        # is populated from DP result (not legacy solar-only simulation).
+        config_options = self._build_optimizer_config_options()
+        self._optimizer_facade.run_inline(
+            data=data, now_dt=ctx.now_dt, config_options=config_options
+        )
+
+        # ---- Step 6: boost_charge_needed (Phase 4: derive from DP decision) ----
+        self._read_boost_from_plan(data)
+
+        # ---- Step 7: effective_cheap_price (final update) ----
+        # Update effective_cheap_price with actual solar_can_reach_target from forecast.
+        # IMPORTANT: Save the optimizer's threshold BEFORE Step 7 overwrites it.
+        # The optimizer ran with the preliminary threshold from Step 7a. Step 7 recomputes
+        # effective_cheap_price using the optimizer's solar_can_reach_target result.
+        # If the recomputed value differs from the preliminary, we track which was used
+        # so the plan and UI are consistent (Planner Threshold Reconciliation, Fix #xxx).
+        data.planner_threshold_used = data.effective_cheap_price
+        self._price_signals.compute_effective_cheap_price(
+            data=data,
+            now_dt=ctx.now_dt,
+            before_dw=ctx.before_dw,
+            target_hour=ctx.target_hour,
+            target_pct=ctx.target_pct,
+        )
+
+        # ---- Step 8: cheap_charge_stop_price ----
+        # Hardcoded deadband (Issue #214)
+        data.cheap_charge_stop_price = round(
+            data.effective_cheap_price + DEFAULT_CHEAP_PRICE_DEADBAND, 2
+        )
+
+        # ---- Step 4: solar_battery_forecast (legacy - for backwards compatibility) ----
+        # Kept for API compatibility, but values derived from detailed forecast.
+        self._forecast_pipeline.compute_solar_battery_forecast(
+            data=data,
+            now_dt=ctx.now_dt,
+            target_hour=ctx.target_hour,
+            before_dw=ctx.before_dw,
+            after_dw=ctx.after_dw,
+            target_pct=ctx.target_pct,
+        )
+
+        # ---- Steps 9, 10, 10b: spike / price window signals ----
+        self._compute_spike_signals(data, ctx.now_dt)
+
+        # ---- Step 11: solar_weighted_avg_fit ----
+        self._forecast_pipeline.compute_solar_weighted_avg_fit(
+            data=data,
+            now_dt=ctx.now_dt,
+            target_hour=ctx.target_hour,
+            after_dw=ctx.after_dw,
+        )
+
+        # ---- Step 12: decision_log ----
+        self._maybe_log_decision(data, ctx.now_dt)
+
         # ---- Step 16: daily_forecast ----
         # (computed earlier; left intentionally blank)
 
         # ---- Step 17: excess_solar_signals (backlog-high-017) ----
-        self._forecast_pipeline.compute_excess_solar_signals(data, now_dt)
+        self._forecast_pipeline.compute_excess_solar_signals(data, ctx.now_dt)
 
         # ---- Step 18: weather correlation diagnostics (Issue #61) ----
         self._populate_weather_diagnostics(data)

--- a/custom_components/localshift/engine/core.py
+++ b/custom_components/localshift/engine/core.py
@@ -65,6 +65,263 @@ _ACTION_PRIORITY: dict[PlannerAction, int] = {
     PlannerAction.EXPORT_PROACTIVE: 3,
 }
 
+_GRID_CHARGE_ACTIONS = (
+    PlannerAction.CHARGE_GRID_NORMAL,
+    PlannerAction.CHARGE_GRID_BOOST,
+)
+
+
+def _evaluate_action_cost(
+    action: PlannerAction,
+    soc: float,
+    slot: SlotContext,
+    slot_idx: int,
+    slots: list[SlotContext],
+    soc_grid: list[float],
+    dp_next: dict,
+    config: OptimizerConfig,
+    inputs: OptimizerInputs,
+    terminal_penalty_idx: int | None,
+) -> tuple[float, int, float, float, float, float]:
+    """Compute per-action cost for a single (slot, soc-bin, action) triple.
+
+    Returns a plain tuple of (next_soc, next_bin, grid_import, grid_export,
+    charge_kwh, total_cost) with all intermediate quantities already applied:
+    SOC clamping, bin lookup with inf-fallback interpolation, switching cost,
+    Issue #610 solar-opportunity factor, Issue #638 futile-cycling factor, and
+    stage + future cost summation.
+
+    Args:
+
+        action: Action to evaluate.
+        soc: Current SOC percentage.
+        slot: Current slot context.
+        slot_idx: Index of the current slot.
+        slots: All slot contexts.
+        soc_grid: SOC discretisation grid.
+        dp_next: dp[slot_idx + 1] — the next-slot value table (NOT the whole dp list).
+        config: Optimizer config.
+        inputs: Optimizer inputs (for current_action and all_solcast).
+        terminal_penalty_idx: Terminal penalty index or None.
+
+    Returns:
+
+        Tuple of (next_soc, next_bin, grid_import, grid_export, charge_kwh, total_cost).
+
+    """
+
+    next_soc, grid_import, grid_export = _transition(soc, action, slot, config)
+    next_soc = max(config.min_soc_pct, min(config.max_soc_pct, next_soc))
+    next_bin = _map_soc_to_bin(next_soc, soc_grid)
+    future_cost = dp_next.get(next_bin, (float("inf"),))[0]
+
+    if future_cost == float("inf") and dp_next:
+        future_cost = _interpolate_cost_to_soc(
+            next_soc, soc_grid, {k: v[0] for k, v in dp_next.items()}
+        )
+
+    is_switch = (
+        slot_idx == 0
+        and inputs.current_action is not None
+        and action != inputs.current_action
+    )
+
+    # Issue #610: horizon-aware solar opportunity cost
+
+    solar_opp_factor = get_solar_opportunity_penalty_factor(
+        action=action,
+        grid_import_kwh=grid_import,
+        slot=slot,
+        slot_idx=slot_idx,
+        slots=slots,
+        config=config,
+        terminal_penalty_idx=terminal_penalty_idx,
+        all_solcast=inputs.all_solcast,
+    )
+
+    # Issue #638: futile cycling penalty
+
+    charge_kwh = max(0.0, next_soc - soc) / 100.0 * config.battery_capacity_kwh
+
+    futile_factor = get_futile_cycling_penalty_factor(
+        action=action,
+        slot_idx=slot_idx,
+        slots=slots,
+        config=config,
+        soc_after_charge_pct=next_soc,
+        charge_kwh=charge_kwh,
+        terminal_penalty_idx=terminal_penalty_idx,
+    )
+
+    stage = _cost_stage_cost(
+        action,
+        grid_import,
+        grid_export,
+        slot,
+        config,
+        soc_pct=soc,
+        is_switch=is_switch,
+        solar_opportunity_penalty_factor=solar_opp_factor,
+        futile_cycling_penalty_factor=futile_factor,
+    )
+    total_cost = stage.net_cost + future_cost
+
+    return next_soc, next_bin, grid_import, grid_export, charge_kwh, total_cost
+
+
+def _is_urgency_precharge(
+    slot_idx: int,
+    soc: float,
+    terminal_penalty_idx: int | None,
+    config: OptimizerConfig,
+) -> bool:
+    """Return True when this slot qualifies as a demand-window pre-charge that must be exempted from the min-cycle-saving gate.
+
+    Demand-window pre-charge exemption (2026-06-11 sub-target incident): a charge
+    inside the urgency window that is still below the DW target is needed to reach
+    that target, not speculative cycling. Without exempting it, the min-cycle-saving
+    gate drops each early pre-charge slot — its per-slot margin over simply deferring
+    the charge is below the threshold because the charge "could" happen later — and
+    those deferrals compound: by the time charging is forced it is deep in the
+    taper region with too few slots left, so the plan enters the DW under target
+    (live: 91.8% vs a 95% target, holding the first slots instead of charging).
+    Mirrors the SOC-floor anti-sawtooth guard's urgency-window exemption below.
+    Safe vs the #800 overnight sawtooth: those slots are post-DW / far pre-DW and
+    never inside an urgency window, so the gate stays fully active there.
+
+    Target-first eligibility (2026-06-12): when pre_dw_charge_thresholds is
+    active, ANY pre-DW charge below target is target-driven — feasible_actions
+    only offers it at/below that slot's target-funded threshold — so the
+    exemption covers the whole pre-DW range, not just the 4-8h urgency window.
+    Without this, min-cycle-saving re-introduces the procrastination the
+    thresholds exist to fix (each early slot's margin over deferring is thin,
+    the deferrals compound, and the plan undershoots — the #860 incident shape).
+    Post-DW slots are never exempted by either branch.
+
+    Args:
+
+        slot_idx: Index of the current slot.
+        soc: Current SOC percentage.
+        terminal_penalty_idx: Terminal penalty index or None.
+        config: Optimizer config.
+
+    Returns:
+
+        True when the slot should be exempt from the min-cycle-saving gate.
+
+    """
+
+    return (
+        terminal_penalty_idx is not None
+        and slot_idx < terminal_penalty_idx
+        and soc < config.demand_window_target_soc_pct
+        and (
+            config.pre_dw_charge_thresholds is not None
+            or (
+                config.urgency_window_start_idx is not None
+                and config.urgency_window_start_idx <= slot_idx
+            )
+        )
+    )
+
+
+def _min_cycle_saving_blocks(
+    action: PlannerAction,
+    charge_kwh: float,
+    total_cost: float,
+    hold_total_cost: float | None,
+    is_urgency_precharge: bool,
+    config: OptimizerConfig,
+) -> bool:
+    """Return True when the min-cycle-saving gate blocks the given charge action.
+
+    Min-cycle-saving gate (anti-micro-cycling): a grid charge is only worth
+    a battery cycle if it beats simply holding by at least
+    config.min_cycle_saving dollars per kWh charged. The margin
+    (hold_total_cost - total_cost) is the DP's real cost difference, so it
+    already credits every value source the optimizer sees — evening-peak
+    avoidance, the demand-window target, backup readiness — via future_cost.
+    That preserves genuine pre-charge and spike capture while dropping thin
+    speculative arbitrage. A HARD skip; unlike the soft penalties (#606/#804)
+    it cannot be paid through. HOLD is appended first by feasible_actions, so
+    hold_total_cost is set before any charge action is evaluated.
+
+    Args:
+
+        action: Action being evaluated.
+        charge_kwh: kWh of charge gained by the action (from clamped next_soc).
+        total_cost: Total DP cost of the action (stage + future).
+        hold_total_cost: Total DP cost of the HOLD action for this state (or None
+            when HOLD has not yet been evaluated — should not happen in practice).
+        is_urgency_precharge: Whether this slot is exempt from the gate.
+        config: Optimizer config.
+
+    Returns:
+
+        True when the action should be skipped (gate fires).
+
+    """
+
+    if not (
+        config.min_cycle_saving > 0.0
+        and charge_kwh > 0.0
+        and hold_total_cost is not None
+        and not is_urgency_precharge
+        and action in _GRID_CHARGE_ACTIONS
+    ):
+        return False
+    saving = hold_total_cost - total_cost
+    return 0.0 < saving < config.min_cycle_saving * charge_kwh
+
+
+def _floor_guard_blocks(
+    action: PlannerAction,
+    soc: float,
+    next_soc: float,
+    slot_idx: int,
+    terminal_penalty_idx: int | None,
+    config: OptimizerConfig,
+) -> bool:
+    """Return True when the SOC-floor anti-sawtooth guard blocks the given charge action.
+
+    SOC-floor anti-sawtooth guard: at SOC floor, only allow charging if:
+    1. Charge amount is meaningful (> min_floor_charge_gain_pct SOC), OR
+    2. We are within the urgency window before the demand window.
+
+    Tiny charges at the SOC floor without an urgent need produce sawtooth
+    oscillation — the optimizer charges by a hair, decays back to floor,
+    and repeats — so they are skipped. The urgency-window exemption mirrors
+    the min-cycle-saving gate's exemption: slots inside the urgency window
+    are target-driven and must not be blocked.
+
+    Args:
+
+        action: Action being evaluated.
+        soc: Current SOC percentage.
+        next_soc: Next SOC percentage (after clamping).
+        slot_idx: Index of the current slot.
+        terminal_penalty_idx: Terminal penalty index or None.
+        config: Optimizer config.
+
+    Returns:
+
+        True when the action should be skipped (guard fires).
+
+    """
+
+    if not (
+        soc <= config.min_soc_pct + config.min_soc_floor_buffer_pct
+        and action in _GRID_CHARGE_ACTIONS
+    ):
+        return False
+    charge_soc_gain = next_soc - soc
+    in_urgency_window = (
+        terminal_penalty_idx is not None
+        and config.urgency_window_start_idx is not None
+        and slot_idx >= config.urgency_window_start_idx
+    )
+    return charge_soc_gain < config.min_floor_charge_gain_pct and not in_urgency_window
+
 
 class DPPlanner:
     """Deterministic dynamic-programming battery optimizer.
@@ -729,150 +986,47 @@ class DPPlanner:
         states_explored = 0
         hold_total_cost: float | None = None
 
+        # is_urgency_precharge depends only on loop-invariant quantities, so hoist it.
+        urgency_precharge = _is_urgency_precharge(
+            slot_idx, soc, terminal_penalty_idx, config
+        )
+
+        dp_next = dp[slot_idx + 1]
+
         for action in actions:
-            next_soc, grid_import, grid_export = _transition(soc, action, slot, config)
-            next_soc = max(config.min_soc_pct, min(config.max_soc_pct, next_soc))
-            next_bin = _map_soc_to_bin(next_soc, soc_grid)
-            future_cost = dp[slot_idx + 1].get(next_bin, (float("inf"),))[0]
-
-            if future_cost == float("inf") and dp[slot_idx + 1]:
-                future_cost = _interpolate_cost_to_soc(
-                    next_soc, soc_grid, {k: v[0] for k, v in dp[slot_idx + 1].items()}
-                )
-
-            is_switch = (
-                slot_idx == 0
-                and inputs.current_action is not None
-                and action != inputs.current_action
-            )
-
-            # Issue #610: horizon-aware solar opportunity cost
-
-            solar_opp_factor = get_solar_opportunity_penalty_factor(
-                action=action,
-                grid_import_kwh=grid_import,
-                slot=slot,
-                slot_idx=slot_idx,
-                slots=slots,
-                config=config,
-                terminal_penalty_idx=terminal_penalty_idx,
-                all_solcast=inputs.all_solcast,
-            )
-
-            # Issue #638: futile cycling penalty
-
-            charge_kwh = max(0.0, next_soc - soc) / 100.0 * config.battery_capacity_kwh
-
-            futile_factor = get_futile_cycling_penalty_factor(
-                action=action,
-                slot_idx=slot_idx,
-                slots=slots,
-                config=config,
-                soc_after_charge_pct=next_soc,
-                charge_kwh=charge_kwh,
-                terminal_penalty_idx=terminal_penalty_idx,
-            )
-
-            stage = _cost_stage_cost(
-                action,
-                grid_import,
-                grid_export,
-                slot,
-                config,
-                soc_pct=soc,
-                is_switch=is_switch,
-                solar_opportunity_penalty_factor=solar_opp_factor,
-                futile_cycling_penalty_factor=futile_factor,
-            )
-            total_cost = stage.net_cost + future_cost
-
-            # Demand-window pre-charge exemption (2026-06-11 sub-target incident): a charge
-            # inside the urgency window that is still below the DW target is needed to reach
-            # that target, not speculative cycling. Without exempting it, the min-cycle-saving
-            # gate drops each early pre-charge slot — its per-slot margin over simply deferring
-            # the charge is below the threshold because the charge "could" happen later — and
-            # those deferrals compound: by the time charging is forced it is deep in the
-            # taper region with too few slots left, so the plan enters the DW under target
-            # (live: 91.8% vs a 95% target, holding the first slots instead of charging).
-            # Mirrors the SOC-floor anti-sawtooth guard's urgency-window exemption below.
-            # Safe vs the #800 overnight sawtooth: those slots are post-DW / far pre-DW and
-            # never inside an urgency window, so the gate stays fully active there.
-            #
-            # Target-first eligibility (2026-06-12): when pre_dw_charge_thresholds is
-            # active, ANY pre-DW charge below target is target-driven — feasible_actions
-            # only offers it at/below that slot's target-funded threshold — so the
-            # exemption covers the whole pre-DW range, not just the 4-8h urgency window.
-            # Without this, min-cycle-saving re-introduces the procrastination the
-            # thresholds exist to fix (each early slot's margin over deferring is thin,
-            # the deferrals compound, and the plan undershoots — the #860 incident shape).
-            # Post-DW slots are never exempted by either branch.
-            is_urgency_precharge = (
-                terminal_penalty_idx is not None
-                and slot_idx < terminal_penalty_idx
-                and soc < config.demand_window_target_soc_pct
-                and (
-                    config.pre_dw_charge_thresholds is not None
-                    or (
-                        config.urgency_window_start_idx is not None
-                        and config.urgency_window_start_idx <= slot_idx
-                    )
+            next_soc, next_bin, grid_import, grid_export, charge_kwh, total_cost = (
+                _evaluate_action_cost(
+                    action,
+                    soc,
+                    slot,
+                    slot_idx,
+                    slots,
+                    soc_grid,
+                    dp_next,
+                    config,
+                    inputs,
+                    terminal_penalty_idx,
                 )
             )
 
             if action == PlannerAction.HOLD:
                 hold_total_cost = total_cost
-            elif (
-                config.min_cycle_saving > 0.0
-                and charge_kwh > 0.0
-                and hold_total_cost is not None
-                and not is_urgency_precharge
-                and action
-                in (
-                    PlannerAction.CHARGE_GRID_NORMAL,
-                    PlannerAction.CHARGE_GRID_BOOST,
-                )
+            elif _min_cycle_saving_blocks(
+                action,
+                charge_kwh,
+                total_cost,
+                hold_total_cost,
+                urgency_precharge,
+                config,
             ):
-                # Min-cycle-saving gate (anti-micro-cycling): a grid charge is only worth
-                # a battery cycle if it beats simply holding by at least
-                # config.min_cycle_saving dollars per kWh charged. The margin
-                # (hold_total_cost - total_cost) is the DP's real cost difference, so it
-                # already credits every value source the optimizer sees — evening-peak
-                # avoidance, the demand-window target, backup readiness — via future_cost.
-                # That preserves genuine pre-charge and spike capture while dropping thin
-                # speculative arbitrage. A HARD skip; unlike the soft penalties (#606/#804)
-                # it cannot be paid through. HOLD is appended first by feasible_actions, so
-                # hold_total_cost is set before any charge action is evaluated.
-                saving = hold_total_cost - total_cost
-                if 0.0 < saving < config.min_cycle_saving * charge_kwh:
-                    states_explored += 1
-                    continue
+                states_explored += 1
+                continue
 
-            # SOC-floor anti-sawtooth guard
-            if (
-                soc <= config.min_soc_pct + config.min_soc_floor_buffer_pct
-                and action
-                in (
-                    PlannerAction.CHARGE_GRID_NORMAL,
-                    PlannerAction.CHARGE_GRID_BOOST,
-                )
+            if _floor_guard_blocks(
+                action, soc, next_soc, slot_idx, terminal_penalty_idx, config
             ):
-                # At SOC floor, only allow charging if:
-                # 1. Charge amount is meaningful (> min_floor_charge_gain_pct SOC) OR
-                # 2. We are within urgency window before demand window
-                charge_soc_gain = next_soc - soc
-                in_urgency_window = (
-                    terminal_penalty_idx is not None
-                    and config.urgency_window_start_idx is not None
-                    and slot_idx >= config.urgency_window_start_idx
-                )
-
-                if (
-                    charge_soc_gain < config.min_floor_charge_gain_pct
-                    and not in_urgency_window
-                ):
-                    # Tiny charge at SOC floor without urgent need - skip to avoid sawtooth
-                    states_explored += 1
-                    continue
+                states_explored += 1
+                continue
 
             if total_cost < best_cost or (
                 total_cost == best_cost

--- a/custom_components/localshift/engine/pattern_analyzer.py
+++ b/custom_components/localshift/engine/pattern_analyzer.py
@@ -30,11 +30,97 @@ _LOGGER = logging.getLogger(__name__)
 # Minimum samples per group before considering it for bias detection
 MIN_SAMPLES_FOR_BIAS = 10
 
+# Issue #449 Phase 7: compare against PlannerAction (DP-native) values
+_GRID_CHARGE_ACTIONS = frozenset({
+    PlannerAction.CHARGE_GRID_NORMAL,
+    PlannerAction.CHARGE_GRID_BOOST,
+})
+
+# Threshold for 'resulted in export' / 'exported grid energy'
+_SIGNIFICANT_EXPORT_KWH = 0.5
+
+# Lost more than 10% SOC unexpectedly
+_UNDER_CHARGE_SOC_DROP_PCT = -10
+
 # Minimum weeks a pattern must persist before becoming actionable
 MIN_WEEKS_OBSERVED = 2
 
 # Standard deviation threshold for bias detection
 BIAS_STD_DEV_THRESHOLD = 1.0
+
+
+def _mean_and_std(scores: list[float]) -> tuple[float, float]:
+    """Return (mean, sample std) for a non-empty list of scores.
+
+    Uses the n-1 (Bessel-corrected) denominator for sample standard deviation.
+    Returns std of 0.0 when only one sample is present.
+
+    Precondition: scores must be non-empty (callers are responsible for guarding).
+    """
+    n = len(scores)
+    mean = sum(scores) / n
+    if n > 1:
+        variance = sum((s - mean) ** 2 for s in scores) / (n - 1)
+        std = math.sqrt(variance)
+    else:
+        std = 0.0
+    return mean, std
+
+
+def _over_charge_rate(decisions: list[DecisionRecord]) -> float:
+    """Fraction of grid-charge decisions that exported > _SIGNIFICANT_EXPORT_KWH.
+
+    Issue #449 Phase 7: compare against PlannerAction (DP-native) values.
+    Returns 0.0 when there are no grid-charge decisions.
+    """
+    grid_charge_count = sum(
+        1 for d in decisions if d.mode_chosen in _GRID_CHARGE_ACTIONS
+    )
+    if grid_charge_count == 0:
+        return 0.0
+    over_charge_count = sum(
+        1
+        for d in decisions
+        if d.mode_chosen in _GRID_CHARGE_ACTIONS
+        and d.actual_export_kwh is not None
+        and d.actual_export_kwh > _SIGNIFICANT_EXPORT_KWH
+    )
+    return over_charge_count / grid_charge_count
+
+
+def _under_charge_rate(decisions: list[DecisionRecord], sample_count: int) -> float:
+    """Fraction of decisions where SOC dropped unexpectedly (Lost more than 10% SOC unexpectedly).
+
+    CRITICAL INVARIANT: sample_count is the number of decisions with
+    outcome_score IS NOT None — NOT len(decisions). The under-charge count
+    scans ALL decisions. This asymmetry is intentional; do not recompute
+    sample_count from decisions here.
+    """
+    under_charge_count = sum(
+        1
+        for d in decisions
+        if d.actual_soc_change is not None
+        and d.actual_soc_change < _UNDER_CHARGE_SOC_DROP_PCT
+    )
+    return under_charge_count / sample_count
+
+
+def _export_loss_rate(decisions: list[DecisionRecord], sample_count: int) -> float:
+    """Fraction of decisions that exported and imported > _SIGNIFICANT_EXPORT_KWH.
+
+    Captures decisions where grid-purchased energy was subsequently exported
+    (a loss). Scans ALL decisions but is normalised by sample_count (decisions
+    with outcome_score IS NOT None) — same asymmetry as _under_charge_rate.
+    """
+    export_loss_count = sum(
+        1
+        for d in decisions
+        if d.actual_export_kwh is not None
+        and d.actual_export_kwh > _SIGNIFICANT_EXPORT_KWH
+        and d.actual_import_kwh is not None
+        and d.actual_import_kwh > _SIGNIFICANT_EXPORT_KWH
+    )
+    return export_loss_count / sample_count
 
 
 class PatternAnalyzer:
@@ -161,12 +247,7 @@ class PatternAnalyzer:
 
         # Compute global stats
         if all_scores:
-            stats.global_mean = sum(all_scores) / len(all_scores)
-            if len(all_scores) > 1:
-                variance = sum((s - stats.global_mean) ** 2 for s in all_scores) / (
-                    len(all_scores) - 1
-                )
-                stats.global_std = math.sqrt(variance)
+            stats.global_mean, stats.global_std = _mean_and_std(all_scores)
 
         return stats
 
@@ -190,54 +271,7 @@ class PatternAnalyzer:
         if sample_count == 0:
             return PatternBucket(key=key, dimension=dimension)
 
-        mean_score = sum(scores) / sample_count
-
-        # Standard deviation
-        if sample_count > 1:
-            variance = sum((s - mean_score) ** 2 for s in scores) / (sample_count - 1)
-            std_score = math.sqrt(variance)
-        else:
-            std_score = 0.0
-
-        # Over-charge rate: grid charge decisions that resulted in export
-        # Issue #449 Phase 7: compare against PlannerAction (DP-native) values
-        _grid_charge_actions = {
-            PlannerAction.CHARGE_GRID_NORMAL,
-            PlannerAction.CHARGE_GRID_BOOST,
-        }
-        grid_charge_count = sum(
-            1 for d in decisions if d.mode_chosen in _grid_charge_actions
-        )
-        over_charge_count = sum(
-            1
-            for d in decisions
-            if d.mode_chosen in _grid_charge_actions
-            and d.actual_export_kwh is not None
-            and d.actual_export_kwh > 0.5
-        )
-        over_charge_rate = (
-            over_charge_count / grid_charge_count if grid_charge_count > 0 else 0.0
-        )
-
-        # Under-charge rate: SOC dropped below target
-        under_charge_count = sum(
-            1
-            for d in decisions
-            if d.actual_soc_change is not None
-            and d.actual_soc_change < -10  # Lost more than 10% SOC unexpectedly
-        )
-        under_charge_rate = under_charge_count / sample_count
-
-        # Export loss rate: exported grid-purchased energy
-        export_loss_count = sum(
-            1
-            for d in decisions
-            if d.actual_export_kwh is not None
-            and d.actual_export_kwh > 0.5
-            and d.actual_import_kwh is not None
-            and d.actual_import_kwh > 0.5
-        )
-        export_loss_rate = export_loss_count / sample_count
+        mean_score, std_score = _mean_and_std(scores)
 
         return PatternBucket(
             key=key,
@@ -245,9 +279,9 @@ class PatternAnalyzer:
             sample_count=sample_count,
             mean_score=mean_score,
             std_score=std_score,
-            over_charge_rate=over_charge_rate,
-            under_charge_rate=under_charge_rate,
-            export_loss_rate=export_loss_rate,
+            over_charge_rate=_over_charge_rate(decisions),
+            under_charge_rate=_under_charge_rate(decisions, sample_count),
+            export_loss_rate=_export_loss_rate(decisions, sample_count),
         )
 
     def detect_biases(


### PR DESCRIPTION
## Summary

Strictly behavior-preserving decomposition of the three worst-complexity functions in the codebase (radon grade D), one commit per file:

| Function | Before | After |
|---|---|---|
| `DPPlanner._compute_best_action` (engine/core.py) | D (28), 220 lines | B (8) |
| `ComputationEngine.compute_derived_values` (computation_engine.py) | D (23), 266 lines | A (3) |
| `PatternAnalyzer._compute_bucket_stats` (engine/pattern_analyzer.py) | D (21) | A (4) |

All new helpers are grade A/B. No public API or signature changes; all incident-reference comments (#800/#860/#870, 2026-06-11/12, Issues #610/#638/#449/#493) relocated into helper docstrings, not deleted.

**engine/core.py** — extracted module-level `_evaluate_action_cost` (per-action transition + penalties + stage cost), `_is_urgency_precharge`, `_min_cycle_saving_blocks`, `_floor_guard_blocks`, and a `_GRID_CHARGE_ACTIONS` constant. Extraction kept coarse (DP hot loop). One deliberate micro-change: `is_urgency_precharge` is loop-invariant and is now computed once per state instead of once per action — identical logic.

**computation_engine.py** — the orchestrator now reads as the numbered step list; multi-line steps moved to named private methods (`_reset_daily_precharge_latch`, `_detect_hardware_modes`, `_enter_manual_override`, `_bridge_history_results`, `_read_boost_from_plan`, `_compute_spike_signals`, `_maybe_log_decision`) plus a frozen `_DerivedValuesContext`. Step ordering untouched (7a-before-DP, `planner_threshold_used` saved before Step 7, manual-override early return). One deliberate micro-change: `target_pct` options read hoisted before the manual-override return (side-effect-free, documented in the dataclass docstring).

**engine/pattern_analyzer.py** — shared `_mean_and_std` (also de-duplicates the dimension-stats math), named rate helpers, `_GRID_CHARGE_ACTIONS` frozenset, named constants for the 0.5 kWh / −10% thresholds. The sample-count denominator asymmetry (scored decisions vs all decisions) is preserved and now documented as a critical invariant.

## Test plan

- Full suite: 3123 passed, 1 xfailed (matches main baseline; no tests modified)
- ruff check + format clean on all three files
- radon: no function above B in the touched files

Implemented by three parallel Sonnet subagents in isolated worktrees from per-function specs; each diff hand-reviewed against the behavior-preservation invariants before assembly.