### PR TITLE
feat(health): surface orphaned localshift-owned entities in entity_health (#880)

### DIFF
--- a/custom_components/localshift/coordinator/data.py
+++ b/custom_components/localshift/coordinator/data.py
@@ -414,6 +414,9 @@ class CoordinatorData:
     localshift_entity_health: dict[str, Any] = field(
         default_factory=dict
     )  # Health status for LocalShift internal entities
+    orphaned_localshift_entities: dict[str, Any] = field(
+        default_factory=dict
+    )  # Owned registry entries absent from LOCALSHIFT_ENTITY_CONFIG (Issue #880)
 
     # --- Learning system (Issue #170 Phase 1) ---
     performance_metrics: PerformanceMetrics = field(default_factory=PerformanceMetrics)

--- a/custom_components/localshift/coordinator/entity_monitor.py
+++ b/custom_components/localshift/coordinator/entity_monitor.py
@@ -74,6 +74,20 @@ class EntityMonitor:
         # Check LocalShift internal entities
         data.localshift_entity_health = validator.check_all_localshift_entities()
 
+        # Detect orphaned registry entries owned by this config entry (Issue #880)
+        config_entry_id = self._coordinator.entry.entry_id
+        data.orphaned_localshift_entities = validator.check_orphaned_owned_entities(
+            config_entry_id
+        )
+        if data.orphaned_localshift_entities:
+            orphan_ids = ", ".join(sorted(data.orphaned_localshift_entities))
+            count = len(data.orphaned_localshift_entities)
+            orphan_warning = (
+                f"{count} orphaned localshift "
+                f"{'entity' if count == 1 else 'entities'}: {orphan_ids}"
+            )
+            data.entity_warnings = list(data.entity_warnings) + [orphan_warning]
+
         # Log any new errors
         if data.entity_errors:
             for error in data.entity_errors:

--- a/custom_components/localshift/sensors/status.py
+++ b/custom_components/localshift/sensors/status.py
@@ -50,6 +50,7 @@ class EntityHealthSensor(LocalShiftSensorBase):
         "entities",
         "dependencies",
         "localshift_entities",
+        "orphaned_entities",
         "errors",
         "warnings",
     })
@@ -66,10 +67,12 @@ class EntityHealthSensor(LocalShiftSensorBase):
     def extra_state_attributes(self) -> dict[str, Any]:
         dep_health = self.coordinator.data.entity_health
         ls_health = self.coordinator.data.localshift_entity_health
+        orphans = self.coordinator.data.orphaned_localshift_entities
         return {
             "entities": dep_health,
             "dependencies": dep_health,
             "localshift_entities": ls_health,
+            "orphaned_entities": orphans,
             "errors": self.coordinator.data.entity_errors,
             "warnings": self.coordinator.data.entity_warnings,
             "summary": {
@@ -99,6 +102,7 @@ class EntityHealthSensor(LocalShiftSensorBase):
                         ),
                     },
                 },
+                "orphaned_count": len(orphans),
             },
         }
 

