### PR TITLE
fix(solar): normalize accuracy-sampling period keys to UTC so pending forecasts convert (#881)

### DIFF
--- a/custom_components/localshift/coordinator/coordinator.py
+++ b/custom_components/localshift/coordinator/coordinator.py
@@ -626,7 +626,7 @@ class LocalShiftCoordinator:
         ):
             self.data.solar_bias_metrics = self.solar_accuracy_tracker.get_status_dict()
             self.data.solar_forecast_accuracy = (
-                self.solar_accuracy_tracker.metrics.accuracy
+                self.solar_accuracy_tracker.reported_accuracy()
             )
 
         # Compute hybrid accuracy combining LocalShift tracker + Solcast MAPE (Issue #778 Phase 2)
@@ -662,6 +662,12 @@ class LocalShiftCoordinator:
 
         # Convert MAPE to accuracy
         solcast_accuracy = max(0, 100 - solcast_mape)
+
+        # No LocalShift accuracy yet (insufficient samples, #881): defer wholly
+        # to Solcast rather than blending against a fabricated 100%.
+        if localshift_accuracy is None:
+            self.data.hybrid_solar_accuracy = round(solcast_accuracy, 1)
+            return
 
         # Check LocalShift sample count for confidence weighting
         localshift_samples = 0

--- a/custom_components/localshift/coordinator/data.py
+++ b/custom_components/localshift/coordinator/data.py
@@ -439,7 +439,9 @@ class CoordinatorData:
     solar_bias_metrics: dict[str, Any] = field(
         default_factory=dict
     )  # Solar forecast bias metrics and correction factors
-    solar_forecast_accuracy: float = 100.0  # Overall solar forecast accuracy percentage
+    solar_forecast_accuracy: float | None = (
+        None  # Overall solar forecast accuracy %; None until enough samples (#881)
+    )
     hybrid_solar_accuracy: float | None = (
         None  # Combined LocalShift + Solcast MAPE accuracy
     )

--- a/custom_components/localshift/coordinator/tick_scheduler.py
+++ b/custom_components/localshift/coordinator/tick_scheduler.py
@@ -185,7 +185,7 @@ class TickScheduler:
                 self._coordinator.solar_accuracy_tracker.get_status_dict()
             )
             self._coordinator.data.solar_forecast_accuracy = (
-                self._coordinator.solar_accuracy_tracker.metrics.accuracy
+                self._coordinator.solar_accuracy_tracker.reported_accuracy()
             )
 
         # Learn from current temperature/load for weather correlation

--- a/custom_components/localshift/forecast/solar_accuracy.py
+++ b/custom_components/localshift/forecast/solar_accuracy.py
@@ -12,7 +12,7 @@ import math
 from collections import defaultdict, deque
 from collections.abc import Callable
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.helpers.storage import Store
@@ -31,14 +31,28 @@ MIN_SOLAR_CORRECTION_SAMPLES = 20
 def _period_key(period_start: datetime) -> str:
     """Derive the pending-forecast dict key for a 30-min period.
 
-    Floors to the :00/:30 boundary (second/microsecond zeroed) so both sides
-    of the record/backfill handshake agree regardless of caller timestamp
-    quirks. Live Amber slot timestamps carry a +1-second offset (18:00:01),
-    while the coordinator's actuals integration floors to the exact boundary
-    (18:00:00) — keying on the raw isoformat made every backfill pop miss, so
-    no sample was ever recorded (2026-06-12 zero-samples incident: 50 pending,
-    0 samples after a full daytime).
+    Normalizes to UTC *before* flooring to the :00/:30 boundary (second/
+    microsecond zeroed) so both sides of the record/backfill handshake agree
+    regardless of caller timezone or timestamp quirks.
+
+    Two failure modes this guards against (#881):
+
+    1. Timezone asymmetry. The record side (optimizer_facade) parses Amber slot
+       timestamps in their UTC offset ('2026-06-13T03:00:00+00:00'), while the
+       backfill side (tick_scheduler) keys off a LOCAL-time tick
+       ('2026-06-13T13:00:00+10:00'). The SAME instant serialized to two
+       different isoformat strings, so the dict lookup always missed (0 samples
+       even with 80+ pending). Casting both to UTC first makes the key the
+       canonical instant.
+    2. Sub-minute offset. Live Amber slot timestamps carry a +1-second offset
+       (18:00:01) while the actuals integration floors to the exact boundary
+       (18:00:00). Flooring second/microsecond reconciles those.
+
+    Naive datetimes (no tzinfo) are assumed to already be UTC.
     """
