### PR TITLE
fix(optimizer): remove #406 self-consumption double-credit driving the overnight sawtooth

### DIFF
--- a/custom_components/localshift/engine/cost.py
+++ b/custom_components/localshift/engine/cost.py
@@ -55,13 +55,14 @@ def stage_cost(
 
     # Issue #610: horizon-aware solar opportunity cost
     # Penalizes grid import when significant solar is expected later in the horizon.
-    sc_value = (
-        max(0.0, slot.buy_price)
-        if config.optimization_mode == "self_consumption"
-        else 0.0
-    )
-    full_economic_benefit = import_cost + grid_import_kwh * sc_value
-    solar_opportunity_penalty = full_economic_benefit * solar_opportunity_penalty_factor
+    # The opportunity cost of grid-charging now (instead of waiting for free solar) is
+    # the grid import cost itself. This base was previously doubled by adding a
+    # self-consumption credit term (import_cost + grid_import * buy_price) to overcome
+    # the #406 self_consumption_value double-credit in net_cost. That credit is no
+    # longer subtracted (see ObjectiveTerms.net_cost), so the compensating doubling is
+    # removed too — otherwise the penalty over-suppresses genuine price-spike arbitrage
+    # (root-caused with the 2026-06-29 overnight sawtooth fix).
+    solar_opportunity_penalty = import_cost * solar_opportunity_penalty_factor
 
     # Issue #431: uncertainty penalty for grid charging when horizon is short.
     uncertainty_penalty = 0.0
@@ -73,9 +74,13 @@ def stage_cost(
             horizon_penalty_factor = (20.0 - config.forecast_horizon_hours) / 20.0
             uncertainty_penalty = 0.05 * horizon_penalty_factor * grid_import_kwh
 
-    # Calculate self-consumption value (Issue #406)
-    # Battery energy used to cover household load has value because it avoids
-    # buying from grid at retail price.
+    # Calculate self-consumption value (Issue #406) — DIAGNOSTIC ONLY.
+    # Battery energy used to cover household load avoids buying from grid at retail,
+    # but that avoided import is ALREADY reflected in a reduced grid_import_kwh (see
+    # transitions._transition_hold_deficit), hence a lower import_cost above. This
+    # value is therefore NOT subtracted from net_cost (ObjectiveTerms.net_cost);
+    # doing so double-counted the benefit and drove the #406/#800 overnight sawtooth
+    # (root-caused 2026-06-29). Retained as a serialized diagnostic field only.
     self_consumption_value = 0.0
     if config.optimization_mode == "self_consumption":
         net_load = slot.consumption_kwh - slot.solar_kwh

--- a/custom_components/localshift/engine/types.py
+++ b/custom_components/localshift/engine/types.py
@@ -400,7 +400,20 @@ class ObjectiveTerms:
     """Terminal penalty applied at demand window boundary (only for terminal slots)."""
 
     self_consumption_value: float = 0.0
-    """Value of battery energy used for household load (benefit, subtracted from cost)."""
+    """Diagnostic only: value of battery energy used for household load, at retail
+    (``battery_for_load * buy_price``). NOT subtracted from ``net_cost``.
+
+    Issue #406 / #800 overnight sawtooth (root-caused 2026-06-29): subtracting this
+    DOUBLE-COUNTED the self-consumption benefit. When the battery serves load,
+    ``_transition_hold_deficit`` already reduces ``grid_import_kwh`` by the battery's
+    contribution (``transitions.py``: ``grid_import = max(0, load_deficit - battery_to_load)``),
+    so the avoided import is already reflected in a lower ``import_cost``. Crediting it
+    again here valued stored energy at ~2x retail, which made thin overnight
+    charge-and-drain cycling look profitable (~5c/kWh apparent profit on a ~2c/kWh
+    round-trip loss) and is why every soft anti-cycling penalty got "paid through".
+    A deterministic replay of the 2026-06-29 live plan confirmed removing this credit
+    eliminates the overnight sawtooth (11.3 -> 0.0 kWh) while the demand-window
+    pre-charge and target are preserved. Kept as a serialized field for diagnostics."""
 
     switching_penalty: float = 0.0
     """Penalty applied if the action involves a mode switch."""
@@ -417,11 +430,16 @@ class ObjectiveTerms:
 
     @property
     def net_cost(self) -> float:
-        """Net slot cost = import - revenue - self_consumption_value + penalties."""
+        """Net slot cost = import - revenue + penalties.
+
+        ``self_consumption_value`` is deliberately NOT subtracted: the avoided import
+        is already captured by a reduced ``import_cost`` (see the field docstring and
+        ``transitions._transition_hold_deficit``). Subtracting it double-counted the
+        benefit and drove the #406 / #800 overnight sawtooth.
+        """
         return (
             self.import_cost
             - self.export_revenue
-            - self.self_consumption_value
             + self.shortfall_penalty
             + self.uncertainty_penalty
             + self.switching_penalty

--- a/tests/engine/test_floor_charge_guard.py
+++ b/tests/engine/test_floor_charge_guard.py
@@ -22,6 +22,7 @@ from datetime import datetime, timedelta
 
 from custom_components.localshift.engine.core import DPPlanner
 from custom_components.localshift.engine.types import (
+    ObjectiveTerms,
     OptimizerConfig,
     OptimizerInputs,
     PlannerAction,
@@ -29,6 +30,24 @@ from custom_components.localshift.engine.types import (
 )
 
 _CHARGE = (PlannerAction.CHARGE_GRID_NORMAL, PlannerAction.CHARGE_GRID_BOOST)
+
+
+def _restore_406_double_credit(monkeypatch):
+    """Re-inject the #406 self-consumption double-credit removed from net_cost.
+
+    The marginal overnight floor charge these tests A/B was driven by the #406 distortion
+    (discharge-to-load credited at retail on TOP of the avoided import already in
+    import_cost). With that credit removed at source (2026-06-29), the charge no longer
+    appears in scenarios that relied on it, so the "guard is dormant above the buffer"
+    property needs the credit re-injected to have a charge to observe at all. The source
+    fix is covered by tests/engine/test_sawtooth_406_double_credit.py.
+    """
+    orig = ObjectiveTerms.net_cost.fget
+    monkeypatch.setattr(
+        ObjectiveTerms,
+        "net_cost",
+        property(lambda self: orig(self) - self.self_consumption_value),
+    )
 _INTERVAL = 5  # 5-min slots: a normal grid charge gains <2% SOC per slot at the floor
 _START = datetime(2026, 6, 8, 1, 0)  # 1am — deep overnight, far from any demand window
 
@@ -117,8 +136,13 @@ class TestFloorChargeGuard:
             f"charges at {[c.timestamp_iso for c in charges]}"
         )
 
-    def test_guard_dormant_above_floor_buffer(self):
-        """Starting above the buffer, charging is unaffected — the guard only acts at the floor."""
+    def test_guard_dormant_above_floor_buffer(self, monkeypatch):
+        """Starting above the buffer, charging is unaffected — the guard only acts at the floor.
+
+        Needs the #406 double-credit (the charge's driver in this scenario) present to have
+        a charge to observe — see ``_restore_406_double_credit``.
+        """
+        _restore_406_double_credit(monkeypatch)
         guarded = [d for d in _plan(2.0, soc0=15.0).decisions if d.action in _CHARGE]
         unguarded = [d for d in _plan(0.0, soc0=15.0).decisions if d.action in _CHARGE]
         assert guarded and unguarded, (

--- a/tests/engine/test_sawtooth_406_double_credit.py
+++ b/tests/engine/test_sawtooth_406_double_credit.py
@@ -1,0 +1,169 @@
+"""Regression: #406 self-consumption double-credit drove the overnight sawtooth.
+
+Live incident 2026-06-29 (flat/elevated-price day, buy $0.15-0.20, no genuine cheap
+window). The optimizer charged the battery in three wasteful overnight pulses
+(21:20-22:00, ~02:30, 06:00) that each drained to the SOC floor through high overnight
+load before the real demand-window pre-charge at midday — ~11 kWh of grid import that
+funded 0% of the DW target, pure round-trip-loss churn.
+
+Root cause (confirmed by deterministic replay of the live plan): ObjectiveTerms.net_cost
+subtracted self_consumption_value (battery_for_load * buy_price) on top of an import_cost
+that ALREADY netted out battery-served load (transitions._transition_hold_deficit). Stored
+energy was valued at ~2x retail, so thin overnight charge-and-drain looked profitable
+(~5c/kWh apparent profit on a ~2c/kWh round-trip loss). The solar_opportunity_penalty base
+had been doubled to compensate for the same credit; both halves are removed together.
+
+The slot table below is the EXACT live plan input (sensor.localshift_optimizer_plan_detailed,
+55 slots, DW entry idx 42 = 15:00). Replaying it goes RED on the double-credit (overnight
+charge-and-drain reappears, ~11 kWh) and GREEN with the fix (zero overnight charging), while
+the legitimate midday demand-window pre-charge and the 95% target are preserved.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+from custom_components.localshift.engine.core import DPPlanner
+from custom_components.localshift.engine.types import (
+    ObjectiveTerms,
+    OptimizerConfig,
+    OptimizerInputs,
+    PlannerAction,
+    SlotContext,
+)
+
+CHARGE = (PlannerAction.CHARGE_GRID_NORMAL, PlannerAction.CHARGE_GRID_BOOST)
+DW_ENTRY_IDX = 42  # 15:00 — plan stops charging and starts discharging here
+OVERNIGHT_END = 26  # idx < 26 are the overnight/early-morning slots (21:20-06:30)
+INITIAL_SOC = 12.8
+
+# (interval_min, buy, sell, solar_kwh, consumption_kwh) — verbatim live 2026-06-29 plan.
+LIVE = [
+    (5, 0.160, 0.1000, 0.0000, 0.1030), (5, 0.160, 0.1000, 0.0000, 0.1030),
+    (5, 0.180, 0.1033, 0.0000, 0.1030), (5, 0.180, 0.0967, 0.0000, 0.1030),
+    (5, 0.170, 0.0933, 0.0000, 0.1030), (5, 0.160, 0.0867, 0.0000, 0.1030),
+    (5, 0.160, 0.0833, 0.0000, 0.1030), (5, 0.150, 0.0800, 0.0000, 0.1030),
+    (30, 0.150, 0.0800, 0.0000, 0.6350), (30, 0.160, 0.0900, 0.0000, 0.6650),
+    (30, 0.160, 0.0900, 0.0000, 0.5870), (30, 0.160, 0.0900, 0.0000, 0.5420),
+    (30, 0.160, 0.0900, 0.0000, 0.5520), (30, 0.160, 0.0900, 0.0000, 0.5250),
+    (30, 0.160, 0.0900, 0.0000, 0.4760), (30, 0.160, 0.0900, 0.0000, 0.3500),
+    (30, 0.160, 0.0900, 0.0000, 0.3260), (30, 0.160, 0.0900, 0.0000, 0.3210),
+    (30, 0.160, 0.0900, 0.0000, 0.4050), (30, 0.160, 0.0900, 0.0000, 0.4220),
+    (30, 0.180, 0.1000, 0.0000, 0.3920), (30, 0.170, 0.1000, 0.0000, 0.3860),
+    (30, 0.150, 0.0800, 0.0000, 0.3720), (30, 0.150, 0.0800, 0.0000, 0.3690),
+    (30, 0.150, 0.0900, 0.0000, 0.2810), (30, 0.170, 0.1000, 0.0000, 0.2630),
+    (30, 0.200, 0.1300, 0.0110, 0.3920), (30, 0.210, 0.1300, 0.0460, 0.4170),
+    (30, 0.220, 0.1500, 0.1410, 0.4160), (30, 0.180, 0.1100, 0.3230, 0.4150),
+    (30, 0.170, 0.1000, 0.5040, 0.5850), (30, 0.190, 0.1200, 0.6680, 0.6190),
+    (30, 0.180, 0.1000, 0.7790, 0.8330), (30, 0.180, 0.1000, 0.8840, 0.8760),
+    (30, 0.170, 0.0900, 0.9610, 0.9250), (30, 0.170, 0.0900, 0.9930, 0.9350),
+    (30, 0.170, 0.0900, 0.9820, 0.9410), (30, 0.170, 0.0800, 0.9210, 0.9420),
+    (30, 0.170, 0.0900, 0.8280, 0.6830), (30, 0.180, 0.1000, 0.6970, 0.6310),
+    (30, 0.180, 0.1000, 0.5680, 0.5730), (30, 0.190, 0.1100, 0.4090, 0.5620),
+    (30, 0.200, 0.1300, 0.2460, 0.4280), (30, 0.200, 0.1200, 0.0880, 0.4020),
+    (30, 0.190, 0.1600, 0.0210, 0.4570), (30, 0.190, 0.1600, 0.0030, 0.4680),
+    (30, 0.210, 0.1700, 0.0000, 0.6480), (30, 0.230, 0.2000, 0.0000, 0.6840),
+    (30, 0.230, 0.1900, 0.0000, 0.6600), (30, 0.280, 0.2400, 0.0000, 0.6550),
+    (30, 0.470, 0.4100, 0.0000, 0.5690), (30, 0.220, 0.1800, 0.0000, 0.5520),
+    (30, 0.220, 0.1800, 0.0000, 0.5310), (30, 0.190, 0.1600, 0.0000, 0.5270),
+    (30, 0.200, 0.2000, 0.0000, 0.4320),
+]
+
+
+def _slots() -> list[SlotContext]:
+    base = datetime(2026, 6, 29, 21, 15)
+    out: list[SlotContext] = []
+    t = base
+    for i, (interval, buy, sell, solar, cons) in enumerate(LIVE):
+        out.append(
+            SlotContext(
+                slot_index=i,
+                timestamp_iso=t.isoformat(),
+                slot_interval_minutes=interval,
+                buy_price=buy,
+                sell_price=sell,
+                solar_kwh=solar,
+                consumption_kwh=cons,
+                is_demand_window_entry=(i == DW_ENTRY_IDX),
+                is_demand_window_slot=(i >= DW_ENTRY_IDX),
+            )
+        )
+        t += timedelta(minutes=interval)
+    return out
+
+
+def _config() -> OptimizerConfig:
+    return OptimizerConfig(
+        optimization_mode="self_consumption",
+        battery_capacity_kwh=13.5,
+        charge_efficiency=0.92,
+        discharge_efficiency=0.95,
+        min_soc_pct=10.0,
+        max_soc_pct=100.0,
+        demand_window_target_soc_pct=95.0,
+        allow_dw_entry_under_target=False,
+        effective_cheap_price=0.18,
+        base_cheap_price=0.16,
+        max_precharge_price=0.20,
+        target_shortfall_penalty_per_pct=0.10,
+        switching_penalty=0.08,
+        min_cycle_saving=0.25,
+        soc_bins=100,
+    )
+
+
+def _plan(monkeypatch=None, *, double_credit=False):
+    """Run the planner; with double_credit=True, restore the #406 bug to prove RED."""
+    if double_credit:
+        orig = ObjectiveTerms.net_cost.fget
+        monkeypatch.setattr(
+            ObjectiveTerms,
+            "net_cost",
+            property(lambda self: orig(self) - self.self_consumption_value),
+        )
+    inputs = OptimizerInputs(
+        cycle_id="sawtooth-406", initial_soc_pct=INITIAL_SOC,
+        slots=_slots(), config=_config(), all_solcast=[],
+    )
+    return DPPlanner(_config()).plan(inputs)
+
+
+def _overnight_charge_kwh(result) -> float:
+    return sum(
+        max(0.0, getattr(d, "grid_import_kwh", 0.0))
+        for d in result.decisions
+        if d.slot_index < OVERNIGHT_END and d.action in CHARGE
+    )
+
+
+def test_no_overnight_sawtooth_with_fix():
+    """GREEN: the corrected objective does not charge-and-drain overnight."""
+    result = _plan()
+    assert result.success
+    overnight = [d.slot_index for d in result.decisions[:OVERNIGHT_END] if d.action in CHARGE]
+    assert overnight == [], f"overnight sawtooth charges reappeared at {overnight}"
+    assert _overnight_charge_kwh(result) == 0.0
+
+
+def test_double_credit_reproduces_sawtooth(monkeypatch):
+    """RED guard: restoring the #406 double-credit brings the overnight churn back.
+
+    Pins the root cause — if this stops failing under the bug, the credit is no longer
+    driving the sawtooth and the regression guard above would be testing nothing.
+    """
+    result = _plan(monkeypatch, double_credit=True)
+    assert result.success
+    overnight = [d.slot_index for d in result.decisions[:OVERNIGHT_END] if d.action in CHARGE]
+    assert overnight, "expected the double-credit to reintroduce overnight charging"
+    assert _overnight_charge_kwh(result) > 5.0  # live double-credit drew ~11 kWh overnight
+
+
+def test_demand_window_precharge_preserved():
+    """The fix must not regress legitimate DW pre-charge: target still funded midday."""
+    result = _plan()
+    assert result.success
+    midday_charges = [
+        d.slot_index for d in result.decisions[OVERNIGHT_END:DW_ENTRY_IDX] if d.action in CHARGE
+    ]
+    assert midday_charges, "the plan must still pre-charge for the demand window"
+    assert result.decisions[DW_ENTRY_IDX].predicted_soc_pct >= 90.0

--- a/tests/engine/test_sawtooth_gate.py
+++ b/tests/engine/test_sawtooth_gate.py
@@ -29,6 +29,7 @@ from custom_components.localshift.engine.constraints import (
 )
 from custom_components.localshift.engine.core import DPPlanner
 from custom_components.localshift.engine.types import (
+    ObjectiveTerms,
     OptimizerConfig,
     OptimizerInputs,
     PlannerAction,
@@ -36,6 +37,24 @@ from custom_components.localshift.engine.types import (
 )
 
 INTERVAL = 30
+
+
+def _restore_406_double_credit(monkeypatch):
+    """Re-inject the #406 self-consumption double-credit removed from net_cost.
+
+    The post-DW overnight sawtooth this base-gating guard blocks was driven by the #406
+    distortion (discharge-to-load credited at retail on TOP of the avoided import already
+    in import_cost). That credit was removed at source on 2026-06-29, so the sawtooth no
+    longer appears even unguarded. These tests re-inject it to exercise the base-gating
+    guard against the distortion it defends against; the source fix is covered by
+    tests/engine/test_sawtooth_406_double_credit.py.
+    """
+    orig = ObjectiveTerms.net_cost.fget
+    monkeypatch.setattr(
+        ObjectiveTerms,
+        "net_cost",
+        property(lambda self: orig(self) - self.self_consumption_value),
+    )
 _START = datetime(2026, 6, 3, 12, 0)  # day-1 noon
 
 # Price bands ($/kWh)
@@ -143,12 +162,14 @@ def _post_dw_overnight_charges(result):
 class TestSawtoothGate:
     """End-to-end DP behaviour for the overnight sawtooth."""
 
-    def test_inflated_threshold_reproduces_sawtooth_when_unguarded(self):
+    def test_inflated_threshold_reproduces_sawtooth_when_unguarded(self, monkeypatch):
         """Without base gating (base_cheap_price=None) the inflated threshold leaks.
 
         Documents the bug: post-DW overnight slots (price > base, <= inflated) get
-        charged then drained — the sawtooth.
+        charged then drained — the sawtooth. Requires the #406 double-credit (its driver)
+        to be present — see ``_restore_406_double_credit``.
         """
+        _restore_406_double_credit(monkeypatch)
         result = _plan(base_cheap_price=None)
         charges = _post_dw_overnight_charges(result)
         assert charges, (
@@ -158,8 +179,13 @@ class TestSawtoothGate:
         # All such charges are classed CHEAP_IMPORT_WINDOW, matching the field report.
         assert any(c.reason_code.value == "CHEAP_IMPORT_WINDOW" for c in charges)
 
-    def test_base_gating_eliminates_sawtooth(self):
-        """With base gating, no post-DW overnight charge above the real base occurs."""
+    def test_base_gating_eliminates_sawtooth(self, monkeypatch):
+        """With base gating, no post-DW overnight charge above the real base occurs.
+
+        Exercised with the #406 double-credit present (so the sawtooth would otherwise
+        appear), proving the base-gating guard blocks it — not merely the source fix.
+        """
+        _restore_406_double_credit(monkeypatch)
         result = _plan(base_cheap_price=_BASE_CHEAP)
         charges = _post_dw_overnight_charges(result)
         assert charges == [], (

--- a/tests/test_min_cycle_saving_gate.py
+++ b/tests/test_min_cycle_saving_gate.py
@@ -21,11 +21,30 @@ from custom_components.localshift.engine.optimizer_dp import (
     PlannerAction,
     SlotContext,
 )
+from custom_components.localshift.engine.types import ObjectiveTerms
 
 CHARGE_ACTIONS = {
     PlannerAction.CHARGE_GRID_NORMAL,
     PlannerAction.CHARGE_GRID_BOOST,
 }
+
+
+def _restore_406_double_credit(monkeypatch):
+    """Re-inject the #406 self-consumption double-credit removed from net_cost.
+
+    The micro-overnight arbitrage this gate was built to block was driven by the #406
+    distortion (discharge-to-load credited at retail on TOP of the avoided import, which
+    is already in import_cost). That credit was removed at source on 2026-06-29, so the
+    micro-arbitrage no longer appears at all (even with the gate disabled). These gate
+    tests re-inject it so the gate itself is exercised against the distortion it defends
+    against; the source fix is covered by tests/engine/test_sawtooth_406_double_credit.py.
+    """
+    orig = ObjectiveTerms.net_cost.fget
+    monkeypatch.setattr(
+        ObjectiveTerms,
+        "net_cost",
+        property(lambda self: orig(self) - self.self_consumption_value),
+    )
 
 PROD_DEFAULT = 0.25  # production DEFAULT_MIN_CYCLE_SAVING
 
@@ -138,16 +157,26 @@ def _plan_live(min_saving, rows=None):
     return DPPlanner().plan(inputs)
 
 
-def test_gate_disabled_reproduces_micro_arbitrage():
-    """min_cycle_saving=0 (disabled) -> the live overnight charge happens."""
+def test_gate_disabled_reproduces_micro_arbitrage(monkeypatch):
+    """min_cycle_saving=0 (disabled) -> the live overnight charge happens.
+
+    Requires the #406 double-credit (its driver) to be present — see
+    ``_restore_406_double_credit``.
+    """
+    _restore_406_double_credit(monkeypatch)
     charges = _charge_slots(_plan_live(0.0))
     assert 23 in charges and 24 in charges, (
         f"baseline should reproduce the live 01:00/01:30 charge, got {charges}"
     )
 
 
-def test_gate_blocks_micro_overnight_arbitrage():
-    """At 25c, tonight's ~1c/kWh arbitrage isn't worth a cycle -> removed entirely."""
+def test_gate_blocks_micro_overnight_arbitrage(monkeypatch):
+    """At 25c, tonight's ~1c/kWh arbitrage isn't worth a cycle -> removed entirely.
+
+    Exercised with the #406 double-credit present (so a charge would otherwise appear),
+    proving the gate itself blocks it — not merely the source fix.
+    """
+    _restore_406_double_credit(monkeypatch)
     charges = _charge_slots(_plan_live(PROD_DEFAULT))
     assert charges == [], (
         f"min-cycle-saving gate should block the micro arbitrage, got {charges}"

--- a/tests/test_solar_opportunity_penalty.py
+++ b/tests/test_solar_opportunity_penalty.py
@@ -704,19 +704,21 @@ class TestSelfConsumptionCreditFix:
 
 
 class TestSolarOpportunityPenaltyStrengthened:
-    """Fix B: solar opportunity penalty base includes downstream self-consumption credit.
+    """Solar opportunity penalty base is the grid import cost (#406 double-credit fix).
 
-    The penalty must overcome both the import cost AND the self-consumption credit
-    that the charged energy will generate. Previously penalty = import_cost * factor,
-    which capped the penalty below the self-consumption credit when credit > import_cost.
+    The penalty base was previously DOUBLED (import_cost + grid_import * buy_price) to
+    overcome the #406 self_consumption_value double-credit in net_cost. That credit is
+    no longer subtracted (root-caused with the 2026-06-29 overnight sawtooth), so the
+    compensating doubling is removed: the opportunity cost of grid-charging now instead
+    of waiting for free solar is simply the grid import cost. Leaving the doubling in
+    would over-suppress genuine price-spike arbitrage.
     """
 
-    def test_penalty_base_reflects_full_economic_benefit(self, default_config):
-        """Solar opportunity penalty should exceed import_cost × factor alone.
+    def test_penalty_base_is_import_cost(self, default_config):
+        """Solar opportunity penalty base == import_cost (no double-credit doubling).
 
-        When buy_price = $0.14 and self_consumption_value = $0.14 per kWh,
-        the full economic benefit of charging is $0.14 (import) + $0.14*RTE (future credit).
-        The penalty must overwhelm both, so its base should be > import_cost alone.
+        With factor=1.0 the penalty equals the grid import cost exactly. It must NOT be
+        inflated by a phantom self-consumption credit (the #406 distortion).
         """
         slot = make_slot(
             0,
@@ -742,12 +744,10 @@ class TestSolarOpportunityPenaltyStrengthened:
             solar_opportunity_penalty_factor=1.0,  # full penalty for test clarity
         )
 
-        # With factor=1.0, OLD penalty = import_cost = $0.07
-        # NEW penalty should be larger (includes self-consumption credit component)
-        # Expected: > $0.07 when self-consumption mode is active
-        assert terms.solar_opportunity_penalty > import_cost, (
-            f"Solar opportunity penalty ({terms.solar_opportunity_penalty:.4f}) should exceed "
-            f"import_cost ({import_cost:.4f}) alone — penalty base must include downstream credit"
+        # With factor=1.0 the penalty base is the honest import cost — no doubling.
+        assert terms.solar_opportunity_penalty == pytest.approx(import_cost), (
+            f"Solar opportunity penalty ({terms.solar_opportunity_penalty:.4f}) should equal "
+            f"import_cost ({import_cost:.4f}) — the #406 double-credit doubling is removed"
         )
 
 


### PR DESCRIPTION
## Summary

The recurring overnight **sawtooth** (charge cheap → drain to floor → recharge, cycling the battery for marginal/no benefit) is root-caused to the **#406 self-consumption double-credit** in the DP objective.

`ObjectiveTerms.net_cost` subtracted `self_consumption_value` (`battery_for_load * buy_price`) on top of an `import_cost` that **already** nets out battery-served load (`transitions._transition_hold_deficit`: `grid_import = max(0, load_deficit - battery_to_load)`). Stored energy was therefore valued at **~2× retail**, flipping a ~2¢/kWh round-trip loss into a ~5¢/kWh apparent profit. That is why every soft anti-cycling penalty over the last ~15 months got "paid through".

## Evidence

Root cause confirmed by a **deterministic replay of the live 2026-06-29 plan** (flat/elevated-price day, buy $0.15–0.20):

| | Overnight charging | DW-entry SOC |
|---|---|---|
| Baseline (reproduces live) | **11.34 kWh** churn | 95.2% |
| Ablate `self_consumption_value` | **0.00 kWh** | 93.1% (target still met) |
| `target_penalty` 0.10→0.03 | 11.34 kWh (no effect) | 95.2% |
| Disable #886 hard floor | 20.13 kWh (**worse** — floor is protective) | 97.2% |

So #406 is the **sole** driver; `target_penalty` is irrelevant and the #886 hard DW-target floor is protective, not causal.

## Changes

- **`net_cost`** no longer subtracts `self_consumption_value`; the field is retained as a serialized **diagnostic** only.
- **`solar_opportunity_penalty`** base reverts from `import_cost + grid_import*buy_price` to `import_cost`. The doubling existed only to overcome the double-credit; once removed, leaving it doubled over-suppresses genuine price-spike arbitrage (caught by the existing spike-capture test).
- **New regression** `tests/engine/test_sawtooth_406_double_credit.py` replays the exact live 55-slot plan: RED with the credit restored, GREEN with the fix, DW pre-charge + 95% target preserved.
- The sawtooth-gate / min-cycle-saving / floor-charge **guards stay as defence-in-depth**; their bug-reproduction tests now re-inject the double-credit so they still exercise the guard against the distortion it was built for.

## Testing

- Full suite: **3166 passed, 1 xfailed**. The single failure (`test_config_flow.py::TestOptionsFlowMigration::test_options_flow_empty_initial_options`) is **pre-existing and unrelated** (fails on `main`; HA config-entry init issue).
- `ruff check` + `ruff format --check` + `vulture` clean on `custom_components/localshift`.

## Notable

Fixing #406 made **three** separate anti-cycling guard tests stop reproducing their bug scenarios — strong evidence those soft guards were all compensating for the double-credit. Kept as defence-in-depth here; **evaluating their removal is a clean follow-up**.

Not yet deployed to live.

https://claude.ai/code/session_012m2ttgNQTWWhRAcBKy7ALK