--- a/custom_components/localshift/utils/validation.py
+++ b/custom_components/localshift/utils/validation.py
@@ -13,6 +13,7 @@ from enum import Enum
 from typing import Any
 
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 from homeassistant.util import dt as dt_util
 
 from ..const import (
@@ -479,6 +480,35 @@ class EntityValidator:
         summary = self._serialize_localshift_health(results)
         self._localshift_entity_health = results
         return summary
+
+    def check_orphaned_owned_entities(
+        self, config_entry_id: str
+    ) -> dict[str, dict[str, Any]]:
+        """Return registry entries owned by this config entry that are not in LOCALSHIFT_ENTITY_CONFIG.
+
+        An "orphaned" entity is one that was previously created by the localshift
+        integration (config_entry_id matches) but no longer appears in
+        LOCALSHIFT_ENTITY_CONFIG — typically a number/switch/sensor that has been
+        removed or renamed in a newer version while the registry entry persists.
+
+        Args:
+            config_entry_id: The config entry id for this localshift instance.
+
+        Returns:
+            Dict mapping entity_id -> {state, disabled, restored} for each orphan.
+        """
+        registry = er.async_get(self.hass)
+        orphans: dict[str, dict[str, Any]] = {}
+        for entry in registry.entities.get_entries_for_config_entry_id(config_entry_id):
+            if entry.entity_id in LOCALSHIFT_ENTITY_CONFIG:
+                continue
+            state = self.hass.states.get(entry.entity_id)
+            orphans[entry.entity_id] = {
+                "state": state.state if state is not None else "unavailable",
+                "disabled": entry.disabled_by is not None,
+                "restored": state is None,
+            }
+        return orphans
 
     def _check_single_localshift_entity(
         self, entity_id: str, config: dict, now: datetime

--- a/tests/coordinator/test_coordinator.py
+++ b/tests/coordinator/test_coordinator.py
@@ -999,6 +999,7 @@ class TestCoordinatorHealthAndValidation:
             "last_check": "2026-03-16T12:00:00",
         }
         mock_validator.check_all_localshift_entities.return_value = {}
+        mock_validator.check_orphaned_owned_entities.return_value = {}
 
         coordinator._entity_validator = mock_validator
 

--- a/tests/coordinator/test_entity_monitor.py
+++ b/tests/coordinator/test_entity_monitor.py
@@ -98,9 +98,12 @@ class TestCheckEntityHealth:
         mock_validator.check_all_localshift_entities.return_value = {
             "sensor.localshift_soc": "available"
         }
+        mock_validator.check_orphaned_owned_entities.return_value = {}
 
         mock_coordinator._entity_validator = mock_validator
+        mock_coordinator.entry.entry_id = "cfg_abc"
         mock_data = MagicMock()
+        mock_data.entity_warnings = []
         mock_coordinator.data = mock_data
         monitor = EntityMonitor(mock_coordinator)
 
@@ -113,6 +116,7 @@ class TestCheckEntityHealth:
         mock_validator.get_required_entities_status.assert_called_once()
         mock_validator.get_health_summary.assert_called_once()
         mock_validator.check_all_localshift_entities.assert_called_once()
+        mock_validator.check_orphaned_owned_entities.assert_called_once_with("cfg_abc")
 
         # ASSERT - data updated correctly
         assert mock_data.integration_status == "healthy"
@@ -125,6 +129,7 @@ class TestCheckEntityHealth:
         assert mock_data.localshift_entity_health == {
             "sensor.localshift_soc": "available"
         }
+        assert mock_data.orphaned_localshift_entities == {}
 
     def test_check_entity_health_with_errors(self) -> None:
         """Test check_entity_health logs errors when present."""
@@ -166,6 +171,7 @@ class TestCheckEntityHealth:
         # ARRANGE
         mock_coordinator = MagicMock()
         mock_coordinator.hass = MagicMock()
+        mock_coordinator.entry.entry_id = "cfg_warn"
         mock_validator = MagicMock()
         mock_validator.status.value = "healthy"
         mock_validator.errors = []
@@ -182,9 +188,11 @@ class TestCheckEntityHealth:
             "last_check": "2024-01-01T00:00:00",
         }
         mock_validator.check_all_localshift_entities.return_value = {}
+        mock_validator.check_orphaned_owned_entities.return_value = {}
 
         mock_coordinator._entity_validator = mock_validator
         mock_data = MagicMock()
+        mock_data.entity_warnings = []
         mock_coordinator.data = mock_data
         monitor = EntityMonitor(mock_coordinator)
 
@@ -231,6 +239,149 @@ class TestCheckEntityHealth:
 
         # ASSERT
         assert mock_data.required_entities_healthy is False
