### PR TITLE
fix(controller): read minimum_target_soc from config option, not data entity (#894)

### DIFF
--- a/custom_components/localshift/coordinator/coordinator.py
+++ b/custom_components/localshift/coordinator/coordinator.py
@@ -263,7 +263,11 @@ class LocalShiftCoordinator:
             self.hass, self.entry, self._entity_validator, _pricing_provider
         )
         self._cost_tracker = CostTracker(self.hass)
-        self._battery_controller = BatteryController(self.hass, self.get_entity_id)
+        # Pass get_option so the controller reads minimum_target_soc correctly
+        # (it's a config_entry OPTION, not a data entity — Issue #894).
+        self._battery_controller = BatteryController(
+            self.hass, self.get_entity_id, get_option_func=self.get_option
+        )
         self._notification_service = NotificationService(
             self.hass, self.entry, self.get_entity_id, self.get_switch_state
         )

--- a/custom_components/localshift/integration/controller.py
+++ b/custom_components/localshift/integration/controller.py
@@ -6,10 +6,12 @@ import logging
 import time
 from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from ..const import (
     BACKUP_RESERVE_MAX_VALID,
+    CONF_MINIMUM_TARGET_SOC,
+    DEFAULT_MINIMUM_TARGET_SOC,
     TESLEMETRY_EXPORT_BATTERY_OK,
     TESLEMETRY_EXPORT_PV_ONLY,
 )
@@ -70,16 +72,22 @@ class BatteryController:
         self,
         hass: HomeAssistant,
         get_entity_id_func: callable,
+        get_option_func: Callable[[str, Any], Any] | None = None,
     ) -> None:
         """Initialize the battery controller.
 
         Args:
             hass: Home Assistant instance
             get_entity_id_func: Function to get entity IDs by config key
+            get_option_func: Optional function to read config_entry options by
+                key (mirrors the state machine's ``_get_option``). Used to read
+                ``minimum_target_soc`` correctly — it's an option, not a data
+                entity, so the entity-id lookup always returned "" (Issue #894).
 
         """
         self.hass = hass
         self._get_entity_id = get_entity_id_func
+        self._get_option = get_option_func
         self._service_client = PowerwallServiceClient(hass, get_entity_id_func)
         self._validator = TransitionValidator(hass, get_entity_id_func)
 
@@ -484,14 +492,31 @@ class BatteryController:
         return True
 
     def _get_minimum_target_soc(self) -> float:
-        """Read the minimum target SOC from the configured entity.
+        """Read the minimum target SOC from the configured option.
+
+        Issue #894: previously looked up an entity id for ``minimum_target_soc``
+        and read it as a state, but that key is NOT in DEFAULT_ENTITY_IDS — it's
+        a config_entry OPTION, not a data entity. ``_get_entity_id`` returned ""
+        and ``read_float("")`` silently fell back to a hardcoded 10.0, ignoring
+        the user's configured slider value during SPIKE_DISCHARGE.
+
+        Now reads via the ``get_option_func`` (mirrors the state machine's
+        ``_get_option``), falling back to DEFAULT_MINIMUM_TARGET_SOC (20, not
+        the buggy 10) when the function isn't wired or the option is unset.
 
         Returns:
-            Minimum target SOC percentage (default 10 if entity unavailable).
+            Minimum target SOC percentage.
 
         """
-        entity_id = self._get_entity_id("minimum_target_soc")
-        return self._validator.read_float(entity_id, default=10.0)
+        if self._get_option is not None:
+            try:
+                value = self._get_option(
+                    CONF_MINIMUM_TARGET_SOC, DEFAULT_MINIMUM_TARGET_SOC
+                )
+                return float(value)
+            except (TypeError, ValueError):
+                return float(DEFAULT_MINIMUM_TARGET_SOC)
+        return float(DEFAULT_MINIMUM_TARGET_SOC)
 
     async def set_force_discharge(
         self,

--- a/tests/test_battery_controller.py
+++ b/tests/test_battery_controller.py
@@ -4,11 +4,13 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from custom_components.localshift.integration.controller import BatteryController
 from custom_components.localshift.const import (
+    CONF_MINIMUM_TARGET_SOC,
+    DEFAULT_MINIMUM_TARGET_SOC,
     TESLEMETRY_EXPORT_BATTERY_OK,
     TESLEMETRY_EXPORT_PV_ONLY,
 )
+from custom_components.localshift.integration.controller import BatteryController
 
 
 @pytest.fixture
@@ -33,7 +35,9 @@ def mock_get_entity_id():
             "teslemetry_allow_export": "select.tesla_powerwall_allow_export",
             "teslemetry_grid_power": "sensor.tesla_powerwall_grid_power",
             "teslemetry_allow_charging_from_grid": "switch.tesla_powerwall_allow_charging_from_grid",
-            "minimum_target_soc": "number.minimum_target_soc",
+            # NOTE: minimum_target_soc is NOT here — it's a config_entry OPTION,
+            # not a data entity. The controller reads it via get_option_func
+            # (Issue #894). Mapping it here masked the production bug for months.
         }
         return entity_map.get(key)
 
@@ -42,8 +46,20 @@ def mock_get_entity_id():
 
 @pytest.fixture
 def battery_controller(mock_hass, mock_get_entity_id):
-    """Create a BatteryController instance."""
-    return BatteryController(mock_hass, mock_get_entity_id)
+    """Create a BatteryController instance.
+
+    Wired with a get_option_func so minimum_target_soc reads work (Issue #894).
+    Individual tests can override the options dict by mutating the controller's
+    _get_option closure, or by constructing their own controller.
+    """
+    options = {CONF_MINIMUM_TARGET_SOC: DEFAULT_MINIMUM_TARGET_SOC}
+
+    def get_option(key, default=None):
+        return options.get(key, default)
+
+    return BatteryController(
+        mock_hass, mock_get_entity_id, get_option_func=get_option
+    )
 
 
 @pytest.fixture
@@ -346,11 +362,11 @@ class TestSetForceDischarge:
             if "operation_mode" in entity_id:
                 state.state = "autonomous"
             elif "backup_reserve" in entity_id:
-                state.state = "10"
+                # Must match the option-derived minimum_target_soc (20, the
+                # fixture default) so validation passes (Issue #894).
+                state.state = str(DEFAULT_MINIMUM_TARGET_SOC)
             elif "allow_export" in entity_id:
                 state.state = TESLEMETRY_EXPORT_BATTERY_OK
-            elif "minimum_target_soc" in entity_id:
-                state.state = "10"
             return state
 
         mock_hass.states.get = mock_get_state
@@ -415,10 +431,26 @@ class TestSetForceDischarge:
     @pytest.mark.asyncio
     @pytest.mark.usefixtures("mock_battery_sleep")
     async def test_set_force_discharge_uses_minimum_target_soc(
-        self, battery_controller, coordinator_data, mock_hass
+        self, mock_hass, mock_get_entity_id, coordinator_data
     ):
-        """Test that force discharge uses minimum_target_soc when no override."""
+        """Test that force discharge uses the configured minimum_target_soc.
+
+        Issue #894: previously the controller tried to read minimum_target_soc
+        as a data ENTITY (which doesn't exist in DEFAULT_ENTITY_IDS), silently
+        falling back to 10.0. Now reads via get_option_func (config_entry
+        option), so the user's configured slider value flows through.
+        """
         mock_hass.services.async_call.return_value = None
+
+        # Configure minimum_target_soc=15 via the option path (production wiring).
+        options = {CONF_MINIMUM_TARGET_SOC: 15.0}
+
+        def get_option(key, default=None):
+            return options.get(key, default)
+
+        controller = BatteryController(
+            mock_hass, mock_get_entity_id, get_option_func=get_option
+        )
 
         def mock_get_state(entity_id):
             if entity_id is None:
@@ -430,13 +462,11 @@ class TestSetForceDischarge:
                 state.state = "15"
             elif "allow_export" in entity_id:
                 state.state = TESLEMETRY_EXPORT_BATTERY_OK
-            elif "minimum_target_soc" in entity_id:
-                state.state = "15"
             return state
 
         mock_hass.states.get = mock_get_state
 
-        result = await battery_controller.set_force_discharge(coordinator_data)
+        result = await controller.set_force_discharge(coordinator_data)
 
         assert result is True
         # Should have used minimum_target_soc (15) for reserve
@@ -487,6 +517,82 @@ class TestSetForceDischarge:
                     break
         assert export_call is not None
         assert export_call[0][2]["option"] == TESLEMETRY_EXPORT_BATTERY_OK
+
+
+# =============================================================================
+# MINIMUM_TARGET_SOC READ TESTS (Issue #894)
+# =============================================================================
+
+
+class TestMinimumTargetSocRead:
+    """Tests that the controller reads the configured minimum_target_soc.
+
+    Issue #894: ``_get_minimum_target_soc`` looked up an entity id for
+    ``minimum_target_soc``, but that key is NOT in DEFAULT_ENTITY_IDS — it's a
+    config_entry OPTION, not a data entity. So ``_get_entity_id`` returned "" and
+    ``read_float("")`` returned the hardcoded default (10.0), silently ignoring
+    the user's configured slider value during SPIKE_DISCHARGE.
+
+    The pre-existing test ``test_set_force_discharge_uses_minimum_target_soc``
+    masked this for months because its ``mock_get_entity_id`` fixture provided a
+    ``minimum_target_soc`` → entity_id mapping that production never sets up.
+    These tests model the REAL production wiring (option-based, not entity-based).
+    """
+
+    @pytest.fixture
+    def battery_controller_with_options(self, mock_hass, mock_get_entity_id):
+        """Controller wired with a get_option_func like the state machine.
+
+        Production coordinator passes ``self.get_option`` (reads config_entry
+        options). The controller needs this to read minimum_target_soc correctly.
+        """
+        options = {CONF_MINIMUM_TARGET_SOC: 25.0}
+
+        def get_option(key, default=None):
+            return options.get(key, default)
+
+        return BatteryController(
+            mock_hass, mock_get_entity_id, get_option_func=get_option
+        )
+
+    def test_get_minimum_target_soc_reads_configured_value(
+        self, battery_controller_with_options
+    ):
+        """Configured minimum_target_soc (25.0) must flow through, not 10.0."""
+        assert (
+            battery_controller_with_options._get_minimum_target_soc() == 25.0
+        )
+
+    def test_get_minimum_target_soc_falls_back_to_default_when_unset(
+        self, mock_hass, mock_get_entity_id
+    ):
+        """When the option isn't set, fall back to DEFAULT_MINIMUM_TARGET_SOC.
+
+        Note: the const default is 20, NOT the 10.0 that was hardcoded in the
+        buggy version — that was a second bug (default mismatch).
+        """
+        options = {}
+
+        def get_option(key, default=None):
+            return options.get(key, default)
+
+        controller = BatteryController(
+            mock_hass, mock_get_entity_id, get_option_func=get_option
+        )
+
+        assert controller._get_minimum_target_soc() == DEFAULT_MINIMUM_TARGET_SOC
+
+    def test_get_minimum_target_soc_no_option_func(
+        self, mock_hass, mock_get_entity_id
+    ):
+        """Backward compat: no get_option_func → fall back to default.
+
+        Older callers that don't pass get_option_func still work; they get the
+        const default rather than crashing.
+        """
+        controller = BatteryController(mock_hass, mock_get_entity_id)
+
+        assert controller._get_minimum_target_soc() == DEFAULT_MINIMUM_TARGET_SOC
 
 
 # =============================================================================
@@ -1117,23 +1223,35 @@ class TestHelperMethods:
 
         assert result == "default"
 
-    def test_get_minimum_target_soc(self, battery_controller, mock_hass):
-        """Test _get_minimum_target_soc reads from entity."""
-        state = MagicMock()
-        state.state = "15"
-        mock_hass.states.get = MagicMock(return_value=state)
+    def test_get_minimum_target_soc(self, mock_hass, mock_get_entity_id):
+        """Test _get_minimum_target_soc reads from config option.
 
-        result = battery_controller._get_minimum_target_soc()
+        Issue #894: minimum_target_soc is a config_entry OPTION, not a data
+        entity. The controller reads it via get_option_func (mirrors the state
+        machine), not via entity-id lookup.
+        """
+        options = {CONF_MINIMUM_TARGET_SOC: 15.0}
+
+        def get_option(key, default=None):
+            return options.get(key, default)
+
+        controller = BatteryController(
+            mock_hass, mock_get_entity_id, get_option_func=get_option
+        )
+
+        result = controller._get_minimum_target_soc()
 
         assert result == 15.0
 
     def test_get_minimum_target_soc_default(self, battery_controller, mock_hass):
-        """Test _get_minimum_target_soc returns default when unavailable."""
-        mock_hass.states.get = MagicMock(return_value=None)
+        """Test _get_minimum_target_soc returns DEFAULT_MINIMUM_TARGET_SOC when unset.
 
+        The fixture wires get_option_func with the option unset, so the default
+        from const.py (20) applies — NOT the old hardcoded 10.0 (Issue #894).
+        """
         result = battery_controller._get_minimum_target_soc()
 
-        assert result == 10.0
+        assert result == float(DEFAULT_MINIMUM_TARGET_SOC)
 
     def test_read_fresh_soc_success(self, battery_controller, mock_hass):
         """Issue #559 Phase 4: test read_fresh_soc() returns float on valid state."""


### PR DESCRIPTION
## Summary

`_get_minimum_target_soc` looked up an entity id for `minimum_target_soc` and read it as HA state, but that key is **NOT in `DEFAULT_ENTITY_IDS`** — it's a config_entry OPTION, not a data entity. `_get_entity_id` returned `` and `read_float()` silently fell back to a hardcoded `10.0`, ignoring the user's configured slider value during `SPIKE_DISCHARGE` (and any path calling `set_force_discharge` with `reserve_soc=None`).

**Live evidence (validated read-only):** `number.localshift_minimum_target_soc` = `10.0` (the default). The bug is latent for this install today, but the moment the user raises the slider, the spike-discharge path ignores it and drains to 10%.

## Two bugs fixed

1. **Controller reads from the wrong source.** Now accepts a `get_option_func` (mirrors the state machine's `_get_option`) and reads `CONF_MINIMUM_TARGET_SOC` via it. Wired at the coordinator: `BatteryController(..., get_option_func=self.get_option)`.
2. **Hardcoded fallback was wrong.** Was `10.0`; the const `DEFAULT_MINIMUM_TARGET_SOC` is `20`. Now uses the const.

## Test quality bug also fixed

The pre-existing `test_set_force_discharge_uses_minimum_target_soc` **passed for months despite the production bug** because its `mock_get_entity_id` fixture mapped `minimum_target_soc` → an entity_id that production never sets up. The fixture mapping is removed; the test now models the real option-based wiring.

## Changes
- `integration/controller.py`: `__init__` accepts `get_option_func`; `_get_minimum_target_soc` reads from options (or const default).
- `coordinator/coordinator.py`: wires `get_option_func=self.get_option`.
- `tests/test_battery_controller.py`: 3 new tests in `TestMinimumTargetSocRead`; 3 existing tests updated to reflect real wiring; misleading fixture mapping removed.

## Validation
- TDD: failing tests first (`TypeError` on missing kwarg, `assert 1.0 == 20` on default mismatch), then implementation.
- **Full suite: 3217 passed, 1 xfailed. Coverage: 95%.**
- `uv run ruff check` clean on changed files.

## Unblocks
- #895 (`set_proactive_export` draining to 4% on SOC=0) — depends on this fix to floor reserve at the configured minimum.