+    if period_start.tzinfo is None:
+        period_start = period_start.replace(tzinfo=UTC)
+    period_start = period_start.astimezone(UTC)
     return period_start.replace(
         minute=(period_start.minute // 30) * 30, second=0, microsecond=0
     ).isoformat()
@@ -244,14 +258,29 @@ class SolarAccuracyTracker:
                 except Exception as err:
                     _LOGGER.warning("Failed to load solar period record: %s", err)
 
+            # Restore in-flight pending forecasts (#881): a mid-day restart must
+            # not silently drop periods whose forecast was recorded but whose
+            # actual had not yet been backfilled. Re-key through _period_key so a
+            # tz-format change can never strand a restored pending.
+            pending_data = data.get("pending_forecasts", [])
+            for record_data in pending_data:
+                try:
+                    record = SolarPeriodRecord.from_dict(record_data)
+                    self._pending_forecasts[_period_key(record.period_start)] = record
+                except Exception as err:
+                    _LOGGER.warning("Failed to load pending solar forecast: %s", err)
+            # Drop any pending that is already too old to ever receive an actual.
+            self.evict_stale_pendings()
+
             if self._period_records:
                 self._recompute_metrics()
             elif "metrics" in data:
                 self._metrics = SolarBiasMetrics.from_dict(data["metrics"])
 
             _LOGGER.info(
-                "Loaded solar accuracy data: %d records, bias=%.2f, samples=%d",
+                "Loaded solar accuracy data: %d records, %d pending, bias=%.2f, samples=%d",
                 len(self._period_records),
+                len(self._pending_forecasts),
                 self._metrics.overall_bias,
                 self._metrics.sample_count,
             )
@@ -266,6 +295,9 @@ class SolarAccuracyTracker:
         try:
             data = {
                 "period_records": [r.to_dict() for r in self._period_records],
+                "pending_forecasts": [
+                    r.to_dict() for r in self._pending_forecasts.values()
+                ],
                 "metrics": self._metrics.to_dict(),
             }
             await self._store.async_save(data)
@@ -300,6 +332,7 @@ class SolarAccuracyTracker:
             is_boost_period=is_boost,
         )
         self._pending_forecasts[key] = record