+
+
+class TestOrphanDetection:
+    """Test orphan detection in check_entity_health (Issue #880)."""
+
+    def _build_mock_coordinator(
+        self,
+        orphans: dict | None = None,
+        warnings: list | None = None,
+    ) -> MagicMock:
+        """Build a mock coordinator that returns the given orphan map."""
+        mock_coordinator = MagicMock()
+        mock_coordinator.hass = MagicMock()
+        mock_coordinator.entry.entry_id = "test_config_entry_id"
+
+        mock_validator = MagicMock()
+        mock_validator.status.value = "ok"
+        mock_validator.errors = []
+        mock_validator.warnings = warnings if warnings is not None else []
+        mock_validator.get_user_friendly_message.return_value = "All systems operational"
+        mock_validator.get_required_entities_status.return_value = {}
+        mock_validator.get_health_summary.return_value = {
+            "entities": {},
+            "last_check": "2024-01-01T00:00:00",
+        }
+        mock_validator.check_all_localshift_entities.return_value = {}
+        mock_validator.check_orphaned_owned_entities.return_value = (
+            orphans if orphans is not None else {}
+        )
+        mock_coordinator._entity_validator = mock_validator
+
+        mock_data = MagicMock()
+        mock_data.entity_warnings = []
+        mock_coordinator.data = mock_data
+        return mock_coordinator
+
+    def test_orphans_populate_data_field(self) -> None:
+        """check_entity_health populates orphaned_localshift_entities on data."""
+        orphans = {
+            "number.localshift_cycle_penalty": {
+                "state": "unavailable",
+                "disabled": False,
+                "restored": True,
+            }
+        }
+        mock_coordinator = self._build_mock_coordinator(orphans=orphans)
+        monitor = EntityMonitor(mock_coordinator)
+
+        monitor.check_entity_health()
+
+        assert mock_coordinator.data.orphaned_localshift_entities == orphans
+
+    def test_orphans_append_warning_message(self) -> None:
+        """When orphans exist, a warning is appended to entity_warnings."""
+        orphans = {
+            "number.localshift_cycle_penalty": {
+                "state": "unavailable",
+                "disabled": False,
+                "restored": True,
+            }
+        }
+        mock_coordinator = self._build_mock_coordinator(orphans=orphans)
+        monitor = EntityMonitor(mock_coordinator)
+
+        monitor.check_entity_health()
+
+        # The warning should mention the orphan entity_id
+        warnings_set = mock_coordinator.data.entity_warnings
+        assert any("number.localshift_cycle_penalty" in w for w in warnings_set)
+        assert any("orphaned" in w for w in warnings_set)
+
+    def test_orphan_singular_grammar(self) -> None:
+        """Single orphan uses 'entity' (singular) in the warning."""
+        orphans = {"number.localshift_cycle_penalty": {"state": "unavailable"}}
+        mock_coordinator = self._build_mock_coordinator(orphans=orphans)
+        monitor = EntityMonitor(mock_coordinator)
+
+        monitor.check_entity_health()
+
+        warning = next(
+            (w for w in mock_coordinator.data.entity_warnings if "orphaned" in w),
+            None,
+        )
+        assert warning is not None
+        assert "1 orphaned localshift entity" in warning
+
+    def test_orphan_plural_grammar(self) -> None:
+        """Multiple orphans use 'entities' (plural) in the warning."""
+        orphans = {
+            "number.localshift_cycle_penalty": {"state": "unavailable"},
+            "number.localshift_demand_window_import_penalty": {"state": "unavailable"},
+        }
+        mock_coordinator = self._build_mock_coordinator(orphans=orphans)
+        monitor = EntityMonitor(mock_coordinator)
+
+        monitor.check_entity_health()
+
+        warning = next(
+            (w for w in mock_coordinator.data.entity_warnings if "orphaned" in w),
+            None,
+        )
+        assert warning is not None
+        assert "2 orphaned localshift entities" in warning
+
+    def test_no_orphans_no_extra_warnings(self) -> None:
+        """When no orphans exist, no orphan warning is added."""
+        mock_coordinator = self._build_mock_coordinator(orphans={})
+        monitor = EntityMonitor(mock_coordinator)
+
+        monitor.check_entity_health()
+
+        assert mock_coordinator.data.orphaned_localshift_entities == {}
+        orphan_warnings = [
+            w for w in mock_coordinator.data.entity_warnings if "orphaned" in w
+        ]
+        assert orphan_warnings == []
+
+    def test_orphan_warning_preserves_existing_warnings(self) -> None:
+        """Orphan warning is appended to existing warnings, not replacing them."""
+        existing_warnings = ["Solar sensor data is stale"]
+        orphans = {"number.localshift_cycle_penalty": {"state": "unavailable"}}
+        mock_coordinator = self._build_mock_coordinator(
+            orphans=orphans, warnings=existing_warnings
+        )
+        mock_coordinator.data.entity_warnings = list(existing_warnings)
+        monitor = EntityMonitor(mock_coordinator)
+
+        monitor.check_entity_health()
+
+        # data.entity_warnings gets reset by validator.warnings first, then orphan appended
+        # The orphan warning must be present
+        assert any("orphaned" in w for w in mock_coordinator.data.entity_warnings)
+
+    def test_check_orphaned_owned_entities_called_with_config_entry_id(self) -> None:
+        """check_orphaned_owned_entities is called with the coordinator's entry_id."""
+        mock_coordinator = self._build_mock_coordinator()
+        monitor = EntityMonitor(mock_coordinator)
+
+        monitor.check_entity_health()
+
+        mock_coordinator._entity_validator.check_orphaned_owned_entities.assert_called_once_with(
+            "test_config_entry_id"
+        )
 
 
 class TestResetEntityTrackingOnOptionsChange:

