### PR TITLE
fix(health): only flag unavailable/missing entities as orphans, not untracked-but-active (#880)

### DIFF
--- a/custom_components/localshift/utils/validation.py
+++ b/custom_components/localshift/utils/validation.py
@@ -484,28 +484,44 @@ class EntityValidator:
     def check_orphaned_owned_entities(
         self, config_entry_id: str
     ) -> dict[str, dict[str, Any]]:
-        """Return registry entries owned by this config entry that are not in LOCALSHIFT_ENTITY_CONFIG.
+        """Return registry entries owned by this config entry that are genuinely unprovided.
 
-        An "orphaned" entity is one that was previously created by the localshift
-        integration (config_entry_id matches) but no longer appears in
-        LOCALSHIFT_ENTITY_CONFIG — typically a number/switch/sensor that has been
-        removed or renamed in a newer version while the registry entry persists.
+        A genuine orphan is a registry entry that the integration no longer provides:
+        its live state is either missing (None) or HA reports it as 'unavailable'.
+        This typically occurs for entities (numbers, switches, sensors) that have been
+        removed or renamed in a newer code version while the registry entry persists
+        (e.g. number.localshift_cycle_penalty after the slider was removed).
+
+        Entries that are NOT considered orphans:
+        - Entries in LOCALSHIFT_ENTITY_CONFIG (health-tracked; already handled elsewhere).
+        - User-disabled entries (entry.disabled_by is not None) — a disabled entity
+          is intentionally inactive, not a code-removed ghost.
+        - Entries whose live state is any real value including 'unknown' — the entity
+          is still being provided by the integration (insufficient data, startup, etc.).
 
         Args:
             config_entry_id: The config entry id for this localshift instance.
 
         Returns:
-            Dict mapping entity_id -> {state, disabled, restored} for each orphan.
+            Dict mapping entity_id -> {state, disabled, restored} for each orphan,
+            where restored=True indicates the state was absent (None) rather than
+            'unavailable'.
         """
         registry = er.async_get(self.hass)
         orphans: dict[str, dict[str, Any]] = {}
         for entry in registry.entities.get_entries_for_config_entry_id(config_entry_id):
             if entry.entity_id in LOCALSHIFT_ENTITY_CONFIG:
                 continue
+            # User-disabled entries are intentionally inactive — not ghosts
+            if entry.disabled_by is not None:
+                continue
             state = self.hass.states.get(entry.entity_id)
+            # Only flag when the integration genuinely no longer provides the entity
+            if state is not None and state.state != "unavailable":
+                continue
             orphans[entry.entity_id] = {
-                "state": state.state if state is not None else "unavailable",
-                "disabled": entry.disabled_by is not None,
+                "state": "unavailable",
+                "disabled": False,
                 "restored": state is None,
             }
         return orphans

--- a/tests/utils/test_validation_extended.py
+++ b/tests/utils/test_validation_extended.py
@@ -1502,19 +1502,83 @@ class TestCheckOrphanedOwnedEntities:
         assert orphan["state"] == "unavailable"
         assert orphan["restored"] is True
 
-    def test_orphan_with_live_state(
+    def test_active_owned_entity_not_in_config_is_not_flagged(
         self, mock_hass: MagicMock
     ) -> None:
-        """Orphan with a live state reports state value and restored=False."""
-        orphan_id = "number.localshift_demand_window_import_penalty"
-        entry = self._make_registry_entry(orphan_id, "cfg_1")
+        """REGRESSION GUARD (#883): owned entry NOT in LOCALSHIFT_ENTITY_CONFIG with
+        a real live state (e.g. '0.08', 'on', '67.0') must NOT be reported as an
+        orphan.  The old code flagged these entities causing 13 false-positive orphan
+        warnings in production.
+        """
+        # Simulate an active entity the integration provides but that isn't in the
+        # health watch-list (e.g. a diagnostic number or extra binary_sensor).
+        active_id = "number.localshift_demand_window_import_penalty"
+        entry = self._make_registry_entry(active_id, "cfg_1")
 
         mock_registry = MagicMock()
         mock_registry.entities.get_entries_for_config_entry_id.return_value = [entry]
 
         live_state = MagicMock()
         live_state.state = "0.08"
-        mock_hass.states.get = lambda eid: live_state if eid == orphan_id else None
+        mock_hass.states.get = lambda eid: live_state if eid == active_id else None
+
+        validator = _create_validator(mock_hass)
+
+        with patch(
+            "custom_components.localshift.utils.validation.er.async_get",
+            return_value=mock_registry,
+        ):
+            result = validator.check_orphaned_owned_entities("cfg_1")
+
+        # Active entity must NOT appear in the orphan map
+        assert active_id not in result, (
+            f"Active entity {active_id!r} with state '0.08' was falsely flagged as orphan"
+        )
+
+    def test_active_owned_entity_with_unknown_state_is_not_flagged(
+        self, mock_hass: MagicMock
+    ) -> None:
+        """Owned entry with state 'unknown' (e.g. sensor.localshift_forecast_accuracy_comparison
+        before enough samples) must NOT be reported as an orphan.
+        """
+        active_id = "sensor.localshift_forecast_accuracy_comparison"
+        entry = self._make_registry_entry(active_id, "cfg_1")
+
+        mock_registry = MagicMock()
+        mock_registry.entities.get_entries_for_config_entry_id.return_value = [entry]
+
+        live_state = MagicMock()
+        live_state.state = "unknown"
+        mock_hass.states.get = lambda eid: live_state if eid == active_id else None
+
+        validator = _create_validator(mock_hass)
+
+        with patch(
+            "custom_components.localshift.utils.validation.er.async_get",
+            return_value=mock_registry,
+        ):
+            result = validator.check_orphaned_owned_entities("cfg_1")
+
+        assert active_id not in result, (
+            f"Entity {active_id!r} with state 'unknown' was falsely flagged as orphan"
+        )
+
+    def test_unavailable_owned_entity_not_in_config_is_flagged(
+        self, mock_hass: MagicMock
+    ) -> None:
+        """Owned entry NOT in LOCALSHIFT_ENTITY_CONFIG whose state is 'unavailable'
+        IS a genuine orphan (entity the integration no longer provides) and must be
+        reported.
+        """
+        orphan_id = "number.localshift_cycle_penalty"
+        entry = self._make_registry_entry(orphan_id, "cfg_1")
+
+        mock_registry = MagicMock()
+        mock_registry.entities.get_entries_for_config_entry_id.return_value = [entry]
+
+        unavailable_state = MagicMock()
+        unavailable_state.state = "unavailable"
+        mock_hass.states.get = lambda eid: unavailable_state if eid == orphan_id else None
 
         validator = _create_validator(mock_hass)
 
@@ -1526,15 +1590,19 @@ class TestCheckOrphanedOwnedEntities:
 
         assert orphan_id in result
         orphan = result[orphan_id]
-        assert orphan["state"] == "0.08"
+        assert orphan["state"] == "unavailable"
+        assert orphan["disabled"] is False
         assert orphan["restored"] is False
 
-    def test_orphan_disabled_flag(
+    def test_user_disabled_owned_entry_is_not_flagged(
         self, mock_hass: MagicMock
     ) -> None:
-        """Disabled orphan entry sets disabled=True."""
-        orphan_id = "number.localshift_cycle_penalty"
-        entry = self._make_registry_entry(orphan_id, "cfg_1", disabled=True)
+        """User-disabled owned entry must NOT be reported as an orphan.
+
+        A disabled entity is intentionally inactive — it is not a code-removed ghost.
+        """
+        disabled_id = "number.localshift_cycle_penalty"
+        entry = self._make_registry_entry(disabled_id, "cfg_1", disabled=True)
 
         mock_registry = MagicMock()
         mock_registry.entities.get_entries_for_config_entry_id.return_value = [entry]
@@ -1548,7 +1616,9 @@ class TestCheckOrphanedOwnedEntities:
         ):
             result = validator.check_orphaned_owned_entities("cfg_1")
 
-        assert result[orphan_id]["disabled"] is True
+        assert disabled_id not in result, (
+            f"User-disabled entry {disabled_id!r} was falsely flagged as orphan"
+        )
 
     def test_multiple_orphans(
         self, mock_hass: MagicMock


### PR DESCRIPTION
## Regression from #883

`check_orphaned_owned_entities` introduced in #883 flagged **every** registry entry owned by the localshift config entry that isn't in `LOCALSHIFT_ENTITY_CONFIG` as an orphan. The integration creates ~72 entities but `LOCALSHIFT_ENTITY_CONFIG` only health-tracks 53 of them — buttons, diagnostic sensors, and extra numbers/binary_sensors are intentionally outside the health watch-list but are still actively provided.

**Live evidence:** production reported "13 orphaned localshift entities" where all 13 were live and available — `restored: false`, real states like `'0.25'`, `'67.0'`, `'on'`. None were genuine ghosts.

## What a genuine orphan actually is

A genuine orphan is a registry entry the integration **no longer provides** — typically a number/switch/sensor removed or renamed in a newer code version (e.g. `number.localshift_cycle_penalty` after the switching-penalty slider was removed). Its distinguishing characteristic is that HA has no live state for it (`hass.states.get(...)` returns `None`) or reports it as `'unavailable'`.

Active entities with any other real state — including `'unknown'` (e.g. `sensor.localshift_forecast_accuracy_comparison` before enough solar samples) — are still being provided by the integration and must not be flagged.

## Fix

In `check_orphaned_owned_entities` (`utils/validation.py`):
- **Skip user-disabled entries** (`entry.disabled_by is not None`) — a disabled entity is intentionally inactive, not a code-removed ghost.
- **Include ONLY** when `hass.states.get(entity_id) is None` OR `state.state == "unavailable"`.
- All other states (`'unknown'`, numeric, boolean, string) → skip.
- Updated docstring to document the genuine-orphan definition and the exclusion rules.
- Dict shape `{entity_id: {"state", "disabled", "restored"}}` unchanged; `disabled` is now always `False` in the returned map (disabled entries are excluded before reaching the output).

## Tests

Replaced two stale tests that asserted old (incorrect) behaviour and added four new tests in `TestCheckOrphanedOwnedEntities`:

| Test | Purpose |
|------|---------|
| `test_active_owned_entity_not_in_config_is_not_flagged` | **Regression guard** — fails on old code, passes on fix |
| `test_active_owned_entity_with_unknown_state_is_not_flagged` | `'unknown'` state (startup / insufficient data) is not an orphan |
| `test_unavailable_owned_entity_not_in_config_is_flagged` | Genuine ghost with `'unavailable'` state IS flagged |
| `test_user_disabled_owned_entry_is_not_flagged` | User-disabled entries are excluded |

Downstream tests in `tests/sensors/test_status.py` and `tests/coordinator/test_entity_monitor.py` mock `check_orphaned_owned_entities` directly and are unaffected.

## Local CI results

- `uv run pytest -q`: **3157 passed, 1 xfailed** (coverage 95.2% ≥ 23% gate ✅)
- `uv run ruff check custom_components/localshift`: **All checks passed** ✅
- `uv run ruff format --check custom_components/localshift`: **97 files already formatted** ✅