### PR TITLE
fix(optimizer): hard DW-target feasibility gate so the battery reaches target before the demand window (#885)

### DIFF
--- a/custom_components/localshift/const.py
+++ b/custom_components/localshift/const.py
@@ -247,7 +247,7 @@ DEFAULT_EXPORT_PRICE_MARGIN = (
 )
 DEFAULT_OPTIMIZATION_MODE = OPTIMIZATION_MODE_SELF_CONSUMPTION
 DEFAULT_SWITCHING_PENALTY = 0.02  # $/switch disincentive
-DEFAULT_TARGET_PENALTY = 0.015  # $/%-point demand window urgency
+DEFAULT_TARGET_PENALTY = 0.03  # $/%-point demand window urgency (#885: raised 0.015 -> 0.03 so the soft lever can at least exceed typical charge prices)
 DEFAULT_MIN_CYCLE_SAVING = (
     0.25  # $/kWh minimum saving over holding to justify cycling the battery
 )
@@ -347,7 +347,7 @@ THRESHOLD_RANGES = {
     },
     CONF_TARGET_PENALTY: {
         "min": 0.000,
-        "max": 0.100,
+        "max": 0.200,
         "step": 0.005,
         "unit": "$/%-point",
         "icon": "mdi:target",

--- a/custom_components/localshift/engine/constraints.py
+++ b/custom_components/localshift/engine/constraints.py
@@ -186,7 +186,25 @@ def feasible_actions(
                     and soc_pct + config.max_normal_gain_pct_to_terminal[slot_idx]
                     < config.demand_window_target_soc_pct
                 )
-                if price_is_very_cheap or normal_cannot_reach_target:
+                # Hard DW-target feasibility gate (issue #885): while strictly below the
+                # hard floor in a pre-DW slot, unlock boost so the DP actually HAS a
+                # fast-enough path to clear the floor. Without this, normal-rate charging
+                # can arrive at the DW under target (the live "boost downshifted to grid"
+                # failure) and the terminal pruning would have no feasible action to route
+                # through. The ``slot_idx < terminal_penalty_idx`` guard (shared with the
+                # floor's own scope) confines this to pre-DW slots — a post-DW low SOC can
+                # never unlock overnight boost (#800 protection).
+                hard_floor_needs_boost = (
+                    config.hard_target_floor is not None
+                    and terminal_penalty_idx is not None
+                    and slot_idx < terminal_penalty_idx
+                    and soc_pct < config.hard_target_floor
+                )
+                if (
+                    price_is_very_cheap
+                    or normal_cannot_reach_target
+                    or hard_floor_needs_boost
+                ):
                     actions.append(PlannerAction.CHARGE_GRID_BOOST)
         else:
             actions.append(PlannerAction.CHARGE_GRID_NORMAL)
@@ -518,6 +536,91 @@ def compute_max_normal_gain_pct_to_terminal(
                 )
         gains[j] = cumulative
     return gains
+
+
+def compute_max_feasible_terminal_soc(
+    slots: list[SlotContext],
+    config: OptimizerConfig,
+    terminal_penalty_idx: int | None,
+    initial_soc_pct: float,
+) -> float | None:
+    """Highest SOC the DW-entry slot can physically reach via eligible pre-DW charging.
+
+    Hard DW-target feasibility gate (issue #885). The soft shortfall penalty is
+    structurally capped below grid-charge prices, so the DP pays through it and the
+    battery enters the demand window under target with no backstop. To make target a
+    HARD constraint without forcing charging through ineligible (expensive) or
+    post-DW slots, the solver needs to know what SOC is actually *reachable* at the
+    DW-entry slot — the floor it can prune below.
+
+    This forward-simulates the most optimistic eligible trajectory to the DW entry:
+    every pre-DW, non-DW slot whose price is at/below its per-slot eligibility
+    threshold (``cheap_threshold_for_slot`` — the same #870 water-level / urgency-ramp
+    gate ``feasible_actions`` uses, so this NEVER admits a slot the DP could not itself
+    charge in) contributes a boost-rate charge; every other slot evolves on solar/load
+    only. The result is clamped to the charge ceiling (target in self-consumption mode).
+
+    The simulation is measured at the SOC ENTERING the DW-entry slot (before that slot's
+    own consumption drift) — matching how the DP applies the terminal penalty in
+    ``_backward_induction`` (to ``dp[terminal_penalty_idx][bin]``, keyed by the SOC at the
+    START of the entry slot). Measuring post-entry-decay instead would understate the
+    reachable floor by one slot's load and make a physically-reachable target look unmet.
+
+    Because charging is the most this trajectory ever does, the returned SOC is an upper
+    bound on what any feasible plan can reach at the DW entry. The solver uses
+    ``min(target, this)`` as the hard floor: when target is reachable the floor IS the
+    target; when it is physically unreachable (too little time/rate/eligible-cheap
+    energy) the floor degrades gracefully to the max feasible SOC, so the DP still
+    produces a non-empty plan that charges as far as it can rather than an infeasible one.
+
+    Returns ``None`` (gate inert) when there is no demand window, the mode is not
+    self-consumption, or the entry is slot 0 (nothing earlier to charge in).
+    """
+    if (
+        terminal_penalty_idx is None
+        or terminal_penalty_idx <= 0
+        or config.optimization_mode != "self_consumption"
+        or not slots
+        or terminal_penalty_idx >= len(slots)
+    ):
+        return None
+
+    charge_ceiling = config.demand_window_target_soc_pct
+    soc = initial_soc_pct
+    # Iterate only the pre-DW slots: the floor is the SOC ENTERING the DW-entry slot.
+    for i in range(terminal_penalty_idx):
+        slot = slots[i]
+        slot_hours = slot.slot_interval_minutes / 60.0
+        # Solar/load drift first (mirrors the solar-only simulation shape).
+        net_kwh = slot.solar_kwh - slot.consumption_kwh
+        max_solar_transfer = config.solar_charge_rate_kw * slot_hours
+        if net_kwh >= 0:
+            soc += (
+                min(net_kwh, max_solar_transfer)
+                * config.charge_efficiency
+                / config.battery_capacity_kwh
+                * 100.0
+            )
+        else:
+            soc += (
+                max(net_kwh, -max_solar_transfer)
+                / config.discharge_efficiency
+                / config.battery_capacity_kwh
+                * 100.0
+            )
+        # Then the most optimistic eligible grid charge (boost) in this pre-DW slot.
+        if not slot.is_demand_window_slot and soc < charge_ceiling:
+            threshold = cheap_threshold_for_slot(config, i, terminal_penalty_idx)
+            if slot.buy_price <= threshold:
+                soc += (
+                    config.boost_charge_rate_kw
+                    * slot_hours
+                    * config.charge_efficiency
+                    / config.battery_capacity_kwh
+                    * 100.0
+                )
+        soc = max(config.min_soc_pct, min(charge_ceiling, soc))
+    return soc
 
 
 def check_global_solar_sufficiency(

--- a/custom_components/localshift/engine/core.py
+++ b/custom_components/localshift/engine/core.py
@@ -8,6 +8,8 @@ from datetime import datetime, timedelta
 from typing import Any
 
 from custom_components.localshift.engine.constraints import (
+    check_global_solar_sufficiency,
+    compute_max_feasible_terminal_soc,
     compute_max_normal_gain_pct_to_terminal,
     compute_pre_dw_charge_thresholds,
 )
@@ -453,6 +455,7 @@ class DPPlanner:
         # and its inert early-returns never write the water level.
         config.pre_dw_charge_thresholds = None
         config.pre_dw_funding_water_level = None
+        config.hard_target_floor = None
         config.pre_dw_charge_thresholds = compute_pre_dw_charge_thresholds(
             slots, config, terminal_penalty_idx, inputs.initial_soc_pct
         )
@@ -468,8 +471,28 @@ class DPPlanner:
             compute_max_normal_gain_pct_to_terminal(slots, config, terminal_penalty_idx)
         )
 
+        # Hard DW-target feasibility gate (issue #885). In strict mode
+        # (allow_dw_entry_under_target=False, self-consumption) the soft shortfall penalty
+        # is structurally capped below grid-charge prices, so the DP holds and enters the
+        # demand window under target. Compute the HARD floor the terminal-penalty slot
+        # must clear: min(target, max physically/eligibly reachable SOC). Below-floor
+        # terminal states are pruned (effectively infinite penalty) in
+        # _initialize_dp_tables, so backward induction routes through the CHEAPEST eligible
+        # pre-DW slots. The floor degrades to the max feasible SOC when target is
+        # unreachable (no infeasible/empty plan), is None when solar alone reaches target
+        # (don't fight #816/#849), and is None outside strict self-consumption (legacy).
+        config.hard_target_floor = self._compute_hard_target_floor(
+            slots, config, terminal_penalty_idx, inputs, solar_capable
+        )
+
         dp, terminal_penalty_by_bin = self._initialize_dp_tables(
-            n_slots, soc_grid, config, terminal_penalty_idx, solar_capable, inputs
+            n_slots,
+            soc_grid,
+            config,
+            terminal_penalty_idx,
+            solar_capable,
+            inputs,
+            config.hard_target_floor,
         )
 
         # Issue #719: Derive negative-FIT avoidance context before backward induction
@@ -702,6 +725,49 @@ class DPPlanner:
                 return i
         return terminal_penalty_idx
 
+    def _compute_hard_target_floor(
+        self,
+        slots: list[SlotContext],
+        config: OptimizerConfig,
+        terminal_penalty_idx: int | None,
+        inputs: OptimizerInputs,
+        solar_capable: bool,
+    ) -> float | None:
+        """Hard SOC floor the DW-entry slot must clear (issue #885), or None when inert.
+
+        Returns ``min(target, max_feasible_terminal_soc)`` so the gate forces charging up
+        to — but never beyond — the target, routing the DP through the cheapest eligible
+        pre-DW slots. Returns ``None`` (gate dormant, legacy soft-penalty behaviour) when:
+
+        - ``allow_dw_entry_under_target`` is True (target may be met mid-DW via solar — the
+          penalty stays at the horizon boundary and pre-charge must not be forced), or
+        - the mode is not self-consumption / there is no demand window / the entry is slot
+          0 (``compute_max_feasible_terminal_soc`` returns None), or
+        - solar alone is projected to reach the target by the DW entry — either at the DW
+          entry slot (``check_global_solar_sufficiency`` from the current SOC) or anywhere
+          during the DW (``solar_capable``). Forcing grid charge then would fight the
+          stale-solar / over-optimistic-solar protections (#816/#849).
+
+        The floor is the SOC the battery must reach ENTERING the demand window (the SOC at
+        the START of ``terminal_penalty_idx``), matching where the DP applies the terminal
+        penalty (``dp[terminal_penalty_idx][bin]``) and how the shortfall is measured.
+        """
+        if config.allow_dw_entry_under_target:
+            return None
+        if solar_capable:
+            return None
+        # Solar alone reaches target by the DW entry: don't force grid charge (#816/#849).
+        if check_global_solar_sufficiency(
+            inputs.initial_soc_pct, 0, slots, config, terminal_penalty_idx
+        ):
+            return None
+        max_feasible = compute_max_feasible_terminal_soc(
+            slots, config, terminal_penalty_idx, inputs.initial_soc_pct
+        )
+        if max_feasible is None:
+            return None
+        return min(config.demand_window_target_soc_pct, max_feasible)
+
     def _initialize_dp_tables(
         self,
         n_slots: int,
@@ -710,6 +776,7 @@ class DPPlanner:
         terminal_penalty_idx: int | None,
         solar_can_reach_target: bool,
         inputs: OptimizerInputs,
+        hard_target_floor: float | None = None,
     ) -> tuple[
         list[dict[int, tuple[float, PlannerAction, int, float, float, float]]],
         dict[int, float],
@@ -824,7 +891,18 @@ class DPPlanner:
             for bin_idx, soc in enumerate(soc_grid):
                 effective_soc = soc + future_solar_gain_pct
 
-                if use_hard_constraint and effective_soc < target:
+                # Hard DW-target feasibility gate (issue #885). When a hard floor is set
+                # (strict mode, solar insufficient), DW-entry states below the floor are
+                # pruned with the effectively-infinite penalty so backward induction MUST
+                # route a charging path that clears it. The floor is min(target, max
+                # feasible), so an unreachable target degrades gracefully — every bin up to
+                # the max feasible SOC is admitted and the DP charges as far as it can.
+                # The penalty is monotonic in the gap, so among below-floor states the DP
+                # still prefers the highest reachable SOC (no infeasible/empty plan).
+                if hard_target_floor is not None and effective_soc < hard_target_floor:
+                    shortfall = hard_target_floor - effective_soc
+                    shortfall_penalty = shortfall * hard_constraint_penalty
+                elif use_hard_constraint and effective_soc < target:
                     shortfall = target - effective_soc
                     shortfall_penalty = shortfall * hard_constraint_penalty
                 else:
@@ -879,8 +957,14 @@ class DPPlanner:
 
         dw_entry_soc = None
 
-        if terminal_penalty_idx is not None and decisions:
-            dw_entry_soc = decisions[terminal_penalty_idx].predicted_soc_pct
+        if (
+            terminal_penalty_idx is not None
+            and decisions
+            and terminal_penalty_idx < len(decisions)
+        ):
+            # SOC entering the window (start of the entry slot) — consistent with the
+            # terminal penalty / #885 hard floor and with _compute_terminal_shortfall.
+            dw_entry_soc = self._dw_entry_soc(decisions, terminal_penalty_idx)
 
         return {
             "accuracy_discount_factor": round(accuracy_discount, 2),
@@ -1246,11 +1330,33 @@ class DPPlanner:
             return max(0.0, target - max_soc_in_dw)
 
         if terminal_penalty_idx < len(decisions):
-            terminal_soc = decisions[terminal_penalty_idx].predicted_soc_pct
+            terminal_soc = self._dw_entry_soc(decisions, terminal_penalty_idx)
 
             return max(0.0, target - terminal_soc)
 
         return 0.0
+
+    @staticmethod
+    def _dw_entry_soc(
+        decisions: list[PlannedSlotDecision], terminal_penalty_idx: int
+    ) -> float:
+        """SOC entering the demand window — the SOC at the START of the DW-entry slot.
+
+        The DP applies the target/shortfall penalty and the #885 hard floor to
+        ``dp[terminal_penalty_idx][bin]``, which is keyed by the SOC at the START of the
+        entry slot (= the end-of-slot SOC of ``terminal_penalty_idx - 1``), NOT the SOC
+        after the entry slot's own consumption has drained it. Measuring the shortfall at
+        that same point keeps the reported ``terminal_shortfall_pct`` / ``dw_entry_soc_pct``
+        consistent with what the optimizer actually controls; measuring post-decay instead
+        booked a phantom ~1 slot of load as an unavoidable shortfall even when the battery
+        entered the window exactly at target (issue #885).
+
+        Falls back to the entry slot's own predicted SOC when the entry is slot 0 (nothing
+        precedes it — the in-progress-DW edge handled by ``_find_demand_window_bounds``).
+        """
+        if terminal_penalty_idx <= 0:
+            return decisions[terminal_penalty_idx].predicted_soc_pct
+        return decisions[terminal_penalty_idx - 1].predicted_soc_pct
 
     # ------------------------------------------------------------------
 

--- a/custom_components/localshift/engine/types.py
+++ b/custom_components/localshift/engine/types.py
@@ -276,6 +276,26 @@ class OptimizerConfig:
     ``base_cheap_price`` — the #800 overnight-sawtooth protection is untouched).
     None ⇒ legacy behaviour."""
 
+    hard_target_floor: float | None = None
+    """Solver-derived (set by ``DPPlanner._solve``): the hard DW-target feasibility floor
+    (issue #885) — ``min(target, max feasible/eligible SOC at DW entry)``.
+
+    When set (strict mode: ``allow_dw_entry_under_target=False``, self-consumption, a
+    demand window exists, and solar alone does not reach target), two things happen:
+
+    - ``_initialize_dp_tables`` prunes DW-entry states below this floor with an effectively
+      infinite penalty, so backward induction MUST route a charging path that clears it
+      (through the cheapest eligible pre-DW slots), rather than paying through the soft
+      shortfall penalty and holding under target, and
+    - ``feasible_actions`` unlocks boost charging in eligible pre-DW slots while
+      ``soc_pct < hard_target_floor``, so the DP actually HAS a fast-enough path to the
+      floor when normal-rate charging would arrive at the DW under target (the live
+      "boost downshifted to grid" failure).
+
+    Strictly bounded to pre-DW slots (``slot_idx < terminal_penalty_idx``); never forces
+    charging inside/after the DW or overnight (guards the #800 sawtooth). None ⇒ gate
+    dormant (legacy soft-penalty behaviour) for unit tests and direct callers."""
+
     pre_dw_funding_water_level: float | None = None
     """Solver-derived (set by ``DPPlanner._solve`` via ``compute_pre_dw_charge_thresholds``):
     the raw target-funding water level — the marginal buy price of the cheapest set of

--- a/tests/engine/test_hard_dw_target_gate.py
+++ b/tests/engine/test_hard_dw_target_gate.py
@@ -1,0 +1,273 @@
+"""Hard DW-target feasibility gate (issue #885).
+
+The battery used to enter the evening demand window (DW) under target with no hard
+backstop: target attainment was only a *soft* terminal penalty, structurally capped
+below grid-charge prices, so the DP paid through it and held. The 3pm force-charge
+guardrail that used to backstop this was removed 2026-06-12.
+
+These tests encode:
+
+1. The 2026-06-14 live repro: SOC 66%, target 95%, flat-ish price ~0.13 (below the
+   max_pre_charge_price of 0.20), DW ~1h ahead, solar insufficient. With
+   ``allow_dw_entry_under_target=False`` the plan must now reach target.
+2. A sawtooth guard (#800): the hard gate must NOT introduce overnight or post-DW
+   force-charging.
+3. Graceful degradation: when the target is physically unreachable (not enough
+   time/rate), the plan charges to the max feasible SOC without error.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+from custom_components.localshift.engine.core import DPPlanner
+from custom_components.localshift.engine.types import (
+    OptimizerConfig,
+    OptimizerInputs,
+    PlannerAction,
+    SlotContext,
+)
+
+_CHARGE = (PlannerAction.CHARGE_GRID_NORMAL, PlannerAction.CHARGE_GRID_BOOST)
+_INTERVAL = 30
+
+
+def _config(**overrides) -> OptimizerConfig:
+    defaults = dict(
+        min_soc_pct=10.0,
+        max_soc_pct=100.0,
+        demand_window_target_soc_pct=95.0,
+        allow_dw_entry_under_target=False,
+        optimization_mode="self_consumption",
+        battery_capacity_kwh=13.5,
+        charge_rate_kw=3.3,
+        boost_charge_rate_kw=5.0,
+        charge_efficiency=0.92,
+        discharge_efficiency=0.95,
+        effective_cheap_price=0.115,
+        base_cheap_price=0.115,
+        max_precharge_price=0.20,
+        target_shortfall_penalty_per_pct=0.08,
+        soc_bins=100,
+    )
+    defaults.update(overrides)
+    return OptimizerConfig(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# 2026-06-14 live repro: SOC 66%, target 95%, flat ~0.13 price, DW ~1h ahead.
+# ---------------------------------------------------------------------------
+
+_REPRO_START = datetime(2026, 6, 14, 13, 0)
+# DW ~2h ahead -> entry at slot 4 (13:00..14:30 pre-DW, then 15:00 DW). Four boost-rate
+# pre-DW slots make 95% physically reachable (max-feasible peak ~100%), so this is a
+# genuine soft-penalty undercharge, NOT a physical-infeasibility case. Long horizon so
+# there is ample post-DW time the gate must NOT charge in.
+_REPRO_DW_ENTRY_IDX = 4
+_REPRO_N_SLOTS = 16
+
+
+def _repro_slots() -> list[SlotContext]:
+    slots: list[SlotContext] = []
+    for i in range(_REPRO_N_SLOTS):
+        t = _REPRO_START + timedelta(minutes=_INTERVAL * i)
+        is_dw = _REPRO_DW_ENTRY_IDX <= i < _REPRO_DW_ENTRY_IDX + 8  # 4h DW
+        # Flat-ish ~0.13 buy price everywhere (below max_pre_charge_price 0.20),
+        # evening peak inside the DW.
+        buy = 0.30 if is_dw else 0.13
+        slots.append(
+            SlotContext(
+                slot_index=i,
+                timestamp_iso=t.isoformat(),
+                slot_interval_minutes=_INTERVAL,
+                buy_price=buy,
+                sell_price=0.05,
+                # Solar insufficient (net negative): tiny solar, real consumption.
+                solar_kwh=0.05,
+                consumption_kwh=0.3,
+                is_demand_window_entry=(i == _REPRO_DW_ENTRY_IDX),
+                is_demand_window_slot=is_dw,
+            )
+        )
+    return slots
+
+
+def _plan_repro(**config_overrides):
+    slots = _repro_slots()
+    config = _config(**config_overrides)
+    return DPPlanner(config).plan(
+        OptimizerInputs(
+            cycle_id="repro-885",
+            initial_soc_pct=66.0,
+            slots=slots,
+            config=config,
+            all_solcast=[],
+        )
+    )
+
+
+def test_repro_2026_06_14_reaches_target_under_hard_gate():
+    """The 2026-06-14 live repro: plan must reach target with the hard gate.
+
+    SOC 66 -> 95 on a 13.5 kWh battery needs ~3.9 kWh stored; the four boost-rate
+    pre-DW slots can reach ~100% peak, so target is physically reachable. Price 0.13 <
+    max_pre_charge_price 0.20, so the slots ARE eligible. The hard gate must route a
+    charge through them so the DW-entry SOC lands at target.
+
+    MUST FAIL on origin/main (soft penalty caps below price -> DW entry ~93.6%, shortfall
+    ~1.4%) and PASS with the fix (shortfall -> ~0).
+    """
+    result = _plan_repro()
+    assert result.success
+    assert result.terminal_shortfall_pct < 0.5, (
+        "hard gate must drive DW entry to target; got shortfall "
+        f"{result.terminal_shortfall_pct}%"
+    )
+    # The SOC entering the demand window (start of the entry slot) should be at/near
+    # target. This is the value the DP controls and reports as dw_entry_soc_pct.
+    assert result.dw_entry_soc_pct is not None
+    assert result.dw_entry_soc_pct >= 94.5, (
+        f"DW entry SOC {result.dw_entry_soc_pct}% under target"
+    )
+
+
+def test_repro_charges_only_in_eligible_pre_dw_slots():
+    """Charging happens, only pre-DW, and only at eligible (<= max_pre_charge_price) prices."""
+    result = _plan_repro()
+    charges = [d for d in result.decisions if d.action in _CHARGE]
+    assert charges, "expected grid charging to reach target (was all-HOLD)"
+    for c in charges:
+        idx = next(
+            d.slot_index for d in result.decisions if d.timestamp_iso == c.timestamp_iso
+        )
+        assert idx < _REPRO_DW_ENTRY_IDX, (
+            f"charge at slot {idx} is not strictly pre-DW (entry={_REPRO_DW_ENTRY_IDX})"
+        )
+        assert c.buy_price <= 0.20, f"charge at ineligible price {c.buy_price}"
+
+
+def test_does_not_charge_above_target():
+    """The gate must not over-charge: peak SOC stays at/near target, not 100%."""
+    result = _plan_repro()
+    assert result.success
+    # Target is 95; allow a small overshoot from bin granularity but never near 100.
+    assert result.peak_soc_pct is not None
+    assert result.peak_soc_pct <= 97.0, (
+        f"plan over-charged above target; peak {result.peak_soc_pct}%"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Sawtooth guard (#800): no overnight / post-DW force-charging.
+# ---------------------------------------------------------------------------
+
+
+def test_hard_gate_no_post_dw_or_overnight_charge():
+    """The hard gate is strictly bounded to pre-DW slots (guards #800)."""
+    result = _plan_repro()
+    assert result.success
+    for d in result.decisions:
+        if d.action not in _CHARGE:
+            continue
+        idx = d.slot_index
+        assert idx < _REPRO_DW_ENTRY_IDX, (
+            "no charging inside or after the DW (sawtooth guard); "
+            f"got charge at slot {idx}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Solar sufficiency: don't fight #816/#849.
+# ---------------------------------------------------------------------------
+
+
+def test_no_grid_charge_when_solar_reaches_target():
+    """When solar alone projects to target, the hard gate must not force grid charging."""
+    # Move the DW far out and give strong pre-DW solar so solar reaches target alone.
+    start = datetime(2026, 6, 14, 8, 0)
+    n = 24
+    dw_entry = 16  # 8h ahead -> plenty of daytime solar before it
+    slots: list[SlotContext] = []
+    for i in range(n):
+        t = start + timedelta(minutes=_INTERVAL * i)
+        is_dw = dw_entry <= i < dw_entry + 6
+        slots.append(
+            SlotContext(
+                slot_index=i,
+                timestamp_iso=t.isoformat(),
+                slot_interval_minutes=_INTERVAL,
+                buy_price=0.30 if is_dw else 0.13,
+                sell_price=0.05,
+                # Strong solar before the DW, easily reaching target from 66%.
+                solar_kwh=3.0 if (not is_dw and i < dw_entry) else 0.0,
+                consumption_kwh=0.3,
+                is_demand_window_entry=(i == dw_entry),
+                is_demand_window_slot=is_dw,
+            )
+        )
+    config = _config()
+    result = DPPlanner(config).plan(
+        OptimizerInputs(
+            cycle_id="repro-885-solar",
+            initial_soc_pct=66.0,
+            slots=slots,
+            config=config,
+            all_solcast=[],
+        )
+    )
+    assert result.success
+    charges = [d for d in result.decisions if d.action in _CHARGE]
+    assert charges == [], (
+        "solar reaches target on its own — the hard gate must not grid-charge; "
+        f"got charges at {[d.timestamp_iso for d in charges]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Graceful degradation: unreachable target -> max feasible, no error/empty plan.
+# ---------------------------------------------------------------------------
+
+
+def test_unreachable_target_degrades_to_max_feasible():
+    """Insufficient time/rate before the DW: charge to max feasible, no error."""
+    start = datetime(2026, 6, 14, 14, 30)
+    # DW entry at slot 1 (only ONE 30-min pre-DW slot). From 20% to 95% needs ~10 kWh;
+    # one boost slot stores ~2.3 kWh -> physically unreachable.
+    n = 12
+    dw_entry = 1
+    slots: list[SlotContext] = []
+    for i in range(n):
+        t = start + timedelta(minutes=_INTERVAL * i)
+        is_dw = dw_entry <= i < dw_entry + 6
+        slots.append(
+            SlotContext(
+                slot_index=i,
+                timestamp_iso=t.isoformat(),
+                slot_interval_minutes=_INTERVAL,
+                buy_price=0.30 if is_dw else 0.13,
+                sell_price=0.05,
+                solar_kwh=0.0,
+                consumption_kwh=0.3,
+                is_demand_window_entry=(i == dw_entry),
+                is_demand_window_slot=is_dw,
+            )
+        )
+    config = _config()
+    result = DPPlanner(config).plan(
+        OptimizerInputs(
+            cycle_id="repro-885-unreachable",
+            initial_soc_pct=20.0,
+            slots=slots,
+            config=config,
+            all_solcast=[],
+        )
+    )
+    assert result.success
+    assert result.decisions, "plan must not be empty when target is unreachable"
+    # Still a meaningful shortfall (target physically unreachable), but the single
+    # eligible pre-DW slot should be used to charge as much as possible.
+    assert result.terminal_shortfall_pct > 0.0
+    pre_dw_charge = [
+        d for d in result.decisions if d.action in _CHARGE and d.slot_index < dw_entry
+    ]
+    assert pre_dw_charge, "the one eligible pre-DW slot must be used to charge"

--- a/tests/engine/test_terminal_cost_regression.py
+++ b/tests/engine/test_terminal_cost_regression.py
@@ -328,12 +328,16 @@ class TestIssue816DiagnosticsAfterFix:
         assert result.success
 
         if result.dw_entry_soc_pct is not None:
-            # Find the DW entry decision (slot_index >= n_pre_dw_slots=6)
-            dw_entry_decisions = [d for d in result.decisions if d.slot_index >= 6]
-            if dw_entry_decisions:
-                actual_dw_soc = dw_entry_decisions[0].predicted_soc_pct
+            # dw_entry_soc_pct is the SOC ENTERING the demand window — the SOC at the START
+            # of the DW-entry slot (= the end-of-slot SOC of the slot just before it),
+            # which is what the DP applies the terminal penalty / #885 hard floor to.
+            # Compare against that trajectory point (slot index 5, the last pre-DW slot):
+            # a large gap there would indicate the diagnostic is fictitiously inflated.
+            pre_entry_decisions = [d for d in result.decisions if d.slot_index == 5]
+            if pre_entry_decisions:
+                actual_dw_soc = pre_entry_decisions[0].predicted_soc_pct
                 assert abs(result.dw_entry_soc_pct - actual_dw_soc) < 2.0, (
                     f"dw_entry_soc_pct={result.dw_entry_soc_pct:.2f}% must be close to "
-                    f"actual DW entry SOC={actual_dw_soc:.2f}% in decisions. "
+                    f"the SOC entering the DW={actual_dw_soc:.2f}% in decisions. "
                     f"Large gap indicates solar inflation is still present."
                 )

--- a/tests/test_optimizer_runner_integration.py
+++ b/tests/test_optimizer_runner_integration.py
@@ -209,8 +209,8 @@ class TestBuildOptimizerConfig:
     ):
         """target_shortfall_penalty_per_pct defaults when not in options."""
         config = _build_optimizer_config(mock_coordinator_data, {})
-        # Default is 0.015 (DEFAULT_TARGET_PENALTY)
-        assert config.target_shortfall_penalty_per_pct == 0.015
+        # Default is 0.03 (DEFAULT_TARGET_PENALTY; #885 raised 0.015 -> 0.03)
+        assert config.target_shortfall_penalty_per_pct == 0.03
 
     def test_config_uses_default_allow_dw_entry_under_target(
         self, mock_coordinator_data


### PR DESCRIPTION
## Root cause (#885)

The battery entered the evening demand window (DW) under target with **no hard backstop**. `allow_dw_entry_under_target` (default False) only changed *where* the soft shortfall penalty was applied (DW-entry slot vs horizon end) — it was never a feasibility constraint. The terminal penalty (`shortfall_pct × target_shortfall_penalty_per_pct`, max 0.10 $/%-point) is structurally **capped below grid-charge prices**, so the DP paid through it and held. The 3pm force-charge guardrail that used to backstop this was removed 2026-06-12, leaving the optimizer unbackstopped.

Live repro (2026-06-14): SOC 66%, target 95%, flat ~0.13 price (below `max_pre_charge_price` 0.20), DW ~1h ahead, solar insufficient → plan entered at 86.83% and the gate **downshifted Boost → Grid** despite the projected shortfall. Raising the penalty slider to its 0.10 max barely moved it (the experiment in #885).

## The fix — hard feasibility gate (terminal-feasibility framing)

Rather than a per-slot "force a charge" rule (which reintroduced the #800 sawtooth when the 3pm guardrail existed), this prunes infeasible **terminal** states and lets backward induction route through the cheapest eligible pre-DW slots:

- **`compute_max_feasible_terminal_soc()`** forward-simulates the most optimistic *eligible* pre-DW trajectory — boost in every #870-eligible slot (same `cheap_threshold_for_slot` water-level/ramp gate the DP itself uses, so it never admits a slot the DP couldn't charge in), solar/load drift elsewhere — measured at the SOC **entering** the DW-entry slot.
- **`_compute_hard_target_floor()`** = `min(target, max_feasible)`. Returns `None` (gate dormant, legacy soft behaviour) when `allow_dw_entry_under_target`, not strict self-consumption, no DW, the entry is slot 0, or **solar alone reaches target** (`check_global_solar_sufficiency` — don't fight #816/#849).
- **`_initialize_dp_tables`** prunes DW-entry states below the floor with the effectively-infinite penalty, so backward induction *must* route a charging path that clears it — through the **cheapest** eligible pre-DW slots (never above target, never through ineligible expensive slots). The penalty is monotonic in the gap, so an **unreachable** target degrades gracefully to the max feasible SOC — never an infeasible/empty plan.
- **`feasible_actions`** unlocks boost while `soc < hard_target_floor` in eligible pre-DW slots, fixing the live "boost downshifted to grid" failure where normal-rate charging arrived at the DW under target.

Everything is scoped strictly to `slot_idx < terminal_penalty_idx`: the gate **never** forces charging inside/after the DW or overnight — the #800 sawtooth guard is intact.

### Measurement consistency
`terminal_shortfall_pct` / `dw_entry_soc_pct` now measure the SOC **entering** the window (start of the entry slot — what the DP's terminal penalty/floor actually controls), instead of post-entry-decay, which booked a phantom ~1 slot of load as an unavoidable shortfall even when the battery entered exactly at target.

## Penalty-cap raise (complementary, low-risk)

`const.py`: `target_shortfall_penalty` number max **0.10 → 0.20** and `DEFAULT_TARGET_PENALTY` **0.015 → 0.03**, so the soft lever can at least exceed typical charge prices.

## Tests

`tests/engine/test_hard_dw_target_gate.py`:
- **repro** — the 2026-06-14 live scenario; **fails on origin/main** (shortfall 1.42%, DW entry under target) and **passes** with the fix (shortfall < 0.5%, DW entry ≥ 94.5%).
- **sawtooth guard** — asserts no overnight/post-DW force-charging (all charges strictly pre-DW); guards #800.
- **solar-sufficiency carve-out** — strong pre-DW solar ⇒ no grid charge.
- **graceful degradation** — one eligible pre-DW slot, deep deficit ⇒ charges to max feasible, non-empty plan, no error.

Existing soft-behaviour tests updated for the entry-start measurement (`test_terminal_cost_regression.py`) and the new default penalty (`test_optimizer_runner_integration.py`). Full suite: 3163 passed, coverage 95.2%; ruff check/format, vulture, interrogate, bandit all green; pyright clean on touched files.

Closes #885
