### PR TITLE
fix(pricing): read amber_express v2.0.0 detailedForecast attribute

### DIFF
--- a/custom_components/localshift/pricing/provider.py
+++ b/custom_components/localshift/pricing/provider.py
@@ -187,8 +187,22 @@ class AmberExpressProvider(_ProviderMixin):
         raw_forecasts = self._read_attribute(hass, detailed_entity, "forecasts", [])
 
         if not raw_forecasts:
-            _LOGGER.debug("%s has no forecasts, trying simple entity", detailed_entity)
-            raw_forecasts = self._read_attribute(hass, price_entity_id, "forecast", [])
+            # amber_express v2.0.0 (2026-06-25) removed the separate
+            # *_price_detailed entity and folded its forecast onto the main
+            # price entity as a `detailedForecast` attribute, replacing the old
+            # `forecasts` attribute. Slots retain start_time/end_time/duration/
+            # per_kwh/demand_window, so _normalize_slot handles them unchanged.
+            # NOTE: the simple `forecast` attribute ({time, value}, used by HAEO)
+            # is NOT usable here — it lacks start_time/per_kwh and cannot be
+            # normalized, which is what caused the KeyError-per-slot failure.
+            _LOGGER.debug(
+                "%s unavailable; reading detailedForecast from %s",
+                detailed_entity,
+                price_entity_id,
+            )
+            raw_forecasts = self._read_attribute(
+                hass, price_entity_id, "detailedForecast", []
+            )
 
         if not raw_forecasts:
             _LOGGER.warning("No forecasts found for %s", price_entity_id)

--- a/tests/pricing/test_provider.py
+++ b/tests/pricing/test_provider.py
@@ -176,8 +176,16 @@ def test_amber_express_entity_prefix():
     assert provider.name == "amber_express"
 
 
-def test_amber_express_provider_falls_back_to_simple_entity():
-    """Test AmberExpressProvider falls back to simple entity when detailed missing."""
+def test_amber_express_v2_reads_detailed_forecast_from_main_entity():
+    """Test AmberExpressProvider reads v2.0.0 ``detailedForecast`` attribute.
+
+    amber_express v2.0.0 (2026-06-25) removed the separate ``*_price_detailed``
+    entity and folded its rich forecast onto the main price entity as a
+    ``detailedForecast`` attribute. When the legacy detailed entity is absent,
+    the provider must read ``detailedForecast`` off the main price entity and
+    normalize those slots (start_time / per_kwh / duration, is_spike from
+    demand_window) exactly as it did the legacy ``forecasts``.
+    """
     from unittest.mock import MagicMock
 
     from custom_components.localshift.pricing.provider import AmberExpressProvider
@@ -185,25 +193,74 @@ def test_amber_express_provider_falls_back_to_simple_entity():
     provider = AmberExpressProvider()
 
     hass = MagicMock()
-    # Detailed entity returns None
-    simple_state = MagicMock()
-    simple_state.attributes = {
+    main_state = MagicMock()
+    main_state.attributes = {
+        # The simple HAEO list is also present on the real entity; it must be
+        # ignored in favour of detailedForecast.
         "forecast": [
+            {"time": "2026-03-16T12:00:00+11:00", "value": 0.20},
+            {"time": "2026-03-16T12:30:00+11:00", "value": 2.50},
+        ],
+        "detailedForecast": [
             {
                 "start_time": "2026-03-16T12:00:01+11:00",
                 "end_time": "2026-03-16T12:30:00+11:00",
                 "per_kwh": 0.20,
                 "demand_window": False,
             },
-        ]
+            {
+                "start_time": "2026-03-16T12:30:01+11:00",
+                "end_time": "2026-03-16T13:00:00+11:00",
+                "per_kwh": 2.50,
+                "demand_window": True,
+            },
+        ],
     }
+    # Legacy _price_detailed entity is gone in v2.0.0 → returns None.
     hass.states.get.side_effect = lambda eid: (
-        None if "detailed" in eid else simple_state
+        None if "detailed" in eid else main_state
     )
 
     slots = provider.read_forecasts(hass, "sensor.amber_express_100h_general_price")
-    assert len(slots) == 1
+
+    assert len(slots) == 2
     assert slots[0].per_kwh == 0.20
