### PR TITLE
fix(learning): solar-accuracy sampling never worked live — period-key second-offset mismatch + 5-min slot contamination

### DIFF
--- a/custom_components/localshift/engine/optimizer_facade.py
+++ b/custom_components/localshift/engine/optimizer_facade.py
@@ -66,6 +66,13 @@ class OptimizerFacade:
 
         recorded = 0
         for slot in slots:
+            # Only 30-min slots represent a full accuracy period. The hybrid
+            # schedule's near-term 5-min slots can land on a :00/:30 boundary
+            # and would otherwise overwrite the pending with ~5 minutes of
+            # forecast energy — compared against a 30-min actual, that reads
+            # as a systematic ~6x under-forecast.
+            if getattr(slot, "slot_interval_minutes", 30) != 30:
+                continue
             period_start = datetime.fromisoformat(slot.timestamp_iso)
             if not self._is_backfillable_period_start(period_start):
                 continue

--- a/custom_components/localshift/forecast/solar_accuracy.py
+++ b/custom_components/localshift/forecast/solar_accuracy.py
@@ -28,6 +28,22 @@ BIAS_HALF_LIFE_DAYS = 7.0
 MIN_SOLAR_CORRECTION_SAMPLES = 20
 
 
+def _period_key(period_start: datetime) -> str:
+    """Derive the pending-forecast dict key for a 30-min period.
+
+    Floors to the :00/:30 boundary (second/microsecond zeroed) so both sides
+    of the record/backfill handshake agree regardless of caller timestamp
+    quirks. Live Amber slot timestamps carry a +1-second offset (18:00:01),
+    while the coordinator's actuals integration floors to the exact boundary
+    (18:00:00) — keying on the raw isoformat made every backfill pop miss, so
+    no sample was ever recorded (2026-06-12 zero-samples incident: 50 pending,
+    0 samples after a full daytime).
+    """
+    return period_start.replace(
+        minute=(period_start.minute // 30) * 30, second=0, microsecond=0
+    ).isoformat()
+
+
 @dataclass
 class SolarPeriodRecord:
     """Record of forecast vs actual for a 30-min period.
@@ -268,9 +284,9 @@ class SolarAccuracyTracker:
         """Record a solar forecast for a 30-min period.
 
         Called when building slots - stores forecast for later comparison.
-        Uses the key as ISO format string for pending lookup.
+        Keyed by the floored 30-min boundary (see _period_key).
         """
-        key = period_start.isoformat()
+        key = _period_key(period_start)
         time_of_day = self._get_time_of_day(period_start)
         season = self._get_season(period_start)
 
@@ -312,7 +328,7 @@ class SolarAccuracyTracker:
                 state during the period itself. ``None`` (default) preserves the
                 pending's existing flag — backward compatible with old callers.
         """
-        key = period_start.isoformat()
+        key = _period_key(period_start)
         pending = self._pending_forecasts.pop(key, None)
 
         if pending is None:

--- a/tests/forecast/test_solar_accuracy.py
+++ b/tests/forecast/test_solar_accuracy.py
@@ -1,6 +1,6 @@
 """Tests for forecast/solar_accuracy.py - Solar forecast accuracy tracking."""
 
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -317,6 +317,47 @@ class TestSolarAccuracyTracker:
 
         # Should be no records
         assert len(tracker._period_records) == 0
+
+    def test_backfill_matches_offset_second_timestamps(self, tracker):
+        """Live Amber slot timestamps carry +1s (18:00:01); the actuals
+        integration floors to the boundary (18:00:00). The period key must
+        floor both sides or every backfill misses (2026-06-12 zero-samples
+        incident: 50 pending, 0 samples after a full daytime)."""
+        tz = timezone(timedelta(hours=10))
+        recorded_at = datetime(2026, 6, 12, 10, 0, 1, tzinfo=tz)
+        flushed_at = datetime(2026, 6, 12, 10, 0, 0, tzinfo=tz)
+
+        tracker.record_forecast(recorded_at, 2.5, "sunny")
+        tracker.backfill_actual(flushed_at, 2.0)
+
+        assert tracker._pending_forecasts == {}
+        assert len(tracker._period_records) == 1
+        assert tracker._metrics.sample_count == 1
+
+    def test_backfill_matches_thirty_minute_boundary_with_seconds(self, tracker):
+        """The :30 boundary floors the same way as :00."""
+        tz = timezone(timedelta(hours=10))
+        tracker.record_forecast(
+            datetime(2026, 6, 12, 10, 30, 1, tzinfo=tz), 1.5, "sunny"
+        )
+        tracker.backfill_actual(datetime(2026, 6, 12, 10, 30, 0, tzinfo=tz), 1.2)
+
+        assert len(tracker._period_records) == 1
+
+    def test_rerecord_with_different_seconds_overwrites_single_pending(self, tracker):
+        """Re-recording the same period with a different second offset must
+        replace the pending, not create a duplicate key."""
+        tz = timezone(timedelta(hours=10))
+        tracker.record_forecast(
+            datetime(2026, 6, 12, 10, 0, 1, tzinfo=tz), 2.5, "sunny"
+        )
+        tracker.record_forecast(
+            datetime(2026, 6, 12, 10, 0, 0, tzinfo=tz), 3.0, "sunny"
+        )
+
+        assert len(tracker._pending_forecasts) == 1
+        (record,) = tracker._pending_forecasts.values()
+        assert record.forecast_kwh == 3.0
 
     def test_backfill_multiple_records(self, tracker):
         """Test multiple backfills."""
@@ -907,9 +948,10 @@ class TestNormalizeWeather:
 
 def _fill_tracker_with_bias(tracker, forecast: float, actual: float, count: int):
     """Helper: add `count` period records with given forecast/actual values."""
-    from datetime import datetime, timezone
+    from datetime import datetime
+
     for i in range(count):
-        period = datetime(2026, 1, 1, 6 + i // 2, (i % 2) * 30, tzinfo=timezone.utc)
+        period = datetime(2026, 1, 1, 6 + i // 2, (i % 2) * 30, tzinfo=UTC)
         tracker.record_forecast(period, forecast, "sunny")
         tracker.backfill_actual(period, actual)
 
@@ -1028,7 +1070,9 @@ class TestAccuracyConfidenceCeiling:
         """Returns 1.0 (no cap) when fewer than MIN_SOLAR_CORRECTION_SAMPLES records exist."""
         # tracker fixture starts empty → 0 samples
         assert tracker.accuracy_confidence_ceiling() == pytest.approx(1.0)
-        assert tracker.accuracy_confidence_ceiling(low=0.2, high=0.9) == pytest.approx(1.0)
+        assert tracker.accuracy_confidence_ceiling(low=0.2, high=0.9) == pytest.approx(
+            1.0
+        )
 
     def test_accuracy_ceiling_low_when_poor_accuracy(self, tracker):
         """Returns 'low' param when accuracy is ≤ 50%."""

--- a/tests/test_optimizer_facade.py
+++ b/tests/test_optimizer_facade.py
@@ -248,6 +248,36 @@ def test_record_forecasts_for_slots_records_only_backfillable_timestamps():
     )
 
 
+def test_record_forecasts_for_slots_skips_5min_hybrid_slots():
+    """A near-term 5-min hybrid slot landing on a :00/:30 boundary must not
+    be recorded as the period forecast: its solar_kwh covers ~5 minutes, and
+    comparing it against a 30-min actual reads as a systematic ~6x
+    under-forecast."""
+    tracker = MagicMock()
+    slots = [
+        SimpleNamespace(
+            solar_kwh=0.1,
+            timestamp_iso="2026-06-12T10:00:01+10:00",
+            slot_interval_minutes=5,
+        ),
+        SimpleNamespace(
+            solar_kwh=0.6,
+            timestamp_iso="2026-06-12T10:30:01+10:00",
+            slot_interval_minutes=30,
+        ),
+    ]
+
+    facade = OptimizerFacade(slot_builder_cls=_StubSlotBuilder)
+    facade.set_solar_accuracy_tracker(tracker)
+    facade._record_forecasts_for_slots(slots, "sunny")
+
+    assert tracker.record_forecast.call_count == 1
+    assert (
+        tracker.record_forecast.call_args.kwargs["period_start"].isoformat()
+        == "2026-06-12T10:30:01+10:00"
+    )
+
+
 def test_record_forecasts_for_slots_passes_boost_flag():
     tracker = MagicMock()
     slots = [


### PR DESCRIPTION
## Summary

Solar forecast accuracy sampling has **never recorded a sample live**. Verified on the live system today (2026-06-12, a full daytime after the #861 persistence deploy): `sample_count: 0`, `pending_forecasts: 50`, `accuracy_discount_factor` pinned at 1.0.

**Root cause 1 — key mismatch (the zero-samples bug).** Live Amber slot timestamps carry a +1-second offset (`18:00:01`, visible in the hybrid-slot logs). `record_forecast` keyed pendings with `slot.timestamp_iso` verbatim (`...T18:00:01+10:00`); the actuals integration in `tick_scheduler` floors to the 30-min boundary (`...T18:00:00+10:00`). The `pop` never matched, every backfill hit the DEBUG-only "No pending forecast" path, and pendings accumulated until the 4-hour eviction. Tests never caught it because they all use clean `:00` timestamps.

**Root cause 2 — latent 5-min slot contamination.** `_is_backfillable_period_start` only checks `minute in (0, 30)`, so the hybrid schedule's near-term **5-minute** slots landing on a boundary passed the filter and overwrote the pending with ~5 minutes of forecast energy. Since the last write before a period starts always comes from the 5-min window, fixing bug 1 alone would have produced systematically wrong samples (~6× under-forecast) instead of none.

## Fix

- `_period_key()` in `solar_accuracy.py` floors to the :00/:30 boundary (second/microsecond zeroed) and is used by **both** `record_forecast` and `backfill_actual` — caller-proof regardless of timestamp quirks.
- `_record_forecasts_for_slots` in `optimizer_facade.py` skips slots with `slot_interval_minutes != 30`.

## Impact

Unblocks the dormant accuracy-driven machinery: the #849 accuracy confidence ceiling (needs 20 samples), the #856 pre-charge gate accuracy discount (currently a no-op at factor 1.0), and the #845 solar-credit suppression gate explicitly described as data-bottlenecked on this pipeline.

## Test plan

- 4 new regression tests using the live timestamp shape (`:01` seconds, +10:00 offset): record/backfill key match at :00 and :30, single-pending overwrite, 5-min hybrid slot exclusion
- Full suite: 3127 passed, 1 xfailed; ruff check + format clean

## Verification after deploy

`sensor.localshift_solar_forecast_accuracy` should show `sample_count` climbing within ~35 minutes of daytime operation, and "Solar period HH:MM: forecast=…, actual=…, bias=…" INFO lines should appear in the log.