+        self._save_pending = True
         _LOGGER.debug(
             "Recorded solar forecast for %s: %.3f kWh, weather=%s, time=%s, season=%s",
             period_start.strftime("%H:%M"),
@@ -547,6 +580,18 @@ class SolarAccuracyTracker:
             return "foggy"
         else:
             return "unknown"
+
+    def reported_accuracy(self) -> float | None:
+        """Realized accuracy percentage, or None while under-sampled (#881).
+
+        Returns None until MIN_SOLAR_CORRECTION_SAMPLES periods are recorded so
+        the sensor reports 'insufficient data' rather than a fabricated perfect
+        100% (the SolarBiasMetrics.accuracy default). Once enough samples exist
+        it returns the measured accuracy.
+        """
+        if not self.has_sufficient_samples():
+            return None
+        return self._metrics.accuracy
 
     def has_sufficient_samples(self) -> bool:
         """Check if we have enough samples for bias correction.

--- a/custom_components/localshift/sensors/optimizer.py
+++ b/custom_components/localshift/sensors/optimizer.py
@@ -166,8 +166,10 @@ class SolarForecastAccuracySensor(LocalShiftSensorBase):
     _attr_icon = "mdi:solar-power-variant"
 
     def _update_from_coordinator(self) -> None:
+        # None until enough samples are collected (#881) — surfaces as
+        # 'unknown'/'insufficient data' rather than a fabricated perfect 100%.
         self._attr_native_value = getattr(
-            self.coordinator.data, "solar_forecast_accuracy", 100.0
+            self.coordinator.data, "solar_forecast_accuracy", None
         )
 
     @property

--- a/tests/coordinator/test_tick_scheduler.py
+++ b/tests/coordinator/test_tick_scheduler.py
@@ -701,7 +701,7 @@ async def test_handle_medium_tick_with_solar_tracker(coordinator):
         return_value={"bias": 0.1, "correction_active": False}
     )
     coordinator.solar_accuracy_tracker.metrics = MagicMock()
-    coordinator.solar_accuracy_tracker.metrics.accuracy = 0.95
+    coordinator.solar_accuracy_tracker.reported_accuracy = MagicMock(return_value=0.95)
 
     coordinator.data = MagicMock()
     coordinator.data.solar_bias_metrics = None

--- a/tests/forecast/test_solar_accuracy.py
+++ b/tests/forecast/test_solar_accuracy.py
@@ -334,6 +334,29 @@ class TestSolarAccuracyTracker:
         assert len(tracker._period_records) == 1
         assert tracker._metrics.sample_count == 1
 
+    def test_backfill_matches_across_record_utc_vs_backfill_local(self, tracker):
+        """#881: the record side keys off an Amber UTC-offset timestamp while
+        the backfill side keys off a LOCAL-time tick for the SAME instant. The
+        two isoformat strings differ ('...T03:00:00+00:00' vs
+        '...T13:00:00+10:00'), so before the UTC-normalization fix the dict
+        lookup always missed and sample_count stayed 0 even with pendings."""
+        local_tz = timezone(timedelta(hours=10))
+        # Record: Amber slot timestamp, UTC offset, +1s quirk.
+        recorded_at = datetime(2026, 6, 13, 3, 0, 1, tzinfo=UTC)
+        # Backfill: same 30-min instant, but reconstructed in local time as the
+        # tick_scheduler does (start_local floored).
+        flushed_at = recorded_at.astimezone(local_tz).replace(
+            minute=0, second=0, microsecond=0
+        )
+        assert recorded_at.isoformat() != flushed_at.isoformat()
+
+        tracker.record_forecast(recorded_at, 2.5, "sunny")
+        tracker.backfill_actual(flushed_at, 2.0)
+
+        assert tracker._pending_forecasts == {}
+        assert len(tracker._period_records) == 1
+        assert tracker._metrics.sample_count == 1
+
     def test_backfill_matches_thirty_minute_boundary_with_seconds(self, tracker):
         """The :30 boundary floors the same way as :00."""
         tz = timezone(timedelta(hours=10))
@@ -845,6 +868,66 @@ class TestSolarAccuracyTracker:
         assert reloaded._period_records[0].forecast_kwh == 2.0
         assert reloaded._period_records[0].actual_kwh == 1.5
         assert reloaded.metrics.overall_bias == tracker.metrics.overall_bias
+
+    @pytest.mark.asyncio
+    async def test_pending_forecasts_survive_restart(self, mock_hass):
+        """#881: a forecast recorded but not yet backfilled must survive a
+        process restart, so a mid-day restart does not silently drop the
+        pending (which would strand the actual and lose the sample)."""
+        saved_payload = {}
+        store = MagicMock()
+
+        async def _save(data):
+            saved_payload.clear()
+            saved_payload.update(data)
+
+        async def _load():
+            return saved_payload or None
+
+        store.async_save = AsyncMock(side_effect=_save)
+        store.async_load = AsyncMock(side_effect=_load)
+
+        tracker = SolarAccuracyTracker(mock_hass, "test_entry")
+        tracker._store = store
+
+        # A future-dated pending (won't be evicted as stale on reload).
+        period_start = dt_util.now().replace(
+            minute=0, second=0, microsecond=0
+        ) + timedelta(hours=1)
+        tracker.record_forecast(period_start, 2.5, "sunny")
+        assert tracker._save_pending is True
+        await tracker.async_save()
+
+        # Fresh tracker on the same store == a restart.
+        reloaded = SolarAccuracyTracker(mock_hass, "test_entry")
+        reloaded._store = store
+        await reloaded.async_load()
+
+        assert len(reloaded._pending_forecasts) == 1
+        # The restored pending still converts when its actual arrives.
+        reloaded.backfill_actual(period_start, 2.0)
+        assert reloaded.metrics.sample_count == 1
+
+    def test_reported_accuracy_none_below_min_samples(self, tracker):
+        """#881: reported_accuracy() is None while under-sampled so the sensor
+        shows 'insufficient data' rather than a fabricated perfect 100%."""
+        # Empty tracker, then 19 samples (below the 20-sample threshold).
+        assert tracker.reported_accuracy() is None
+        for i in range(19):
+            period_start = datetime(2026, 1, 1 + i, 10, 0, tzinfo=UTC)
+            tracker.record_forecast(period_start, 2.0, "sunny")
+            tracker.backfill_actual(period_start, 1.0)
+        assert tracker.reported_accuracy() is None
+
+    def test_reported_accuracy_value_at_or_above_min_samples(self, tracker):
+        """Once enough samples exist, reported_accuracy() mirrors metrics."""
+        for i in range(20):
+            period_start = datetime(2026, 1, 1 + i, 10, 0, tzinfo=UTC)
+            tracker.record_forecast(period_start, 2.0, "sunny")
+            tracker.backfill_actual(period_start, 2.0)
+        reported = tracker.reported_accuracy()
+        assert reported is not None
+        assert reported == pytest.approx(tracker.metrics.accuracy)
 
 
 class TestGetTimeOfDay:

--- a/tests/sensors/test_optimizer.py
+++ b/tests/sensors/test_optimizer.py
@@ -372,7 +372,7 @@ class TestSolarForecastAccuracySensor:
     """Tests for SolarForecastAccuracySensor."""
 
     def test_native_value_default(self):
-        """Test native_value defaults to 100.0 when no attribute."""
+        """Default is None (insufficient data), not a fabricated 100% (#881)."""
         mock_coordinator, data = create_mock_coordinator_with_data()
         # Don't set solar_forecast_accuracy
         mock_entry = MagicMock()
@@ -380,7 +380,7 @@ class TestSolarForecastAccuracySensor:
         sensor = SolarForecastAccuracySensor(mock_coordinator, mock_entry)
         sensor._update_from_coordinator()
 
-        assert sensor._attr_native_value == 100.0
+        assert sensor._attr_native_value is None
 
     def test_native_value_set(self):
         """Test native_value reads from coordinator data."""


### PR DESCRIPTION
Closes #881

## Root cause (confirmed with concrete example keys)

Solar-forecast accuracy sampling never converged (0 samples / many pending) because the record side and the backfill side keyed the *same 30-min instant* with *different* dict-key strings.

- **Record** (`engine/optimizer_facade.py`): parses Amber slot timestamps in their UTC offset, then `_period_key` floored while **preserving** the UTC tzinfo → key `2026-06-13T03:00:00+00:00`.
- **Backfill** (`coordinator/tick_scheduler.py`): accumulates energy keyed off a **local-timezone** tick, floored inline, then calls `backfill_actual` → `_period_key` produced `2026-06-13T13:00:00+10:00`.

Same instant, two strings → `self._pending_forecasts.pop(key)` always missed → no sample ever recorded, while the sensor fabricated a constant 100% (the `SolarBiasMetrics.accuracy` default). The #876 flooring was correct; the tz asymmetry was the live defect.

Demonstrated keys for one real period:
```
record key  : 2026-06-13T03:00:00+00:00
backfill key: 2026-06-13T13:00:00+10:00   # same instant, different string -> miss
```

## Fix

- `_period_key` now casts to UTC (`astimezone(UTC)`) **before** flooring + serializing, so both sides produce the canonical-instant key regardless of caller timezone. Naive datetimes are treated as UTC defensively. Both record and backfill route through `_period_key`, so they always agree.

### Defense-in-depth / secondary asks
- **Persist pendings across restart**: `_pending_forecasts` is now serialized in `async_save` and restored in `async_load` (re-keyed through `_period_key`, with a stale-eviction pass on load), so a mid-day restart no longer silently drops in-flight forecasts. Recording a forecast now marks `_save_pending`.
- **Stop fabricating 100%**: new `reported_accuracy()` returns `None` until `MIN_SOLAR_CORRECTION_SAMPLES` samples exist. Coordinator wiring (medium tick + `_update_hybrid_accuracy`), the `CoordinatorData.solar_forecast_accuracy` default, and `SolarForecastAccuracySensor` now report `None`/unknown (insufficient data) instead of a false perfect score. Informative attributes (`sample_count`, `pending_forecasts`, `samples_until_active`, etc.) are unchanged.

## Tests
- `test_backfill_matches_across_record_utc_vs_backfill_local` — records with a UTC-offset Amber timestamp, backfills the actual from a local-time tick for the same period, asserts `sample_count == 1`. **Fails on old code** (pending stranded under UTC key), passes after the fix.
- `test_pending_forecasts_survive_restart` — pending survives `async_save` -> fresh-tracker `async_load` and still converts.
- `test_reported_accuracy_none_below_min_samples` / `_value_at_or_above_min_samples` — accuracy is `None` under the threshold, mirrors metrics once enough samples exist.
- Updated existing tests that asserted the old 100.0 default.

Full suite (3139 passed), ruff (lint + format), vulture, bandit, interrogate all green locally. Pyright unchanged at 32 pre-existing errors (non-blocking CI job).