+    assert slots[0].duration == 30
+    assert slots[0].is_spike is False
+    assert slots[1].per_kwh == 2.50
+    assert slots[1].duration == 30
+    assert slots[1].is_spike is True  # demand_window=True
+
+
+def test_amber_express_simple_forecast_only_yields_empty():
+    """Negative lock: a main entity exposing only the simple ``forecast`` list.
+
+    The simple ``forecast`` attribute ({time, value}, used by HAEO) lacks
+    start_time / per_kwh and cannot be normalized. The provider must NOT fall
+    back to it — doing so was the original bug, producing a KeyError per slot.
+    With the legacy detailed entity gone and no ``detailedForecast`` present,
+    the result must be an empty list (no crash, no KeyError leakage).
+    """
+    from unittest.mock import MagicMock
+
+    from custom_components.localshift.pricing.provider import AmberExpressProvider
+
+    provider = AmberExpressProvider()
+
+    hass = MagicMock()
+    main_state = MagicMock()
+    main_state.attributes = {
+        "forecast": [
+            {"time": "2026-03-16T12:00:00+11:00", "value": 0.20},
+            {"time": "2026-03-16T12:30:00+11:00", "value": 2.50},
+        ],
+    }
+    hass.states.get.side_effect = lambda eid: (
+        None if "detailed" in eid else main_state
+    )
+
+    slots = provider.read_forecasts(hass, "sensor.amber_express_100h_general_price")
+    assert slots == []
 
 
 def test_amber_express_provider_returns_empty_when_no_forecasts():


### PR DESCRIPTION
## Problem

LocalShift stopped optimising overnight — the DP optimizer was a no-op every cycle (optimizer summary `disabled`, plan `0`, no load shifting since ~2026-06-28 22:47 Sydney). Log signature repeating ~96×/poll:

```
WARNING pricing.provider     Skipping malformed forecast slot: 'start_time'
WARNING engine.slot_schedule compute_hybrid_slot_schedule: Empty general_forecast
WARNING engine.optimizer_facade DP optimizer: no slots available, skipping
```

## Root cause

The upstream **`amber_express` integration upgraded to v2.0.0** (released 2026-06-25; landed live ~2026-06-28 22:47) — a deliberate breaking change ([release notes](https://github.com/hass-energy/amber-express/releases/tag/v2.0.0)):

- The separate `*_price_detailed` sensors were **removed** (now `unavailable`).
- Their forecast now lives in a **`detailedForecast`** attribute on the **primary** price sensor, replacing the old `forecasts` attribute.
- The lightweight `forecast` list (`{time, value}`, used by HAEO) is unchanged.

`AmberExpressProvider.read_forecasts` read `forecasts` off the (now-gone) `_price_detailed` entity → `[]`, then fell back to the main sensor's simple `forecast` list. That list lacks `start_time`/`per_kwh`, so `_normalize_slot()` raised `KeyError` per slot → empty price forecast → empty schedule → optimizer skipped.

## Fix

Replace the dead simple-`forecast` fallback with a `detailedForecast` read off the main price entity. Those slots retain `start_time/end_time/duration/per_kwh/demand_window/spike_status`, so `_normalize_slot()` handles them unchanged and `is_spike()` already keys off `demand_window`. The legacy `_price_detailed`.`forecasts` lookup is kept for v1.x back-compat (it just falls through now). Slug-agnostic — no `100h`-specific handling needed.

## Tests

- **v2.0 path** — main sensor exposes `detailedForecast`, `_price_detailed` absent → non-empty normalized slots, `is_spike` from `demand_window`.
- **Negative lock** — main sensor exposes only the simple `{time, value}` `forecast` → `[]` (no crash, no KeyError leakage); pins the bug shut.
- **Back-compat** — legacy `_price_detailed`.`forecasts` (v1.x) still parses.
- **Empty case** — neither source present → `[]` + warning.

## Gates

- `ruff` clean
- `3164 passed, 1 xfailed`; coverage **95%** total, `provider.py` **98%** (2 uncovered lines are a pre-existing `except` branch, unrelated to this change)

## Live validation (deployed + HA restarted 2026-06-29)

- optimizer summary `disabled` → **`success`**
- optimizer plan `0` → **`55`** slots
- integration status **`ok`**
- `Skipping malformed forecast slot` / `Empty general_forecast` warnings **gone**; no localshift ERROR-level entries

## Follow-up

Consider pinning `amber_express` in HACS — it bumped a major and removed entities, and may do so again.

https://claude.ai/code/session_016Y4rm9nuVmudMzcXA3aCfK