### PR TITLE
fix(state): stop Tesla-override false-positive freezing the battery

### DIFF
--- a/custom_components/localshift/binary_sensor.py
+++ b/custom_components/localshift/binary_sensor.py
@@ -9,6 +9,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.util import dt as dt_util
 
 from .const import DOMAIN
 from .coordinator import LocalShiftCoordinator
@@ -270,11 +271,35 @@ class TeslaOverrideActiveSensor(LocalShiftBinarySensorBase):
         else:
             description = "Tesla is not overriding control"
 
-        return {
+        attributes: dict[str, Any] = {
             "operation_mode": self.coordinator.data.operation_mode,
             "backup_reserve": self.coordinator.data.backup_reserve,
+            "grid_services_active": self.coordinator.data.grid_services_active,
+            "storm_watch_active": self.coordinator.data.storm_watch_active,
             "description": description,
         }
+
+        state_machine = self.coordinator._state_machine
+        if state_machine is not None:
+            info = state_machine.get_tesla_override_info()
+            detected_at = info.get("detected_at")
+            duration_minutes = None
+            if self._attr_is_on and detected_at is not None:
+                duration_minutes = round(
+                    (dt_util.now() - detected_at).total_seconds() / 60.0, 1
+                )
+            attributes.update({
+                "detected_at": detected_at.isoformat() if detected_at else None,
+                "duration_minutes": duration_minutes,
+                "corroborated": info.get("corroborated"),
+                "last_probe_at": (
+                    info["last_probe_at"].isoformat()
+                    if info.get("last_probe_at")
+                    else None
+                ),
+            })
+
+        return attributes
 
 
 # ---------------------------------------------------------------------------

--- a/custom_components/localshift/const.py
+++ b/custom_components/localshift/const.py
@@ -104,6 +104,9 @@ CONF_TESLEMETRY_SOLAR_POWER = "teslemetry_solar_power"
 CONF_TESLEMETRY_LOAD_POWER = "teslemetry_load_power"
 CONF_TESLEMETRY_ALLOW_EXPORT = "teslemetry_allow_export"
 CONF_TESLEMETRY_ALLOW_CHARGING_FROM_GRID = "teslemetry_allow_charging_from_grid"
+# Corroboration signals for Tesla override detection (Storm Watch / Grid Event / VPP)
+CONF_TESLEMETRY_GRID_SERVICES = "teslemetry_grid_services"
+CONF_TESLEMETRY_STORM_WATCH = "teslemetry_storm_watch"
 
 CONF_TESLEMETRY_SOLAR_ENERGY = "teslemetry_solar_energy"
 
@@ -169,6 +172,8 @@ DEFAULT_ENTITY_IDS = {
     CONF_TESLEMETRY_LOAD_POWER: "sensor.my_home_load_power",
     CONF_TESLEMETRY_ALLOW_EXPORT: "select.my_home_allow_export",
     CONF_TESLEMETRY_ALLOW_CHARGING_FROM_GRID: "switch.my_home_allow_charging_from_grid",
+    CONF_TESLEMETRY_GRID_SERVICES: "binary_sensor.my_home_grid_services_enabled",
+    CONF_TESLEMETRY_STORM_WATCH: "binary_sensor.my_home_storm_watch_active",
     CONF_TESLEMETRY_SOLAR_ENERGY: "sensor.my_home_solar_energy",
     CONF_PRICING_GENERAL_PRICE: "",  # Empty - discovered during config flow
     CONF_PRICING_FEED_IN_PRICE: "",  # Empty - discovered during config flow
@@ -573,6 +578,14 @@ STATE_MACHINE_TRANSITION_GRACE_SECONDS = 30
 # Coalesce entity state changes before running expensive reevaluation.
 STATE_CHANGE_COALESCE_SECONDS = 15
 
+# Post-acceptance reserve settle-verify (Tesla-override freeze fix).
+# After a transition is accepted, Tesla can silently revert a backup-reserve
+# write a few seconds later (the write races the still-settling op-mode change).
+# Re-read the reserve after this delay and, if it reverted, re-issue the write
+# once and poll for it to stick before declaring the transition successful.
+VALIDATION_RESERVE_SETTLE_SECONDS = 10
+VALIDATION_RESERVE_RETRY_TIMEOUT_SECONDS = 10
+
 # -----------------------------------------------------------------------------
 # Proactive Export Constants
 # -----------------------------------------------------------------------------
@@ -608,3 +621,19 @@ NEGATIVE_FIT_DW_EXPORT_MIN_BENEFIT_PER_KWH: Final[float] = 0.02
 # external API commands until the event ends.
 TESLA_OVERRIDE_RESERVE_PERCENT = 80.0
 TESLA_OVERRIDE_TOLERANCE_PERCENT = 1.0
+
+# The reserve≈80 + self_consumption signature is also reachable by LocalShift's
+# own daily force-charge clamp (Tesla firmware resets 81-99 -> 80). When Tesla's
+# grid-services / storm-watch signals are unavailable, suppress override
+# detection if LocalShift itself commanded a matching state within this window.
+TESLA_OVERRIDE_SELF_COMMAND_GRACE_MINUTES = 15
+
+# While yielding to an *uncorroborated* override (signature present but grid
+# services / storm watch unknown), re-issue the commanded mode on this cadence
+# to test whether control has returned. Bounds a false-positive yield instead
+# of yielding indefinitely.
+TESLA_OVERRIDE_REPROBE_INTERVAL_MINUTES = 30
+
+# After Tesla releases control (signature clears on its own), wait this long
+# before resuming health-check corrections so a genuinely-ending event settles.
+TESLA_OVERRIDE_RELEASE_COOLDOWN_MINUTES = 30

--- a/custom_components/localshift/coordinator/data.py
+++ b/custom_components/localshift/coordinator/data.py
@@ -168,6 +168,12 @@ class CoordinatorData:
     soc: float = 0.0
     operation_mode: str = ""
     backup_reserve: float = 0.0
+    # Tesla override corroboration signals (Storm Watch / Grid Event / VPP).
+    # Tri-state: True/False when the entity reports on/off, None when the entity
+    # is unavailable/unknown/unconfigured. None must NOT be coerced to False —
+    # override detection distinguishes "no event" from "signal unavailable".
+    grid_services_active: bool | None = None
+    storm_watch_active: bool | None = None
     general_price: float = 0.0
     feed_in_price: float = 0.0
     price_spike: bool = False

--- a/custom_components/localshift/integration/controller.py
+++ b/custom_components/localshift/integration/controller.py
@@ -130,6 +130,7 @@ class BatteryController:
             expected_export_mode=recipe.expectation.export_mode,
             expected_grid_charging_allowed=recipe.expectation.grid_charging_allowed,
             timeout=recipe.expectation.timeout,
+            retry_reserve_write=self._service_client.set_backup_reserve,
         ):
             if recipe.on_validation_failure:
                 recipe.on_validation_failure()
@@ -710,6 +711,7 @@ class BatteryController:
         expected_export_mode: str | None = None,
         expected_grid_charging_allowed: bool | None = None,
         timeout: int = 10,
+        retry_reserve_write: Callable[[float | int], Awaitable[bool]] | None = None,
     ) -> bool:
         """Validate that hardware state matches expected values after transition."""
         return await self._validator.validate_transition(
@@ -718,6 +720,7 @@ class BatteryController:
             expected_export_mode=expected_export_mode,
             expected_grid_charging_allowed=expected_grid_charging_allowed,
             timeout=timeout,
+            retry_reserve_write=retry_reserve_write,
         )
 
     async def verify_current_state(

--- a/custom_components/localshift/services/notification_service.py
+++ b/custom_components/localshift/services/notification_service.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable
+from datetime import timedelta
 from typing import TYPE_CHECKING
 
 from ..const import (
@@ -472,6 +473,66 @@ class NotificationService:
         )
 
         await self.send_notification(title, message)
+
+    async def send_tesla_override_notification(
+        self,
+        data: CoordinatorData,
+        detected: bool,
+        corroborated: bool,
+        duration: timedelta | None = None,
+        release_reason: str | None = None,
+    ) -> None:
+        """Notify when Tesla takes or releases control of the Powerwall.
+
+        Args:
+            data: Current coordinator data
+            detected: True on first detection, False on release
+            corroborated: Whether a Tesla signal (grid services / storm watch)
+                confirmed the event; when False, detection/yield was heuristic
+            duration: How long the override lasted (release only)
+            release_reason: Why the override ended (release only)
+
+        """
+        if not self._is_notification_enabled(SWITCH_NOTIFICATIONS_ENABLED):
+            _LOGGER.debug("Notifications disabled, skipping Tesla override")
+            return
+
+        dry_run_prefix = self._get_dry_run_prefix()
+
+        if detected:
+            corroboration = (
+                "Confirmed by Tesla grid services / storm watch."
+                if corroborated
+                else "Tesla signals unavailable — detected heuristically; "
+                "will re-probe every 30 min."
+            )
+            title = f"{dry_run_prefix}{NOTIFICATION_PREFIX}Tesla Override Detected"
+            message = (
+                f"Tesla has taken control of the Powerwall "
+                f"(op={data.operation_mode}, reserve={data.backup_reserve:.0f}%). "
+                f"{corroboration} Yielding control. Battery at {data.soc:.0f}%."
+            )
+        else:
+            duration_str = self._format_duration(duration)
+            reason = f" ({release_reason})" if release_reason else ""
+            title = f"{dry_run_prefix}{NOTIFICATION_PREFIX}Tesla Override Released"
+            message = (
+                f"Tesla override ended after {duration_str}{reason}. "
+                f"Resuming automation. Battery at {data.soc:.0f}%."
+            )
+
+        await self.send_notification(title, message)
+
+    @staticmethod
+    def _format_duration(duration: timedelta | None) -> str:
+        """Format a timedelta as a compact 'Nh Nm' string."""
+        if duration is None:
+            return "an unknown period"
+        total_minutes = int(duration.total_seconds() // 60)
+        hours, minutes = divmod(total_minutes, 60)
+        if hours:
+            return f"{hours}h {minutes}m"
+        return f"{minutes}m"
 
     async def send_manual_action_notification(
         self, action: str, data: CoordinatorData

--- a/custom_components/localshift/state/machine.py
+++ b/custom_components/localshift/state/machine.py
@@ -22,7 +22,10 @@ from ..const import (
     PROACTIVE_EXPORT_SOC_BUFFER_PERCENT,
     STATE_MACHINE_MIN_CORRECTION_INTERVAL_MINUTES,
     STATE_MACHINE_TRANSITION_GRACE_SECONDS,
+    TESLA_OVERRIDE_RELEASE_COOLDOWN_MINUTES,
+    TESLA_OVERRIDE_REPROBE_INTERVAL_MINUTES,
     TESLA_OVERRIDE_RESERVE_PERCENT,
+    TESLA_OVERRIDE_SELF_COMMAND_GRACE_MINUTES,
     TESLA_OVERRIDE_TOLERANCE_PERCENT,
     TESLEMETRY_EXPORT_BATTERY_OK,
     TESLEMETRY_EXPORT_PV_ONLY,
@@ -40,8 +43,6 @@ if TYPE_CHECKING:
 
 
 _LOGGER = logging.getLogger(__name__)
-
-TESLA_OVERRIDE_COOLDOWN = timedelta(minutes=30)
 
 
 class StateMachine:
@@ -114,21 +115,35 @@ class StateMachine:
         self._tesla_override_released_at: datetime | None = (
             None  # Track when Tesla released control
         )
+        # True when detection was corroborated by a real Tesla signal
+        # (grid services / storm watch ON); False when yielding purely on the
+        # uncorroborated heuristic (both signals unavailable). Drives the
+        # re-probe decision below.
+        self._tesla_override_corroborated: bool = False
+        # Last time an uncorroborated override was re-probed (commanded mode
+        # re-issued to test whether control returned).
+        self._tesla_override_last_probe_at: datetime | None = None
+        # Suppression window: if LocalShift itself commanded a reserve≈80
+        # self_consumption state within this window, treat a matching signature
+        # as our own leftovers rather than a Tesla override.
+        self._SELF_COMMAND_GRACE = timedelta(
+            minutes=TESLA_OVERRIDE_SELF_COMMAND_GRACE_MINUTES
+        )
+        self._REPROBE_INTERVAL = timedelta(
+            minutes=TESLA_OVERRIDE_REPROBE_INTERVAL_MINUTES
+        )
+        self._RELEASE_COOLDOWN = timedelta(
+            minutes=TESLA_OVERRIDE_RELEASE_COOLDOWN_MINUTES
+        )
 
-    def _detect_tesla_override(self, data: CoordinatorData) -> bool:
-        """Detect if Tesla has taken control (Storm Watch, Grid Event, VPP).
+    def _matches_override_signature(self, data: CoordinatorData) -> bool:
+        """Return True if hardware shows the Tesla-override signature.
 
-        Indicators: operation_mode=self_consumption, backup_reserve≈80%
-
-        Args:
-            data: Coordinator data with current hardware state
-
-        Returns:
-            True if Tesla override is detected, False otherwise.
-
+        Signature: operation_mode=self_consumption with backup_reserve≈80%.
+        Tesla sets this during Storm Watch, Grid Events, and VPP — but
+        LocalShift's own daily force-charge clamp (81-99 -> 80) can reach the
+        same state, so a signature match alone is not proof of an override.
         """
-        # Tesla override signature: self_consumption mode with 80% reserve
-        # This combination is set by Tesla during Storm Watch, Grid Events, VPP
         if data.operation_mode == "self_consumption":
             reserve = data.backup_reserve
             if (
@@ -139,6 +154,68 @@ class StateMachine:
                 return True
         return False
 
+    def _is_signature_self_inflicted(self, now: datetime) -> bool:
+        """Return True if LocalShift itself explains the reserve≈80 signature.
+
+        Used only when Tesla's corroboration signals are unavailable. Two ways
+        the signature can be our own doing:
+          (i) the mode LocalShift currently commands expects a self_consumption
+              reserve ≈80 (e.g. HOLD preserving an ~80% SOC), or
+          (ii) LocalShift completed a transition recently and a reserve write
+               may still be settling or was reverted by Tesla just after
+               acceptance (the incident's revert-after-validation race).
+        """
+        expected_op, expected_reserve, _, _ = self._get_expected_state_for_mode(
+            self._commanded_mode
+        )
+        if (
+            expected_op == "self_consumption"
+            and abs(expected_reserve - TESLA_OVERRIDE_RESERVE_PERCENT)
+            < TESLA_OVERRIDE_TOLERANCE_PERCENT
+        ):
+            return True
+        return (
+            self._last_successful_transition is not None
+            and now - self._last_successful_transition < self._SELF_COMMAND_GRACE
+        )
+
+    def _detect_tesla_override(self, data: CoordinatorData, now: datetime) -> bool:
+        """Detect if Tesla has taken control (Storm Watch, Grid Event, VPP).
+
+        Corroborates the hardware signature against Tesla's grid-services and
+        storm-watch signals, falling back to self-awareness heuristics only when
+        those signals are unavailable:
+
+        - signature absent                      -> no override
+        - either signal ON                      -> override (real event, yield)
+        - both signals known-OFF                -> no override (drift, not event)
+        - signals unavailable + self-inflicted  -> no override (our own leftovers)
+        - signals unavailable + not self-caused -> override (legacy heuristic)
+
+        Args:
+            data: Coordinator data with current hardware state and signals.
+            now: Current time, for the self-command suppression window.
+
+        Returns:
+            True if a Tesla override is detected, False otherwise.
+
+        """
+        if not self._matches_override_signature(data):
+            return False
+
+        signals = (data.grid_services_active, data.storm_watch_active)
+        if any(signal is True for signal in signals):
+            # A real Tesla event is active — genuinely yield control.
+            return True
+        if all(signal is False for signal in signals):
+            # Both signals explicitly report no event: the signature is drift
+            # (e.g. a reverted reserve write), not a Tesla override.
+            return False
+
+        # At least one signal is unavailable and none reports an active event.
+        # Fall back to self-awareness: suppress if this is our own doing.
+        return not self._is_signature_self_inflicted(now)
+
     def is_tesla_override_active(self) -> bool:
         """Check if Tesla override is currently active.
 
@@ -147,6 +224,16 @@ class StateMachine:
 
         """
         return self._tesla_override_detected
+
+    def get_tesla_override_info(self) -> dict[str, Any]:
+        """Return Tesla override state for observability (binary sensor attrs)."""
+        return {
+            "active": self._tesla_override_detected,
+            "detected_at": self._tesla_override_detected_at,
+            "corroborated": self._tesla_override_corroborated,
+            "last_probe_at": self._tesla_override_last_probe_at,
+            "released_at": self._tesla_override_released_at,
+        }
 
     def _get_decision_fingerprint(self, data: CoordinatorData) -> str | None:
         """Generate the discrete decision-context fingerprint.
@@ -987,39 +1074,107 @@ class StateMachine:
         else:  # MANUAL or unknown
             return ("", -1, "", False)
 
-    def _handle_tesla_override_state(
+    async def _handle_tesla_override_state(
         self, data: CoordinatorData, now: datetime
     ) -> bool:
-        """Handle Tesla override detection and cooldown.
+        """Handle Tesla override detection, bounded yield, and cooldown.
 
         Returns True if health checks should be skipped.
         """
         # --- Tesla Override Detection ---
         # Check if Tesla has taken control (Storm Watch, Grid Event, VPP)
-        if self._detect_tesla_override(data):
+        if self._detect_tesla_override(data, now):
+            corroborated_now = (
+                data.grid_services_active is True or data.storm_watch_active is True
+            )
             if not self._tesla_override_detected:
                 # First time detecting Tesla override
                 self._tesla_override_detected = True
                 self._tesla_override_detected_at = now
+                self._tesla_override_corroborated = corroborated_now
+                self._tesla_override_last_probe_at = now
                 _LOGGER.warning(
                     "[TESLA OVERRIDE] Detected Tesla has taken control of Powerwall "
-                    "(Storm Watch, Grid Event, or VPP active). Hardware state: "
-                    "op=%s, reserve=%.1f%%. Yielding control until event ends.",
+                    "(Storm Watch, Grid Event, or VPP). Hardware state: "
+                    "op=%s, reserve=%.1f%%, corroborated=%s. Yielding control.",
                     data.operation_mode,
                     data.backup_reserve,
+                    corroborated_now,
                 )
-            else:
-                # Already in Tesla override mode - check if we should log status
-                if self._tesla_override_detected_at is not None:
-                    duration = now - self._tesla_override_detected_at
+                await self._notification_service.send_tesla_override_notification(
+                    data, detected=True, corroborated=corroborated_now
+                )
+                return True
+
+            # Already in override — refresh corroboration (an initially
+            # uncorroborated detection can become corroborated later).
+            self._tesla_override_corroborated = (
+                self._tesla_override_corroborated or corroborated_now
+            )
+            duration = (
+                now - self._tesla_override_detected_at
+                if self._tesla_override_detected_at
+                else timedelta(0)
+            )
+
+            if corroborated_now:
+                # Real event: never fight it. Keep yielding, hold the probe timer.
+                self._tesla_override_last_probe_at = now
+                _LOGGER.info(
+                    "[TESLA OVERRIDE] Still active (corroborated) for %s. "
+                    "Skipping health check corrections.",
+                    duration,
+                )
+                return True
+
+            # Uncorroborated yield: periodically re-probe to bound a false
+            # positive instead of yielding indefinitely.
+            last_probe = (
+                self._tesla_override_last_probe_at or self._tesla_override_detected_at
+            )
+            if last_probe is not None and now - last_probe >= self._REPROBE_INTERVAL:
+                self._tesla_override_last_probe_at = now
+                _LOGGER.warning(
+                    "[TESLA OVERRIDE] Re-probing after %s: re-issuing commanded mode "
+                    "%s to test whether control has returned.",
+                    duration,
+                    self._commanded_mode.value,
+                )
+                probe_success = await self._execute_mode_transition(
+                    data, self._commanded_mode
+                )
+                if probe_success:
                     _LOGGER.info(
-                        "[TESLA OVERRIDE] Still active for %s. Skipping health check corrections.",
+                        "[TESLA OVERRIDE] Re-probe succeeded after %s — control "
+                        "restored, resuming health checks.",
                         duration,
                     )
-            # Skip all health check corrections while Tesla has control
+                    self._tesla_override_detected = False
+                    self._tesla_override_detected_at = None
+                    self._tesla_override_corroborated = False
+                    self._tesla_override_last_probe_at = None
+                    # Hardware just validated under our command — no cooldown.
+                    self._tesla_override_released_at = None
+                    await self._notification_service.send_tesla_override_notification(
+                        data,
+                        detected=False,
+                        corroborated=False,
+                        duration=duration,
+                        release_reason="re-probe succeeded",
+                    )
+                    return False
+                _LOGGER.warning(
+                    "[TESLA OVERRIDE] Re-probe failed — still yielding control."
+                )
+                return True
+
+            _LOGGER.info(
+                "[TESLA OVERRIDE] Still active for %s. Skipping health check corrections.",
+                duration,
+            )
             return True
 
-        # Tesla override has ended
+        # Tesla override has ended (signature cleared on its own)
         if self._tesla_override_detected:
             duration = (
                 now - self._tesla_override_detected_at
@@ -1030,11 +1185,21 @@ class StateMachine:
                 "[TESLA OVERRIDE] Tesla has released control after %s. "
                 "Applying %s cooldown before resuming health checks.",
                 duration,
-                TESLA_OVERRIDE_COOLDOWN,
+                self._RELEASE_COOLDOWN,
             )
+            was_corroborated = self._tesla_override_corroborated
             self._tesla_override_detected = False
             self._tesla_override_released_at = now
             self._tesla_override_detected_at = None
+            self._tesla_override_corroborated = False
+            self._tesla_override_last_probe_at = None
+            await self._notification_service.send_tesla_override_notification(
+                data,
+                detected=False,
+                corroborated=was_corroborated,
+                duration=duration,
+                release_reason="hardware released",
+            )
 
         # --- Tesla Override Cooldown ---
         # After Tesla releases control, wait for cooldown period before resuming
@@ -1042,8 +1207,8 @@ class StateMachine:
             return False
 
         time_since_release = now - self._tesla_override_released_at
-        if time_since_release < TESLA_OVERRIDE_COOLDOWN:
-            remaining = (TESLA_OVERRIDE_COOLDOWN - time_since_release).total_seconds()
+        if time_since_release < self._RELEASE_COOLDOWN:
+            remaining = (self._RELEASE_COOLDOWN - time_since_release).total_seconds()
             _LOGGER.debug(
                 "[HEALTH CHECK] Skipping - in Tesla override cooldown (%.0fs remaining)",
                 remaining,
@@ -1075,14 +1240,16 @@ class StateMachine:
         )
         return True
 
-    def _should_skip_health_check(self, data: CoordinatorData, now: datetime) -> bool:
+    async def _should_skip_health_check(
+        self, data: CoordinatorData, now: datetime
+    ) -> bool:
         """Check if health check should be skipped."""
         # Skip health check during manual override - user is in control
         if data.manual_override:
             _LOGGER.debug("[HEALTH CHECK] Skipping - manual override active")
             return True
 
-        if self._handle_tesla_override_state(data, now):
+        if await self._handle_tesla_override_state(data, now):
             return True
 
         if self._should_skip_transition_grace(now):
@@ -1104,7 +1271,7 @@ class StateMachine:
         health checks would fight against their manual commands.
         """
         now = dt_util.now()
-        if self._should_skip_health_check(data, now):
+        if await self._should_skip_health_check(data, now):
             return
 
         expected_op, expected_reserve, expected_export, expected_grid_charging = (

--- a/custom_components/localshift/state/reader.py
+++ b/custom_components/localshift/state/reader.py
@@ -27,10 +27,12 @@ from ..const import (
     CONF_TESLEMETRY_BACKUP_RESERVE,
     CONF_TESLEMETRY_BATTERY_POWER,
     CONF_TESLEMETRY_GRID_POWER,
+    CONF_TESLEMETRY_GRID_SERVICES,
     CONF_TESLEMETRY_LOAD_POWER,
     CONF_TESLEMETRY_OPERATION_MODE,
     CONF_TESLEMETRY_SOC,
     CONF_TESLEMETRY_SOLAR_POWER,
+    CONF_TESLEMETRY_STORM_WATCH,
     CONF_WEATHER_ENTITY,
     DEFAULT_COMPARISON_MODE,
     DEFAULT_ENTITY_IDS,
@@ -147,6 +149,17 @@ class StateReader:
     def _read_bool(self, entity_id: str) -> bool:
         """Read a boolean value from an entity's state (on/off)."""
         return self._read_state(entity_id) == "on"
+
+    def _read_bool_optional(self, entity_id: str) -> bool | None:
+        """Read a boolean, returning None when the entity is unavailable.
+
+        Used for the Tesla-override corroboration signals where we must
+        distinguish "event not active" (off) from "signal unavailable" (None).
+        """
+        state = self.hass.states.get(entity_id)
+        if state is None or state.state in ("unknown", "unavailable"):
+            return None
+        return state.state == "on"
 
     def _read_attribute(self, entity_id: str, attr: str, default: Any = None) -> Any:
         """Read an attribute from an entity."""
@@ -678,6 +691,13 @@ class StateReader:
         )
         data.allow_export = self._read_state(
             self._get_entity_id(CONF_TESLEMETRY_ALLOW_EXPORT)
+        )
+        # Tesla override corroboration signals (tri-state; None when unavailable)
+        data.grid_services_active = self._read_bool_optional(
+            self._get_entity_id(CONF_TESLEMETRY_GRID_SERVICES)
+        )
+        data.storm_watch_active = self._read_bool_optional(
+            self._get_entity_id(CONF_TESLEMETRY_STORM_WATCH)
         )
 
         # Pricing - read prices with unavailable detection

--- a/custom_components/localshift/state/validator.py
+++ b/custom_components/localshift/state/validator.py
@@ -5,7 +5,13 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
+from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING
+
+from ..const import (
+    VALIDATION_RESERVE_RETRY_TIMEOUT_SECONDS,
+    VALIDATION_RESERVE_SETTLE_SECONDS,
+)
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
@@ -73,6 +79,7 @@ class TransitionValidator:
         expected_export_mode: str | None = None,
         expected_grid_charging_allowed: bool | None = None,
         timeout: int = 10,
+        retry_reserve_write: Callable[[float | int], Awaitable[bool]] | None = None,
     ) -> bool:
         """Validate that hardware state matches expected values after transition.
 
@@ -82,6 +89,10 @@ class TransitionValidator:
             expected_export_mode: Optional expected allow_export mode
             expected_grid_charging_allowed: Optional expected grid charging switch state
             timeout: Maximum seconds to wait for validation (default: 10)
+            retry_reserve_write: Optional callback to re-issue the backup-reserve
+                write if Tesla reverts it shortly after acceptance (the
+                revert-after-validation race). When None, a reverted reserve is
+                logged but still accepted (lenient bare-wrapper behavior).
 
         Returns:
             True if validation passes, False otherwise.
@@ -170,7 +181,11 @@ class TransitionValidator:
                     attempt + 1,
                     timeout,
                 )
-                return True
+                return await self._settle_verify_reserve(
+                    backup_reserve_entity,
+                    expected_backup_reserve,
+                    retry_reserve_write,
+                )
 
             # Log failure only once (first failure) to avoid log flooding
             if not first_failure_logged:
@@ -221,7 +236,11 @@ class TransitionValidator:
                     "[VALIDATION] ACCEPTED via operation_mode + grid_charging match after %.1fs (reserve/export may lag)",
                     elapsed,
                 )
-                return True
+                return await self._settle_verify_reserve(
+                    backup_reserve_entity,
+                    expected_backup_reserve,
+                    retry_reserve_write,
+                )
 
             # Operation mode matches but grid_charging doesn't - this is a FAILURE
             # Grid charging control is critical for preventing unwanted grid charging
@@ -247,6 +266,72 @@ class TransitionValidator:
             expected_grid_charging_allowed,
             final_operation_mode,
             final_grid_charging,
+        )
+        return False
+
+    async def _settle_verify_reserve(
+        self,
+        backup_reserve_entity: str,
+        expected_backup_reserve: float | int,
+        retry_reserve_write: Callable[[float | int], Awaitable[bool]] | None,
+    ) -> bool:
+        """Re-verify the backup reserve after a transition is accepted.
+
+        Tesla can silently revert a reserve write a few seconds after the
+        transition validates (the write races the still-settling op-mode
+        change). Wait for the reserve to settle, and if it reverted, re-issue
+        the write once and poll for it to stick.
+
+        Returns:
+            True if the reserve holds (or no retry callback is available),
+            False if it stays reverted after the retry.
+
+        """
+        await asyncio.sleep(VALIDATION_RESERVE_SETTLE_SECONDS)
+
+        current = self.read_float(backup_reserve_entity, -1)
+        if abs(current - expected_backup_reserve) < 1:
+            _LOGGER.info(
+                "[VALIDATION] Reserve settle-verified at %s%% (expected %s%%)",
+                current,
+                expected_backup_reserve,
+            )
+            return True
+
+        if retry_reserve_write is None:
+            _LOGGER.warning(
+                "[VALIDATION] Reserve reverted after acceptance "
+                "(expected=%s, actual=%s), no retry callback — accepting",
+                expected_backup_reserve,
+                current,
+            )
+            return True
+
+        _LOGGER.warning(
+            "[VALIDATION] Reserve reverted after acceptance "
+            "(expected=%s, actual=%s) — retrying write once",
+            expected_backup_reserve,
+            current,
+        )
+        if not await retry_reserve_write(expected_backup_reserve):
+            _LOGGER.error("[VALIDATION] Reserve retry write failed")
+            return False
+
+        for _ in range(VALIDATION_RESERVE_RETRY_TIMEOUT_SECONDS):
+            await asyncio.sleep(1)
+            current = self.read_float(backup_reserve_entity, -1)
+            if abs(current - expected_backup_reserve) < 1:
+                _LOGGER.info(
+                    "[VALIDATION] Reserve settle-verified after retry at %s%%",
+                    current,
+                )
+                return True
+
+        _LOGGER.error(
+            "[VALIDATION] Reserve still reverted after retry "
+            "(expected=%s, actual=%s) — failing transition",
+            expected_backup_reserve,
+            current,
         )
         return False
 

--- a/custom_components/localshift/utils/entity_configs.py
+++ b/custom_components/localshift/utils/entity_configs.py
@@ -22,10 +22,12 @@ from ..const import (
     CONF_TESLEMETRY_BACKUP_RESERVE,
     CONF_TESLEMETRY_BATTERY_POWER,
     CONF_TESLEMETRY_GRID_POWER,
+    CONF_TESLEMETRY_GRID_SERVICES,
     CONF_TESLEMETRY_LOAD_POWER,
     CONF_TESLEMETRY_OPERATION_MODE,
     CONF_TESLEMETRY_SOC,
     CONF_TESLEMETRY_SOLAR_POWER,
+    CONF_TESLEMETRY_STORM_WATCH,
     CONF_WEATHER_ENTITY,
 )
 
@@ -86,6 +88,16 @@ ENTITY_CONFIG: dict[str, dict[str, Any]] = {
         "expected_type": str,
         "valid_values": ["pv_only", "battery_ok"],
         "description": "Export mode",
+    },
+    CONF_TESLEMETRY_GRID_SERVICES: {
+        "category": EntityCategory.OPTIONAL,
+        "expected_type": bool,
+        "description": "Grid services / VPP event active (Tesla override corroboration)",
+    },
+    CONF_TESLEMETRY_STORM_WATCH: {
+        "category": EntityCategory.OPTIONAL,
+        "expected_type": bool,
+        "description": "Storm Watch active (Tesla override corroboration)",
     },
     CONF_PRICING_GENERAL_PRICE: {
         "category": EntityCategory.REQUIRED,

--- a/tests/fixtures/ha_entities.py
+++ b/tests/fixtures/ha_entities.py
@@ -381,6 +381,8 @@ def create_default_entity_states(
     feed_in_price: float = 0.08,
     price_spike: bool = False,
     allow_export: str = "pv_only",
+    grid_services_active: bool = False,
+    storm_watch_active: bool = False,
 ) -> dict[str, MockState]:
     """Create a complete set of entity states for LocalShift testing.
 
@@ -458,6 +460,14 @@ def create_default_entity_states(
                 "friendly_name": "Allow Export",
                 "options": ["pv_only", "battery_ok"],
             },
+        ),
+        "binary_sensor.my_home_grid_services_enabled": create_binary_sensor_state(
+            "binary_sensor.my_home_grid_services_enabled",
+            grid_services_active,
+        ),
+        "binary_sensor.my_home_storm_watch_active": create_binary_sensor_state(
+            "binary_sensor.my_home_storm_watch_active",
+            storm_watch_active,
         ),
         # Pricing entities (generic naming - discovered during config flow)
         "sensor.general_price": create_price_state(
@@ -544,9 +554,7 @@ def create_sample_solcast_forecast(
 
         # Roll the date forward with timedelta so this stays valid on the last
         # day of a month (replace(day=day+1) overflowed on the 30th/31st).
-        period_start = base_date.replace(hour=hour % 24) + timedelta(
-            days=hour // 24
-        )
+        period_start = base_date.replace(hour=hour % 24) + timedelta(days=hour // 24)
 
         forecasts.append({
             "period_start": period_start.isoformat(),

--- a/tests/services/test_notification_service.py
+++ b/tests/services/test_notification_service.py
@@ -1,5 +1,6 @@
 """Unit tests for NotificationService."""
 
+from datetime import timedelta
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -486,6 +487,65 @@ class TestAlertNotifications:
         assert "Manual Override Timeout" in title
         assert "4.0 hours" in message
         assert "Automation resuming" in message
+
+    @pytest.mark.asyncio
+    async def test_tesla_override_detected_corroborated(
+        self, notification_service, coordinator_data, mock_hass
+    ):
+        """Detected notification names the confirming signal when corroborated."""
+        await notification_service.send_tesla_override_notification(
+            coordinator_data, detected=True, corroborated=True
+        )
+
+        data = mock_hass.services.async_call.call_args[0][2]
+        assert "Tesla Override Detected" in data["title"]
+        assert "Confirmed by Tesla" in data["message"]
+
+    @pytest.mark.asyncio
+    async def test_tesla_override_detected_heuristic(
+        self, notification_service, coordinator_data, mock_hass
+    ):
+        """Uncorroborated detection flags heuristic + re-probe in the message."""
+        await notification_service.send_tesla_override_notification(
+            coordinator_data, detected=True, corroborated=False
+        )
+
+        data = mock_hass.services.async_call.call_args[0][2]
+        assert "Tesla Override Detected" in data["title"]
+        assert "heuristically" in data["message"]
+        assert "re-probe" in data["message"]
+
+    @pytest.mark.asyncio
+    async def test_tesla_override_released(
+        self, notification_service, coordinator_data, mock_hass
+    ):
+        """Release notification reports the duration and reason."""
+        await notification_service.send_tesla_override_notification(
+            coordinator_data,
+            detected=False,
+            corroborated=False,
+            duration=timedelta(hours=17, minutes=48),
+            release_reason="re-probe succeeded",
+        )
+
+        data = mock_hass.services.async_call.call_args[0][2]
+        assert "Tesla Override Released" in data["title"]
+        assert "17h 48m" in data["message"]
+        assert "re-probe succeeded" in data["message"]
+
+    @pytest.mark.asyncio
+    async def test_tesla_override_notification_suppressed_when_disabled(
+        self, notification_service_with_switches, coordinator_data, mock_hass
+    ):
+        """No notification is sent when notifications are disabled."""
+        service, switch_states = notification_service_with_switches
+        switch_states[SWITCH_NOTIFICATIONS_ENABLED] = False
+
+        await service.send_tesla_override_notification(
+            coordinator_data, detected=True, corroborated=True
+        )
+
+        mock_hass.services.async_call.assert_not_called()
 
 
 # =============================================================================

--- a/tests/state/test_state_machine.py
+++ b/tests/state/test_state_machine.py
@@ -50,17 +50,21 @@ class TestTeslaOverrideDetection:
         """Test Tesla override not detected when not in override state."""
         coordinator_data.operation_mode = "self_consumption"
         coordinator_data.backup_reserve = 10
-        result = state_machine._detect_tesla_override(coordinator_data)
+        now = dt_aware(2026, 3, 1, 10, 0, 0)
+        result = state_machine._detect_tesla_override(coordinator_data, now)
         assert result is False
 
     @pytest.mark.asyncio
     async def test_detect_tesla_override_detected(
         self, state_machine, coordinator_data
     ):
-        """Test Tesla override detected with 80% reserve."""
+        """Signature + signals unavailable + not self-inflicted -> override."""
         coordinator_data.operation_mode = "self_consumption"
         coordinator_data.backup_reserve = 80
-        result = state_machine._detect_tesla_override(coordinator_data)
+        coordinator_data.grid_services_active = None
+        coordinator_data.storm_watch_active = None
+        now = dt_aware(2026, 3, 1, 10, 0, 0)
+        result = state_machine._detect_tesla_override(coordinator_data, now)
         assert result is True
 
     @pytest.mark.asyncio
@@ -70,8 +74,92 @@ class TestTeslaOverrideDetection:
         """Test Tesla override detection within tolerance."""
         coordinator_data.operation_mode = "self_consumption"
         coordinator_data.backup_reserve = 80.5
-        result = state_machine._detect_tesla_override(coordinator_data)
+        coordinator_data.grid_services_active = None
+        coordinator_data.storm_watch_active = None
+        now = dt_aware(2026, 3, 1, 10, 0, 0)
+        result = state_machine._detect_tesla_override(coordinator_data, now)
         assert result is True
+
+    @pytest.mark.asyncio
+    async def test_detect_tesla_override_grid_services_on(
+        self, state_machine, coordinator_data
+    ):
+        """Signature + grid services ON -> override even if self-inflicted."""
+        coordinator_data.operation_mode = "self_consumption"
+        coordinator_data.backup_reserve = 80
+        coordinator_data.grid_services_active = True
+        now = dt_aware(2026, 3, 1, 10, 0, 0)
+        # Recent own transition would otherwise mark this self-inflicted.
+        state_machine._last_successful_transition = now - timedelta(seconds=10)
+        assert state_machine._detect_tesla_override(coordinator_data, now) is True
+
+    @pytest.mark.asyncio
+    async def test_detect_tesla_override_storm_watch_on(
+        self, state_machine, coordinator_data
+    ):
+        """Signature + storm watch ON (grid services off) -> override."""
+        coordinator_data.operation_mode = "self_consumption"
+        coordinator_data.backup_reserve = 80
+        coordinator_data.grid_services_active = False
+        coordinator_data.storm_watch_active = True
+        now = dt_aware(2026, 3, 1, 10, 0, 0)
+        assert state_machine._detect_tesla_override(coordinator_data, now) is True
+
+    @pytest.mark.asyncio
+    async def test_detect_tesla_override_signals_off_is_drift(
+        self, state_machine, coordinator_data
+    ):
+        """Incident regression: signature + both signals OFF + recent own
+        transition -> NOT an override (reverted reserve write, not a Tesla event)."""
+        coordinator_data.operation_mode = "self_consumption"
+        coordinator_data.backup_reserve = 80
+        coordinator_data.grid_services_active = False
+        coordinator_data.storm_watch_active = False
+        now = dt_aware(2026, 3, 1, 15, 0, 0)
+        state_machine._last_successful_transition = now - timedelta(seconds=10)
+        assert state_machine._detect_tesla_override(coordinator_data, now) is False
+
+    @pytest.mark.asyncio
+    async def test_detect_tesla_override_unknown_recent_self_command(
+        self, state_machine, coordinator_data
+    ):
+        """Signals unavailable + own transition within grace -> self-inflicted -> no override."""
+        coordinator_data.operation_mode = "self_consumption"
+        coordinator_data.backup_reserve = 80
+        coordinator_data.grid_services_active = None
+        coordinator_data.storm_watch_active = None
+        now = dt_aware(2026, 3, 1, 15, 0, 0)
+        state_machine._last_successful_transition = now - timedelta(minutes=5)
+        assert state_machine._detect_tesla_override(coordinator_data, now) is False
+        # ...but once the grace window passes, the legacy heuristic fires.
+        state_machine._last_successful_transition = now - timedelta(minutes=20)
+        assert state_machine._detect_tesla_override(coordinator_data, now) is True
+
+    @pytest.mark.asyncio
+    async def test_detect_tesla_override_unknown_hold_reserve_self_inflicted(
+        self, state_machine, coordinator_data
+    ):
+        """Signals unavailable + commanded mode expects reserve≈80 -> no override."""
+        coordinator_data.operation_mode = "self_consumption"
+        coordinator_data.backup_reserve = 80
+        coordinator_data.grid_services_active = None
+        coordinator_data.storm_watch_active = None
+        now = dt_aware(2026, 3, 1, 15, 0, 0)
+        state_machine._commanded_mode = BatteryMode.HOLD
+        state_machine._self_consumption_reserve = 80.0
+        assert state_machine._detect_tesla_override(coordinator_data, now) is False
+
+    @pytest.mark.asyncio
+    async def test_detect_tesla_override_no_signature(
+        self, state_machine, coordinator_data
+    ):
+        """Grid-charging (op=backup, reserve=80) never matches the signature."""
+        coordinator_data.operation_mode = "backup"
+        coordinator_data.backup_reserve = 80
+        coordinator_data.grid_services_active = None
+        coordinator_data.storm_watch_active = None
+        now = dt_aware(2026, 3, 1, 15, 0, 0)
+        assert state_machine._detect_tesla_override(coordinator_data, now) is False
 
     @pytest.mark.asyncio
     async def test_is_tesla_override_active(self, state_machine):
@@ -137,6 +225,7 @@ def mock_notification_service():
     service.send_health_correction_notification = AsyncMock()
     service.send_manual_override_timeout_notification = AsyncMock()
     service.send_automation_disabled_notification = AsyncMock()
+    service.send_tesla_override_notification = AsyncMock()
     return service
 
 
@@ -991,11 +1080,15 @@ class TestStateMachineInternalBranches:
         coordinator_data.backup_reserve = 80.0
         now = dt_aware(2026, 3, 1, 10, 0, 0)
 
-        should_skip = state_machine._handle_tesla_override_state(coordinator_data, now)
+        should_skip = asyncio.run(
+            state_machine._handle_tesla_override_state(coordinator_data, now)
+        )
 
         assert should_skip is True
         assert state_machine._tesla_override_detected is True
         assert state_machine._tesla_override_detected_at == now
+        # First detection notifies exactly once.
+        state_machine._notification_service.send_tesla_override_notification.assert_awaited_once()
 
     def test_tesla_override_cooldown_blocks_then_expires(
         self, state_machine, coordinator_data
@@ -1005,14 +1098,16 @@ class TestStateMachineInternalBranches:
         coordinator_data.backup_reserve = 80.0
         detected_at = dt_aware(2026, 3, 1, 10, 0, 0)
 
-        state_machine._handle_tesla_override_state(coordinator_data, detected_at)
+        asyncio.run(
+            state_machine._handle_tesla_override_state(coordinator_data, detected_at)
+        )
 
         coordinator_data.operation_mode = "autonomous"
         coordinator_data.backup_reserve = 20.0
 
         released_at = dt_aware(2026, 3, 1, 10, 5, 0)
-        should_skip_during_cooldown = state_machine._handle_tesla_override_state(
-            coordinator_data, released_at
+        should_skip_during_cooldown = asyncio.run(
+            state_machine._handle_tesla_override_state(coordinator_data, released_at)
         )
 
         assert should_skip_during_cooldown is True
@@ -1020,12 +1115,126 @@ class TestStateMachineInternalBranches:
         assert state_machine._tesla_override_released_at == released_at
 
         after_cooldown = released_at + timedelta(minutes=31)
-        should_skip_after_cooldown = state_machine._handle_tesla_override_state(
-            coordinator_data, after_cooldown
+        should_skip_after_cooldown = asyncio.run(
+            state_machine._handle_tesla_override_state(coordinator_data, after_cooldown)
         )
 
         assert should_skip_after_cooldown is False
         assert state_machine._tesla_override_released_at is None
+
+    def test_tesla_override_corroborated_never_reprobes(
+        self, state_machine, coordinator_data
+    ):
+        """A corroborated override (grid services ON) must never re-probe."""
+        coordinator_data.operation_mode = "self_consumption"
+        coordinator_data.backup_reserve = 80.0
+        coordinator_data.grid_services_active = True
+        state_machine._execute_mode_transition = AsyncMock(return_value=True)
+
+        detected_at = dt_aware(2026, 3, 1, 10, 0, 0)
+        asyncio.run(
+            state_machine._handle_tesla_override_state(coordinator_data, detected_at)
+        )
+        assert state_machine._tesla_override_corroborated is True
+
+        # 31 minutes later — well past the probe interval — still no probe.
+        later = detected_at + timedelta(minutes=31)
+        should_skip = asyncio.run(
+            state_machine._handle_tesla_override_state(coordinator_data, later)
+        )
+        assert should_skip is True
+        state_machine._execute_mode_transition.assert_not_awaited()
+
+    def test_tesla_override_uncorroborated_reprobes_and_releases(
+        self, state_machine, coordinator_data
+    ):
+        """Uncorroborated override re-probes at the interval; success releases
+        without cooldown."""
+        coordinator_data.operation_mode = "self_consumption"
+        coordinator_data.backup_reserve = 80.0
+        coordinator_data.grid_services_active = None
+        coordinator_data.storm_watch_active = None
+        state_machine._execute_mode_transition = AsyncMock(return_value=True)
+
+        detected_at = dt_aware(2026, 3, 1, 10, 0, 0)
+        asyncio.run(
+            state_machine._handle_tesla_override_state(coordinator_data, detected_at)
+        )
+        assert state_machine._tesla_override_corroborated is False
+
+        # Before the interval: no probe.
+        before = detected_at + timedelta(minutes=15)
+        asyncio.run(
+            state_machine._handle_tesla_override_state(coordinator_data, before)
+        )
+        state_machine._execute_mode_transition.assert_not_awaited()
+
+        # At the interval: probe fires, succeeds, override released, no cooldown.
+        at_interval = detected_at + timedelta(minutes=31)
+        should_skip = asyncio.run(
+            state_machine._handle_tesla_override_state(coordinator_data, at_interval)
+        )
+        state_machine._execute_mode_transition.assert_awaited_once()
+        assert should_skip is False
+        assert state_machine._tesla_override_detected is False
+        assert state_machine._tesla_override_released_at is None
+
+    def test_tesla_override_reprobe_failure_stays_yielded(
+        self, state_machine, coordinator_data
+    ):
+        """A failed re-probe keeps yielding and resets the probe timer."""
+        coordinator_data.operation_mode = "self_consumption"
+        coordinator_data.backup_reserve = 80.0
+        coordinator_data.grid_services_active = None
+        coordinator_data.storm_watch_active = None
+        state_machine._execute_mode_transition = AsyncMock(return_value=False)
+
+        detected_at = dt_aware(2026, 3, 1, 10, 0, 0)
+        asyncio.run(
+            state_machine._handle_tesla_override_state(coordinator_data, detected_at)
+        )
+
+        at_interval = detected_at + timedelta(minutes=31)
+        should_skip = asyncio.run(
+            state_machine._handle_tesla_override_state(coordinator_data, at_interval)
+        )
+        assert should_skip is True
+        assert state_machine._tesla_override_detected is True
+        state_machine._execute_mode_transition.assert_awaited_once()
+
+        # Timer reset: the very next minute must not probe again.
+        one_min_later = at_interval + timedelta(minutes=1)
+        asyncio.run(
+            state_machine._handle_tesla_override_state(coordinator_data, one_min_later)
+        )
+        state_machine._execute_mode_transition.assert_awaited_once()
+
+    def test_tesla_override_corroboration_upgrades(
+        self, state_machine, coordinator_data
+    ):
+        """An initially-uncorroborated override becomes corroborated when a
+        signal later turns ON."""
+        coordinator_data.operation_mode = "self_consumption"
+        coordinator_data.backup_reserve = 80.0
+        coordinator_data.grid_services_active = None
+        coordinator_data.storm_watch_active = None
+
+        detected_at = dt_aware(2026, 3, 1, 10, 0, 0)
+        asyncio.run(
+            state_machine._handle_tesla_override_state(coordinator_data, detected_at)
+        )
+        assert state_machine._tesla_override_corroborated is False
+
+        coordinator_data.storm_watch_active = True
+        asyncio.run(
+            state_machine._handle_tesla_override_state(
+                coordinator_data, detected_at + timedelta(minutes=1)
+            )
+        )
+        assert state_machine._tesla_override_corroborated is True
+        info = state_machine.get_tesla_override_info()
+        assert info["active"] is True
+        assert info["corroborated"] is True
 
     def test_handle_debounce_timing_clears_stale_and_starts_timer(self, state_machine):
         """Debounce helper should clear stale timers and start desired timer."""
@@ -1104,8 +1313,10 @@ class TestStateMachineInternalBranches:
         """Health check skip helper should skip during manual override."""
         coordinator_data.manual_override = True
 
-        should_skip = state_machine._should_skip_health_check(
-            coordinator_data, dt_aware(2026, 3, 1, 10, 0, 0)
+        should_skip = asyncio.run(
+            state_machine._should_skip_health_check(
+                coordinator_data, dt_aware(2026, 3, 1, 10, 0, 0)
+            )
         )
 
         assert should_skip is True
@@ -1743,16 +1954,27 @@ class TestDecisionTokenInvariant:
 
         # 4 price intervals, ~6 evals each (tick + coalesce cadence). Each eval
         # the plan oscillates between two immediate modes.
-        prices = [0.25, 0.25, 0.25, 0.30, 0.30, 0.30, 0.20, 0.20, 0.20, 0.40, 0.40, 0.40]
+        prices = [
+            0.25,
+            0.25,
+            0.25,
+            0.30,
+            0.30,
+            0.30,
+            0.20,
+            0.20,
+            0.20,
+            0.40,
+            0.40,
+            0.40,
+        ]
         oscillate = [BatteryMode.GRID_CHARGING, BatteryMode.SPIKE_DISCHARGE]
         distinct_fps = set()
         for i, price in enumerate(prices):
             coordinator_data.general_price = price
             coordinator_data.price_spike = False
             engine.plan_mode = oscillate[i % 2]
-            distinct_fps.add(
-                state_machine._get_decision_fingerprint(coordinator_data)
-            )
+            distinct_fps.add(state_machine._get_decision_fingerprint(coordinator_data))
             self._run(state_machine, coordinator_data, engine)
 
         # The crown jewel: at most one transition per distinct decision context.
@@ -1808,8 +2030,7 @@ class TestDecisionTokenInvariant:
         assert coordinator_data.active_mode == BatteryMode.SELF_CONSUMPTION
         assert coordinator_data.decision_timestamp is None
         assert (
-            coordinator_data.debug_plan_mode_pending
-            == BatteryMode.GRID_CHARGING.value
+            coordinator_data.debug_plan_mode_pending == BatteryMode.GRID_CHARGING.value
         )
 
     def test_frozen_eval_pins_mode_no_decision_timestamp(
@@ -1833,7 +2054,9 @@ class TestDecisionTokenInvariant:
 
         assert coordinator_data.active_mode == BatteryMode.SELF_CONSUMPTION
         assert coordinator_data.decision_timestamp is None
-        assert coordinator_data.debug_plan_mode_pending == BatteryMode.GRID_CHARGING.value
+        assert (
+            coordinator_data.debug_plan_mode_pending == BatteryMode.GRID_CHARGING.value
+        )
         mock_battery_controller.set_force_charge.assert_not_called()
 
     def test_deferred_token_kill(
@@ -1895,9 +2118,7 @@ class TestDecisionTokenInvariant:
         assert coordinator_data.active_mode == BatteryMode.GRID_CHARGING
         mock_battery_controller.set_force_charge.assert_called_once()
 
-    def test_spike_onset_grants_one_decision(
-        self, state_machine, coordinator_data
-    ):
+    def test_spike_onset_grants_one_decision(self, state_machine, coordinator_data):
         """price_spike False→True is a context change → one decision."""
         coordinator_data.general_price = 0.25
         coordinator_data.price_spike = False
@@ -1912,9 +2133,7 @@ class TestDecisionTokenInvariant:
         self._run(state_machine, coordinator_data, engine)
         assert engine.last_decision_allowed is False
 
-    def test_dw_active_flip_grants_one_decision(
-        self, state_machine, coordinator_data
-    ):
+    def test_dw_active_flip_grants_one_decision(self, state_machine, coordinator_data):
         """demand_window_active flip is a context change → one decision."""
         coordinator_data.general_price = 0.25
         coordinator_data.demand_window_active = False
@@ -2018,7 +2237,11 @@ class TestConvergeWhileFrozen:
         assert state_machine._commanded_mode == BatteryMode.GRID_CHARGING
 
     def test_validator_blocked_then_unblocked_retries_without_fresh_token(
-        self, state_machine, coordinator_data, mock_battery_controller, mock_entity_validator
+        self,
+        state_machine,
+        coordinator_data,
+        mock_battery_controller,
+        mock_entity_validator,
     ):
         """A validator-blocked transition retries on a later frozen eval once the
         validator allows it — and a DIFFERENT desired mode while frozen does NOT
@@ -2052,9 +2275,7 @@ class TestConvergeWhileFrozen:
 class TestInvalidateDecisionFingerprint:
     """Deliberate re-decision points (#622 gate replacement)."""
 
-    def test_invalidate_grants_next_decision(
-        self, state_machine, coordinator_data
-    ):
+    def test_invalidate_grants_next_decision(self, state_machine, coordinator_data):
         """After invalidate_decision_fingerprint, the next eval decides even with
         an unchanged price."""
         coordinator_data.general_price = 0.25

--- a/tests/state/test_state_reader.py
+++ b/tests/state/test_state_reader.py
@@ -242,6 +242,38 @@ class TestReadBool:
         assert result is False
 
 
+class TestReadBoolOptional:
+    """Tests for _read_bool_optional (tri-state) method."""
+
+    def test_on_returns_true(self, state_reader, mock_hass):
+        state = MagicMock()
+        state.state = "on"
+        mock_hass.states.get.return_value = state
+        assert state_reader._read_bool_optional("binary_sensor.test") is True
+
+    def test_off_returns_false(self, state_reader, mock_hass):
+        state = MagicMock()
+        state.state = "off"
+        mock_hass.states.get.return_value = state
+        assert state_reader._read_bool_optional("binary_sensor.test") is False
+
+    def test_unavailable_returns_none(self, state_reader, mock_hass):
+        state = MagicMock()
+        state.state = "unavailable"
+        mock_hass.states.get.return_value = state
+        assert state_reader._read_bool_optional("binary_sensor.test") is None
+
+    def test_unknown_returns_none(self, state_reader, mock_hass):
+        state = MagicMock()
+        state.state = "unknown"
+        mock_hass.states.get.return_value = state
+        assert state_reader._read_bool_optional("binary_sensor.test") is None
+
+    def test_missing_entity_returns_none(self, state_reader, mock_hass):
+        mock_hass.states.get.return_value = None
+        assert state_reader._read_bool_optional("binary_sensor.test") is None
+
+
 class TestReadAttribute:
     """Tests for _read_attribute method."""
 
@@ -499,6 +531,34 @@ class TestReadAllExternalState:
         assert coordinator_data.battery_power_kw == -1.5
         assert coordinator_data.solar_power_kw == 3.0
         assert coordinator_data.load_power_kw == 4.0
+
+    def test_read_all_external_state_corroboration_signals(
+        self, state_reader, mock_hass, coordinator_data
+    ):
+        """Grid services / storm watch ingest as tri-state (on/off/unavailable)."""
+
+        def make_reader(grid_services_state, storm_watch_state):
+            def mock_get_state(entity_id):
+                state = MagicMock()
+                if "grid_services_enabled" in entity_id:
+                    state.state = grid_services_state
+                elif "storm_watch_active" in entity_id:
+                    state.state = storm_watch_state
+                else:
+                    state.state = "0"
+                return state
+
+            return mock_get_state
+
+        mock_hass.states.get = make_reader("on", "off")
+        state_reader.read_all_external_state(coordinator_data)
+        assert coordinator_data.grid_services_active is True
+        assert coordinator_data.storm_watch_active is False
+
+        mock_hass.states.get = make_reader("unavailable", "unknown")
+        state_reader.read_all_external_state(coordinator_data)
+        assert coordinator_data.grid_services_active is None
+        assert coordinator_data.storm_watch_active is None
 
     def test_read_all_external_state_pricing(
         self, state_reader, mock_hass, coordinator_data

--- a/tests/test_battery_controller.py
+++ b/tests/test_battery_controller.py
@@ -188,7 +188,7 @@ class TestSetForceCharge:
             if "operation_mode" in entity_id:
                 state.state = "backup"
             elif "backup_reserve" in entity_id:
-                state.state = "80"  # Clamped for default target=100
+                state.state = "100"  # Default target=100 is not clamped
             elif "allow_export" in entity_id:
                 state.state = TESLEMETRY_EXPORT_PV_ONLY
             elif "allow_charging_from_grid" in entity_id:
@@ -387,9 +387,9 @@ class TestSetForceDischarge:
             if "operation_mode" in entity_id:
                 state.state = "autonomous"
             elif "backup_reserve" in entity_id:
-                state.state = "100"
+                state.state = "20"
             elif "allow_export" in entity_id:
-                state.state = TESLEMETRY_EXPORT_PV_ONLY
+                state.state = TESLEMETRY_EXPORT_BATTERY_OK
             elif "allow_charging_from_grid" in entity_id:
                 state.state = "on"
             return state
@@ -513,9 +513,9 @@ class TestSetProactiveExport:
             if "operation_mode" in entity_id:
                 state.state = "autonomous"
             elif "backup_reserve" in entity_id:
-                state.state = "100"
+                state.state = "45"  # SOC (50) - 5% buffer
             elif "allow_export" in entity_id:
-                state.state = TESLEMETRY_EXPORT_PV_ONLY
+                state.state = TESLEMETRY_EXPORT_BATTERY_OK
             elif "allow_charging_from_grid" in entity_id:
                 state.state = "on"
             return state
@@ -768,7 +768,9 @@ class TestValidateTransition:
             timeout=2,
         )
 
-        # Should succeed because operation mode matches
+        # Should succeed because operation mode matches. With no
+        # retry_reserve_write callback the settle-verify stays lenient and
+        # accepts the lagging reserve (case a).
         assert result is True
 
     @pytest.mark.asyncio
@@ -796,6 +798,195 @@ class TestValidateTransition:
         )
 
         assert result is True
+
+
+# =============================================================================
+# RESERVE SETTLE-VERIFY TESTS (Tesla-override freeze fix, D1)
+# =============================================================================
+
+
+class TestReserveSettleVerify:
+    """Tests for the post-acceptance reserve settle-verify + retry."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.usefixtures("mock_battery_sleep")
+    async def test_stable_reserve_no_retry(self, battery_controller, mock_hass):
+        """Reserve stable through the settle window -> True, retry not called."""
+
+        def mock_get_state(entity_id):
+            state = MagicMock()
+            if "operation_mode" in entity_id:
+                state.state = "self_consumption"
+            elif "backup_reserve" in entity_id:
+                state.state = "10"
+            elif "allow_export" in entity_id:
+                state.state = TESLEMETRY_EXPORT_PV_ONLY
+            return state
+
+        mock_hass.states.get = mock_get_state
+        retry = AsyncMock(return_value=True)
+
+        result = await battery_controller.validate_transition(
+            expected_operation_mode="self_consumption",
+            expected_backup_reserve=10,
+            expected_export_mode=TESLEMETRY_EXPORT_PV_ONLY,
+            timeout=2,
+            retry_reserve_write=retry,
+        )
+
+        assert result is True
+        retry.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    @pytest.mark.usefixtures("mock_battery_sleep")
+    async def test_full_match_revert_retry_converges(
+        self, battery_controller, mock_hass
+    ):
+        """In-loop match, reserve reverts at settle, retry converges -> True."""
+        reserve_reads = {"n": 0}
+
+        def mock_get_state(entity_id):
+            state = MagicMock()
+            if "operation_mode" in entity_id:
+                state.state = "self_consumption"
+            elif "backup_reserve" in entity_id:
+                reserve_reads["n"] += 1
+                # read 1: loop match (10); read 2: settle sees Tesla revert (80);
+                # read 3+: retry converged (10)
+                state.state = "80" if reserve_reads["n"] == 2 else "10"
+            elif "allow_export" in entity_id:
+                state.state = TESLEMETRY_EXPORT_PV_ONLY
+            return state
+
+        mock_hass.states.get = mock_get_state
+        retry = AsyncMock(return_value=True)
+
+        result = await battery_controller.validate_transition(
+            expected_operation_mode="self_consumption",
+            expected_backup_reserve=10,
+            expected_export_mode=TESLEMETRY_EXPORT_PV_ONLY,
+            timeout=2,
+            retry_reserve_write=retry,
+        )
+
+        assert result is True
+        retry.assert_awaited_once_with(10)
+
+    @pytest.mark.asyncio
+    @pytest.mark.usefixtures("mock_battery_sleep")
+    async def test_fallback_accept_revert_retry_converges(
+        self, battery_controller, mock_hass
+    ):
+        """Fallback (op + grid_charging) acceptance also settle-verifies reserve."""
+        reserve = {"val": "80"}
+
+        async def _retry(_value):
+            reserve["val"] = "10"
+            return True
+
+        def mock_get_state(entity_id):
+            state = MagicMock()
+            if "operation_mode" in entity_id:
+                state.state = "self_consumption"
+            elif "backup_reserve" in entity_id:
+                state.state = reserve["val"]
+            elif "allow_export" in entity_id:
+                state.state = TESLEMETRY_EXPORT_PV_ONLY
+            elif "allow_charging_from_grid" in entity_id:
+                state.state = "off"
+            return state
+
+        mock_hass.states.get = mock_get_state
+        retry = AsyncMock(side_effect=_retry)
+
+        # Reserve never matches in the loop (80 vs 10) -> op+grid fallback accept.
+        result = await battery_controller.validate_transition(
+            expected_operation_mode="self_consumption",
+            expected_backup_reserve=10,
+            expected_export_mode=TESLEMETRY_EXPORT_PV_ONLY,
+            expected_grid_charging_allowed=False,
+            timeout=2,
+            retry_reserve_write=retry,
+        )
+
+        assert result is True
+        retry.assert_awaited_once_with(10)
+
+    @pytest.mark.asyncio
+    @pytest.mark.usefixtures("mock_battery_sleep")
+    async def test_retry_write_fails_returns_false(self, battery_controller, mock_hass):
+        """A failed retry write fails the transition."""
+        reserve_reads = {"n": 0}
+
+        def mock_get_state(entity_id):
+            state = MagicMock()
+            if "operation_mode" in entity_id:
+                state.state = "self_consumption"
+            elif "backup_reserve" in entity_id:
+                reserve_reads["n"] += 1
+                state.state = "80" if reserve_reads["n"] == 2 else "10"
+            elif "allow_export" in entity_id:
+                state.state = TESLEMETRY_EXPORT_PV_ONLY
+            return state
+
+        mock_hass.states.get = mock_get_state
+        retry = AsyncMock(return_value=False)
+
+        result = await battery_controller.validate_transition(
+            expected_operation_mode="self_consumption",
+            expected_backup_reserve=10,
+            expected_export_mode=TESLEMETRY_EXPORT_PV_ONLY,
+            timeout=2,
+            retry_reserve_write=retry,
+        )
+
+        assert result is False
+        retry.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    @pytest.mark.usefixtures("mock_battery_sleep")
+    async def test_revert_after_validation_race_end_to_end(
+        self, battery_controller, mock_hass
+    ):
+        """The incident: set_self_consumption succeeds despite a reserve revert,
+        re-issuing the reserve write (number.set_value called twice)."""
+        mock_hass.services.async_call.return_value = None
+        reserve_reads = {"n": 0}
+
+        def mock_get_state(entity_id):
+            if entity_id is None:
+                return None
+            state = MagicMock()
+            if "operation_mode" in entity_id:
+                state.state = "self_consumption"
+            elif "backup_reserve" in entity_id:
+                reserve_reads["n"] += 1
+                # loop match (10) -> settle sees revert (80) -> retry converges (10)
+                state.state = "80" if reserve_reads["n"] == 2 else "10"
+            elif "allow_export" in entity_id:
+                state.state = TESLEMETRY_EXPORT_PV_ONLY
+            elif "allow_charging_from_grid" in entity_id:
+                state.state = "off"
+            return state
+
+        mock_hass.states.get = mock_get_state
+
+        from custom_components.localshift.coordinator import CoordinatorData
+
+        data = CoordinatorData()
+        data.soc = 50.0
+        data.preserve_soc = None  # -> reserve 10
+
+        result = await battery_controller.set_self_consumption(data)
+
+        assert result is True
+        reserve_writes = [
+            call
+            for call in mock_hass.services.async_call.call_args_list
+            if call.args[:2] == ("number", "set_value")
+        ]
+        # Once in the transition recipe, once in the settle-verify retry.
+        assert len(reserve_writes) == 2
 
 
 # =============================================================================

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -48,9 +48,18 @@ def mock_coordinator():
     coordinator.data.safe_additional_load_kw = 3.0
     coordinator.data.operation_mode = "autonomous"
     coordinator.data.backup_reserve = 20
+    coordinator.data.grid_services_active = None
+    coordinator.data.storm_watch_active = None
     coordinator.data.recent_decision_log = []
     coordinator._state_machine = MagicMock()
     coordinator._state_machine.is_tesla_override_active.return_value = False
+    coordinator._state_machine.get_tesla_override_info.return_value = {
+        "active": False,
+        "detected_at": None,
+        "corroborated": False,
+        "last_probe_at": None,
+        "released_at": None,
+    }
     return coordinator
 
 
@@ -403,6 +412,35 @@ class TestTeslaOverrideActiveSensor:
         assert attrs["operation_mode"] == "autonomous"
         assert attrs["backup_reserve"] == 20
         assert "Tesla is not overriding control" in attrs["description"]
+
+    def test_extra_state_attributes_include_override_info(
+        self, mock_coordinator, mock_entry
+    ):
+        """Override info + corroboration signals surface as attributes."""
+        from datetime import datetime, timedelta, timezone
+
+        detected_at = datetime(2026, 7, 3, 15, 0, tzinfo=timezone(timedelta(hours=10)))
+        mock_coordinator._state_machine.is_tesla_override_active.return_value = True
+        mock_coordinator._state_machine.get_tesla_override_info.return_value = {
+            "active": True,
+            "detected_at": detected_at,
+            "corroborated": True,
+            "last_probe_at": None,
+            "released_at": None,
+        }
+        mock_coordinator.data.grid_services_active = True
+        mock_coordinator.data.storm_watch_active = False
+        sensor = TeslaOverrideActiveSensor(mock_coordinator, mock_entry)
+        sensor._attr_is_on = True
+
+        attrs = sensor.extra_state_attributes
+
+        assert attrs["corroborated"] is True
+        assert attrs["grid_services_active"] is True
+        assert attrs["storm_watch_active"] is False
+        assert attrs["detected_at"] == detected_at.isoformat()
+        assert attrs["duration_minutes"] is not None
+        assert attrs["last_probe_at"] is None
 
 
 class TestAsyncSetupEntry:


### PR DESCRIPTION
## Problem

On **2026-07-03 15:00 → 2026-07-04 08:48 (17h48m)** the Powerwall was frozen at ~80% SOC through the demand window and overnight — ~\$1.40 of grid import while ~9.5 kWh of usable battery sat locked, and LocalShift reported healthy the entire time.

Confirmed chain (HA recorder + `home-assistant.log`):
1. 14:55 pre-DW force charge left hardware at `op=backup, reserve=80` (Tesla firmware clamps 81–99 → 80).
2. 15:00:37 DW transition wrote `reserve→10`; validation passed at **t=1.0s**.
3. **15:00:44 Tesla reverted the reserve 10→80** (the write raced the still-settling op-mode change).
4. 15:00:49 `_detect_tesla_override` saw `self_consumption + reserve≈80` — the signature the optimizer had *itself* just produced — declared a Tesla override, and **disabled all health-check corrections with no timeout and no corroboration**. `grid_services_enabled` was OFF the whole time (no real event).
5. No mode change until 08:45 next morning → the deadlock never self-cleared.

## Fix (four defects, one PR)

- **D1 — validation settle-verify** (`state/validator.py`, `integration/controller.py`): after *any* acceptance, re-read the reserve ~10s later and re-issue the write once if Tesla reverted it; a still-reverted reserve now fails the transition instead of being silently accepted.
- **D2 — detection corroboration** (`state/machine.py`, `state/reader.py`, `coordinator/data.py`): corroborate the signature against two new tri-state reads, `binary_sensor.my_home_grid_services_enabled` and `binary_sensor.my_home_storm_watch_active`. Either ON → real override; both known-OFF → drift (no override); signals unavailable → fall back to self-awareness (own recent command / commanded reserve≈80). Replayed on the incident, recovery drops from 17h48m to ~2 min.
- **D3 — bounded yield** (`state/machine.py`): an *uncorroborated* override re-probes every 30 min by re-issuing the commanded mode; success releases immediately (no cooldown). A corroborated event still yields fully. No unbounded freeze is possible.
- **D4 — surfacing** (`services/notification_service.py`, `binary_sensor.py`): notify on detect (naming the confirming signal, or flagging heuristic detection) and release (duration + reason); expose `detected_at`, `duration_minutes`, `corroborated`, `last_probe_at`, and both raw signals on the override sensor.

## Tests

Full suite green (**3214 passed, 1 xfailed**). New coverage includes the incident regression (`signature + grid_services OFF + recent own transition → NOT an override`), the full detection decision table, the re-probe lifecycle (corroborated never probes; uncorroborated probes at 30 min; success releases without cooldown; failure resets the timer), the settle-verify + revert-retry race end-to-end, reader tri-state, and the notification content.

## Notes / risks

- Adds ~10s to each non-dry-run transition (the settle window); decision-lag telemetry rises accordingly.
- Residual risk (per plan): a real Storm Watch that leaves *both* signals OFF would cause command churn (Tesla wins), not a freeze — now smaller since we corroborate against storm-watch too.
- No config-flow fields added — the new entities use the existing `DEFAULT_ENTITY_IDS` fallback, matching how `allow_export`/`allow_charging_from_grid` are already handled (no migration needed).
- **Not yet deployed to live** (HA config SMB share not mounted at deploy time). Needs a full HA restart on deploy since it touches state-machine module imports.

https://claude.ai/code/session_01LKNTH8TwZj9zBUcnN1Ub5o