### PR TITLE
fix(optimizer): scope min-cycle-saving exemption to target-funding charges

### DIFF
--- a/custom_components/localshift/engine/constraints.py
+++ b/custom_components/localshift/engine/constraints.py
@@ -300,11 +300,16 @@ def compute_pre_dw_charge_thresholds(
     eligibility keeps widening toward the ceiling as the DW approaches, so taper optimism
     cannot strand the target.
 
+    Side effect: records the raw funding water level (None when there is no deficit) on
+    ``config.pre_dw_funding_water_level`` so the min-cycle-saving exemption can scope
+    itself to genuinely target-funding charges (see ``core._is_urgency_precharge``).
+
     Returns None (feature inert, legacy behaviour) when there is no demand window, the
     mode is not self-consumption, ``max_precharge_price`` is unset, or the ceiling does
-    not exceed the ramp base. Callers must reset ``config.pre_dw_charge_thresholds`` to
-    None before invoking (this function reads legacy thresholds via
-    ``cheap_threshold_for_slot``, which consults that field).
+    not exceed the ramp base. Callers must reset ``config.pre_dw_charge_thresholds`` AND
+    ``config.pre_dw_funding_water_level`` to None before invoking (this function reads
+    legacy thresholds via ``cheap_threshold_for_slot``, which consults the former, and
+    the inert early-returns never touch the latter).
     """
     if (
         terminal_penalty_idx is None
@@ -354,8 +359,14 @@ def compute_pre_dw_charge_thresholds(
         slots, config, terminal_penalty_idx, initial_soc_pct
     )
     water = _target_funding_water_level(
-        slots, config, terminal_penalty_idx, required_stored_kwh, ramp_base, max_price
+        slots, config, terminal_penalty_idx, required_stored_kwh, max_price
     )
+    # Expose the raw funding water level (None when there is no deficit) so the
+    # min-cycle-saving exemption can distinguish target-funding charges (price ≤ water)
+    # from merely legacy-cheap ones (see ``_is_urgency_precharge``). Deliberately NOT
+    # floored at ramp_base: the floor would re-admit every base-percentile-cheap slot,
+    # which is exactly the non-funding population the exemption must exclude.
+    config.pre_dw_funding_water_level = water
 
     thresholds: list[float] = []
     for j, slot in enumerate(slots):
@@ -371,7 +382,8 @@ def compute_pre_dw_charge_thresholds(
         # ramp_j and water are ≤ max_price by construction; legacy is deliberately NOT
         # clamped to the ceiling — on a spike day whose percentile base exceeds
         # max_precharge_price this function must never tighten the existing gate.
-        thresholds.append(max(legacy[j], ramp_j, water))
+        # ramp_j ≥ ramp_base always, so a None water (no deficit) needs no substitute.
+        thresholds.append(max(legacy[j], ramp_j, water if water is not None else 0.0))
     return thresholds
 
 
@@ -413,18 +425,21 @@ def _target_funding_water_level(
     config: OptimizerConfig,
     terminal_penalty_idx: int,
     required_stored_kwh: float,
-    ramp_base: float,
     max_price: float,
-) -> float:
+) -> float | None:
     """Marginal buy price of the cheapest pre-DW slot set that closes the deficit.
 
     Eligibility by ``price <= water level`` IS cheapest-sufficient-set funding: the DP
     funds the target from the cheapest slots first and pricier slots unlock only when
     genuinely needed. When even every pre-DW slot together cannot close the deficit,
     the operator's full ``max_precharge_price`` ceiling is authorized.
+
+    Returns the raw water level (un-floored by the ramp base — callers that fold it into
+    the per-slot threshold max already include the ramp term), or None when there is no
+    deficit and hence nothing to fund.
     """
     if required_stored_kwh <= 0.0:
-        return ramp_base
+        return None
 
     candidates: list[tuple[float, float]] = []
     for j in range(terminal_penalty_idx):
@@ -447,7 +462,7 @@ def _target_funding_water_level(
         if cumulative >= required_stored_kwh:
             water = price
             break
-    return max(ramp_base, min(water, max_price))
+    return min(water, max_price)
 
 
 def compute_max_normal_gain_pct_to_terminal(

--- a/custom_components/localshift/engine/core.py
+++ b/custom_components/localshift/engine/core.py
@@ -172,6 +172,7 @@ def _evaluate_action_cost(
 def _is_urgency_precharge(
     slot_idx: int,
     soc: float,
+    buy_price: float,
     terminal_penalty_idx: int | None,
     config: OptimizerConfig,
 ) -> bool:
@@ -189,19 +190,29 @@ def _is_urgency_precharge(
     Safe vs the #800 overnight sawtooth: those slots are post-DW / far pre-DW and
     never inside an urgency window, so the gate stays fully active there.
 
-    Target-first eligibility (2026-06-12): when pre_dw_charge_thresholds is
-    active, ANY pre-DW charge below target is target-driven — feasible_actions
-    only offers it at/below that slot's target-funded threshold — so the
-    exemption covers the whole pre-DW range, not just the 4-8h urgency window.
-    Without this, min-cycle-saving re-introduces the procrastination the
-    thresholds exist to fix (each early slot's margin over deferring is thin,
-    the deferrals compound, and the plan undershoots — the #860 incident shape).
-    Post-DW slots are never exempted by either branch.
+    Target-first eligibility (2026-06-12): a pre-DW charge at/below the funding
+    water level (config.pre_dw_funding_water_level — the marginal price of the
+    cheapest sufficient slot set) is target-driven even outside the 4-8h urgency
+    window, so it is exempted too. Without this, min-cycle-saving re-introduces
+    the procrastination the per-slot thresholds exist to fix (each early slot's
+    margin over deferring is thin, the deferrals compound, and the plan
+    undershoots — the #860 incident shape).
+
+    The water-level test is deliberately NOT "pre_dw_charge_thresholds is not
+    None": those thresholds are max(legacy, ramp, water), and the LEGACY
+    component keeps slots eligible for reasons unrelated to funding the target.
+    A blanket exemption re-enabled the #800 overnight sawtooth (2026-06-13
+    regression: a 12.5¢ floor-bounce charge at 03:00, fully drained before the
+    8.3¢ midday slots that actually fund the DW target). Energy charged in a
+    far-out, above-water slot drains to the SOC floor before the DW, funds
+    nothing, and must face the gate. Post-DW slots are never exempted by either
+    branch.
 
     Args:
 
         slot_idx: Index of the current slot.
         soc: Current SOC percentage.
+        buy_price: The slot's grid buy price ($/kWh).
         terminal_penalty_idx: Terminal penalty index or None.
         config: Optimizer config.
 
@@ -216,7 +227,10 @@ def _is_urgency_precharge(
         and slot_idx < terminal_penalty_idx
         and soc < config.demand_window_target_soc_pct
         and (
-            config.pre_dw_charge_thresholds is not None
+            (
+                config.pre_dw_funding_water_level is not None
+                and buy_price <= config.pre_dw_funding_water_level
+            )
             or (
                 config.urgency_window_start_idx is not None
                 and config.urgency_window_start_idx <= slot_idx
@@ -435,8 +449,10 @@ class DPPlanner:
         # so the demand-window target is fundable from the cheapest sufficient slots up
         # to max_precharge_price, and time-consistent (each slot gated at the urgency it
         # will have when it arrives, not today's now-scalar). Reset first: the precompute
-        # reads legacy thresholds via cheap_threshold_for_slot, which consults this field.
+        # reads legacy thresholds via cheap_threshold_for_slot, which consults this field,
+        # and its inert early-returns never write the water level.
         config.pre_dw_charge_thresholds = None
+        config.pre_dw_funding_water_level = None
         config.pre_dw_charge_thresholds = compute_pre_dw_charge_thresholds(
             slots, config, terminal_penalty_idx, inputs.initial_soc_pct
         )
@@ -988,7 +1004,7 @@ class DPPlanner:
 
         # is_urgency_precharge depends only on loop-invariant quantities, so hoist it.
         urgency_precharge = _is_urgency_precharge(
-            slot_idx, soc, terminal_penalty_idx, config
+            slot_idx, soc, slot.buy_price, terminal_penalty_idx, config
         )
 
         dp_next = dp[slot_idx + 1]

--- a/custom_components/localshift/engine/types.py
+++ b/custom_components/localshift/engine/types.py
@@ -276,6 +276,19 @@ class OptimizerConfig:
     ``base_cheap_price`` — the #800 overnight-sawtooth protection is untouched).
     None ⇒ legacy behaviour."""
 
+    pre_dw_funding_water_level: float | None = None
+    """Solver-derived (set by ``DPPlanner._solve`` via ``compute_pre_dw_charge_thresholds``):
+    the raw target-funding water level — the marginal buy price of the cheapest set of
+    pre-DW slots whose combined boost capacity closes the SOC deficit to the demand-window
+    target ($/kWh), clamped to ``max_precharge_price``. None when there is no deficit (or
+    the thresholds are inert).
+
+    Distinct from the (b)/(c) max in ``pre_dw_charge_thresholds``: this carries ONLY the
+    funding component, un-floored by the ramp base, so the min-cycle-saving exemption can
+    tell a genuinely target-funding charge (price ≤ water level, part of the
+    cheapest-sufficient set) from a merely legacy-cheap one whose energy drains to the SOC
+    floor before the demand window (the 2026-06-13 overnight sawtooth regression)."""
+
     base_cheap_price: float | None = None
     """Un-inflated "genuinely cheap" threshold (percentile-derived), $/kWh.
 

--- a/tests/engine/test_target_first_eligibility.py
+++ b/tests/engine/test_target_first_eligibility.py
@@ -25,8 +25,7 @@ from custom_components.localshift.engine.constraints import (
     compute_pre_dw_charge_thresholds,
     feasible_actions,
 )
-from custom_components.localshift.engine.core import DPPlanner
-from custom_components.localshift.engine.dp_math import urgency_ramp_price
+from custom_components.localshift.engine.core import DPPlanner, _is_urgency_precharge
 from custom_components.localshift.engine.types import (
     OptimizerConfig,
     OptimizerInputs,
@@ -137,6 +136,20 @@ class TestComputePreDwChargeThresholds:
         # Slot 0 is 6h out — outside any urgency window — so legacy applies untouched.
         assert thresholds[0] == cheap_threshold_for_slot(config, 0, 12)
 
+    def test_water_level_is_published_raw_on_config(self):
+        """The funding water level lands on the config un-floored by the ramp base.
+
+        Same deficit as test_water_level_is_marginal_price_of_cheapest_sufficient_set
+        (water $0.12), but the published value must equal the raw marginal price even
+        when it sits below a higher ramp base — flooring it at the base would re-admit
+        every base-percentile-cheap slot into the min-cycle-saving exemption, which is
+        exactly the non-funding population the scope fix excludes.
+        """
+        slots = _slots([0.10] * 4 + [0.12] * 4 + [0.16] * 4, [0.30] * 2)
+        config = _config(base_cheap_price=0.13, effective_cheap_price=0.13)
+        compute_pre_dw_charge_thresholds(slots, config, 12, 20.0)
+        assert config.pre_dw_funding_water_level == 0.12
+
     def test_inert_without_dw_mode_or_ceiling(self):
         slots = _slots([0.10] * 4, [0.30] * 2)
         assert compute_pre_dw_charge_thresholds(slots, _config(), None, 20.0) is None
@@ -171,6 +184,9 @@ class TestComputePreDwChargeThresholds:
         # 12 × (1.5 − 0.25) kWh ≈ 13.8 kWh stored-equivalent of solar wipes the deficit:
         # no water level, slot 0 (outside the ramp window) stays at legacy.
         assert thresholds[0] == cheap_threshold_for_slot(config, 0, 12)
+        # With nothing to fund, no water level is published either — the
+        # min-cycle-saving exemption must not widen beyond the urgency window.
+        assert config.pre_dw_funding_water_level is None
 
 
 class TestGateIntegration:
@@ -263,3 +279,167 @@ class TestEndToEndPlan:
         assert not any(
             d.action in _CHARGE_ACTIONS for d in result.decisions if d.slot_index >= 16
         )
+
+
+class TestMinCycleSavingExemptionScope:
+    """The gate exemption follows the target-FUNDING components, not mere eligibility.
+
+    2026-06-13 regression: #870 exempted every pre-DW below-target slot from the
+    min-cycle-saving gate whenever the per-slot thresholds were active. But those
+    thresholds are max(legacy, ramp, water) and the LEGACY component keeps slots
+    eligible for non-funding reasons, so the blanket exemption re-enabled the #800
+    overnight sawtooth: a 12.5¢ floor-bounce charge at 03:00, fully drained before
+    the 8.3¢ midday slots that actually fund the DW target. The exemption must hold
+    only inside the urgency window or at/below the funding water level.
+    """
+
+    def _cfg(self, *, water, uw_start) -> OptimizerConfig:
+        config = _config()
+        config.pre_dw_charge_thresholds = [0.13] * 12  # active thresholds either way
+        config.pre_dw_funding_water_level = water
+        config.urgency_window_start_idx = uw_start
+        return config
+
+    def test_above_water_outside_window_is_not_exempt(self):
+        """The regression case: legacy-cheap overnight slot, far from the DW."""
+        config = self._cfg(water=0.084, uw_start=8)
+        assert not _is_urgency_precharge(2, 10.0, 0.126, 12, config)
+
+    def test_at_or_below_water_is_exempt_anywhere_pre_dw(self):
+        config = self._cfg(water=0.084, uw_start=8)
+        assert _is_urgency_precharge(2, 10.0, 0.084, 12, config)
+        assert _is_urgency_precharge(2, 10.0, 0.080, 12, config)
+
+    def test_inside_urgency_window_is_exempt_regardless_of_water(self):
+        config = self._cfg(water=0.084, uw_start=8)
+        assert _is_urgency_precharge(9, 10.0, 0.126, 12, config)
+
+    def test_no_deficit_means_no_water_exemption(self):
+        config = self._cfg(water=None, uw_start=8)
+        assert not _is_urgency_precharge(2, 10.0, 0.080, 12, config)
+
+    def test_post_dw_and_above_target_never_exempt(self):
+        config = self._cfg(water=0.084, uw_start=8)
+        assert not _is_urgency_precharge(12, 10.0, 0.080, 12, config)
+        assert not _is_urgency_precharge(2, 96.0, 0.080, 12, config)
+
+
+class TestOvernightSawtoothReplay:
+    """DP-level replay of the 2026-06-13 overnight sawtooth (re-introduced by #870).
+
+    Live shape (plan computed 19:02, DW 15:00 next day, target 95%): SOC drains from
+    60% to the 10% floor by ~02:00, the plan grid-charges 4 kWh at 03:00-03:30
+    (12.4-12.6¢ — below the $0.13 percentile base but far above the $0.084 funding
+    water level), drains straight back to the floor by 07:30, then does the real
+    pre-charge at 8.2-8.7¢ midday. The bounce funds 0% of the DW target, pays the
+    futile-cycling penalty plus round-trip losses, and exists only because the #870
+    blanket exemption switched the min-cycle-saving gate off across the whole pre-DW
+    range (the double-counted self-consumption credit then makes the thin fake
+    arbitrage look profitable — the exact #800/#804 shape the gate was built for).
+    """
+
+    # 30-min slots from 21:00; DW entry at idx 36 (15:00 next day).
+    # (buy, solar_kwh, consumption_kwh)
+    OVERNIGHT = [  # idx 0-19, 21:00-06:30
+        (0.142, 0.0, 0.57),
+        (0.141, 0.0, 0.57),
+        (0.140, 0.0, 0.83),
+        (0.139, 0.0, 0.83),
+        (0.137, 0.0, 0.55),
+        (0.136, 0.0, 0.55),
+        (0.136, 0.0, 0.36),
+        (0.135, 0.0, 0.36),
+        (0.132, 0.0, 0.25),
+        (0.130, 0.0, 0.25),
+        (0.128, 0.0, 0.23),
+        (0.126, 0.0, 0.23),
+        (0.124, 0.0, 0.23),  # 03:00 — the live bounce-charge slot
+        (0.124, 0.0, 0.39),
+        (0.125, 0.0, 0.39),
+        (0.127, 0.0, 0.33),
+        (0.130, 0.0, 0.33),
+        (0.131, 0.0, 0.48),
+        (0.132, 0.0, 0.48),
+        (0.129, 0.0, 0.30),
+    ]
+    MORNING = [  # idx 20-23, 07:00-08:30
+        (0.119, 0.02, 0.47),
+        (0.111, 0.07, 0.47),
+        (0.101, 0.21, 0.39),
+        (0.096, 0.39, 0.38),
+    ]
+    MIDDAY = [  # idx 24-35, 09:00-14:30
+        (0.092, 0.60, 0.63),
+        (0.088, 0.79, 0.63),
+        (0.084, 0.97, 0.88),
+        (0.082, 1.14, 0.88),
+        (0.082, 1.23, 0.89),
+        (0.083, 1.21, 0.89),
+        (0.087, 1.14, 0.65),
+        (0.095, 1.03, 0.65),
+        (0.104, 0.95, 0.48),
+        (0.110, 0.90, 0.48),
+        (0.120, 0.77, 0.43),
+        (0.131, 0.57, 0.43),
+    ]
+    DW = [  # idx 36-39, 15:00-16:30
+        (0.151, 0.34, 0.42),
+        (0.150, 0.11, 0.41),
+        (0.149, 0.03, 0.50),
+        (0.149, 0.00, 0.52),
+    ]
+
+    def _plan(self):
+        base = datetime(2026, 6, 12, 21, 0)
+        rows = [*self.OVERNIGHT, *self.MORNING, *self.MIDDAY, *self.DW]
+        n_pre = len(rows) - len(self.DW)
+        slots = [
+            SlotContext(
+                slot_index=i,
+                timestamp_iso=(base + timedelta(minutes=INTERVAL * i)).isoformat(),
+                slot_interval_minutes=INTERVAL,
+                buy_price=buy,
+                sell_price=max(0.005, buy - 0.07),
+                solar_kwh=solar,
+                consumption_kwh=cons,
+                is_demand_window_entry=(i == n_pre),
+                is_demand_window_slot=(i >= n_pre),
+            )
+            for i, (buy, solar, cons) in enumerate(rows)
+        ]
+        config = _config(
+            base_cheap_price=0.13,
+            effective_cheap_price=0.14,
+            min_cycle_saving=0.25,
+            target_shortfall_penalty_per_pct=0.08,
+            switching_penalty=0.08,
+            soc_bins=100,
+        )
+        inputs = OptimizerInputs(
+            cycle_id="sawtooth-2026-06-13",
+            initial_soc_pct=60.0,
+            slots=slots,
+            config=config,
+            all_solcast=[],
+        )
+        return DPPlanner(config).plan(inputs)
+
+    def test_no_overnight_floor_bounce_charge(self):
+        """RED on the #870 blanket exemption (charges ~03:00), GREEN with water scope."""
+        result = self._plan()
+        assert result.success
+        overnight = result.decisions[:20]
+        bounce = [d.slot_index for d in overnight if d.action in _CHARGE_ACTIONS]
+        assert bounce == [], (
+            f"overnight floor-bounce charge re-appeared at slots {bounce}"
+        )
+
+    def test_midday_target_funding_is_preserved(self):
+        """Scoping the exemption must not regress #870's fix: the DW is still funded."""
+        result = self._plan()
+        assert result.success
+        midday_charges = [
+            d.slot_index for d in result.decisions[20:36] if d.action in _CHARGE_ACTIONS
+        ]
+        assert midday_charges, "the plan must still pre-charge for the DW"
+        assert result.decisions[36].predicted_soc_pct >= 90.0


### PR DESCRIPTION
## Problem

Overnight sawtooth re-introduced (first night under #870): the live plan computed 2026-06-12 19:02 drains to the 10% floor by ~02:00, **grid-charges 4 kWh at 03:00–03:30 (12.4–12.6c)**, drains straight back to the floor by 07:30, then does the real demand-window pre-charge at 8.2–8.7c midday. The bounce funds 0% of the DW target (every kWh is consumed before the midday charge begins), pays the futile-cycling penalty plus round-trip losses, and costs battery cycles for nothing.

## Root cause

#870 exempted **every** pre-DW below-target slot from the min-cycle-saving hard gate whenever `pre_dw_charge_thresholds` was active, on the premise that "feasible_actions only offers charges at/below that slot's target-funded threshold, so any pre-DW charge is target-driven."

That premise is false: the per-slot threshold is `max(legacy, ramp, water)`, and the **legacy** component (cheap-percentile base, $0.13 that night) keeps overnight slots eligible for reasons unrelated to funding the target. The actual funding water level was ~$0.084 (midday slots); the 12.5c overnight slots were legacy-eligible only, and their energy drains to the floor before the DW.

With the gate switched off there, the double-counted self-consumption credit (Issue #406: discharge-to-load is credited at full retail *on top of* the avoided import) makes thin overnight fake-arbitrage look ~4c/kWh profitable. That is exactly the #800/#804 shape the gate was built to block — soft penalties get paid through; the hard gate was the lever that worked.

## Fix

The exemption now requires the charge to actually be target-funding:

- **inside the urgency window** (pre-#870 behaviour — the ramp legitimately applies there), OR
- **priced at/below the funding water level** (i.e. part of the cheapest-sufficient set).

`compute_pre_dw_charge_thresholds` publishes the raw water level on `config.pre_dw_funding_water_level` — `None` when there is no deficit, and deliberately **un-floored by the ramp base** (the floor would re-admit every base-percentile-cheap slot, the exact non-funding population being excluded).

#870's actual fix is preserved: on funding-constrained days the water level rises toward the `max_precharge_price` ceiling, so genuinely-needed pricier slots stay exempt; days where overnight *is* the cheapest sufficient set keep their overnight exemption.

## Tests

- **Replay of the 2026-06-13 plan shape** — verified RED on the blanket exemption (reproduces the bounce charge at the 03:00 trough slot, mirroring live) and GREEN with the scope fix.
- A/B asserting midday DW funding is preserved (entry ≥ 90%).
- Unit coverage of the exemption scope (above-water/outside-window blocked; ≤ water exempt anywhere pre-DW; window exempt regardless; no-deficit ⇒ no water exemption; post-DW/above-target never exempt) and of the published water level (raw, un-floored, None on no deficit).
- #870's own suite untouched and green; full suite: **3135 passed, 1 xfailed**.

## Deployment note

#870 is live, so tonight's plan will execute the 03:00 floor-bounce on hardware unless this lands first.