### PR TITLE
fix(config_flow): align target_penalty slider max with THRESHOLD_RANGES (#898)

### DIFF
--- a/custom_components/localshift/config_flow/__init__.py
+++ b/custom_components/localshift/config_flow/__init__.py
@@ -775,7 +775,9 @@ class LocalShiftOptionsFlow(OptionsFlow):
             ): selector.NumberSelector(
                 selector.NumberSelectorConfig(
                     min=0.000,
-                    max=0.100,
+                    # Issue #898: must match THRESHOLD_RANGES max (0.200). Was
+                    # 0.100, silently clamping values the NumberEntity allows.
+                    max=0.200,
                     step=0.005,
                     unit_of_measurement="$/%-point",
                     mode=selector.NumberSelectorMode.SLIDER,

--- a/tests/config_flow/test_schemas.py
+++ b/tests/config_flow/test_schemas.py
@@ -84,3 +84,49 @@ class TestBuildSolcastSchema:
             include_notify=False,
         )
         assert isinstance(result, vol.Schema)
+
+
+class TestAdvancedSchemaBounds:
+    """Tests that the advanced-options slider bounds match THRESHOLD_RANGES.
+
+    Issue #898: the options-flow NumberSelector for target_penalty capped at
+    0.100 while THRESHOLD_RANGES (used by the NumberEntity) allowed 0.200. A
+    user who set 0.15 via the number entity would be silently clamped to 0.100
+    on re-opening the options flow. Assert every advanced-schema selector's max
+    matches the corresponding THRESHOLD_RANGES entry so this drift can't recur.
+    """
+
+    @pytest.mark.parametrize(
+        "conf_key",
+        [
+            "cheap_price_percentile",
+            "max_pre_charge_price",
+            "battery_target",
+            "minimum_target_soc",
+            "target_penalty",
+            "min_cycle_saving",
+        ],
+    )
+    def test_advanced_schema_selector_max_matches_threshold_ranges(
+        self, conf_key: str
+    ):
+        from custom_components.localshift.config_flow import LocalShiftOptionsFlow
+        from custom_components.localshift.const import THRESHOLD_RANGES
+
+        flow = LocalShiftOptionsFlow()
+        schema = flow._build_advanced_schema({})
+
+        # Find the selector for this conf_key and compare its max to const.
+        expected_max = THRESHOLD_RANGES[conf_key]["max"]
+        for field, selector_obj in schema.schema.items():
+            # voluptuous Required/Optional markers expose the key via .schema
+            field_key = getattr(field, "schema", field)
+            if field_key == conf_key:
+                # selector_obj.config is the NumberSelectorConfig dict
+                actual_max = selector_obj.config["max"]
+                assert actual_max == expected_max, (
+                    f"{conf_key}: options-flow max ({actual_max}) != "
+                    f"THRESHOLD_RANGES max ({expected_max})"
+                )
+                return
+        pytest.fail(f"{conf_key} not found in advanced schema")


### PR DESCRIPTION
## Summary

The options-flow `NumberSelector` for `target_penalty` capped at `max=0.100`, but `THRESHOLD_RANGES` (used by the `NumberEntity`) allows `max=0.200`. A user who set `0.15` via the number entity would be **silently clamped to `0.100`** on re-opening the options flow.

`const.py:250` comment confirms `0.200` is intended: _"#885: raised 0.015 -> 0.03 ... the soft lever can at least exceed typical charge prices"_.

## Changes

- `config_flow/__init__.py:778`: `max=0.100` → `max=0.200` (matches `THRESHOLD_RANGES`).
- New parametrized regression test `TestAdvancedSchemaBounds` asserts every advanced-schema selector's `max` matches `THRESHOLD_RANGES`, so this drift can't recur silently.

## Validation

- TDD: failing test (`assert 0.1 == 0.2`), then fix.
- **Full suite: 3220 passed, 1 xfailed. Coverage: 95%.**
- `uv run ruff check` clean.

## Note on entity-name drift (out of scope)

Live HA has `number.localshift_target_shortfall_penalty` but the code builds `number.localshift_target_penalty` (from `CONF_TARGET_PENALTY = "target_penalty"`). This is a **deployment-drift** artifact (the live install was running an older version where the key was `target_shortfall_penalty`), not a code bug. It'll self-resolve when the integration is reloaded with current code. Not changed in this PR.