### PR TITLE
fix(sensors): treat 0.0 solar accuracy as a real value, not 'missing' (#892)

### DIFF
--- a/custom_components/localshift/sensors/solcast.py
+++ b/custom_components/localshift/sensors/solcast.py
@@ -142,12 +142,17 @@ class ForecastAccuracyComparisonSensor(LocalShiftSensorBase):
         # Calculate combined score (weighted average)
         # When both available, weight equally
         # When only one available, use that one
-        if localshift_accuracy and solcast_mape is not None:
+        #
+        # Issue #892 (H4): use `is not None` rather than truthiness. A genuine
+        # 0.0% accuracy (terrible forecast, every sample wrong) is a real value
+        # that must be reported, not collapsed to "unavailable" — which would
+        # mislabel the sensor and skip the blend branch.
+        if localshift_accuracy is not None and solcast_mape is not None:
             # MAPE is error %, so convert to accuracy %
             solcast_accuracy = max(0, 100 - solcast_mape)
             combined = (localshift_accuracy + solcast_accuracy) / 2
             self._attr_native_value = round(combined, 1)
-        elif localshift_accuracy:
+        elif localshift_accuracy is not None:
             self._attr_native_value = round(localshift_accuracy, 1)
         elif solcast_mape is not None:
             # Convert MAPE to accuracy
@@ -161,9 +166,10 @@ class ForecastAccuracyComparisonSensor(LocalShiftSensorBase):
         localshift_accuracy = self.coordinator.data.solar_forecast_accuracy
         solcast_mape = self.coordinator.data.solcast_mape
 
+        # Issue #892 (H4): `is not None` so 0.0% is reported, not None.
         attrs = {
             "localshift_accuracy_pct": round(localshift_accuracy, 1)
-            if localshift_accuracy
+            if localshift_accuracy is not None
             else None,
             "solcast_mape_pct": round(solcast_mape, 1)
             if solcast_mape is not None
@@ -171,7 +177,7 @@ class ForecastAccuracyComparisonSensor(LocalShiftSensorBase):
         }
 
         # Calculate divergence if both available
-        if localshift_accuracy and solcast_mape is not None:
+        if localshift_accuracy is not None and solcast_mape is not None:
             # Both are percentages, but MAPE is error while localshift is accuracy
             # Convert MAPE to accuracy for comparison
             solcast_accuracy = max(0, 100 - solcast_mape)

--- a/tests/sensors/test_solcast.py
+++ b/tests/sensors/test_solcast.py
@@ -238,3 +238,49 @@ class TestForecastAccuracyComparisonSensor:
 
         sensor = ForecastAccuracyComparisonSensor(coordinator_with_analysis, Mock())
         assert sensor.entity_category == EntityCategory.DIAGNOSTIC
+
+    def test_zero_accuracy_is_not_treated_as_missing(self):
+        """Issue #892 (H4): accuracy of exactly 0.0 must NOT be collapsed to None.
+
+        ``if localshift_accuracy:`` treats 0.0 the same as None (unavailable),
+        so a genuinely-0% accuracy (terrible forecast, all samples wrong)
+        would be misreported as the Solcast-only value or None. Use
+        ``is not None`` instead.
+        """
+        coordinator = Mock()
+        coordinator.data = Mock()
+        coordinator.data.solar_forecast_accuracy = 0.0  # Genuinely 0%
+        coordinator.data.solcast_mape = None
+        coordinator.data.low_confidence_periods = []
+
+        sensor = ForecastAccuracyComparisonSensor(coordinator, Mock())
+        sensor._update_from_coordinator()
+
+        # Must report 0.0 (the LocalShift value), NOT None or a Solcast fallback.
+        assert sensor.native_value == 0.0
+
+        attrs = sensor.extra_state_attributes
+        # Attribute must be 0.0, not None.
+        assert attrs["localshift_accuracy_pct"] == 0.0
+
+    def test_zero_accuracy_blended_with_solcast(self):
+        """Issue #892 (H4): 0.0 LocalShift + Solcast MAPE blends correctly.
+
+        Pre-fix the 0.0 was truthy-false so the blend branch was skipped and
+        only Solcast was reported. Post-fix both contribute.
+        """
+        coordinator = Mock()
+        coordinator.data = Mock()
+        coordinator.data.solar_forecast_accuracy = 0.0
+        coordinator.data.solcast_mape = 10.0  # 90% accuracy
+        coordinator.data.low_confidence_periods = []
+
+        sensor = ForecastAccuracyComparisonSensor(coordinator, Mock())
+        sensor._update_from_coordinator()
+
+        # Combined = (0.0 + 90.0) / 2 = 45.0
+        assert sensor.native_value == 45.0
+
+        attrs = sensor.extra_state_attributes
+        assert attrs["localshift_accuracy_pct"] == 0.0
+        assert attrs["divergence_pct"] == 90.0  # |0 - 90|


### PR DESCRIPTION
## Summary

`ForecastAccuracyComparisonSensor` used `if localshift_accuracy:` (truthiness) in four places, which treats a genuine **0.0% accuracy** — a terrible forecast where every sample was wrong — identically to `None` (unavailable). The sensor would then report only the Solcast-derived value (or `None`) instead of the blend, and the `localshift_accuracy_pct` attribute would collapse to `None`.

This is a latent correctness bug — only bites when accuracy is exactly 0.0 — but it masks the underlying value and breaks the blend branch in exactly the scenario where the LocalShift-tracked value matters most (systematic forecast failure).

## Changes

Replaced every `if localshift_accuracy` with `if localshift_accuracy is not None` in `custom_components/localshift/sensors/solcast.py`:
- The blend branch (`localshift + solcast` / 2).
- The localshift-only branch.
- The `localshift_accuracy_pct` attribute emission.
- The divergence calculation guard.

## Validation

- TDD: two failing tests first:
  - `test_zero_accuracy_is_not_treated_as_missing` — 0.0 alone must report 0.0, not None.
  - `test_zero_accuracy_blended_with_solcast` — 0.0 + MAPE 10% must blend to 45.0, not skip to Solcast's 90.0.
- All 15 solcast sensor tests pass.
- Full suite: 3216 passed, 1 xfailed. No regressions.

## Out of scope

The live `sensor.localshift_solar_forecast_accuracy` reading `unknown` is a **separate** root-cause issue (coverage gate in `tick_scheduler._backfill_solar_actual` too strict — 70 pending, 0 samples). Tracked in a follow-up issue. This PR only fixes the truthiness handling so that when accuracy DOES populate, 0.0 is reported correctly.