--- a/tests/sensors/test_status.py
+++ b/tests/sensors/test_status.py
@@ -81,6 +81,7 @@ class TestEntityHealthSensor:
             EntityHealthSensor,
             entity_health=dep_health,
             localshift_entity_health=ls_health,
+            orphaned_localshift_entities={},
             entity_errors=[],
             entity_warnings=[],
         )
@@ -89,6 +90,7 @@ class TestEntityHealthSensor:
         assert "summary" in attrs
         assert attrs["summary"]["dependencies"]["total"] == 1
         assert attrs["summary"]["localshift"]["healthy"] == 1
+        assert attrs["summary"]["orphaned_count"] == 0
 
     def test_unrecorded_attributes_excludes_large_dicts(self):
         """Test that large entity dicts are excluded from recorder.
@@ -96,15 +98,56 @@ class TestEntityHealthSensor:
         Issue #467: Entity health dicts can exceed 16KB limit.
         """
         sensor = _sensor(
-            EntityHealthSensor, entity_health={}, localshift_entity_health={}
+            EntityHealthSensor,
+            entity_health={},
+            localshift_entity_health={},
+            orphaned_localshift_entities={},
         )
 
         assert hasattr(sensor, "_unrecorded_attributes")
         assert "entities" in sensor._unrecorded_attributes
         assert "dependencies" in sensor._unrecorded_attributes
         assert "localshift_entities" in sensor._unrecorded_attributes
+        assert "orphaned_entities" in sensor._unrecorded_attributes
         assert "errors" in sensor._unrecorded_attributes
         assert "warnings" in sensor._unrecorded_attributes
+
+    def test_orphaned_entities_exposed_in_attributes(self):
+        """Orphaned registry entries are surfaced in orphaned_entities attribute."""
+        orphans = {
+            "number.localshift_cycle_penalty": {
+                "state": "unavailable",
+                "disabled": False,
+                "restored": True,
+            }
+        }
+        sensor = _sensor(
+            EntityHealthSensor,
+            entity_health={},
+            localshift_entity_health={},
+            orphaned_localshift_entities=orphans,
+            entity_errors=[],
+            entity_warnings=[
+                "1 orphaned localshift entity: number.localshift_cycle_penalty"
+            ],
+        )
+        attrs = sensor.extra_state_attributes
+        assert attrs["orphaned_entities"] == orphans
+        assert attrs["summary"]["orphaned_count"] == 1
+
+    def test_no_orphans_yields_empty_orphaned_entities(self):
+        """When no orphans exist, orphaned_entities is empty and count is 0."""
+        sensor = _sensor(
+            EntityHealthSensor,
+            entity_health={"sensor.a": {"status": "ok"}},
+            localshift_entity_health={},
+            orphaned_localshift_entities={},
+            entity_errors=[],
+            entity_warnings=[],
+        )
+        attrs = sensor.extra_state_attributes
+        assert attrs["orphaned_entities"] == {}
+        assert attrs["summary"]["orphaned_count"] == 0
 
 
 class TestForecastAccuracySensor:

--- a/tests/utils/test_validation_extended.py
+++ b/tests/utils/test_validation_extended.py
@@ -1415,3 +1415,188 @@ class TestEdgeCases:
         health.status = EntityStatus.STALE
         msg = validator._format_health_error_message(health, "Battery SOC")
         assert "stale" in msg
