### PR TITLE
feat(binary_sensor): surface optimizer_soc_underprepared (#891)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,4 +114,4 @@ uv run pytest
 ```
 
 ## Entity Counts
-Sensors 35 | Binary Sensors 11 | Switches 8 | Numbers 7 | Selects 2 | Buttons 2 (Total 65)
+Sensors 35 | Binary Sensors 12 | Switches 8 | Numbers 7 | Selects 2 | Buttons 2 (Total 66)

--- a/custom_components/localshift/binary_sensor.py
+++ b/custom_components/localshift/binary_sensor.py
@@ -38,6 +38,8 @@ async def async_setup_entry(
         TeslaOverrideActiveSensor(coordinator, entry),
         # Amber Express demand window (Issue #300)
         AmberExpressDemandWindowSensor(coordinator, entry),
+        # Optimizer SOC underprepared (Issue #891)
+        OptimizerSocUnderpreparedSensor(coordinator, entry),
     ]
 
     async_add_entities(entities)
@@ -321,3 +323,38 @@ class AmberExpressDemandWindowSensor(LocalShiftBinarySensorBase):
     def _update_from_coordinator(self) -> None:
         """Update state from coordinator data."""
         self._attr_is_on = self.coordinator.data.demand_window_amber
+
+
+# ---------------------------------------------------------------------------
+# Optimizer SOC Underprepared Binary Sensor (Issue #891)
+# ---------------------------------------------------------------------------
+
+
+class OptimizerSocUnderpreparedSensor(LocalShiftBinarySensorBase):
+    """Whether the battery entered the demand window far below target.
+
+    Surfaces ``data.optimizer_soc_underprepared`` (set by
+    ``OptimizerFacade._warn_soc_divergence`` when a demand window is active
+    but the live SOC is more than 20 points below target). The 2026-06-30
+    silent miss saw the battery enter the DW at ~10% while the summary
+    reported a healthy DW-entry SOC; this sensor makes that failure mode
+    visible to dashboards and automations without tailing logs.
+    """
+
+    _attr_unique_id = "localshift_optimizer_soc_underprepared"
+    _attr_name = "Optimizer SOC Underprepared"
+
+    @property
+    def icon(self) -> str:
+        """Return icon based on state."""
+        return "mdi:alert" if self._attr_is_on else "mdi:check-circle"
+
+    def _update_from_coordinator(self) -> None:
+        """Update state from coordinator data.
+
+        Defaults to False when the flag is not yet populated (e.g. before the
+        first optimizer cycle has run).
+        """
+        self._attr_is_on = bool(
+            getattr(self.coordinator.data, "optimizer_soc_underprepared", False)
+        )

--- a/custom_components/localshift/sensors/optimizer.py
+++ b/custom_components/localshift/sensors/optimizer.py
@@ -136,6 +136,11 @@ class OptimizerSummarySensor(LocalShiftSensorBase):
             "accuracy_discount_factor": summary.get("accuracy_discount_factor"),
             "adjusted_solar_gain_pct": summary.get("adjusted_solar_gain_pct"),
             "effective_soc_at_terminal": summary.get("effective_soc_at_terminal"),
+            # Issue #891: surface the underprepared flag so the post-6/30
+            # silent-failure mode is visible to dashboards/alerts, not just logs.
+            "optimizer_soc_underprepared": bool(
+                getattr(d, "optimizer_soc_underprepared", False)
+            ),
             "solar_confidence_avg": avg_confidence,
             "solar_confidence_regime": (
                 "high"

--- a/docs/ENTITY_REFERENCE.md
+++ b/docs/ENTITY_REFERENCE.md
@@ -9,7 +9,7 @@ The integration creates **63 entities** grouped under a single "LocalShift" devi
 | Category | Count | Entity Type |
 |----------|-------|-------------|
 | Sensors | 35 | `sensor` |
-| Binary Sensors | 11 | `binary_sensor` |
+| Binary Sensors | 12 | `binary_sensor` |
 | Switches | 8 | `switch` |
 | Numbers | 5 | `number` |
 | Selects | 2 | `select` |
@@ -1091,6 +1091,29 @@ State: on
 ```
 
 **Icon:** Dynamic (clock-alert when on, clock-check when off)
+
+---
+
+### 12. binary_sensor.localshift_optimizer_soc_underprepared (Issue #891)
+
+**Purpose:** Surfaces whether the battery entered the demand window far below target.
+
+Added in Issue #891. The 2026-06-30 silent miss saw the battery enter the demand
+window at ~10% while the optimizer summary reported a healthy DW-entry SOC. The
+underprepared flag (`data.optimizer_soc_underprepared`) is set by
+`OptimizerFacade._warn_soc_divergence` when a demand window is active but the
+live SOC is more than 20 points below target — this sensor makes that failure
+mode visible to dashboards and automations without tailing logs. The flag is also
+exposed as an attribute on `sensor.localshift_optimizer_summary`.
+
+**State:** `on` when the optimizer detects the battery is materially under target during an active demand window, `off` otherwise
+
+**Example Data:**
+```
+State: off
+```
+
+**Icon:** Dynamic (alert when on, check-circle when off)
 
 ---
 

--- a/tests/sensors/test_optimizer.py
+++ b/tests/sensors/test_optimizer.py
@@ -331,6 +331,41 @@ class TestOptimizerSummarySensor:
         assert attrs["terminal_shortfall_pct"] == 0.0
         assert attrs["initial_soc_pct"] == 50.0
 
+    def test_extra_state_attributes_surfaces_optimizer_soc_underprepared(self):
+        """Issue #891: the underprepared flag must be visible on the summary.
+
+        The 2026-06-30 silent miss saw the battery enter the demand window at
+        ~10% while the summary reported a healthy DW-entry SOC. The flag exists
+        on CoordinatorData but was never surfaced — only a WARNING log line.
+        Assert it appears as a summary attribute so dashboards/alerts can see it.
+        """
+        mock_coordinator, data = create_mock_coordinator_with_data(
+            optimizer_summary={"enabled": True, "success": True},
+            optimizer_soc_underprepared=True,
+        )
+        sensor = OptimizerSummarySensor(mock_coordinator, MagicMock())
+
+        attrs = sensor.extra_state_attributes
+
+        assert attrs["optimizer_soc_underprepared"] is True
+
+    def test_extra_state_attributes_optimizer_soc_underprepared_defaults_false(
+        self,
+    ):
+        """Issue #891: missing flag attribute defaults to False, not None."""
+        mock_coordinator, data = create_mock_coordinator_with_data(
+            optimizer_summary={"enabled": True, "success": True},
+        )
+        # Fresh CoordinatorData — optimizer_soc_underprepared not yet set
+        assert hasattr(data, "optimizer_soc_underprepared") is False or getattr(
+            data, "optimizer_soc_underprepared", False
+        ) is False
+        sensor = OptimizerSummarySensor(mock_coordinator, MagicMock())
+
+        attrs = sensor.extra_state_attributes
+
+        assert attrs["optimizer_soc_underprepared"] is False
+
     def test_icon_success(self):
         """Test icon for success state."""
         mock_coordinator, data = create_mock_coordinator_with_data(

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -18,6 +18,7 @@ from custom_components.localshift.binary_sensor import (
     ForecastExpensivePeriodSensor,
     ForecastSpikeWithinWindowSensor,
     LocalShiftBinarySensorBase,
+    OptimizerSocUnderpreparedSensor,
     SolarCanReachTargetSensor,
     TeslaOverrideActiveSensor,
     async_setup_entry,
@@ -50,6 +51,7 @@ def mock_coordinator():
     coordinator.data.backup_reserve = 20
     coordinator.data.grid_services_active = None
     coordinator.data.storm_watch_active = None
+    coordinator.data.optimizer_soc_underprepared = False
     coordinator.data.recent_decision_log = []
     coordinator._state_machine = MagicMock()
     coordinator._state_machine.is_tesla_override_active.return_value = False
@@ -459,7 +461,7 @@ class TestAsyncSetupEntry:
 
         await async_setup_entry(MagicMock(), mock_entry, mock_async_add_entities)
 
-        assert len(added_entities) == 11
+        assert len(added_entities) == 12
 
         sensor_classes = [type(s) for s in added_entities]
         assert ForecastSpikeWithinWindowSensor in sensor_classes
@@ -473,6 +475,7 @@ class TestAsyncSetupEntry:
         assert ExcessSolarAvailableSensor in sensor_classes
         assert TeslaOverrideActiveSensor in sensor_classes
         assert AmberExpressDemandWindowSensor in sensor_classes
+        assert OptimizerSocUnderpreparedSensor in sensor_classes
 
     @pytest.mark.asyncio
     async def test_async_setup_entry_passes_coordinator(
@@ -490,3 +493,69 @@ class TestAsyncSetupEntry:
         for sensor in added_entities:
             assert sensor.coordinator == mock_coordinator
             assert sensor._entry == mock_entry
+
+
+# ---------------------------------------------------------------------------
+# OptimizerSocUnderpreparedSensor (Issue #891)
+# ---------------------------------------------------------------------------
+
+
+class TestOptimizerSocUnderpreparedSensor:
+    """Tests for OptimizerSocUnderpreparedSensor.
+
+    Surfaces data.optimizer_soc_underprepared so the 2026-06-30 silent-failure
+    mode (battery entered the demand window far below target while the summary
+    reported healthy) is visible without tailing logs.
+    """
+
+    def test_sensor_initialization(self, mock_coordinator, mock_entry):
+        """Test sensor initializes with correct attributes."""
+        sensor = OptimizerSocUnderpreparedSensor(mock_coordinator, mock_entry)
+
+        assert sensor._attr_unique_id == "localshift_optimizer_soc_underprepared"
+        assert sensor._attr_name == "Optimizer SOC Underprepared"
+
+    def test_sensor_state_off_when_flag_false(self, mock_coordinator, mock_entry):
+        """Test sensor reports off when the underprepared flag is False."""
+        mock_coordinator.data.optimizer_soc_underprepared = False
+        sensor = OptimizerSocUnderpreparedSensor(mock_coordinator, mock_entry)
+
+        sensor._update_from_coordinator()
+
+        assert sensor._attr_is_on is False
+
+    def test_sensor_state_on_when_flag_true(self, mock_coordinator, mock_entry):
+        """Test sensor reports on when the underprepared flag is True."""
+        mock_coordinator.data.optimizer_soc_underprepared = True
+        sensor = OptimizerSocUnderpreparedSensor(mock_coordinator, mock_entry)
+
+        sensor._update_from_coordinator()
+
+        assert sensor._attr_is_on is True
+
+    def test_sensor_state_off_when_flag_missing(self, mock_coordinator, mock_entry):
+        """Test sensor defaults to off when the flag attribute is missing.
+
+        Defensive: on a fresh coordinator data (before the first optimizer
+        cycle) the attribute may not be populated yet.
+        """
+        del mock_coordinator.data.optimizer_soc_underprepared
+        sensor = OptimizerSocUnderpreparedSensor(mock_coordinator, mock_entry)
+
+        sensor._update_from_coordinator()
+
+        assert sensor._attr_is_on is False
+
+    def test_icon_when_on(self, mock_coordinator, mock_entry):
+        """Test icon changes to alert when sensor is on."""
+        sensor = OptimizerSocUnderpreparedSensor(mock_coordinator, mock_entry)
+        sensor._attr_is_on = True
+
+        assert sensor.icon == "mdi:alert"
+
+    def test_icon_when_off(self, mock_coordinator, mock_entry):
+        """Test icon is checked when sensor is off."""
+        sensor = OptimizerSocUnderpreparedSensor(mock_coordinator, mock_entry)
+        sensor._attr_is_on = False
+
+        assert sensor.icon == "mdi:check-circle"


### PR DESCRIPTION
## Summary

The 2026-06-30 silent miss saw the battery enter the demand window at ~10% while the optimizer summary reported a healthy DW-entry SOC (96.94%). PR #889 added the `optimizer_soc_underprepared` flag on `CoordinatorData` — set by `OptimizerFacade._warn_soc_divergence` when a demand window is active but the live SOC is more than 20 points below target — but the flag was never surfaced. **Only a WARNING log line existed.** The silent-failure tripwire was itself silent in production.

**Live evidence (validated read-only against the running HA):** Querying `sensor.localshift_optimizer_summary` for the `optimizer_soc_underprepared` attribute returned `matched no attribute keys`. The flag exists in code only.

## Changes

- **New entity `binary_sensor.localshift_optimizer_soc_underprepared`** — reads `coordinator.data.optimizer_soc_underprepared`; defaults to `off` on fresh data before the first optimizer cycle. Icon: `mdi:alert` when on, `mdi:check-circle` when off.
- **New attribute on `sensor.localshift_optimizer_summary`** — `optimizer_soc_underprepared` (bool), so dashboards/alerts can surface it without tailing logs.
- Entity counts updated: Binary Sensors 11 → 12, Total 65 → 66 (in `AGENTS.md` and `docs/ENTITY_REFERENCE.md`).

## Validation

- TDD: failing tests first (`KeyError` on missing attribute, `ImportError` on missing class), then implementation.
- 6 new binary-sensor tests + 2 new summary-sensor tests.
- **Full suite: 3222 passed, 1 xfailed. Package coverage: 95%** (meets AGENTS.md threshold).
- `uv run ruff check` clean on changed source files (6 pre-existing warnings in untouched test code).

## Why this matters

This is the **detection** half of S3 (the 6/30 incident root cause is still live — #889 fixed SOC freshness and observability but the actual pre-charge-suppressing gate is unidentified). With this sensor, the next occurrence is visible to dashboards/automations instead of only in logs — unblocking prevention work in a follow-up.

## Test plan
- [x] Unit tests pass (3222)
- [x] Coverage ≥95%
- [ ] Deploy and verify entity appears + reflects flag state during next DW