### PR TITLE
fix(state,pricing): bound entity-id replace() to first occurrence (#900)

### DIFF
--- a/custom_components/localshift/pricing/provider.py
+++ b/custom_components/localshift/pricing/provider.py
@@ -132,7 +132,7 @@ class AmberProvider(_ProviderMixin):
         self, hass: HomeAssistant, price_entity_id: str
     ) -> list[ForecastSlot]:
         """Read forecasts from separate forecast entity."""
-        forecast_entity = price_entity_id.replace("_price", "_forecast")
+        forecast_entity = price_entity_id.replace("_price", "_forecast", 1)
         raw_forecasts = self._read_attribute(hass, forecast_entity, "forecasts", [])
 
         if not raw_forecasts:
@@ -183,7 +183,7 @@ class AmberExpressProvider(_ProviderMixin):
             )
             price_entity_id = corrected
 
-        detailed_entity = price_entity_id.replace("_price", "_price_detailed")
+        detailed_entity = price_entity_id.replace("_price", "_price_detailed", 1)
         raw_forecasts = self._read_attribute(hass, detailed_entity, "forecasts", [])
 
         if not raw_forecasts:

--- a/custom_components/localshift/state/reader.py
+++ b/custom_components/localshift/state/reader.py
@@ -242,10 +242,10 @@ class StateReader:
         else:
             # For amber, need separate forecast entities - try to derive them
             shadow_general_forecast = self._read_attribute(
-                shadow_general_entity.replace("_price", "_forecast"), "forecasts", []
+                shadow_general_entity.replace("_price", "_forecast", 1), "forecasts", []
             )
             shadow_feed_in_forecast = self._read_attribute(
-                shadow_feed_in_entity.replace("_price", "_forecast"), "forecasts", []
+                shadow_feed_in_entity.replace("_price", "_forecast", 1), "forecasts", []
             )
 
         return {
@@ -464,8 +464,8 @@ class StateReader:
         Handles both Amber Express (detailed entities) and standard forecast sensors.
         """
         if pricing_source == PRICING_SOURCE_AMBER_EXPRESS:
-            general_detailed = general_price_entity.replace("_price", "_price_detailed")
-            feed_in_detailed = feed_in_price_entity.replace("_price", "_price_detailed")
+            general_detailed = general_price_entity.replace("_price", "_price_detailed", 1)
+            feed_in_detailed = feed_in_price_entity.replace("_price", "_price_detailed", 1)
 
             general_forecast = self._read_attribute(general_detailed, "forecasts", [])
             feed_in_forecast = self._read_attribute(feed_in_detailed, "forecasts", [])
@@ -831,7 +831,7 @@ class StateReader:
             if price_spike_entity:
                 # Replace "price_spike" with "demand_window" to get the entity
                 demand_window_entity = price_spike_entity.replace(
-                    "price_spike", "demand_window"
+                    "price_spike", "demand_window", 1
                 )
                 data.demand_window_amber = self._read_bool(demand_window_entity)
                 _LOGGER.debug(

--- a/tests/state/test_state_reader.py
+++ b/tests/state/test_state_reader.py
@@ -2239,3 +2239,55 @@ def test_read_shadow_prices_fallback_without_provider(mock_hass, mock_entry):
     # Should have fallback data (empty lists since mocked hass returns None)
     assert isinstance(shadow["general_forecast_shadow"], list)
     assert isinstance(shadow["feed_in_forecast_shadow"], list)
+
+
+class TestEntityIdDerivationCount:
+    """Issue #900: entity-id derivation must replace only the FIRST occurrence.
+
+    The codebase derives forecast/detailed/demand_window entity ids from price
+    entity ids via str.replace. Unbounded replace() swaps EVERY occurrence,
+    which corrupts ids containing the substring more than once (rare but
+    possible with custom renames). The correct pattern is replace(..., 1).
+    """
+
+    def test_read_legacy_forecasts_replaces_only_first_price_substring(
+        self, mock_hass
+    ):
+        """_read_legacy_forecasts derives _price_detailed from _price; only first.
+
+        An entity id like 'sensor.amber_price_price' must become
+        'sensor.amber_price_detailed_price', NOT
+        'sensor.amber_price_detailed_price_detailed'.
+        """
+        from custom_components.localshift.const import PRICING_SOURCE_AMBER_EXPRESS
+
+        entry = MagicMock()
+        entry.data = {}
+        validator = MagicMock()
+        validator.should_allow_automation = MagicMock(return_value=True)
+
+        reader = StateReader(mock_hass, entry, validator, pricing_provider=None)
+
+        # Capture which entity ids _read_attribute is called with.
+        requested_ids: list[str] = []
+        mock_hass.states.get = MagicMock(
+            side_effect=lambda eid: requested_ids.append(eid) or None
+        )
+
+        # Double '_price' substring in the input entity id.
+        reader._read_legacy_forecasts(
+            data=CoordinatorData(),
+            general_price_entity="sensor.amber_price_price",
+            feed_in_price_entity="sensor.amber_feed_in_price_price",
+            pricing_source=PRICING_SOURCE_AMBER_EXPRESS,
+        )
+
+        # The detailed derivation must replace only the FIRST '_price'.
+        assert "sensor.amber_price_detailed_price" in requested_ids
+        assert "sensor.amber_feed_in_price_detailed_price" in requested_ids
+        # And NOT produce the double-replaced form.
+        assert "sensor.amber_price_detailed_price_detailed" not in requested_ids
+        assert (
+            "sensor.amber_feed_in_price_detailed_price_detailed"
+            not in requested_ids
+        )


### PR DESCRIPTION
## Summary

Entity-id derivation used unbounded `str.replace()` in 7 places, swapping **EVERY** occurrence of the substring. For ids containing the substring more than once (rare but possible with custom renames like `sensor.amber_price_price`), the result was malformed — e.g. `sensor.amber_price_detailed_price_detailed` instead of `sensor.amber_price_detailed_price`.

This matches the existing correct pattern at `reader.py:198`/`203` which already used `count=1` for the `amber_express_` prefix transform. The inconsistency was the bug.

## Changes — added `count=1` to all 7 sites

- `state/reader.py`:
  - `_read_shadow_prices` (2 sites: `_price` → `_forecast`)
  - `_read_legacy_forecasts` (2 sites: `_price` → `_price_detailed`)
  - `read_all_external_state` demand_window derivation (1 site: `price_spike` → `demand_window`)
- `pricing/provider.py`:
  - `AmberProvider.read_forecasts` (1 site)
  - `AmberExpressProvider.read_forecasts` (1 site)

## Validation

- TDD: failing test `TestEntityIdDerivationCount` with double `_price` substring asserting only the first occurrence is replaced. Confirmed the unbounded replace produced `sensor.amber_price_detailed_price_detailed` (both replaced); after fix produces `sensor.amber_price_detailed_price`.
- **Full suite: 3216 passed, 1 xfailed. Coverage: 95%.**
- `uv run ruff check` clean.