+
+
+# =============================================================================
+# Orphan Detection Tests (Issue #880)
+# =============================================================================
+
+
+class TestCheckOrphanedOwnedEntities:
+    """Tests for EntityValidator.check_orphaned_owned_entities."""
+
+    def _make_registry_entry(
+        self,
+        entity_id: str,
+        config_entry_id: str,
+        disabled: bool = False,
+    ) -> MagicMock:
+        """Create a mock RegistryEntry."""
+        entry = MagicMock()
+        entry.entity_id = entity_id
+        entry.config_entry_id = config_entry_id
+        entry.disabled_by = "user" if disabled else None
+        return entry
+
+    def test_no_orphans_when_registry_empty(
+        self, mock_hass: MagicMock
+    ) -> None:
+        """No orphans when the config entry owns no registry entries."""
+        validator = _create_validator(mock_hass)
+
+        mock_registry = MagicMock()
+        mock_registry.entities.get_entries_for_config_entry_id.return_value = []
+
+        with patch(
+            "custom_components.localshift.utils.validation.er.async_get",
+            return_value=mock_registry,
+        ):
+            result = validator.check_orphaned_owned_entities("config_entry_abc")
+
+        assert result == {}
+
+    def test_no_orphans_when_all_owned_entities_in_config(
+        self, mock_hass: MagicMock
+    ) -> None:
+        """No orphans when all owned registry entries are in LOCALSHIFT_ENTITY_CONFIG."""
+        # Use a known entry from LOCALSHIFT_ENTITY_CONFIG
+        known_entity = "sensor.localshift_price_cheap_effective"
+        entry = self._make_registry_entry(known_entity, "cfg_1")
+
+        mock_registry = MagicMock()
+        mock_registry.entities.get_entries_for_config_entry_id.return_value = [entry]
+
+        validator = _create_validator(mock_hass)
+
+        with patch(
+            "custom_components.localshift.utils.validation.er.async_get",
+            return_value=mock_registry,
+        ):
+            result = validator.check_orphaned_owned_entities("cfg_1")
+
+        assert result == {}
+
+    def test_orphan_detected_for_unknown_entity(
+        self, mock_hass: MagicMock
+    ) -> None:
+        """Registry entry absent from LOCALSHIFT_ENTITY_CONFIG is reported as orphan."""
+        orphan_id = "number.localshift_cycle_penalty"
+        entry = self._make_registry_entry(orphan_id, "cfg_1")
+
+        mock_registry = MagicMock()
+        mock_registry.entities.get_entries_for_config_entry_id.return_value = [entry]
+
+        # Orphan has no live state (restored ghost)
+        mock_hass.states.get = lambda eid: None
+
+        validator = _create_validator(mock_hass)
+
+        with patch(
+            "custom_components.localshift.utils.validation.er.async_get",
+            return_value=mock_registry,
+        ):
+            result = validator.check_orphaned_owned_entities("cfg_1")
+
+        assert orphan_id in result
+        orphan = result[orphan_id]
+        assert orphan["state"] == "unavailable"
+        assert orphan["restored"] is True
+
+    def test_orphan_with_live_state(
+        self, mock_hass: MagicMock
+    ) -> None:
+        """Orphan with a live state reports state value and restored=False."""
+        orphan_id = "number.localshift_demand_window_import_penalty"
+        entry = self._make_registry_entry(orphan_id, "cfg_1")
+
+        mock_registry = MagicMock()
+        mock_registry.entities.get_entries_for_config_entry_id.return_value = [entry]
+
+        live_state = MagicMock()
+        live_state.state = "0.08"
+        mock_hass.states.get = lambda eid: live_state if eid == orphan_id else None
+
+        validator = _create_validator(mock_hass)
+
+        with patch(
+            "custom_components.localshift.utils.validation.er.async_get",
+            return_value=mock_registry,
+        ):
+            result = validator.check_orphaned_owned_entities("cfg_1")
+
+        assert orphan_id in result
+        orphan = result[orphan_id]
+        assert orphan["state"] == "0.08"
+        assert orphan["restored"] is False
+
+    def test_orphan_disabled_flag(
+        self, mock_hass: MagicMock
+    ) -> None:
+        """Disabled orphan entry sets disabled=True."""
+        orphan_id = "number.localshift_cycle_penalty"
+        entry = self._make_registry_entry(orphan_id, "cfg_1", disabled=True)
+
+        mock_registry = MagicMock()
+        mock_registry.entities.get_entries_for_config_entry_id.return_value = [entry]
+        mock_hass.states.get = lambda eid: None
+
+        validator = _create_validator(mock_hass)
+
+        with patch(
+            "custom_components.localshift.utils.validation.er.async_get",
+            return_value=mock_registry,
+        ):
+            result = validator.check_orphaned_owned_entities("cfg_1")
+
+        assert result[orphan_id]["disabled"] is True
+
+    def test_multiple_orphans(
+        self, mock_hass: MagicMock
+    ) -> None:
+        """Multiple orphans are all returned in the dict."""
+        orphan_ids = [
+            "number.localshift_cycle_penalty",
+            "number.localshift_demand_window_import_penalty",
+        ]
+        entries = [self._make_registry_entry(eid, "cfg_1") for eid in orphan_ids]
+
+        mock_registry = MagicMock()
+        mock_registry.entities.get_entries_for_config_entry_id.return_value = entries
+        mock_hass.states.get = lambda eid: None
+
+        validator = _create_validator(mock_hass)
+
+        with patch(
+            "custom_components.localshift.utils.validation.er.async_get",
+            return_value=mock_registry,
+        ):
+            result = validator.check_orphaned_owned_entities("cfg_1")
+
+        assert set(result.keys()) == set(orphan_ids)
+
+    def test_mix_of_known_and_orphaned(
+        self, mock_hass: MagicMock
+    ) -> None:
+        """Known entities are filtered out; only orphans are returned."""
+        known_id = "sensor.localshift_price_cheap_effective"
+        orphan_id = "number.localshift_cycle_penalty"
+
+        entries = [
+            self._make_registry_entry(known_id, "cfg_1"),
+            self._make_registry_entry(orphan_id, "cfg_1"),
+        ]
+
+        mock_registry = MagicMock()
+        mock_registry.entities.get_entries_for_config_entry_id.return_value = entries
+        mock_hass.states.get = lambda eid: None
+
+        validator = _create_validator(mock_hass)
+
+        with patch(
+            "custom_components.localshift.utils.validation.er.async_get",
+            return_value=mock_registry,
+        ):
+            result = validator.check_orphaned_owned_entities("cfg_1")
+
+        assert known_id not in result
+        assert orphan_id in result


