### PR TITLE
fix(costs): clear _last_soc_pct on midnight reset; wire reset_daily_accumulators (#899)

### DIFF
--- a/custom_components/localshift/coordinator/tick_scheduler.py
+++ b/custom_components/localshift/coordinator/tick_scheduler.py
@@ -248,20 +248,30 @@ class TickScheduler:
         accumulators (battery_savings, battery_charge_cost, solar_yield_value,
         grid_export_revenue) and the target_reached flag.
 
+        Issue #899: delegates to ``CostTracker.reset_daily_accumulators`` so the
+        SOC baseline (``_last_soc_pct``) is also cleared — preventing the first
+        post-midnight grid-charge sample from attributing the overnight SOC
+        delta to the new day. Falls back to inline zeroing if no cost_tracker
+        (defensive — should always be present post-init).
+
         Notifies listeners and logs the reset for debugging.
         """
-        self._coordinator.data.grid_import_cost = 0.0
-        self._coordinator.data.grid_export_revenue = 0.0
-        self._coordinator.data.battery_savings = 0.0
-        self._coordinator.data.battery_charge_cost = 0.0
-        self._coordinator.data.target_reached_today = False
-        # Issue #868: reset the daily energy accumulators alongside the cost
-        # accumulators so the performance-metric ratios start fresh each day.
-        self._coordinator.data.grid_import_kwh_today = 0.0
-        self._coordinator.data.grid_export_kwh_today = 0.0
-        self._coordinator.data.grid_to_battery_kwh_today = 0.0
-        self._coordinator.data.soc_gain_during_grid_charge_kwh_today = 0.0
-        self._coordinator.data.export_while_battery_not_full_kwh_today = 0.0
+        if self._coordinator.cost_tracker is not None:
+            self._coordinator.cost_tracker.reset_daily_accumulators(
+                self._coordinator.data
+            )
+        else:
+            # Defensive fallback — should never happen post-init.
+            self._coordinator.data.grid_import_cost = 0.0
+            self._coordinator.data.grid_export_revenue = 0.0
+            self._coordinator.data.battery_savings = 0.0
+            self._coordinator.data.battery_charge_cost = 0.0
+            self._coordinator.data.target_reached_today = False
+            self._coordinator.data.grid_import_kwh_today = 0.0
+            self._coordinator.data.grid_export_kwh_today = 0.0
+            self._coordinator.data.grid_to_battery_kwh_today = 0.0
+            self._coordinator.data.soc_gain_during_grid_charge_kwh_today = 0.0
+            self._coordinator.data.export_while_battery_not_full_kwh_today = 0.0
 
         if self._coordinator.learning_orchestrator is not None:
             self._coordinator.learning_orchestrator.handle_midnight_reset(

--- a/custom_components/localshift/utils/costs.py
+++ b/custom_components/localshift/utils/costs.py
@@ -118,6 +118,13 @@ class CostTracker:
         """Reset daily cost and energy accumulators and the target flag.
 
         Replaces YAML A12 (localshift_reset_target_reached).
+
+        Issue #899: also clears ``_last_soc_pct`` so the first grid-charge
+        sample after midnight establishes a fresh baseline. Without this, a
+        grid charge spanning midnight leaves the baseline at the pre-midnight
+        SOC, and the next sample attributes the entire overnight gain to the
+        new day's ``soc_gain_during_grid_charge_kwh_today`` — corrupting
+        ``grid_charge_efficiency``.
         """
         data.grid_import_cost = 0.0
         data.grid_export_revenue = 0.0
@@ -125,6 +132,7 @@ class CostTracker:
         data.battery_charge_cost = 0.0
         data.target_reached_today = False
         self._reset_energy_accumulators(data)
+        self._last_soc_pct = None
 
     def _reset_energy_accumulators(self, data: CoordinatorData) -> None:
         """Reset the Issue #868 daily energy accumulators."""

--- a/tests/utils/test_costs.py
+++ b/tests/utils/test_costs.py
@@ -344,3 +344,73 @@ class TestAccumulateEnergyKwh:
         assert data.grid_to_battery_kwh_today == 0.0
         assert data.soc_gain_during_grid_charge_kwh_today == 0.0
         assert data.export_while_battery_not_full_kwh_today == 0.0
+
+    def test_reset_daily_accumulators_clears_last_soc_pct(self, cost_tracker):
+        """Issue #899: reset must clear _last_soc_pct to avoid cross-day smear.
+
+        Without this, a grid charge spanning midnight leaves _last_soc_pct at
+        the pre-midnight value (e.g. 40%). The first accumulate_costs after
+        midnight then computes soc_delta = (current - 40)% and attributes the
+        entire overnight gain to the new day's soc_gain_during_grid_charge_kwh,
+        corrupting grid_charge_efficiency.
+        """
+        data = self._make_data()
+        data.soc = 40.0
+        data.charging_from_grid = True
+        # Prime _last_soc_pct via a real accumulation.
+        cost_tracker.accumulate_costs(data)
+        assert cost_tracker._last_soc_pct == 40.0
+
+        cost_tracker.reset_daily_accumulators(data)
+
+        assert cost_tracker._last_soc_pct is None
+
+    def test_no_phantom_soc_gain_after_midnight_reset(self, cost_tracker):
+        """Issue #899 end-to-end: post-midnight sample must not attribute the
+        overnight SOC delta to the new day.
+
+        Steps:
+        1. Pre-midnight grid charge: SOC 40 -> 50 over the sample.
+        2. Midnight reset.
+        3. Post-midnight sample at SOC 51 (only +1 since reset).
+        Without the fix, step 3 sees soc_delta = 51 - 50 (last_soc_pct not
+        cleared) ... wait, the bug is that _last_soc_pct is NOT cleared, so
+        step 3 computes 51 - 50 = 1 (correct only if last_soc_pct was 50).
+
+        Actually the real bug: if the LAST pre-midnight sample left
+        _last_soc_pct at 50, and the next grid-charge sample after reset is
+        at 51, that's correct. The bug is when there's NO accumulation between
+        reset and the post-midnight charge — _last_soc_pct stays at the
+        pre-reset value and the first new sample computes delta from there.
+
+        Simulate: pre-midnight SOC ends at 50 (last_soc_pct=50). Reset.
+        Post-midnight: SOC jumps to 80 (battery charged by solar, not grid,
+        between samples). Now grid charge sample at SOC 81.
+        Without fix: delta = 81 - 50 = 31% attributed to grid charge (wrong).
+        With fix: delta = 81 - 81... no, _last_soc_pct=None so first sample
+        establishes baseline at 81, no phantom gain.
+        """
+        data = self._make_data()
+
+        # Pre-midnight grid charge: SOC rises 40 -> 50.
+        data.soc = 40.0
+        data.charging_from_grid = True
+        cost_tracker.accumulate_costs(data)
+        data.soc = 50.0
+        cost_tracker.accumulate_costs(data)
+        assert cost_tracker._last_soc_pct == 50.0
+
+        # Midnight reset.
+        cost_tracker.reset_daily_accumulators(data)
+        assert cost_tracker._last_soc_pct is None
+
+        # Post-midnight: SOC jumped to 80 (solar, not grid, between samples).
+        # First grid-charge sample of the new day at SOC 81.
+        data.soc = 81.0
+        gain_before = data.soc_gain_during_grid_charge_kwh_today
+        cost_tracker.accumulate_costs(data)
+
+        # First post-reset sample must establish a NEW baseline (_last_soc_pct
+        # = 81), not attribute any gain. The phantom 31% delta must NOT appear.
+        assert data.soc_gain_during_grid_charge_kwh_today == gain_before
+        assert cost_tracker._last_soc_pct == 81.0


### PR DESCRIPTION
## Summary

Two related issues:

1. **`CostTracker.reset_daily_accumulators` was dead code** (zero callers in `custom_components/` — only tests exercised it). The midnight-reset path (`tick_scheduler.handle_midnight_reset`) inlined the same field-zeroing logic but did **NOT** clear `_last_soc_pct`.

2. **The omission corrupts `grid_charge_efficiency`:** a grid charge spanning midnight leaves `_last_soc_pct` at the pre-midnight SOC. The first `accumulate_costs` after midnight computes `soc_delta = current_soc - _last_soc_pct` and attributes the **entire overnight SOC gain** to the new day's `soc_gain_during_grid_charge_kwh_today`, inflating the ratio.

## Changes

- `utils/costs.py:reset_daily_accumulators`: now also clears `self._last_soc_pct = None` so the first post-midnight grid-charge sample establishes a fresh baseline.
- `coordinator/tick_scheduler.py:handle_midnight_reset`: delegates to `cost_tracker.reset_daily_accumulators(data)` (with a defensive inline fallback if `cost_tracker` is somehow `None`). Replaces the inline field-zeroing that was duplicating `CostTracker`'s logic and missing the SOC baseline clear.

## Validation

- TDD: 2 failing tests in `TestAccumulateEnergyKwh`:
  - `test_reset_daily_accumulators_clears_last_soc_pct` — `_last_soc_pct` must be `None` after reset (was `40.0`).
  - `test_no_phantom_soc_gain_after_midnight_reset` — end-to-end: pre-midnight charge to SOC 50, reset, post-midnight sample at 81 must NOT attribute the 31-point delta (was `50.0`, not `None`).
- All 57 CostTracker + tick_scheduler tests pass.
- **Full suite: 3216 passed, 1 xfailed. Coverage: 95%.**
- `uv run ruff check` clean.