### PR TITLE
fix(pricing): coerce per_kwh to float in _normalize_slot (#897)

### DIFF
--- a/custom_components/localshift/pricing/provider.py
+++ b/custom_components/localshift/pricing/provider.py
@@ -72,10 +72,15 @@ class _ProviderMixin:
         duration = raw.get("duration")
         if duration is None:
             duration = self._infer_duration_minutes(raw)
+        # Issue #897: coerce per_kwh to float. HA state attributes aren't
+        # guaranteed numeric — Amber/Amber Express slots can arrive with
+        # per_kwh as a JSON string ("0.25") or int (0). The surrounding
+        # read_forecasts already catches ValueError/TypeError raised by a
+        # totally-uncoercible value.
         return ForecastSlot(
             start_time=self._parse_timestamp(raw["start_time"]),
             duration=int(duration),
-            per_kwh=raw["per_kwh"],
+            per_kwh=float(raw["per_kwh"]),
             is_spike=self.is_spike(raw),  # type: ignore[attr-defined]
             source_type=self.name,  # type: ignore[attr-defined]
         )

--- a/tests/pricing/test_provider.py
+++ b/tests/pricing/test_provider.py
@@ -517,3 +517,43 @@ def test_normalize_slot_negative_duration_defaults_to_5():
     }
     slot = provider._normalize_slot(raw)
     assert slot.duration == 5  # -30 min: abs diffs = |35|, |45|, |60|; 5 wins
+
+
+def test_normalize_slot_coerces_string_per_kwh_to_float():
+    """Issue #897: per_kwh arriving as a JSON string must be coerced to float.
+
+    Same bug family as #887 (which fixed the attribute NAME). HA state
+    attributes aren't guaranteed numeric — Amber/Amber Express slots can
+    arrive with per_kwh as \"0.25\" (string). Pre-fix the ForecastSlot held
+    the string verbatim, breaking downstream arithmetic and comparison.
+    """
+    from custom_components.localshift.pricing.provider import AmberExpressProvider
+
+    provider = AmberExpressProvider()
+    raw = {
+        "start_time": "2026-03-16T10:00:01+00:00",
+        "end_time": "2026-03-16T10:30:00+00:00",
+        "per_kwh": "0.25",  # string, not float
+        "demand_window": False,
+    }
+    slot = provider._normalize_slot(raw)
+
+    assert isinstance(slot.per_kwh, float)
+    assert slot.per_kwh == 0.25
+
+
+def test_normalize_slot_integer_per_kwh_coerced_to_float():
+    """Issue #897: integer per_kwh (e.g. 0) also coerced to float for consistency."""
+    from custom_components.localshift.pricing.provider import AmberExpressProvider
+
+    provider = AmberExpressProvider()
+    raw = {
+        "start_time": "2026-03-16T10:00:01+00:00",
+        "end_time": "2026-03-16T10:30:00+00:00",
+        "per_kwh": 0,  # int (e.g. negative-price slot clamped to 0)
+        "demand_window": False,
+    }
+    slot = provider._normalize_slot(raw)
+
+    assert isinstance(slot.per_kwh, float)
+    assert slot.per_kwh == 0.0


### PR DESCRIPTION
## Summary

`per_kwh` was passed through verbatim from the raw forecast dict (`provider.py:78`). HA state attributes aren't guaranteed numeric — Amber/Amber Express slots can arrive with `per_kwh` as a JSON string (`"0.25"`) or int (`0`). Pre-fix the `ForecastSlot` held the raw type, breaking downstream arithmetic (`TypeError` on `string * float`) and comparison (lexicographic on `str`).

**Same bug family as #887** (which fixed the attribute *name* for amber_express v2.0.0); this fixes the *type*.

## Changes

`pricing/provider.py:_normalize_slot`:
```python
per_kwh=float(raw["per_kwh"]),
```

The surrounding `read_forecasts` already catches `ValueError`/`TypeError` raised by a totally-uncoercible value (e.g. `None`).

## Validation

- TDD: 2 failing tests (string `'0.25'` → `assert isinstance('0.25', float)`; int `0` → `assert isinstance(0, float)`), then fix.
- All 39 pricing tests pass.
- **Full suite: 3216 passed, 1 xfailed. Coverage: 95%.**
- `uv run ruff check` clean.