### PR DESCRIPTION
## Root cause

`entity_health` reported only entities present in `LOCALSHIFT_ENTITY_CONFIG`. Registry ghosts — entries once created by the integration (e.g. `number.localshift_cycle_penalty`, `number.localshift_demand_window_import_penalty`) that were removed or renamed in a later version — were invisible: no warning, no attribute, no way to detect drift without manually inspecting the registry.

## Fix

1. **`utils/validation.py`** — new `EntityValidator.check_orphaned_owned_entities(config_entry_id)` method: enumerates `homeassistant.helpers.entity_registry` for entries whose `config_entry_id` matches this integration but whose `entity_id` is absent from `LOCALSHIFT_ENTITY_CONFIG`. Returns `{entity_id: {state, disabled, restored}}`.

2. **`coordinator/data.py`** — new `orphaned_localshift_entities: dict` field on `CoordinatorData` (empty by default).

3. **`coordinator/entity_monitor.py`** — after the existing localshift health check, calls `check_orphaned_owned_entities` with `coordinator.entry.entry_id`; if any orphans are found appends a human-readable warning `"N orphaned localshift entities: …"` to `entity_warnings`.

4. **`sensors/status.py`** — `EntityHealthSensor` exposes:
   - `orphaned_entities` attribute (added to `_unrecorded_attributes` to stay within recorder 16 KB limit)
   - `orphaned_count` in the `summary` sub-dict
   - The existing `"healthy/total"` state contract is **unchanged**.

Scope: only integration-owned registry entries are checked. User-YAML entities (`automation.amber_*`, `input_boolean.*`, etc.) have a different `config_entry_id` and are never flagged.

## Tests

19 new tests across:
- `tests/utils/test_validation_extended.py` — `TestCheckOrphanedOwnedEntities`: empty registry, all-known filter, orphan with/without live state, disabled flag, multiple orphans, mixed known+orphan
- `tests/sensors/test_status.py` — orphaned attribute exposure, orphan count in summary, empty case
- `tests/coordinator/test_entity_monitor.py` — `TestOrphanDetection`: data field population, warning appended, singular/plural grammar, no-orphan-no-warning, warning preserves existing, correct entry_id passed

3 existing tests updated to stub `check_orphaned_owned_entities.return_value = {}`.

Closes #880