### PR TITLE
fix(execution): commit plan-wanted pre-charge — token phase starvation, urgency backstop, dw_entry_actual telemetry

### DIFF
--- a/custom_components/localshift/computation_engine.py
+++ b/custom_components/localshift/computation_engine.py
@@ -61,7 +61,10 @@ from .engine import (
 )
 from .engine.excess_solar import ExcessSolarEngine
 from .engine.optimizer_dp import DPPlanner
-from .engine.optimizer_facade import OptimizerFacade
+from .engine.optimizer_facade import (
+    PRECHARGE_BACKSTOP_SHORTFALL_PCT,
+    OptimizerFacade,
+)
 from .engine.optimizer_runner import _find_current_slot_index
 from .engine.price_signal_engine import PriceSignalEngine
 from .engine.slot_schedule import TOTAL_SLOTS
@@ -294,6 +297,69 @@ class ComputationEngine:
         if data.last_target_reset_date != today:
             data.target_reached_today = False
             data.last_target_reset_date = today
+            # The DW-entry actual (2026-07-27) is a once-per-day capture and shares
+            # this latch: clearing it here re-arms tomorrow's capture.
+            data.dw_entry_actual_soc_pct = None
+            data.dw_entry_actual_at = None
+            data.dw_entry_actual_target_pct = None
+            data.dw_entry_actual_shortfall_pct = None
+            data.dw_entry_actual_date = None
+
+    def _capture_dw_entry_actual(
+        self, data: CoordinatorData, ctx: _DerivedValuesContext
+    ) -> None:
+        """Record the SOC the battery ACTUALLY entered today's demand window at.
+
+        2026-07-27 incident: the window was entered at 64.0% against a 95% target,
+        and the log could not show it afterwards. The optimizer's *projected*
+        ``dw_entry_soc_pct`` legitimately rolls over to tomorrow's window the instant
+        today's window starts — the 15:00 line reported 98.5% / shortfall 0.0 /
+        ``first_charge=2026-07-28T13:00`` — so by the time anyone looked, the miss had
+        been overwritten by a projection about a different day.
+
+        Captured once per day, on the first evaluation with the window live, and held
+        untouched for the rest of the day (later ticks inside the window must not
+        overwrite it with a recovered SOC). A ``None`` SOC at the exact boundary defers
+        rather than recording a null: the next evaluation is ≤1 min away.
+
+        Runs BEFORE the manual-override early return — this is telemetry about the
+        battery, not about the optimizer, and the miss matters just as much when the
+        user has taken manual control.
+        """
+        if not data.demand_window_active:
+            return
+        if data.dw_entry_actual_date == ctx.today:
+            return
+        soc = data.soc
+        if soc is None:
+            return
+
+        target = float(ctx.target_pct)
+        shortfall = max(0.0, target - float(soc))
+
+        data.dw_entry_actual_soc_pct = float(soc)
+        data.dw_entry_actual_at = ctx.now_dt
+        data.dw_entry_actual_target_pct = target
+        data.dw_entry_actual_shortfall_pct = shortfall
+        data.dw_entry_actual_date = ctx.today
+
+        # Same threshold the execution backstop fires on — one number, not two.
+        if shortfall > PRECHARGE_BACKSTOP_SHORTFALL_PCT:
+            _LOGGER.warning(
+                "DEMAND WINDOW ENTERED UNDER TARGET: %.1f%% against a %.0f%% target "
+                "(%.1f points short) at %s. Pre-charge did not execute.",
+                soc,
+                target,
+                shortfall,
+                ctx.now_dt.isoformat(),
+            )
+        else:
+            _LOGGER.info(
+                "Demand window entered at %.1f%% (target %.0f%%, shortfall %.1f).",
+                soc,
+                target,
+                shortfall,
+            )
 
     def _detect_hardware_modes(self, data: CoordinatorData) -> None:
         """---- Step 2: Mode detection from Teslemetry state ----"""
@@ -338,6 +404,12 @@ class ComputationEngine:
         data.debug_forecast_slot_time = ""
         data.debug_first_forecast_slot_time = ""
         data.debug_time_gap_seconds = 0.0
+        # The facade never runs on this path, so a pending plan mode left by an
+        # earlier tick would go stale here and still feed the state machine's
+        # plan-charge epoch — a phantom grant off a plan that is arbitrarily old.
+        # Same reasoning as _mark_mode_debug_fallback's clear.
+        data.debug_plan_mode_pending = None
+        data.optimizer_precharge_backstop_active = False
         return True
 
     def _bridge_history_results(self, data: CoordinatorData, now_dt: datetime) -> None:
@@ -524,6 +596,11 @@ class ComputationEngine:
 
         # ---- Step 3: demand_window_active ----
         self._compute_demand_window_active(data, ctx)
+
+        # ---- Step 3b: actual DW-entry capture (2026-07-27) ----
+        # Immediately after the boundary is computed and before any early return, so
+        # the number survives manual override and a failed optimizer cycle alike.
+        self._capture_dw_entry_actual(data, ctx)
 
         # ---- Manual override check ----
         if self._enter_manual_override(data):

--- a/custom_components/localshift/coordinator/coordinator.py
+++ b/custom_components/localshift/coordinator/coordinator.py
@@ -762,10 +762,19 @@ class LocalShiftCoordinator:
                 they may update the plan but must NOT grant a mode change.
 
         """
-        if invalidate_decision and self._state_machine is not None:
-            self._state_machine.invalidate_decision_fingerprint(
-                "async_recompute_and_evaluate (config change)"
-            )
+        if self._state_machine is not None:
+            if invalidate_decision:
+                self._state_machine.invalidate_decision_fingerprint(
+                    "async_recompute_and_evaluate (config change)"
+                )
+            else:
+                # Honour "must NOT grant a mode change" against the plan-charge
+                # trigger too: _compute_derived_values below runs the facade out of
+                # lock and writes debug_plan_mode_pending, which the evaluation
+                # that follows would otherwise read back with zero lag and grant on.
+                self._state_machine.suppress_next_plan_charge_grant(
+                    "async_recompute_and_evaluate (reoptimize)"
+                )
         self._compute_derived_values()
         self.notify_listeners()
         await self.async_evaluate_state_machine()

--- a/custom_components/localshift/coordinator/data.py
+++ b/custom_components/localshift/coordinator/data.py
@@ -576,6 +576,51 @@ class CoordinatorData:
     """True only on evaluations where the decision context changed (one decision
     per price/spike/DW-boundary/SOC-floor change). Transient; not persisted."""
 
+    mode_decision_plan_charge_only: bool = False
+    """True when this evaluation's decision token was granted *solely* because the
+    plan wants to START charging while frozen (the plan-charge epoch advanced but
+    the price/spike/DW/floor context did not).
+
+    Such a grant may only commit a CHARGE mode. Without this the trigger is
+    one-directional in what ARMS it but not in what it COMMITS: a charge-wanted
+    epoch would hand the facade a generic re-decision, and a plan whose slot-0 had
+    wandered to spike_discharge would force-discharge the battery on a token
+    granted because the plan wanted to charge. Transient; not persisted."""
+
+    mode_backstop_allowed: bool = False
+    """Transient in-lock permission for the pre-charge execution backstop. Opened by
+    ``StateMachine._apply_decision_token`` and closed in the evaluate finally block,
+    so the OUT-OF-LOCK compute_derived_values in
+    ``coordinator.async_recompute_and_evaluate`` can never force a charge. Default
+    False so any path that forgets to set it stays inert."""
+
+    optimizer_precharge_backstop_active: bool = False
+    """True while the pre-charge execution backstop is force-committing BOOST_CHARGING
+    this cycle. Surfaced on the optimizer summary sensor."""
+
     debug_plan_mode_pending: str | None = None
     """When the decision is frozen, the mode the plan would have selected
     ("plan wants X, decision held at Y"). None when no decision is pending."""
+
+    # ---------------------------------------------------------------------------
+    # --- Actual demand-window entry (2026-07-27 pre-charge incident) ---
+    # ---------------------------------------------------------------------------
+    # The optimizer's PROJECTED dw_entry_soc_pct rolls over to tomorrow's window the
+    # instant today's window starts, which is what erased the 64%-vs-95% miss from the
+    # log. These five record what actually happened, captured once at the DW boundary
+    # and held for the rest of the day. Reset by _reset_daily_precharge_latch.
+
+    dw_entry_actual_soc_pct: float | None = None
+    """SOC (%) observed at the first evaluation inside today's demand window."""
+
+    dw_entry_actual_at: datetime | None = None
+    """Timestamp of that capture. None before the window opens."""
+
+    dw_entry_actual_target_pct: float | None = None
+    """The battery target the capture is measured against."""
+
+    dw_entry_actual_shortfall_pct: float | None = None
+    """max(0, target - actual) in %-points. 0.0 when the target was met."""
+
+    dw_entry_actual_date: date | None = None
+    """Date the capture belongs to — the once-per-day latch."""

--- a/custom_components/localshift/engine/core.py
+++ b/custom_components/localshift/engine/core.py
@@ -428,6 +428,13 @@ class DPPlanner:
             config, demand_bounds
         )
 
+        # Publish the DW-entry slot index on the config alongside its siblings below.
+        # urgency_window_start_idx is only interpretable against this bound, and
+        # out-of-solver consumers (the pre-charge execution backstop) need "before the
+        # demand window" without re-deriving the window. Must be assigned, not merely
+        # local: the backstop reads it off the config after the plan returns.
+        config.terminal_penalty_idx = terminal_penalty_idx
+
         # Issue #800 follow-up: the urgency-inflated effective_cheap_price is only valid
         # near the demand window. Record where the urgency window begins so the cheap-price
         # gate uses the inflated value only there and the un-inflated base elsewhere

--- a/custom_components/localshift/engine/optimizer_facade.py
+++ b/custom_components/localshift/engine/optimizer_facade.py
@@ -27,6 +27,18 @@ from .slots import SlotBuilder
 
 _LOGGER = logging.getLogger(__name__)
 
+# Projected DW-entry shortfall (%-points) above which the execution backstop takes
+# over from the token-gated commit path (2026-07-27 incident). Deliberately NOT a
+# config entity: this is a failure detector, not a tuning knob — it only fires when
+# the plan already wants a pre-DW charge that the decision token never sampled.
+PRECHARGE_BACKSTOP_SHORTFALL_PCT = 5.0
+
+# Modes that constitute "the battery is being charged from the grid". Mirrors
+# ``state.machine._CHARGE_MODES``; a decision token granted purely because the plan
+# wanted to START charging may commit one of these and nothing else.
+_CHARGE_MODES = (_BatteryMode.GRID_CHARGING, _BatteryMode.BOOST_CHARGING)
+_CHARGE_MODE_VALUES = frozenset(m.value for m in _CHARGE_MODES)
+
 
 class OptimizerFacade:
     """Facade that runs the DP optimizer and writes results to CoordinatorData."""
@@ -46,6 +58,13 @@ class OptimizerFacade:
         self._planner = planner or DPPlanner()
         self._slot_builder_cls = slot_builder_cls
         self._solar_accuracy_tracker: Any = None
+        # True while a forced BOOST from the pre-charge execution backstop is the
+        # committed mode. The backstop commits OUTSIDE a fingerprint change, which
+        # breaks the property every other commit has — that a change of mode implies
+        # the decision context just moved, so another change is imminent. Without
+        # this latch a forced boost can outlive its own conditions indefinitely on a
+        # flat-price stretch or a stuck price sensor. See _release_backstop_hold.
+        self._backstop_holding: bool = False
 
     def set_solar_accuracy_tracker(self, tracker: Any) -> None:
         """Set the solar accuracy tracker for bias correction."""
@@ -232,13 +251,18 @@ class OptimizerFacade:
             )
             result = self._planner.plan(inputs)
 
-            self._log_precharge_decision(data, result, initial_soc, optimizer_config)
-
             self._write_optimizer_fields(
                 data, result, slot_metadata, config_options, cycle_id, soc_info
             )
 
             self._assign_active_mode(data, result, optimizer_config, config_options)
+
+            # Logged AFTER _assign_active_mode, not before: the line reports
+            # optimizer_precharge_backstop_active, which _assign_active_mode is what
+            # sets. Logging first reported the PREVIOUS cycle's backstop state on
+            # every line — in a change whose whole purpose is making the next miss
+            # reconstructable from the log alone.
+            self._log_precharge_decision(data, result, initial_soc, optimizer_config)
 
             # Run shadow optimizer for comparison if enabled
             self._run_shadow_comparison(data, now_dt, config_options, slot_metadata)
@@ -283,6 +307,31 @@ class OptimizerFacade:
             initial_soc_info=initial_soc_info,
         )
 
+        # Actual DW-entry telemetry (2026-07-27). Injected here rather than inside
+        # ``_build_summary`` because that is a pure result→dict function shared with
+        # the batch/test path and has no coordinator handle. The CoordinatorData
+        # fields remain the single source of truth; the summary only mirrors them so
+        # the projected and actual DW-entry SOC sit side by side in one payload.
+        dw_entry_actual_at = getattr(data, "dw_entry_actual_at", None)
+        dw_entry_actual_date = getattr(data, "dw_entry_actual_date", None)
+        data.optimizer_summary["dw_entry_actual_soc_pct"] = getattr(
+            data, "dw_entry_actual_soc_pct", None
+        )
+        data.optimizer_summary["dw_entry_actual_at"] = (
+            dw_entry_actual_at.isoformat() if dw_entry_actual_at is not None else None
+        )
+        data.optimizer_summary["dw_entry_actual_shortfall_pct"] = getattr(
+            data, "dw_entry_actual_shortfall_pct", None
+        )
+        data.optimizer_summary["dw_entry_actual_target_pct"] = getattr(
+            data, "dw_entry_actual_target_pct", None
+        )
+        data.optimizer_summary["dw_entry_actual_date"] = (
+            dw_entry_actual_date.isoformat()
+            if dw_entry_actual_date is not None
+            else None
+        )
+
         data.forecast_horizon_hours = slot_metadata.horizon_hours
 
         data.solar_can_reach_target = result.can_solar_reach_target
@@ -305,6 +354,10 @@ class OptimizerFacade:
         SOC). Logs the SOC the planner actually used, the target, the planned
         DW-entry/peak SOC, and whether/when a grid charge is scheduled — so a
         future miss is diagnosable from the log alone. Never raises.
+
+        Carries ``dw_entry_actual`` (2026-07-27) alongside the projection: the
+        projected ``dw_entry_soc_pct`` rolls over to tomorrow's window the instant
+        today's DW starts, which is what erased the 64%-vs-95% miss from the log.
         """
         try:
             decisions = getattr(result, "decisions", None) or []
@@ -319,7 +372,7 @@ class OptimizerFacade:
             _LOGGER.info(
                 "Pre-charge decision: initial_soc=%.1f%% target=%s dw_entry_soc=%s "
                 "peak_soc=%s shortfall=%s dw_active=%s charge_slots=%d "
-                "first_charge=%s",
+                "first_charge=%s dw_entry_actual=%s backstop=%s",
                 initial_soc,
                 f"{target_soc:.0f}%" if target_soc is not None else "n/a",
                 f"{dw_entry:.1f}%" if dw_entry is not None else "n/a",
@@ -328,10 +381,26 @@ class OptimizerFacade:
                 getattr(data, "demand_window_active", False),
                 len(charge_decisions),
                 getattr(first_charge, "timestamp_iso", None),
+                self._format_dw_entry_actual(data),
+                getattr(data, "optimizer_precharge_backstop_active", False),
             )
             self._warn_soc_divergence(data, initial_soc, dw_entry, target_soc)
         except Exception as exc:  # noqa: BLE001
             _LOGGER.debug("Pre-charge decision log failed (non-fatal): %s", exc)
+
+    @staticmethod
+    def _format_dw_entry_actual(data: CoordinatorData) -> str:
+        """Render today's captured DW-entry actual as ``64.0%@15:00``, or ``n/a``.
+
+        ``getattr`` guarded because the capture is a coordinator-side concern: a
+        cycle that runs before the first capture of the day (or a bare
+        ``CoordinatorData`` in a unit test) simply reads ``n/a``.
+        """
+        soc = getattr(data, "dw_entry_actual_soc_pct", None)
+        at = getattr(data, "dw_entry_actual_at", None)
+        if soc is None or at is None:
+            return "n/a"
+        return f"{soc:.1f}%@{at:%H:%M}"
 
     def _warn_soc_divergence(
         self,
@@ -346,6 +415,10 @@ class OptimizerFacade:
         — i.e. pre-charge appears to have been missed. Sets
         ``data.optimizer_soc_underprepared`` (a sensor / coordinator notification
         can surface it) and emits a WARNING so the failure is never silent again.
+
+        The message carries the *captured* DW-entry actual as well as the live SOC
+        (2026-07-27): by the time this trips, the battery may have recovered some
+        charge inside the window, so the live number understates the miss.
         """
         threshold = target_soc if target_soc is not None else 95.0
         in_dw = getattr(data, "demand_window_active", False)
@@ -355,11 +428,13 @@ class OptimizerFacade:
         if underprepared:
             _LOGGER.warning(
                 "SOC UNDERPREPARED: demand window active but battery at %.1f%% "
-                "(target %.0f%%, planned DW-entry %s). Pre-charge appears to have "
-                "been missed — verify the optimizer scheduled a charge.",
+                "(target %.0f%%, planned DW-entry %s, entered at %s). Pre-charge "
+                "appears to have been missed — verify the optimizer scheduled a "
+                "charge.",
                 initial_soc,
                 threshold,
                 f"{dw_entry:.1f}%" if dw_entry is not None else "n/a",
+                self._format_dw_entry_actual(data),
             )
 
     def _assign_active_mode(
@@ -394,6 +469,11 @@ class OptimizerFacade:
         data.debug_forecast_slot_time = slot_hhmm
         data.debug_first_forecast_slot_time = first_hhmm
         data.debug_time_gap_seconds = gap_seconds
+
+        # Cleared up-front so the flag can never go stale on any branch below (the
+        # safety-block return and the invalid-mode fallback both exit without
+        # reaching the backstop check).
+        data.optimizer_precharge_backstop_active = False
 
         # #622 gate replacement: the mode may be (re-)decided only on an allowed
         # evaluation. When frozen, every branch below records its block-status /
@@ -434,15 +514,53 @@ class OptimizerFacade:
             new_mode = _BatteryMode(battery_mode_str)
             data.optimizer_last_apply_status = "ready_to_apply"
             data.optimizer_safety_block_reason = ""
-            self._commit_or_hold_mode(
-                data, new_mode, decision_allowed, mode_source="optimizer"
-            )
+
+            # A token granted purely by the plan-charge trigger is one-directional in
+            # what committed it, so it must be one-directional in what it commits.
+            # Otherwise a grant raised because the plan wanted to START charging is
+            # spent on whatever slot-0 has drifted to by the time the facade re-plans
+            # — including a discharge. Fall back to frozen: the wanted charge stays
+            # visible on debug_plan_mode_pending and the execution backstop (below)
+            # remains the deterministic path.
+            if (
+                decision_allowed
+                and getattr(data, "mode_decision_plan_charge_only", False)
+                and new_mode not in _CHARGE_MODES
+            ):
+                _LOGGER.debug(
+                    "Plan-charge grant not spent: fresh plan selected %s, "
+                    "not a charge mode — holding",
+                    battery_mode_str,
+                )
+                decision_allowed = False
+
             _LOGGER.info(
                 "DP optimizer: selected %s (action=%s, slot=%d, decision_allowed=%s)",
                 battery_mode_str,
                 apply_plan.get("action"),
                 current_slot_idx,
                 decision_allowed,
+            )
+            # Execution backstop (2026-07-27): strictly after the safety gate, so a
+            # blocked cycle can never reach it. Force-commits the pre-charge the plan
+            # already contains when the token has starved it out.
+            backstop_mode = self._precharge_backstop_mode(
+                data, result, optimizer_config, current_slot_idx
+            )
+            data.optimizer_precharge_backstop_active = backstop_mode is not None
+            if backstop_mode is not None:
+                self._backstop_holding = True
+                self._commit_or_hold_mode(
+                    data, backstop_mode, True, mode_source="precharge_backstop"
+                )
+                return
+            if self._release_backstop_hold(data):
+                self._commit_or_hold_mode(
+                    data, new_mode, True, mode_source="precharge_backstop_release"
+                )
+                return
+            self._commit_or_hold_mode(
+                data, new_mode, decision_allowed, mode_source="optimizer"
             )
         except ValueError:
             _LOGGER.warning(
@@ -457,6 +575,212 @@ class OptimizerFacade:
                 decision_allowed,
                 mode_source="fallback",
             )
+
+    def _release_backstop_hold(self, data: CoordinatorData) -> bool:
+        """Return True when a forced BOOST must be released this cycle.
+
+        The backstop is the only path that commits a mode WITHOUT a decision-context
+        change. Every other commit carries an implicit guarantee — the fingerprint
+        just moved, so it will move again shortly and the mode will be revisited.
+        A forced BOOST has no such guarantee: once its conditions clear
+        (``soc >= hard_target_floor``, typically) the backstop simply returns None
+        and the ordinary frozen path PINS the boost. On a flat-price stretch or a
+        stuck price sensor the fingerprint never changes, the plan-charge trigger is
+        one-directional and will not grant a wanted STOP, and the battery keeps
+        force-charging at full import price until the demand window flips.
+
+        So the release is made symmetric with the force: the same latch that opened
+        an ungated commit closes it with one.
+        """
+        if not self._backstop_holding:
+            return False
+        # Confined to the same in-lock window as the force. The release is an ungated
+        # commit too, so the out-of-lock compute_derived_values in
+        # ``coordinator.async_recompute_and_evaluate`` — where the backstop returns
+        # None purely because permission is closed, not because its conditions
+        # cleared — must not consume the latch or command hardware.
+        if not getattr(data, "mode_backstop_allowed", False):
+            return False
+        self._backstop_holding = False
+        # Only an ungated release is needed while the forced boost is still what is
+        # committed. If an ordinary grant already moved the mode on, there is nothing
+        # to release — drop the latch and let the normal path decide.
+        return data.active_mode in _CHARGE_MODES
+
+    def _precharge_backstop_mode(
+        self,
+        data: CoordinatorData,
+        result: Any,
+        optimizer_config: Any,
+        current_slot_idx: int,
+    ) -> Any | None:
+        """Return BOOST_CHARGING when the pre-charge execution backstop must fire.
+
+        2026-07-27 incident: the demand window was entered at 64% against a 95%
+        target. The DP planned the pre-charge correctly — ``first_charge=NOW`` on
+        plan after plan — but the #622 decision token only grants on a
+        price/spike/DW/floor change, and at every grant instant the freshly-computed
+        plan's slot-0 action happened to be "hold" (the cheapest first-charge slot
+        drifts forward on every replan). The wanted charge was recorded dozens of
+        times in ``debug_plan_mode_pending`` and never committed.
+
+        This is the executor-side backstop for that class of failure: when the plan
+        *already contains* a pre-DW grid charge, the live SOC is below the #885 hard
+        DW-target floor, we are inside the urgency window and the projected shortfall
+        is material, the mode is force-committed regardless of the token. Every gate
+        reuses an existing engine decision — notably ``hard_target_floor``, which is
+        already dormant whenever pre-charge is not required (``allow_dw_entry_under_
+        target``, solar alone reaches target, no demand window, non-self-consumption)
+        — so this never invents charge intent it only executes intent the DP
+        expressed. BOOST is the right mode because ``constraints.feasible_actions``
+        unlocks boost under exactly this predicate (``soc_pct < hard_target_floor``
+        in a pre-DW slot).
+
+        Never raises (mirrors ``_log_precharge_decision``): a failing backstop check
+        must never take down the optimizer cycle.
+        """
+        try:
+            if not self._backstop_context_permits(data):
+                return None
+
+            # Primary reuse: the #885/#886 hard DW-target feasibility floor. None ⇒
+            # pre-charge is not required today; the backstop is dormant with it.
+            hard_floor = getattr(optimizer_config, "hard_target_floor", None)
+            if hard_floor is None:
+                return None
+
+            soc = getattr(data, "soc", None)
+            if soc is None or soc >= hard_floor:
+                return None
+
+            window = self._backstop_urgency_window(optimizer_config, current_slot_idx)
+            if window is None:
+                return None
+            urgency_start_idx, terminal_penalty_idx = window
+
+            shortfall = self._projected_shortfall_pct(result, optimizer_config)
+            if shortfall <= PRECHARGE_BACKSTOP_SHORTFALL_PCT:
+                return None
+
+            pre_dw_charge_slots = self._count_pre_dw_charge_slots(
+                data.optimizer_decisions, terminal_penalty_idx
+            )
+            if pre_dw_charge_slots == 0:
+                return None
+
+            if self._price_above_precharge_ceiling(data, optimizer_config):
+                return None
+
+            _LOGGER.warning(
+                "PRE-CHARGE BACKSTOP: forcing BOOST_CHARGING — soc=%.1f%% "
+                "hard_floor=%.1f%% projected shortfall=%.1f%% slot=%d "
+                "(urgency window %d..%d), plan has %d pre-DW charge slot(s) but the "
+                "decision token never committed one.",
+                soc,
+                hard_floor,
+                shortfall,
+                current_slot_idx,
+                urgency_start_idx,
+                terminal_penalty_idx,
+                pre_dw_charge_slots,
+            )
+            return _BatteryMode.BOOST_CHARGING
+        except Exception as exc:  # noqa: BLE001
+            _LOGGER.debug("Pre-charge backstop check failed (non-fatal): %s", exc)
+            return None
+
+    @staticmethod
+    def _backstop_context_permits(data: CoordinatorData) -> bool:
+        """The three gates that depend only on coordinator state, not on the plan."""
+        # In-lock only. Set by the state machine alongside the decision token and
+        # cleared in its finally block, so the out-of-lock recompute in
+        # ``coordinator.async_recompute_and_evaluate`` can never command hardware.
+        if not getattr(data, "mode_backstop_allowed", False):
+            return False
+
+        # Issue #330: an unavailable price entity reads as general_price = 0.0, not
+        # None, so the pre-charge price ceiling would wave the backstop through at a
+        # completely unknown real price — potentially straight through a spike.
+        # "Grid charging decisions will be deferred" applies to a forced charge most
+        # of all.
+        if not getattr(data, "prices_available", True):
+            return False
+
+        # Pre-DW only — once the DW is live the pre-charge is moot and forcing a
+        # charge would fight the demand-block behaviour.
+        return not getattr(data, "demand_window_active", False)
+
+    @staticmethod
+    def _backstop_urgency_window(
+        optimizer_config: Any, current_slot_idx: int
+    ) -> tuple[int, int] | None:
+        """Return ``(urgency_start_idx, terminal_penalty_idx)`` when the current slot
+        sits inside the urgency pre-charge window, else None.
+
+        Same window the urgency-inflated pre-charge price is legitimate in, and
+        strictly before the DW-entry slot — the scope
+        ``constraints.hard_floor_needs_boost`` already uses at DP level. Either index
+        being None ⇒ no demand window in the horizon (or a direct unit-test caller),
+        so the backstop stays dormant.
+        """
+        urgency_start_idx = getattr(optimizer_config, "urgency_window_start_idx", None)
+        terminal_penalty_idx = getattr(optimizer_config, "terminal_penalty_idx", None)
+        if urgency_start_idx is None or terminal_penalty_idx is None:
+            return None
+        if not urgency_start_idx <= current_slot_idx < terminal_penalty_idx:
+            return None
+        return urgency_start_idx, terminal_penalty_idx
+
+    @staticmethod
+    def _projected_shortfall_pct(result: Any, optimizer_config: Any) -> float:
+        """Worst of the two published DW-entry shortfall measures (%-points).
+
+        The 2026-07-27 log carried both ``terminal_shortfall_pct`` and a
+        ``target - dw_entry_soc_pct`` gap and they can diverge, so the backstop takes
+        the max rather than trusting either alone.
+        """
+        shortfall = float(getattr(result, "terminal_shortfall_pct", None) or 0.0)
+        target = getattr(optimizer_config, "demand_window_target_soc_pct", None)
+        dw_entry = getattr(result, "dw_entry_soc_pct", None)
+        if target is not None and dw_entry is not None:
+            shortfall = max(shortfall, float(target) - float(dw_entry))
+        return shortfall
+
+    @staticmethod
+    def _count_pre_dw_charge_slots(
+        decisions: list[Any] | None, terminal_penalty_idx: int
+    ) -> int:
+        """Count charge slots the plan schedules before the demand-window entry.
+
+        Reads the *serialized* decisions off ``data`` — ``_write_optimizer_fields``
+        runs before ``_assign_active_mode``, so these are this cycle's plan. This is
+        what keeps the backstop honest: it never invents charge intent, it only
+        executes intent the DP already expressed but the token never sampled.
+
+        A decision with no ``slot_index`` is NOT counted. Defaulting it to 0 would
+        make a malformed decision read as a pre-DW charge and arm a forced boost off
+        a plan that never located itself in time.
+        """
+        return sum(
+            1
+            for d in (decisions or [])
+            if d.get("grid_charge")
+            and isinstance(d.get("slot_index"), int)
+            and d["slot_index"] < terminal_penalty_idx
+        )
+
+    @staticmethod
+    def _price_above_precharge_ceiling(
+        data: CoordinatorData, optimizer_config: Any
+    ) -> bool:
+        """True when the live price exceeds the operator's pre-charge ceiling.
+
+        Reuses ``CONF_MAX_PRECHARGE_PRICE`` (already on the config) rather than
+        introducing a backstop-specific price knob.
+        """
+        ceiling = getattr(optimizer_config, "max_precharge_price", None)
+        price = getattr(data, "general_price", None)
+        return ceiling is not None and price is not None and price > ceiling
 
     @staticmethod
     def _commit_or_hold_mode(
@@ -473,6 +797,10 @@ class OptimizerFacade:
         / ``decision_mode`` untouched and records the would-be mode in
         ``debug_plan_mode_pending`` so the dashboard can show "plan wants X,
         decision held at Y".
+
+        ``decision_allowed=True`` is also passed by the pre-charge execution
+        backstop, which is not a token grant but an in-lock override — see
+        ``_precharge_backstop_mode``.
         """
         if not decision_allowed:
             # Frozen: pin the previously-decided mode, surface the pending plan.
@@ -502,10 +830,26 @@ class OptimizerFacade:
 
         Called from run_inline early exits so the debug_* fields never go stale
         when the optimizer did not produce a decision this tick.
+
+        ``debug_plan_mode_pending`` is cleared with them: a stale pending left by an
+        earlier tick would otherwise feed the state machine's plan-charge epoch on a
+        tick where the optimizer produced no decision at all — a phantom grant.
         """
+        if data.debug_plan_mode_pending in _CHARGE_MODE_VALUES:
+            # Dropping a legitimately-pending charge is the correct conservative
+            # call — a token must never be granted off a plan that does not exist —
+            # but it costs the plan-charge trigger one cycle, so say so rather than
+            # discarding it silently.
+            _LOGGER.info(
+                "Pending plan charge (%s) discarded: this cycle produced no "
+                "optimizer decision. The trigger re-arms on the next good plan.",
+                data.debug_plan_mode_pending,
+            )
         data.debug_mode_source = "fallback"
         data.debug_forecast_slot_found = False
         data.debug_forecast_slot_time = ""
+        data.debug_plan_mode_pending = None
+        data.optimizer_precharge_backstop_active = False
 
     def _run_shadow_comparison(
         self,

--- a/custom_components/localshift/engine/types.py
+++ b/custom_components/localshift/engine/types.py
@@ -223,6 +223,18 @@ class OptimizerConfig:
     effective_cheap_price: float = 0.10
     """Price threshold for grid charging in self-consumption mode ($/kWh)."""
 
+    terminal_penalty_idx: int | None = None
+    """Solver-derived (set by ``DPPlanner._solve``): index of the demand-window ENTRY slot,
+    i.e. the slot the terminal shortfall penalty is applied at. None ⇒ no demand window in
+    the rolling horizon.
+
+    Published alongside ``urgency_window_start_idx`` (which is meaningless without it) so
+    consumers outside the solver can express "before the demand window" without
+    re-deriving the window bounds. The pre-charge execution backstop
+    (``OptimizerFacade._backstop_urgency_window``) is the first such consumer: before this
+    field existed it read ``getattr(config, "terminal_penalty_idx", None)``, which was
+    always None, and the backstop was unreachable in production."""
+
     urgency_window_start_idx: int | None = None
     """Solver-derived (set by ``DPPlanner._solve``): index of the first slot within the
     urgency window before the demand-window entry (Issue #800 follow-up). The window width is

--- a/custom_components/localshift/sensors/optimizer.py
+++ b/custom_components/localshift/sensors/optimizer.py
@@ -111,6 +111,8 @@ class OptimizerSummarySensor(LocalShiftSensorBase):
         ]
         avg_confidence = sum(confidences) / len(confidences) if confidences else 1.0
 
+        dw_entry_actual_at = getattr(d, "dw_entry_actual_at", None)
+
         return {
             "enabled": summary.get("enabled", False),
             "success": summary.get("success", False),
@@ -131,6 +133,26 @@ class OptimizerSummarySensor(LocalShiftSensorBase):
             "initial_soc_pct": summary.get("initial_soc_pct"),
             "peak_soc_pct": summary.get("peak_soc_pct"),
             "dw_entry_soc_pct": summary.get("dw_entry_soc_pct"),
+            # Projected (above) and actual (below) sit together deliberately. These
+            # five read from `d`, not `summary`: the summary is rebuilt every cycle
+            # and is empty on a failed cycle — precisely when the real entry SOC
+            # matters most — and its dw_entry_soc_pct rolls over to tomorrow's window
+            # the instant today's DW starts, which erased the 2026-07-27 miss.
+            "dw_entry_actual_soc_pct": getattr(d, "dw_entry_actual_soc_pct", None),
+            "dw_entry_actual_at": (
+                dw_entry_actual_at.isoformat()
+                if dw_entry_actual_at is not None
+                else None
+            ),
+            "dw_entry_actual_shortfall_pct": getattr(
+                d, "dw_entry_actual_shortfall_pct", None
+            ),
+            "dw_entry_actual_target_pct": getattr(
+                d, "dw_entry_actual_target_pct", None
+            ),
+            "precharge_backstop_active": getattr(
+                d, "optimizer_precharge_backstop_active", False
+            ),
             "projected_solar_gain_pct": summary.get("projected_solar_gain_pct"),
             "forecast_accuracy": summary.get("forecast_accuracy"),
             "accuracy_discount_factor": summary.get("accuracy_discount_factor"),

--- a/custom_components/localshift/state/machine.py
+++ b/custom_components/localshift/state/machine.py
@@ -44,6 +44,15 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
+# Plan-disagreement trigger (2026-07-27 pre-charge incident): the modes whose
+# *start* the plan may ask for while the decision is frozen. The trigger is
+# deliberately ONE-DIRECTIONAL — only a wanted START of charging may grant a
+# token; a wanted STOP never does. Charging late costs money; charging one
+# extra interval does not, and the asymmetry is what makes the trigger
+# flap-free (see _update_plan_charge_epoch).
+_CHARGE_MODES = (BatteryMode.GRID_CHARGING, BatteryMode.BOOST_CHARGING)
+_CHARGE_MODE_VALUES = frozenset(m.value for m in _CHARGE_MODES)
+
 
 class StateMachine:
     """Manages battery mode state machine evaluation and transitions."""
@@ -96,6 +105,30 @@ class StateMachine:
         # (not by a transition), which kills the old deferred-redemption bug
         # where a stale token was redeemed minutes later by a non-price input.
         self._last_evaluated_fingerprint: str | None = None
+        # The price/spike/DW/floor half of the fingerprint from the last granted
+        # evaluation, kept separately so a grant can be attributed: same base +
+        # different epoch ⇒ the grant came from the plan alone.
+        self._last_evaluated_base: str | None = None
+        # Plan-disagreement trigger (2026-07-27 pre-charge incident): the plan is
+        # itself a decision input. ``_plan_charge_epoch`` is a MONOTONE counter
+        # incremented on the rising edge of "the plan wants to START charging while
+        # the decision is frozen", and is the 6th fingerprint component.
+        #
+        # The bound is enforced by BUDGET, not by edge memory. An earlier revision
+        # tracked only the last qualifying pending value; because a granted
+        # evaluation clears ``debug_plan_mode_pending``, that memory reset itself on
+        # the very next tick and the "rising edge" re-armed every 2 ticks —
+        # commit → pending clears → pending re-set → fresh rising edge, forever,
+        # inside one unchanged price context (measured: 11 grants over 21 ticks).
+        # ``_plan_charge_context`` + ``_plan_charge_granted`` instead spend at most
+        # one grant per (price context × wanted-charge mode) and refuse to re-grant
+        # until the price/spike/DW/floor context genuinely changes.
+        self._plan_charge_context: str | None = None
+        self._plan_charge_granted: set[str] = set()
+        self._plan_charge_epoch: int = 0
+        # One-shot suppression for callers that explicitly must not grant a mode
+        # change (async_recompute_and_evaluate(invalidate_decision=False)).
+        self._suppress_plan_charge_grant: bool = False
         self._MIN_CORRECTION_INTERVAL = timedelta(
             minutes=STATE_MACHINE_MIN_CORRECTION_INTERVAL_MINUTES
         )
@@ -235,6 +268,92 @@ class StateMachine:
             "released_at": self._tesla_override_released_at,
         }
 
+    def _update_plan_charge_epoch(
+        self, data: CoordinatorData, context: str | None = None
+    ) -> None:
+        """Advance the plan-disagreement epoch (2026-07-27 pre-charge incident).
+
+        The original fingerprint enumerated price/spike/DW/floor as the only
+        legitimate re-decision triggers, silently assuming the plan is stable
+        between them. It is not: the DP's slot-0 action oscillates hold↔charge on
+        every replan because ``first_charge`` chases the cheapest slot forward.
+        The token therefore sampled the plan on a ~5-min stride and, on
+        2026-07-27, nearly every sample landed on a hold-phase plan — the wanted
+        charge was recorded in ``debug_plan_mode_pending`` dozens of times and
+        never committed (DW entered at 64% against a 95% target).
+
+        ``debug_plan_mode_pending`` is the value written by the *previous* tick's
+        facade run — the same documented 1-tick-lag pattern already used for
+        ``dw_active``/``soc_floor_breached`` (all are read pre-refresh).
+
+        Three gates decide whether a pending value qualifies:
+
+        1. it names a CHARGE mode — asymmetry gate #1, only a wanted *start*;
+        2. the committed mode is not already charging — asymmetry gate #2, which
+           is what makes a wanted *stop* ungrantable (a stop waits for the next
+           natural fingerprint change, ≤1 Amber tick);
+        3. SOC is below the battery target — nothing to grant at/above target.
+
+        The bound is a per-context BUDGET, not an edge detector. Edge detection
+        does not work here: a granted evaluation clears
+        ``debug_plan_mode_pending`` (``_commit_or_hold_mode``), so any memory of
+        "the last pending value" is reset by the very grant it is meant to gate,
+        the next frozen tick re-sets the pending value, and the tick after that
+        looks like a fresh rising edge. That re-arms every 2 ticks and re-grants
+        forever inside one unchanged price context — the #622 flap, restored.
+
+        Instead: each (price context × wanted-charge mode) pair may spend the
+        epoch exactly once. ``_plan_charge_granted`` records which charge modes
+        have already been granted in ``_plan_charge_context``, and is cleared only
+        when the price/spike/DW/floor context genuinely changes.
+
+        ⇒ at most ONE extra decision per (price context × wanted-charge mode) —
+        two charge modes exist, so at most two per context — and it can only start
+        charging. No charge→hold→charge cycle is reachable inside a single price
+        context, and no unbounded re-grant loop is either.
+
+        Args:
+            data: Coordinator data (read-only here).
+            context: The price/spike/DW/floor half of the decision fingerprint.
+                None (price sensor unavailable) resets the budget: we are frozen
+                anyway, and the next real context must not inherit a spent budget.
+
+        """
+        if self._suppress_plan_charge_grant:
+            # Explicit "may update the plan but must NOT grant a mode change"
+            # caller. Still re-baseline the context so the next real evaluation
+            # is not judged against a stale one.
+            self._plan_charge_context = context
+            self._plan_charge_granted.clear()
+            return
+
+        if context != self._plan_charge_context:
+            self._plan_charge_context = context
+            self._plan_charge_granted.clear()
+
+        pending = data.debug_plan_mode_pending
+        battery_target = float(
+            self._get_option(CONF_BATTERY_TARGET, DEFAULT_BATTERY_TARGET)
+        )
+
+        qualifies = (
+            context is not None
+            and pending in _CHARGE_MODE_VALUES
+            and data.active_mode not in _CHARGE_MODES
+            and data.soc is not None
+            and data.soc < battery_target
+        )
+
+        if qualifies and pending not in self._plan_charge_granted:
+            self._plan_charge_granted.add(pending)
+            self._plan_charge_epoch += 1
+            _LOGGER.debug(
+                "Plan-charge disagreement epoch %d (plan wants %s, committed %s)",
+                self._plan_charge_epoch,
+                pending,
+                data.active_mode.value,
+            )
+
     def _get_decision_fingerprint(self, data: CoordinatorData) -> str | None:
         """Generate the discrete decision-context fingerprint.
 
@@ -247,6 +366,9 @@ class StateMachine:
         - spike: price-spike onset
         - dw_active: demand-window boundary crossing
         - soc_floor_breached: SOC dropped below the optimizer's minimum target
+        - plan_charge_epoch: the optimizer plan wants to START charging while the
+          committed decision is frozen (one-directional; see
+          _update_plan_charge_epoch)
 
         ``dw_active`` and ``soc_floor_breached`` are read from ``data`` *before*
         compute_derived_values refreshes them this tick. The resulting 1-tick
@@ -255,6 +377,17 @@ class StateMachine:
         snapshot as the decision context keeps the fingerprint consistent with
         the prices read at the same instant.
 
+        The same 1-tick lag applies to the plan-charge epoch: the pending plan
+        mode it is derived from was written by the previous tick's facade run.
+        Only the rising edge of a wanted charge is visible in the fingerprint —
+        the falling edge (the disagreement resolving) is deliberately invisible,
+        which is what makes the trigger flap-free.
+
+        This method is side-effect-free: it *reads* ``_plan_charge_epoch`` and
+        never updates it (``_apply_decision_token`` calls
+        ``_update_plan_charge_epoch`` first). Tests call it out-of-band to
+        enumerate distinct contexts; a mutating fingerprint would corrupt them.
+
         Args:
             data: Coordinator data with current prices and state.
 
@@ -262,6 +395,20 @@ class StateMachine:
             Fingerprint string or None if prices are unavailable. None must NOT
             count as a context change (the caller freezes on None).
 
+        """
+        base = self._get_decision_context(data)
+        if base is None:
+            return None
+        return f"{base}|{self._plan_charge_epoch}"
+
+    def _get_decision_context(self, data: CoordinatorData) -> str | None:
+        """The price/spike/DW/floor half of the fingerprint, without the epoch.
+
+        Split out so two things can be said precisely: which grants came from the
+        plan alone (same context, different epoch — see
+        ``mode_decision_plan_charge_only``), and when the plan-charge budget
+        should be refilled (``_update_plan_charge_epoch``). Both would be circular
+        if they had to read the full fingerprint, which contains the epoch.
         """
         buy = data.general_price
         sell = data.feed_in_price
@@ -650,19 +797,26 @@ class StateMachine:
             # to decide whether it may re-select active_mode this tick.
             self._apply_decision_token(data)
 
-            computation_engine.compute_derived_values(data)
-
             try:
+                # Inside the try: compute_derived_values runs the optimizer facade,
+                # and an exception from any post-facade step used to escape with
+                # mode_decision_allowed / mode_backstop_allowed still True — leaving
+                # the out-of-lock recompute armed to force a charge.
+                computation_engine.compute_derived_values(data)
                 await self._evaluate_core(data, computation_engine)
             finally:
                 # #622 gate replacement (transience guarantee): the decision
-                # token is valid ONLY within this in-lock window, from
-                # _apply_decision_token above to here. Resetting it (even on
-                # exception) guarantees the flag is never True for the
-                # OUT-OF-LOCK compute_derived_values call at the top of
+                # token — and the pre-charge backstop permission that rides the
+                # same window — are valid ONLY within this in-lock window, from
+                # _apply_decision_token above to here. Resetting both (even on
+                # exception) guarantees neither flag is True for the OUT-OF-LOCK
+                # compute_derived_values call at the top of
                 # coordinator.async_recompute_and_evaluate — so a load-deviation
-                # or solar reoptimize can never commit an ungated mode decision.
+                # or solar reoptimize can never commit an ungated mode decision
+                # nor force one through the backstop.
                 data.mode_decision_allowed = False
+                data.mode_decision_plan_charge_only = False
+                data.mode_backstop_allowed = False
                 if notify_func is not None:
                     notify_func()
 
@@ -678,17 +832,49 @@ class StateMachine:
         A None fingerprint (price sensor unavailable) never grants a decision and
         never overwrites the stored fingerprint: we stay frozen on the last known
         context until a genuinely new value arrives.
+
+        A plan-disagreement grant (the plan wants to start charging while frozen)
+        behaves identically: it is consumed by the evaluation that observes it
+        and does NOT create a deferrable credit for a later tick. It is also
+        *attributed*: when the price/spike/DW/floor context is unchanged and only
+        the epoch moved, ``mode_decision_plan_charge_only`` tells the facade this
+        grant may commit a charge mode and nothing else.
         """
-        fingerprint = self._get_decision_fingerprint(data)
+        # Plan-disagreement trigger: fold the plan into the decision context
+        # BEFORE fingerprinting, so the fingerprint computed here reflects the
+        # epoch this grant is based on. The context is passed in so the epoch's
+        # per-context budget and the fingerprint agree on what "context" means.
+        context = self._get_decision_context(data)
+        self._update_plan_charge_epoch(data, context)
+        self._suppress_plan_charge_grant = False
+
+        fingerprint = (
+            None if context is None else f"{context}|{self._plan_charge_epoch}"
+        )
         decision_allowed = (
             fingerprint is not None and fingerprint != self._last_evaluated_fingerprint
         )
+        # Same price/spike/DW/floor context as the last grant ⇒ the epoch is the
+        # only thing that moved ⇒ the plan alone granted this.
+        plan_charge_only = decision_allowed and context == self._last_evaluated_base
         if decision_allowed:
             # Consume immediately: the evaluation, not the transition, spends the
             # token. Covers every downstream path (including debounce-in-progress).
             self._last_evaluated_fingerprint = fingerprint
-            _LOGGER.debug("Decision token granted (fingerprint=%s)", fingerprint)
+            self._last_evaluated_base = context
+            _LOGGER.debug(
+                "Decision token granted (fingerprint=%s, plan_charge_only=%s)",
+                fingerprint,
+                plan_charge_only,
+            )
         data.mode_decision_allowed = decision_allowed
+        data.mode_decision_plan_charge_only = plan_charge_only
+        # The pre-charge execution backstop is NOT a decision token, but it is
+        # confined to the same in-lock window: opening it here (and closing it in
+        # the evaluate finally block) guarantees the out-of-lock
+        # compute_derived_values in coordinator.async_recompute_and_evaluate can
+        # never trip it.
+        data.mode_backstop_allowed = True
 
     async def _evaluate_core(
         self, data: CoordinatorData, computation_engine: ComputationEngine
@@ -1420,6 +1606,24 @@ class StateMachine:
         """
         _LOGGER.info("Decision fingerprint invalidated: %s", reason)
         self._last_evaluated_fingerprint = None
+        # Cleared with it, or the next grant would be misattributed to the plan
+        # ("same base as last time") and restricted to charge modes only.
+        self._last_evaluated_base = None
+
+    def suppress_next_plan_charge_grant(self, reason: str) -> None:
+        """Bar the NEXT evaluation from granting on the plan-charge trigger.
+
+        The contract of ``async_recompute_and_evaluate(invalidate_decision=False)``
+        is "may update the plan but must NOT grant a mode change". That path runs
+        ``compute_derived_values`` OUT OF LOCK immediately before evaluating, so
+        the frozen facade writes ``debug_plan_mode_pending`` and the evaluation
+        that follows would read it back with zero lag and grant — a mode change
+        caused by a load-deviation reoptimize, which is exactly what the flag
+        exists to prevent. The suppression is one-shot and is cleared by the
+        evaluation it applies to.
+        """
+        _LOGGER.debug("Plan-charge grant suppressed for next evaluation: %s", reason)
+        self._suppress_plan_charge_grant = True
 
     @property
     def in_mode_transition(self) -> bool:

--- a/custom_components/localshift/state/machine.py
+++ b/custom_components/localshift/state/machine.py
@@ -344,7 +344,11 @@ class StateMachine:
             and data.soc < battery_target
         )
 
-        if qualifies and pending not in self._plan_charge_granted:
+        if (
+            qualifies
+            and pending is not None
+            and pending not in self._plan_charge_granted
+        ):
             self._plan_charge_granted.add(pending)
             self._plan_charge_epoch += 1
             _LOGGER.debug(

--- a/tests/coordinator/test_coordinator.py
+++ b/tests/coordinator/test_coordinator.py
@@ -1399,3 +1399,41 @@ class TestCoordinatorDailySummary:
         await coordinator._tick_scheduler._send_daily_summary()
 
         # Verify it completes without error (no assertion needed, just check no exception)
+
+
+class TestRecomputeDecisionContract:
+    """`invalidate_decision=False` means "may update the plan, must NOT grant"."""
+
+    @pytest.mark.asyncio
+    async def test_reoptimize_suppresses_the_plan_charge_grant(self, coordinator):
+        """The reoptimize path runs compute_derived_values OUT OF LOCK before
+        evaluating, so the frozen facade writes debug_plan_mode_pending and the
+        evaluation that follows reads it back with zero lag. Without suppression the
+        plan-charge trigger grants there — a mode change caused by a load-deviation
+        reoptimize, which is exactly what the flag forbids."""
+        state_machine = MagicMock()
+        coordinator._state_machine = state_machine
+        coordinator._compute_derived_values = MagicMock()
+        coordinator.notify_listeners = MagicMock()
+        coordinator.async_evaluate_state_machine = AsyncMock()
+
+        await coordinator.async_recompute_and_evaluate(invalidate_decision=False)
+
+        state_machine.suppress_next_plan_charge_grant.assert_called_once()
+        state_machine.invalidate_decision_fingerprint.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_config_change_still_invalidates_and_does_not_suppress(
+        self, coordinator
+    ):
+        """The deliberate re-decision path is unchanged."""
+        state_machine = MagicMock()
+        coordinator._state_machine = state_machine
+        coordinator._compute_derived_values = MagicMock()
+        coordinator.notify_listeners = MagicMock()
+        coordinator.async_evaluate_state_machine = AsyncMock()
+
+        await coordinator.async_recompute_and_evaluate()
+
+        state_machine.invalidate_decision_fingerprint.assert_called_once()
+        state_machine.suppress_next_plan_charge_grant.assert_not_called()

--- a/tests/engine/test_precharge_backstop.py
+++ b/tests/engine/test_precharge_backstop.py
@@ -1,0 +1,421 @@
+"""Tests for the pre-charge execution backstop (2026-07-27 incident).
+
+Live incident 2026-07-27: the 15:00-21:00 demand window was entered at 64.0% SOC
+against a 95% target (31.0 points short). The DP planned the pre-charge correctly —
+``first_charge=NOW`` on plan after plan from 09:40 onwards, with prices 0.13-0.16
+against a $0.20 ``max_precharge_price`` ceiling, so price was never the blocker. What
+failed was *execution*: the #622-replacement decision token only grants a mode decision
+when the price/spike/DW/floor fingerprint changes (~once per 5-minute Amber tick), and
+the DP's slot-0 action oscillates hold↔charge on every replan because the cheapest
+first-charge slot drifts forward. At nearly every grant instant the fresh plan's slot-0
+action was "hold", so the wanted charge was recorded in ``debug_plan_mode_pending``
+dozens of times and committed zero times. Counterfactual replay committing the wanted
+mode reaches 94.9%.
+
+``OptimizerFacade._precharge_backstop_mode`` is the executor-side backstop: when the
+plan already contains a pre-DW grid charge, the live SOC is below the #885 hard
+DW-target floor, the current slot is inside the urgency window and the projected
+shortfall is material, BOOST_CHARGING is force-committed regardless of the token. Every
+gate reuses an existing engine decision (notably ``hard_target_floor``, which is already
+dormant whenever pre-charge is not required), so the backstop never invents charge
+intent — it only executes intent the DP already expressed.
+
+The per-gate inertness matrix lives with the incident replay in
+``tests/state/test_precharge_execution_replay.py::TestPrechargeBackstop``. This module
+covers the arithmetic and the degradation paths: which shortfall measure wins, the
+threshold's strictness, and the never-raise / dormant-on-legacy-config guarantees.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from custom_components.localshift.const import BatteryMode
+from custom_components.localshift.coordinator import CoordinatorData
+from custom_components.localshift.engine.optimizer_facade import (
+    PRECHARGE_BACKSTOP_SHORTFALL_PCT,
+    OptimizerFacade,
+)
+from custom_components.localshift.engine.types import OptimizerConfig
+
+# The 14:30 line of the evidence pack: SOC 62.2%, price 11.6 c, plan projects a 72.6%
+# DW entry against a 95% target, and the DP has a pre-DW grid charge at slot 4.
+CURRENT_SLOT_IDX = 4
+TERMINAL_PENALTY_IDX = 10
+
+
+def _config(**overrides: Any) -> OptimizerConfig:
+    """A strict-mode config with the #885 hard floor live and the urgency window open."""
+    config = OptimizerConfig(
+        demand_window_target_soc_pct=95.0,
+        max_precharge_price=0.20,
+    )
+    config.hard_target_floor = 95.0
+    config.urgency_window_start_idx = 0
+    # Solver-derived DW-entry slot index, published on the config for the backstop.
+    config.terminal_penalty_idx = TERMINAL_PENALTY_IDX
+    for key, value in overrides.items():
+        setattr(config, key, value)
+    return config
+
+
+def _data(**overrides: Any) -> CoordinatorData:
+    """A frozen evaluation mid-morning: token withheld, backstop permitted."""
+    data = CoordinatorData()
+    data.active_mode = BatteryMode.SELF_CONSUMPTION
+    data.soc = 62.2
+    data.general_price = 0.116
+    data.demand_window_active = False
+    # #622 token frozen — this is the pathology the backstop exists for.
+    data.mode_decision_allowed = False
+    data.mode_backstop_allowed = True
+    data.optimizer_decisions = [
+        {"slot_index": 4, "action": "charge_grid_normal", "grid_charge": True},
+    ]
+    for key, value in overrides.items():
+        setattr(data, key, value)
+    return data
+
+
+def _result(shortfall: float = 22.4, dw_entry: float = 72.6) -> Any:
+    return SimpleNamespace(terminal_shortfall_pct=shortfall, dw_entry_soc_pct=dw_entry)
+
+
+def _run(
+    facade: OptimizerFacade,
+    data: CoordinatorData,
+    config: OptimizerConfig,
+    result: Any,
+) -> None:
+    """Drive ``_assign_active_mode`` with a hold-wanting slot-0 plan.
+
+    The apply plan is pinned to SELF_CONSUMPTION on purpose: that is exactly what the
+    token sampled all day on 2026-07-27 while the plan's later slots wanted to charge.
+    """
+    with (
+        patch(
+            "custom_components.localshift.engine.optimizer_facade.OptimizerSafetyGate"
+        ) as mock_gate,
+        patch(
+            "custom_components.localshift.engine.optimizer_facade._current_slot_debug_info",
+            return_value=(CURRENT_SLOT_IDX, True, "14:30", "13:00", 60.0),
+        ),
+        patch(
+            "custom_components.localshift.engine.optimizer_facade._derive_runtime_apply_plan",
+            return_value={
+                "battery_mode": BatteryMode.SELF_CONSUMPTION.value,
+                "action": "hold",
+            },
+        ),
+    ):
+        mock_gate.return_value.check_admission.return_value = SimpleNamespace(
+            allowed=True, block_reason=None
+        )
+        facade._assign_active_mode(data, result, config, {})
+
+
+class TestPrechargeBackstop:
+    """FIX 2: the plan's pre-charge is executed even when the token never grants."""
+
+    def test_backstop_forces_boost_when_token_frozen(self, caplog) -> None:
+        facade = OptimizerFacade()
+        data = _data()
+
+        with caplog.at_level("WARNING"):
+            _run(facade, data, _config(), _result())
+
+        assert data.active_mode == BatteryMode.BOOST_CHARGING
+        assert data.debug_mode_source == "precharge_backstop"
+        assert data.optimizer_precharge_backstop_active is True
+        # The commit is a real decision: nothing is left pending.
+        assert data.debug_plan_mode_pending is None
+        # The operator-visible artefact — a fired backstop always means the token
+        # path failed to land in time and deserves post-hoc review.
+        assert "PRE-CHARGE BACKSTOP" in caplog.text
+
+    def test_shortfall_takes_the_worse_of_both_published_measures(self) -> None:
+        """The two measures diverged in the 2026-07-27 log; the max must win."""
+        facade = OptimizerFacade()
+        data = _data()
+        # terminal_shortfall_pct reads clean, but the projected DW entry is 30 short.
+        _run(facade, data, _config(), _result(shortfall=0.0, dw_entry=65.0))
+
+        assert data.active_mode == BatteryMode.BOOST_CHARGING
+
+        # ... and symmetrically, with no dw_entry projection published at all.
+        data2 = _data()
+        _run(
+            facade,
+            data2,
+            _config(),
+            SimpleNamespace(terminal_shortfall_pct=22.4, dw_entry_soc_pct=None),
+        )
+        assert data2.active_mode == BatteryMode.BOOST_CHARGING
+
+    def test_threshold_is_a_strict_inequality(self) -> None:
+        """Exactly at the threshold is not "material" — it must not fire."""
+        facade = OptimizerFacade()
+        data = _data()
+        _run(
+            facade,
+            data,
+            _config(),
+            _result(
+                shortfall=PRECHARGE_BACKSTOP_SHORTFALL_PCT,
+                dw_entry=95.0 - PRECHARGE_BACKSTOP_SHORTFALL_PCT,
+            ),
+        )
+
+        assert data.active_mode == BatteryMode.SELF_CONSUMPTION
+        assert data.optimizer_precharge_backstop_active is False
+
+    def test_backstop_check_never_raises(self) -> None:
+        """A malformed plan/result must degrade to "no backstop", not kill the cycle."""
+        facade = OptimizerFacade()
+        data = _data(optimizer_decisions=["not-a-dict"])
+
+        assert (
+            facade._precharge_backstop_mode(
+                data, _result(), _config(), CURRENT_SLOT_IDX
+            )
+            is None
+        )
+
+    def test_legacy_config_without_terminal_penalty_idx_is_inert(self) -> None:
+        """Guards the parallel-safety read: a config predating the new field."""
+        facade = OptimizerFacade()
+        data = _data()
+        config = _config()
+        del config.terminal_penalty_idx
+
+        assert (
+            facade._precharge_backstop_mode(data, _result(), config, CURRENT_SLOT_IDX)
+            is None
+        )
+
+    def test_mock_config_without_backstop_permission_is_inert(self) -> None:
+        """Existing frozen-path tests pass MagicMocks — permission gate short-circuits."""
+        facade = OptimizerFacade()
+        data = _data(mode_backstop_allowed=False)
+
+        assert (
+            facade._precharge_backstop_mode(
+                data, MagicMock(), MagicMock(), CURRENT_SLOT_IDX
+            )
+            is None
+        )
+
+
+class TestBackstopReachability:
+    """The gates the backstop reads must actually exist in production."""
+
+    def test_terminal_penalty_idx_is_published_on_a_real_config(self) -> None:
+        """The whole backstop hangs off this one field.
+
+        It was a local in ``DPPlanner._solve`` and never attached to the config, so
+        ``_backstop_urgency_window`` read None on every live cycle and the backstop
+        was unreachable — dead code that only ever fired in tests that fabricated the
+        attribute with ``setattr``. Assert against a REAL OptimizerConfig, which is
+        what the fabricating tests could not catch.
+        """
+        config = OptimizerConfig()
+
+        assert hasattr(config, "terminal_penalty_idx")
+        # Constructible as a field, not merely settable as an ad-hoc attribute.
+        assert OptimizerConfig(terminal_penalty_idx=10).terminal_penalty_idx == 10
+
+    def test_solver_publishes_terminal_penalty_idx_next_to_its_siblings(self) -> None:
+        """It is written by the same _solve pass that writes urgency_window_start_idx."""
+        import inspect
+
+        from custom_components.localshift.engine import core
+
+        source = inspect.getsource(core.DPPlanner._solve)
+        assert "config.terminal_penalty_idx = terminal_penalty_idx" in source
+
+
+class TestBackstopPriceAvailability:
+    """Issue #330: an unavailable price entity reads 0.0, not None."""
+
+    def test_backstop_inert_when_prices_are_unavailable(self) -> None:
+        """A missing Amber sensor sets general_price = 0.0, so the pre-charge price
+        ceiling (`0.0 > 0.20` is False) waves the backstop straight through at a
+        completely unknown real price. "Grid charging decisions will be deferred"
+        applies hardest to a forced charge."""
+        facade = OptimizerFacade()
+        data = _data(prices_available=False, general_price=0.0)
+
+        _run(facade, data, _config(), _result())
+
+        assert data.active_mode == BatteryMode.SELF_CONSUMPTION
+        assert data.optimizer_precharge_backstop_active is False
+
+    def test_backstop_still_fires_when_prices_are_available(self) -> None:
+        """Negative twin: the new gate must not shut the backstop off wholesale."""
+        facade = OptimizerFacade()
+        data = _data(prices_available=True)
+
+        _run(facade, data, _config(), _result())
+
+        assert data.active_mode == BatteryMode.BOOST_CHARGING
+
+
+class TestBackstopRelease:
+    """The forced BOOST must be released as ungated-ly as it was committed."""
+
+    def test_forced_boost_is_released_when_its_conditions_clear(self) -> None:
+        """The backstop commits WITHOUT a fingerprint change, which breaks the
+        property every other commit has: that the decision context just moved and
+        will move again. Once ``soc >= hard_target_floor`` the backstop returns None
+        and the ordinary frozen path PINS the boost — so on a flat-price stretch (or
+        a stuck price sensor) the battery force-charges at full import price until
+        the demand window flips."""
+        facade = OptimizerFacade()
+        data = _data()
+
+        _run(facade, data, _config(), _result())
+        assert data.active_mode == BatteryMode.BOOST_CHARGING
+
+        # SOC now at the floor: the backstop's conditions have cleared. The token is
+        # STILL frozen and the price context is unchanged — nothing else can release.
+        data.soc = 96.0
+        _run(facade, data, _config(), _result())
+
+        assert data.active_mode == BatteryMode.SELF_CONSUMPTION
+        assert data.debug_mode_source == "precharge_backstop_release"
+        assert data.optimizer_precharge_backstop_active is False
+
+    def test_release_happens_once_and_does_not_re_grant(self) -> None:
+        """The latch is one-shot: subsequent frozen ticks stay frozen."""
+        facade = OptimizerFacade()
+        data = _data()
+        _run(facade, data, _config(), _result())
+        data.soc = 96.0
+        _run(facade, data, _config(), _result())
+
+        data.active_mode = BatteryMode.SPIKE_DISCHARGE
+        _run(facade, data, _config(), _result())
+
+        # Frozen path pinned it — the release did not fire a second time.
+        assert data.active_mode == BatteryMode.SPIKE_DISCHARGE
+
+    def test_release_is_confined_to_the_lock(self) -> None:
+        """Out of lock the backstop returns None because PERMISSION is closed, not
+        because its conditions cleared. Releasing there would be an ungated commit
+        from the very path the permission flag exists to keep inert — and would burn
+        the latch, so the real in-lock release never happens."""
+        facade = OptimizerFacade()
+        data = _data()
+        _run(facade, data, _config(), _result())
+        assert data.active_mode == BatteryMode.BOOST_CHARGING
+
+        # An out-of-lock recompute: same conditions, permission closed.
+        data.mode_backstop_allowed = False
+        _run(facade, data, _config(), _result())
+        assert data.active_mode == BatteryMode.BOOST_CHARGING
+        assert data.debug_mode_source != "precharge_backstop_release"
+
+        # The latch survived, so the genuine in-lock release still fires.
+        data.mode_backstop_allowed = True
+        data.soc = 96.0
+        _run(facade, data, _config(), _result())
+        assert data.active_mode == BatteryMode.SELF_CONSUMPTION
+        assert data.debug_mode_source == "precharge_backstop_release"
+
+    def test_no_release_when_an_ordinary_grant_already_moved_the_mode(self) -> None:
+        """Nothing to release if the boost is no longer what is committed."""
+        facade = OptimizerFacade()
+        data = _data()
+        _run(facade, data, _config(), _result())
+        assert data.active_mode == BatteryMode.BOOST_CHARGING
+
+        # An ordinary token grant lands and moves the mode on.
+        data.soc = 96.0
+        data.active_mode = BatteryMode.SELF_CONSUMPTION
+        _run(facade, data, _config(), _result())
+
+        assert data.debug_mode_source != "precharge_backstop_release"
+
+
+class TestBackstopPlanIntegrity:
+    """It executes intent the DP expressed — and only what the DP expressed."""
+
+    def test_decision_without_a_slot_index_is_not_counted_as_pre_dw_charge(
+        self,
+    ) -> None:
+        """``slot_index`` defaulted to 0, so a malformed decision read as a pre-DW
+        charge and armed a forced boost off a plan that never located itself."""
+        facade = OptimizerFacade()
+        data = _data(
+            optimizer_decisions=[{"action": "charge_grid_normal", "grid_charge": True}]
+        )
+
+        _run(facade, data, _config(), _result())
+
+        assert data.active_mode == BatteryMode.SELF_CONSUMPTION
+        assert data.optimizer_precharge_backstop_active is False
+
+
+class TestPlanChargeGrantIsOneDirectional:
+    """A token granted because the plan wanted to START charging may only charge."""
+
+    @staticmethod
+    def _run_with_plan(facade, data, config, plan_mode: BatteryMode) -> None:
+        with (
+            patch(
+                "custom_components.localshift.engine.optimizer_facade.OptimizerSafetyGate"
+            ) as mock_gate,
+            patch(
+                "custom_components.localshift.engine.optimizer_facade._current_slot_debug_info",
+                return_value=(CURRENT_SLOT_IDX, True, "14:30", "13:00", 60.0),
+            ),
+            patch(
+                "custom_components.localshift.engine.optimizer_facade._derive_runtime_apply_plan",
+                return_value={"battery_mode": plan_mode.value, "action": "x"},
+            ),
+        ):
+            mock_gate.return_value.check_admission.return_value = SimpleNamespace(
+                allowed=True, block_reason=None
+            )
+            facade._assign_active_mode(data, _result(), config, {})
+
+    def test_plan_charge_grant_cannot_commit_a_discharge(self) -> None:
+        """The trigger is one-directional in what ARMS it; it must be one-directional
+        in what it COMMITS too. Otherwise a grant raised because the plan wanted to
+        charge is spent on whatever slot-0 drifted to — force-discharging the battery
+        on a token granted to charge it."""
+        facade = OptimizerFacade()
+        # Backstop off, so only the token path is under test.
+        data = _data(mode_backstop_allowed=False)
+        data.mode_decision_allowed = True
+        data.mode_decision_plan_charge_only = True
+
+        self._run_with_plan(facade, data, _config(), BatteryMode.SPIKE_DISCHARGE)
+
+        assert data.active_mode == BatteryMode.SELF_CONSUMPTION
+        # The disagreement stays visible rather than being spent wrongly.
+        assert data.debug_plan_mode_pending == BatteryMode.SPIKE_DISCHARGE.value
+
+    def test_plan_charge_grant_commits_a_charge(self) -> None:
+        """Negative twin: the grant is still spendable on what it was raised for."""
+        facade = OptimizerFacade()
+        data = _data(mode_backstop_allowed=False)
+        data.mode_decision_allowed = True
+        data.mode_decision_plan_charge_only = True
+
+        self._run_with_plan(facade, data, _config(), BatteryMode.GRID_CHARGING)
+
+        assert data.active_mode == BatteryMode.GRID_CHARGING
+
+    def test_ordinary_grant_is_unrestricted(self) -> None:
+        """A price/spike/DW/floor grant may still commit any mode."""
+        facade = OptimizerFacade()
+        data = _data(mode_backstop_allowed=False)
+        data.mode_decision_allowed = True
+        data.mode_decision_plan_charge_only = False
+
+        self._run_with_plan(facade, data, _config(), BatteryMode.SPIKE_DISCHARGE)
+
+        assert data.active_mode == BatteryMode.SPIKE_DISCHARGE

--- a/tests/sensors/test_optimizer.py
+++ b/tests/sensors/test_optimizer.py
@@ -331,6 +331,67 @@ class TestOptimizerSummarySensor:
         assert attrs["terminal_shortfall_pct"] == 0.0
         assert attrs["initial_soc_pct"] == 50.0
 
+    def test_dw_entry_actual_reads_from_coordinator_not_summary(self):
+        """2026-07-27: the projected dw_entry_soc_pct rolls over to tomorrow's
+        window the instant today's DW starts (98.5% / shortfall 0.0 reported
+        while the battery had entered at 64%). The actual is a per-day capture on
+        the coordinator, so the two sit side by side and disagree."""
+        mock_coordinator, data = create_mock_coordinator_with_data(
+            optimizer_summary={
+                "enabled": True,
+                "success": True,
+                "dw_entry_soc_pct": 98.5,
+                "terminal_shortfall_pct": 0.0,
+            },
+        )
+        data.dw_entry_actual_soc_pct = 64.0
+        data.dw_entry_actual_at = datetime(2026, 7, 27, 15, 0, tzinfo=timezone.utc)
+        data.dw_entry_actual_target_pct = 95.0
+        data.dw_entry_actual_shortfall_pct = 31.0
+        data.optimizer_precharge_backstop_active = True
+
+        sensor = OptimizerSummarySensor(mock_coordinator, MagicMock())
+        attrs = sensor.extra_state_attributes
+
+        assert attrs["dw_entry_soc_pct"] == 98.5
+        assert attrs["dw_entry_actual_soc_pct"] == 64.0
+        assert attrs["dw_entry_actual_target_pct"] == 95.0
+        assert attrs["dw_entry_actual_shortfall_pct"] == 31.0
+        assert attrs["dw_entry_actual_at"] == "2026-07-27T15:00:00+00:00"
+        assert attrs["precharge_backstop_active"] is True
+
+    def test_dw_entry_actual_survives_a_failed_cycle(self):
+        """The summary is rebuilt every cycle and is empty on a failed one —
+        precisely when the real entry SOC matters most. Reading from the
+        coordinator (not the summary) is what keeps it visible."""
+        mock_coordinator, data = create_mock_coordinator_with_data(
+            optimizer_summary={"enabled": True, "success": False},
+        )
+        data.dw_entry_actual_soc_pct = 64.0
+        data.dw_entry_actual_at = datetime(2026, 7, 27, 15, 0, tzinfo=timezone.utc)
+
+        sensor = OptimizerSummarySensor(mock_coordinator, MagicMock())
+        attrs = sensor.extra_state_attributes
+
+        assert attrs["dw_entry_soc_pct"] is None
+        assert attrs["dw_entry_actual_soc_pct"] == 64.0
+        assert attrs["dw_entry_actual_at"] == "2026-07-27T15:00:00+00:00"
+
+    def test_dw_entry_actual_null_before_capture(self):
+        """Before the first capture of the day every key is present and null."""
+        mock_coordinator, _ = create_mock_coordinator_with_data(
+            optimizer_summary={"enabled": True, "success": True},
+        )
+
+        sensor = OptimizerSummarySensor(mock_coordinator, MagicMock())
+        attrs = sensor.extra_state_attributes
+
+        assert attrs["dw_entry_actual_soc_pct"] is None
+        assert attrs["dw_entry_actual_at"] is None
+        assert attrs["dw_entry_actual_target_pct"] is None
+        assert attrs["dw_entry_actual_shortfall_pct"] is None
+        assert attrs["precharge_backstop_active"] is False
+
     def test_icon_success(self):
         """Test icon for success state."""
         mock_coordinator, data = create_mock_coordinator_with_data(

--- a/tests/state/test_precharge_execution_replay.py
+++ b/tests/state/test_precharge_execution_replay.py
@@ -1,0 +1,743 @@
+"""Replay of the 2026-07-27 pre-charge execution failure (#622 token starvation).
+
+Live shape: demand window 15:00-21:00, target 95%. The battery entered at **64.0%**
+— 31.0 points short — after a day on which the DP planned the charge correctly and the
+executor never ran it.
+
+Prices were never the blocker: 0.13-0.16 all morning, dipping to 0.115/0.113/0.116 at
+14:35-14:50, against ``max_pre_charge_price`` 0.20. The pre-charge log shows the plan
+saying ``first_charge=NOW`` at 09:40, 10:00, 10:30, 10:40, 10:50, 11:00, 11:10, 11:20,
+12:40 and 12:50 — and the mode never went to Grid Charging on any of them. The only
+DP-commanded charge all day was 13:41-14:16. From 13:56 the log shows ``first_charge``
+sliding one slot forward on every replan while the projected shortfall climbed
+4.9 → 9.9 → 16.6 → 22.4 → 25.5 → 31.5.
+
+Root cause: ``_get_decision_fingerprint`` enumerates price/spike/DW/floor as the only
+legitimate re-decision triggers, and silently assumes the plan is stable between them.
+It is not — the DP's slot-0 action oscillates hold↔charge on every replan because
+``first_charge`` chases the cheapest slot forward. The token therefore samples the plan
+on a ~5-min stride, and nearly every sample landed on a hold-phase plan.
+``debug_plan_mode_pending`` recorded the wanted charge dozens of times and never
+committed it. **The plan itself is a decision input and was missing from the
+fingerprint.** A counterfactual replay that commits the wanted mode reaches 94.9%.
+
+Three fixes, one class each:
+
+* ``TestPlanChangeTokenReplay`` — FIX 1: a monotone ``_plan_charge_epoch`` joins the
+  fingerprint, so a plan that wants to *start* charging while frozen grants exactly one
+  token. Deliberately one-directional: a wanted *stop* never grants.
+* ``TestPrechargeBackstop`` — FIX 2: an in-lock execution backstop that force-commits
+  BOOST_CHARGING when the projected DW-entry shortfall exceeds
+  ``PRECHARGE_BACKSTOP_SHORTFALL_PCT`` and the plan already contains a pre-DW charge
+  slot the token never sampled.
+* ``TestDwEntryActualTelemetry`` — FIX 3: capture the *real* SOC at demand-window
+  entry once per day. ``optimizer_summary.dw_entry_soc_pct`` is a projection that rolled
+  over to tomorrow's window at 15:00 (98.5%, shortfall 0.0, first_charge 2026-07-28T13:00)
+  and erased the miss from every sensor.
+
+Nothing here exercises the DP. The 2026-07-27 plan was right; only its execution failed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.localshift.computation_engine import ComputationEngine
+from custom_components.localshift.const import BatteryMode
+from custom_components.localshift.coordinator.data import CoordinatorData
+from custom_components.localshift.engine.optimizer_facade import (
+    PRECHARGE_BACKSTOP_SHORTFALL_PCT,
+    OptimizerFacade,
+)
+from custom_components.localshift.engine.types import OptimizerConfig
+from custom_components.localshift.sensors.optimizer import OptimizerSummarySensor
+from custom_components.localshift.state.machine import StateMachine
+
+SYDNEY = timezone(timedelta(hours=10))
+CHARGE_MODES = (BatteryMode.GRID_CHARGING, BatteryMode.BOOST_CHARGING)
+
+
+def dt_syd(year, month, day, hour, minute=0, second=0):
+    """Create a timezone-aware datetime in the live system's timezone."""
+    return datetime(year, month, day, hour, minute, second, tzinfo=SYDNEY)
+
+
+def _interpolate(anchors: list[tuple[int, float]], n: int) -> list[float]:
+    """Linear per-minute interpolation of a sparse live-trace SOC table."""
+    out: list[float] = []
+    for i in range(n):
+        lo = max((a for a in anchors if a[0] <= i), key=lambda a: a[0])
+        later = [a for a in anchors if a[0] > i]
+        if not later:
+            out.append(lo[1])
+            continue
+        hi = min(later, key=lambda a: a[0])
+        span = hi[0] - lo[0]
+        out.append(lo[1] + (hi[1] - lo[1]) * ((i - lo[0]) / span))
+    return out
+
+
+# =============================================================================
+# FIXTURES
+# =============================================================================
+# tests/state/ has no conftest — test_state_machine.py declares its state-machine
+# fixtures at module level — so they are declared here rather than imported across
+# test modules.
+
+
+@pytest.fixture
+def mock_battery_controller():
+    """Create a mock BatteryController."""
+    controller = MagicMock()
+    controller.set_self_consumption = AsyncMock(return_value=True)
+    controller.set_force_charge = AsyncMock(return_value=True)
+    controller.set_boost_charge = AsyncMock(return_value=True)
+    controller.set_force_discharge = AsyncMock(return_value=True)
+    controller.set_proactive_export = AsyncMock(return_value=True)
+    controller.verify_current_state = AsyncMock(return_value=True)
+    return controller
+
+
+@pytest.fixture
+def mock_notification_service():
+    """Create a mock NotificationService."""
+    service = MagicMock()
+    service.send_transition_notification = AsyncMock()
+    service.send_transition_failed_notification = AsyncMock()
+    service.send_health_correction_notification = AsyncMock()
+    service.send_manual_override_timeout_notification = AsyncMock()
+    service.send_automation_disabled_notification = AsyncMock()
+    service.send_tesla_override_notification = AsyncMock()
+    return service
+
+
+@pytest.fixture
+def mock_entity_validator():
+    """Create a mock EntityValidator."""
+    from custom_components.localshift.utils.validation import IntegrationStatus
+
+    validator = MagicMock()
+    validator.should_allow_automation = MagicMock(return_value=True)
+    validator.status = IntegrationStatus.OK
+    validator.errors = []
+    validator.warnings = []
+    return validator
+
+
+@pytest.fixture
+def state_machine(
+    mock_battery_controller, mock_notification_service, mock_entity_validator
+):
+    """StateMachine wired to the live 2026-07-27 config (battery_target 95)."""
+
+    def _get_option(key, default=None):
+        return {"battery_target": 95, "manual_override_timeout": 24.0}.get(key, default)
+
+    return StateMachine(
+        mock_battery_controller,
+        mock_notification_service,
+        lambda key: {"automation_enabled": True}.get(key, False),
+        _get_option,
+        mock_entity_validator,
+    )
+
+
+@pytest.fixture
+def coordinator_data():
+    """CoordinatorData seeded from the 2026-07-27 13:40 live line."""
+    data = CoordinatorData()
+    data.soc = 49.9
+    data.operation_mode = "self_consumption"
+    data.backup_reserve = 10
+    data.general_price = 0.131
+    data.feed_in_price = 0.04
+    data.price_spike = False
+    data.demand_window_active = False
+    data.forecast_ready = True
+    data.automation_ready = True
+    data.active_mode = BatteryMode.SELF_CONSUMPTION
+    return data
+
+
+class FakeFacadeEngine:
+    """Computation-engine stub that mimics the real optimizer-facade contract.
+
+    Real flow: compute_derived_values() → facade._assign_active_mode() pins
+    data.active_mode when data.mode_decision_allowed is False (recording the
+    would-be mode in debug_plan_mode_pending), and re-decides it only when True.
+    This stub reproduces exactly that pin/commit behaviour so the state machine
+    can be driven through the incident without the full optimizer.
+    """
+
+    def __init__(self, plan_mode: BatteryMode) -> None:
+        # The mode the "plan" currently wants (the oscillating slot-0 action).
+        self.plan_mode = plan_mode
+        # data.mode_decision_allowed as observed on the LAST call. The flag is
+        # transient (reset in the evaluate finally block), so a test cannot read
+        # it after evaluate_state_machine returns — it is captured here instead.
+        self.last_decision_allowed: bool | None = None
+
+    def compute_derived_values(self, data) -> None:
+        self.last_decision_allowed = data.mode_decision_allowed
+        if data.mode_decision_allowed:
+            if self.plan_mode != data.active_mode:
+                data.decision_timestamp = dt_syd(2026, 7, 27, 14, 0, 0)
+                data.decision_mode = self.plan_mode
+            data.active_mode = self.plan_mode
+            data.debug_plan_mode_pending = None
+        else:
+            data.debug_plan_mode_pending = (
+                self.plan_mode.value if self.plan_mode != data.active_mode else None
+            )
+
+
+# =============================================================================
+# FIX 1 — the plan is a decision input
+# =============================================================================
+
+
+class TestPlanChangeTokenReplay:
+    """Minute-by-minute replay of the 13:40-15:00 tail, where the miss became fatal."""
+
+    # --- Amber buy price, one entry per simulated minute, changing only on the
+    # 5-minute Amber tick. The 14:35/14:40/14:45/14:50 values (0.115/0.113/0.116/
+    # 0.116) are verbatim from the evidence pack — the day's cheapest pre-DW dip,
+    # far under the 0.20 max_pre_charge_price ceiling. The rest track the pack's
+    # 0.13-0.16 tail down into that dip. Note 14:45 and 14:50 are IDENTICAL: a
+    # repeated price is not a fingerprint change, so that boundary grants nothing
+    # from price alone.
+    PRICE_TICKS = [
+        0.131,  # 13:40
+        0.128,  # 13:45
+        0.130,  # 13:50
+        0.129,  # 13:55
+        0.127,  # 14:00
+        0.126,  # 14:05
+        0.124,  # 14:10
+        0.125,  # 14:15
+        0.123,  # 14:20
+        0.121,  # 14:25
+        0.119,  # 14:30
+        0.115,  # 14:35
+        0.113,  # 14:40
+        0.116,  # 14:45
+        0.116,  # 14:50 — duplicate of 14:45
+        0.114,  # 14:55
+    ]
+    PRICES = [p for p in PRICE_TICKS for _ in range(5)]
+
+    # --- The plan's slot-0 action, one per minute. THE PATHOLOGY: every 5-minute
+    # boundary — the only instant a price change can grant a token — lands on
+    # SELF_CONSUMPTION (hold), while all four intervening minutes want to charge.
+    # The token samples the plan exactly where the plan says "not yet".
+    PLAN_SLOT0 = [
+        BatteryMode.SELF_CONSUMPTION if i % 5 == 0 else BatteryMode.GRID_CHARGING
+        for i in range(len(PRICES))
+    ]
+
+    # --- Live SOC (sensor.my_home_percentage_charged), anchored on the trace:
+    # 13:40 49.9 (dip) → 14:00 57.0 → 14:20 62.6 (peak) → 14:50 60.3 → 15:00 64.0.
+    # Never within 30 points of the 95% target.
+    SOC_ANCHORS = [(0, 49.9), (20, 57.0), (40, 62.6), (70, 60.3), (79, 63.6)]
+    SOC = _interpolate(SOC_ANCHORS, len(PRICES))
+
+    def _replay(self, state_machine, data, engine) -> list[BatteryMode]:
+        """Drive one evaluation per simulated minute; return committed modes."""
+        committed: list[BatteryMode] = []
+        for i, price in enumerate(self.PRICES):
+            data.general_price = price
+            data.soc = self.SOC[i]
+            engine.plan_mode = self.PLAN_SLOT0[i]
+            asyncio.run(state_machine.evaluate_state_machine(data, engine))
+            committed.append(data.active_mode)
+        return committed
+
+    def _wanted_charge_indices(self) -> list[int]:
+        return [i for i, m in enumerate(self.PLAN_SLOT0) if m in CHARGE_MODES]
+
+    def test_prefix_baseline_no_charge_committed_without_plan_trigger(
+        self, state_machine, coordinator_data, monkeypatch
+    ):
+        """RED anchor: with the epoch frozen (pre-fix behaviour) the plan-wanted
+        charge is never committed — exactly the live 2026-07-27 outcome."""
+        engine = FakeFacadeEngine(BatteryMode.SELF_CONSUMPTION)
+        # Simulate the pre-fix fingerprint: the epoch never moves, so only
+        # price/spike/DW/floor can grant. Raises if the method is missing.
+        monkeypatch.setattr(
+            state_machine, "_update_plan_charge_epoch", lambda data, context=None: None
+        )
+
+        committed = self._replay(state_machine, coordinator_data, engine)
+
+        assert [m for m in committed if m in CHARGE_MODES] == []
+        # And the plan really did want to charge — guard against a vacuous pass.
+        assert len(self._wanted_charge_indices()) >= 60
+
+    def test_plan_wanted_charge_is_committed(
+        self, state_machine, coordinator_data, mock_battery_controller
+    ):
+        """The fix: a plan that wants to START charging while frozen grants a
+        token, and the freshly-planned charge is committed within one tick."""
+        engine = FakeFacadeEngine(BatteryMode.SELF_CONSUMPTION)
+
+        committed = self._replay(state_machine, coordinator_data, engine)
+
+        charge_ticks = [i for i, m in enumerate(committed) if m in CHARGE_MODES]
+        # (a) charging actually happens.
+        assert charge_ticks, "plan-wanted charge was never committed"
+        assert BatteryMode.GRID_CHARGING in committed
+        mock_battery_controller.set_force_charge.assert_called()
+
+        # (b) it lands promptly — the pending value is read on the tick AFTER the
+        # facade writes it (the documented 1-tick lag), so ≤2 evaluations.
+        first_wanted = self._wanted_charge_indices()[0]
+        assert charge_ticks[0] - first_wanted <= 2
+
+        # (c) and it STAYS committed, rather than being sampled once and lost.
+        wanted = len(self._wanted_charge_indices())
+        assert len(charge_ticks) >= 0.6 * wanted
+
+    def test_no_flap_within_a_price_interval(
+        self, state_machine, coordinator_data, mock_battery_controller
+    ):
+        """The anti-flap bound: at most one extra decision per (price context ×
+        new wanted-charge mode), and it can only START charging."""
+        engine = FakeFacadeEngine(BatteryMode.SELF_CONSUMPTION)
+
+        transitions: list[BatteryMode] = []
+        original = state_machine._execute_mode_transition
+
+        async def _counting(data, target):
+            result = await original(data, target)
+            if result:
+                transitions.append(target)
+            return result
+
+        state_machine._execute_mode_transition = _counting
+
+        committed = self._replay(state_machine, coordinator_data, engine)
+
+        # No charge → non-charge → charge cycle is reachable inside one price group.
+        for group in range(len(self.PRICE_TICKS)):
+            seq = [m in CHARGE_MODES for m in committed[group * 5 : group * 5 + 5]]
+            # Collapse runs, then reject the flap pattern [True, False, True].
+            runs = [seq[0]] + [b for a, b in zip(seq, seq[1:]) if a != b]
+            assert runs[:3] != [True, False, True], f"flap in price group {group}"
+
+        # The §1.8 bound, computed from the data rather than hardcoded.
+        n_price_groups = len(self.PRICE_TICKS)
+        rising_edges = sum(
+            1
+            for i, m in enumerate(self.PLAN_SLOT0)
+            if m in CHARGE_MODES
+            and (i == 0 or self.PLAN_SLOT0[i - 1] not in CHARGE_MODES)
+        )
+        assert len(transitions) <= n_price_groups + rising_edges
+
+    def test_wanted_stop_never_grants_a_token(
+        self, state_machine, coordinator_data, mock_battery_controller
+    ):
+        """One-directional asymmetry: a plan that wants to STOP charging is never
+        a re-decision trigger — the stop waits for the next natural fingerprint
+        change (≤1 Amber tick)."""
+        coordinator_data.active_mode = BatteryMode.GRID_CHARGING
+        state_machine._commanded_mode = BatteryMode.GRID_CHARGING
+        # Start already frozen on this context, so tick 1 is not a free grant.
+        state_machine._last_evaluated_fingerprint = (
+            state_machine._get_decision_fingerprint(coordinator_data)
+        )
+        coordinator_data.debug_plan_mode_pending = BatteryMode.SELF_CONSUMPTION.value
+        engine = FakeFacadeEngine(BatteryMode.SELF_CONSUMPTION)
+
+        for _ in range(10):
+            asyncio.run(
+                state_machine.evaluate_state_machine(coordinator_data, engine)
+            )
+            assert engine.last_decision_allowed is False
+
+        assert coordinator_data.active_mode == BatteryMode.GRID_CHARGING
+        mock_battery_controller.set_self_consumption.assert_not_called()
+
+    def test_epoch_does_not_increment_on_resolution(
+        self, state_machine, coordinator_data
+    ):
+        """Monotonicity, asserted directly: the epoch rises on the disagreement's
+        rising edge and does NOT move again when the disagreement resolves. That
+        is what stops the commit → pending-clears → grant-again flap loop."""
+        engine = FakeFacadeEngine(BatteryMode.SELF_CONSUMPTION)
+        state_machine._last_evaluated_fingerprint = (
+            state_machine._get_decision_fingerprint(coordinator_data)
+        )
+        assert state_machine._plan_charge_epoch == 0
+
+        # Tick 1: the previous cycle left a wanted-charge pending → rising edge.
+        coordinator_data.debug_plan_mode_pending = BatteryMode.GRID_CHARGING.value
+        engine.plan_mode = BatteryMode.GRID_CHARGING
+        asyncio.run(state_machine.evaluate_state_machine(coordinator_data, engine))
+        assert engine.last_decision_allowed is True
+        assert state_machine._plan_charge_epoch == 1
+        assert coordinator_data.debug_plan_mode_pending is None
+
+        # Tick 2: the disagreement is resolved (pending back to None) — no move.
+        epoch_before = state_machine._plan_charge_epoch
+        asyncio.run(state_machine.evaluate_state_machine(coordinator_data, engine))
+        assert state_machine._plan_charge_epoch == epoch_before
+        assert engine.last_decision_allowed is False
+
+    def test_deferred_redemption_still_dead(
+        self, state_machine, coordinator_data, mock_battery_controller
+    ):
+        """FIX 1 must not reopen #622: a NON-charge plan flip on a stale token is
+        still un-redeemable, on the flip tick and on every tick after it."""
+        state_machine._commanded_mode = BatteryMode.SELF_CONSUMPTION
+        engine = FakeFacadeEngine(BatteryMode.SELF_CONSUMPTION)
+
+        # Tick 1: price change, plan stable. Token spent by the evaluation.
+        asyncio.run(state_machine.evaluate_state_machine(coordinator_data, engine))
+        mock_battery_controller.set_force_discharge.reset_mock()
+
+        # Tick 2: SAME price, plan flips to a non-charge mode. Frozen.
+        engine.plan_mode = BatteryMode.SPIKE_DISCHARGE
+        asyncio.run(state_machine.evaluate_state_machine(coordinator_data, engine))
+        assert engine.last_decision_allowed is False
+        assert (
+            coordinator_data.debug_plan_mode_pending
+            == BatteryMode.SPIKE_DISCHARGE.value
+        )
+
+        # Tick 3: the pending non-charge mode must not grant on the next tick
+        # either — that is precisely the deferred redemption #622 killed.
+        asyncio.run(state_machine.evaluate_state_machine(coordinator_data, engine))
+        assert engine.last_decision_allowed is False
+        assert coordinator_data.active_mode == BatteryMode.SELF_CONSUMPTION
+        mock_battery_controller.set_force_discharge.assert_not_called()
+
+
+# =============================================================================
+# FIX 2 — the pre-charge execution backstop
+# =============================================================================
+
+
+def _backstop_config(**overrides) -> OptimizerConfig:
+    """OptimizerConfig from the 14:30 live line (shortfall 22.4, still pre-DW)."""
+    defaults = dict(
+        optimization_mode="self_consumption",
+        demand_window_target_soc_pct=95.0,
+        battery_capacity_kwh=13.5,
+        charge_rate_kw=3.3,
+        boost_charge_rate_kw=5.0,
+        max_precharge_price=0.20,
+        max_soc_pct=100.0,
+        min_soc_pct=10.0,
+        hard_target_floor=95.0,
+        urgency_window_start_idx=0,
+        terminal_penalty_idx=10,
+    )
+    defaults.update(overrides)
+    return OptimizerConfig(**defaults)
+
+
+def _backstop_data(**overrides) -> CoordinatorData:
+    """CoordinatorData at 14:30: token frozen, plan says hold, DW 30 min away."""
+    data = CoordinatorData()
+    data.active_mode = BatteryMode.SELF_CONSUMPTION
+    data.soc = 62.2
+    data.general_price = 0.116
+    data.demand_window_active = False
+    # The token is frozen — the whole point of the backstop.
+    data.mode_decision_allowed = False
+    data.mode_backstop_allowed = True
+    # A slot bracketing "now" so the current-slot lookup reports idx 0, plus the
+    # pre-DW grid charge the DP planned and the token never sampled.
+    data.optimizer_decisions = [
+        {
+            "action": "hold",
+            "timestamp_iso": "2020-01-01T00:00:00+00:00",
+            "slot_interval_minutes": 9_999_999,
+            "slot_index": 0,
+            "grid_charge": False,
+        },
+        {
+            "action": "charge_grid_normal",
+            "timestamp_iso": "2020-01-01T00:00:00+00:00",
+            "slot_interval_minutes": 9_999_999,
+            "slot_index": 4,
+            "grid_charge": True,
+        },
+    ]
+    for key, value in overrides.items():
+        setattr(data, key, value)
+    return data
+
+
+def _backstop_result(shortfall: float = 22.4, dw_entry: float = 72.6):
+    return SimpleNamespace(
+        terminal_shortfall_pct=shortfall,
+        dw_entry_soc_pct=dw_entry,
+        decisions=[],
+    )
+
+
+def _run_assign(data, result, config):
+    """Run _assign_active_mode with the safety gate admitting and the plan
+    (correctly, per the incident) asking to HOLD in slot 0."""
+    facade = OptimizerFacade()
+    with (
+        patch(
+            "custom_components.localshift.engine.optimizer_facade.OptimizerSafetyGate"
+        ) as mock_gate,
+        patch(
+            "custom_components.localshift.engine.optimizer_facade._derive_runtime_apply_plan",
+            return_value={
+                "battery_mode": BatteryMode.SELF_CONSUMPTION.value,
+                "action": "hold",
+            },
+        ),
+    ):
+        mock_gate.return_value.check_admission.return_value = SimpleNamespace(
+            allowed=True, block_reason=None
+        )
+        facade._assign_active_mode(data, result, config, {})
+    return facade
+
+
+class TestPrechargeBackstop:
+    """The 14:16-14:52 hole: shortfall climbing 16→30% with the battery idle."""
+
+    def test_backstop_forces_boost_when_token_frozen(self, caplog):
+        data = _backstop_data()
+        with caplog.at_level("WARNING"):
+            _run_assign(data, _backstop_result(), _backstop_config())
+
+        assert data.active_mode == BatteryMode.BOOST_CHARGING
+        assert data.debug_mode_source == "precharge_backstop"
+        assert data.optimizer_precharge_backstop_active is True
+        assert data.debug_plan_mode_pending is None
+        assert "PRE-CHARGE BACKSTOP" in caplog.text
+
+    @pytest.mark.parametrize(
+        ("case", "data_overrides", "config_overrides", "result_kwargs"),
+        [
+            # Pointless once the window is live, and it would fight the DW block.
+            ("dw_active", {"demand_window_active": True}, {}, {}),
+            # #886 gate dormant (allow_dw_entry_under_target, or solar reaches
+            # target on its own) ⇒ the backstop is dormant with it. Reuse, not
+            # re-derivation.
+            ("floor_dormant", {}, {"hard_target_floor": None}, {}),
+            # Nothing to force at or above the floor.
+            ("soc_at_floor", {"soc": 96.0}, {}, {}),
+            # Below the failure-detector threshold — a normal plan, not a failure.
+            (
+                "shortfall_small",
+                {},
+                {},
+                {"shortfall": 4.0, "dw_entry": 91.0},
+            ),
+            # Not yet in the urgency window: there is still runway.
+            ("before_urgency_window", {}, {"urgency_window_start_idx": 5}, {}),
+            # Above the operator's own pre-charge price ceiling.
+            ("price_over_ceiling", {"general_price": 0.35}, {}, {}),
+            # Out-of-lock recompute: the backstop must never command hardware.
+            ("out_of_lock", {"mode_backstop_allowed": False}, {}, {}),
+        ],
+    )
+    def test_backstop_inert_when(
+        self, case, data_overrides, config_overrides, result_kwargs
+    ):
+        data = _backstop_data(**data_overrides)
+        _run_assign(
+            data,
+            _backstop_result(**result_kwargs),
+            _backstop_config(**config_overrides),
+        )
+
+        assert data.active_mode == BatteryMode.SELF_CONSUMPTION, case
+        assert data.optimizer_precharge_backstop_active is False, case
+
+    def test_backstop_inert_without_a_pre_dw_charge_in_the_plan(self):
+        """It never invents charge intent — only executes intent the DP expressed."""
+        data = _backstop_data()
+        for decision in data.optimizer_decisions:
+            decision["grid_charge"] = False
+
+        _run_assign(data, _backstop_result(), _backstop_config())
+
+        assert data.active_mode == BatteryMode.SELF_CONSUMPTION
+        assert data.optimizer_precharge_backstop_active is False
+
+    def test_backstop_inert_when_charge_is_only_inside_the_demand_window(self):
+        """The negative twin: a charge at/after terminal_penalty_idx is not
+        pre-charge intent and must not count."""
+        data = _backstop_data()
+        data.optimizer_decisions[1]["slot_index"] = 12  # terminal_penalty_idx = 10
+
+        _run_assign(data, _backstop_result(), _backstop_config())
+
+        assert data.active_mode == BatteryMode.SELF_CONSUMPTION
+        assert data.optimizer_precharge_backstop_active is False
+
+    def test_backstop_never_runs_when_safety_gate_blocks(self):
+        """Hard constraint: the backstop sits AFTER check_admission and never
+        runs on the blocked path."""
+        data = _backstop_data()
+        facade = OptimizerFacade()
+        with patch(
+            "custom_components.localshift.engine.optimizer_facade.OptimizerSafetyGate"
+        ) as mock_gate:
+            mock_gate.return_value.check_admission.return_value = SimpleNamespace(
+                allowed=False, block_reason="stale forecast"
+            )
+            facade._assign_active_mode(
+                data, _backstop_result(), _backstop_config(), {}
+            )
+
+        assert data.active_mode == BatteryMode.SELF_CONSUMPTION
+        assert data.optimizer_precharge_backstop_active is False
+        assert data.optimizer_last_apply_status == "blocked"
+
+    def test_backstop_is_idempotent(self):
+        """It re-asserts every tick while its conditions hold, without churn."""
+        data = _backstop_data()
+        config = _backstop_config()
+        modes = []
+        for _ in range(5):
+            _run_assign(data, _backstop_result(), config)
+            modes.append(data.active_mode)
+
+        assert set(modes) == {BatteryMode.BOOST_CHARGING}
+        assert data.optimizer_precharge_backstop_active is True
+
+
+# =============================================================================
+# FIX 3 — the DW-entry actual that the 15:00 rollover erased
+# =============================================================================
+
+
+@pytest.fixture
+def dw_entry_engine(mock_hass, mock_get_entity_id):
+    """ComputationEngine with the live 2026-07-27 window (15:00-21:00, target 95)."""
+    entry = MagicMock()
+    entry.data = {}
+    entry.options = {
+        "battery_target": 95,
+        "demand_window_start": "15:00:00",
+        "demand_window_end": "21:00:00",
+    }
+    return ComputationEngine(
+        mock_hass,
+        entry,
+        mock_get_entity_id,
+        lambda key: {"demand_window_block": True}.get(key, False),
+    )
+
+
+def _tick(engine, data, now_dt):
+    """One capture tick: refresh demand_window_active, then capture the actual."""
+    with patch(
+        "custom_components.localshift.computation_engine.dt_util.now",
+        return_value=now_dt,
+    ):
+        ctx = engine._build_step_context()
+    engine._compute_demand_window_active(data, ctx)
+    engine._capture_dw_entry_actual(data, ctx)
+    return ctx
+
+
+class TestDwEntryActualTelemetry:
+    """The real number: 64.0% at 15:00 against a 95% target."""
+
+    def test_captured_at_window_start(self, dw_entry_engine):
+        data = CoordinatorData()
+        data.soc = 64.0
+
+        _tick(dw_entry_engine, data, dt_syd(2026, 7, 27, 14, 59))
+        assert data.demand_window_active is False
+        assert data.dw_entry_actual_soc_pct is None
+
+        _tick(dw_entry_engine, data, dt_syd(2026, 7, 27, 15, 0))
+        assert data.demand_window_active is True
+        assert data.dw_entry_actual_soc_pct == 64.0
+        assert data.dw_entry_actual_target_pct == 95.0
+        assert data.dw_entry_actual_shortfall_pct == pytest.approx(31.0)
+        assert data.dw_entry_actual_at == dt_syd(2026, 7, 27, 15, 0)
+        assert data.dw_entry_actual_date == dt_syd(2026, 7, 27, 15, 0).date()
+
+    def test_survives_the_rollover_that_erased_the_miss(self, dw_entry_engine):
+        """The 15:00 log line reported dw_entry 98.5 / shortfall 0.0 /
+        first_charge 2026-07-28T13:00 — tomorrow's window. The projection is
+        allowed to roll over; the actual is not."""
+        data = CoordinatorData()
+        data.soc = 64.0
+        _tick(dw_entry_engine, data, dt_syd(2026, 7, 27, 15, 0))
+
+        data.optimizer_summary = {
+            "enabled": True,
+            "success": True,
+            "dw_entry_soc_pct": 98.5,
+            "terminal_shortfall_pct": 0.0,
+            "first_charge": "2026-07-28T13:00",
+        }
+
+        assert data.dw_entry_actual_soc_pct == 64.0
+        assert data.dw_entry_actual_shortfall_pct == pytest.approx(31.0)
+
+        coordinator = MagicMock()
+        coordinator.data = data
+        sensor = OptimizerSummarySensor(coordinator, MagicMock())
+        with patch(
+            "custom_components.localshift.sensors.optimizer.dt_util.now",
+            return_value=datetime(2026, 7, 27, 5, 0, tzinfo=UTC),
+        ):
+            attrs = sensor.extra_state_attributes
+
+        # Projected and actual sit side by side and disagree — which is the point.
+        assert attrs["dw_entry_soc_pct"] == 98.5
+        assert attrs["dw_entry_actual_soc_pct"] == 64.0
+        assert attrs["dw_entry_actual_shortfall_pct"] == pytest.approx(31.0)
+        assert attrs["dw_entry_actual_target_pct"] == 95.0
+        assert attrs["dw_entry_actual_at"] == dt_syd(2026, 7, 27, 15, 0).isoformat()
+        assert attrs["precharge_backstop_active"] is False
+
+    def test_none_soc_defers_capture(self, dw_entry_engine):
+        """A None SOC at the exact boundary must defer, not record a null — the
+        next tick (≤1 min) retries."""
+        data = CoordinatorData()
+        data.soc = None
+
+        _tick(dw_entry_engine, data, dt_syd(2026, 7, 27, 15, 0))
+        assert data.dw_entry_actual_soc_pct is None
+        assert data.dw_entry_actual_date is None
+
+        data.soc = 64.0
+        _tick(dw_entry_engine, data, dt_syd(2026, 7, 27, 15, 1))
+        assert data.dw_entry_actual_soc_pct == 64.0
+        assert data.dw_entry_actual_at == dt_syd(2026, 7, 27, 15, 1)
+
+    def test_capture_is_once_per_day_and_resets_on_date_change(self, dw_entry_engine):
+        data = CoordinatorData()
+        data.soc = 64.0
+        _tick(dw_entry_engine, data, dt_syd(2026, 7, 27, 15, 0))
+
+        # Later ticks in the same window must not overwrite the entry value.
+        data.soc = 88.0
+        _tick(dw_entry_engine, data, dt_syd(2026, 7, 27, 17, 30))
+        assert data.dw_entry_actual_soc_pct == 64.0
+        assert data.dw_entry_actual_at == dt_syd(2026, 7, 27, 15, 0)
+
+        # The daily latch reset clears all five fields on the date change.
+        dw_entry_engine._reset_daily_precharge_latch(data, dt_syd(2026, 7, 28, 0, 5).date())
+        assert data.dw_entry_actual_soc_pct is None
+        assert data.dw_entry_actual_at is None
+        assert data.dw_entry_actual_date is None
+        assert data.dw_entry_actual_target_pct is None
+        assert data.dw_entry_actual_shortfall_pct is None
+
+    def test_shortfall_threshold_is_the_backstop_constant(self):
+        """The capture logs at WARNING above the same threshold the backstop
+        fires on — one number, not two."""
+        assert PRECHARGE_BACKSTOP_SHORTFALL_PCT == 5.0

--- a/tests/state/test_precharge_token_replay.py
+++ b/tests/state/test_precharge_token_replay.py
@@ -1,0 +1,552 @@
+"""Replay of the 2026-07-27 pre-charge execution failure (FIX 1: token starvation).
+
+Incident: demand window 15:00-21:00, battery target 95%, entered at 64.0% —
+31.0 points short. Prices were 0.13-0.16 all morning and dipped to 0.115 at
+14:35 against a max_pre_charge_price of 0.20, so price was never the blocker.
+The DP plan said ``first_charge=NOW`` at 09:40, 10:00, 10:30, 10:40, 10:50,
+11:00, 11:10, 11:20, 12:40 and 12:50 and the mode never went to Grid Charging;
+the only DP-commanded charge of the day was 13:41-14:16. The pre-charge log
+from 13:56 to 14:50 shows ``first_charge`` sliding one slot forward on every
+replan while the projected shortfall climbed 4.9 → 31.5.
+
+Root cause: ``_get_decision_fingerprint`` enumerated price/spike/DW/floor as
+the only legitimate re-decision triggers, assuming the plan is stable between
+them. It is not — the DP's slot-0 action oscillates hold↔charge on every
+replan because ``first_charge`` chases the cheapest slot forward. The token
+therefore sampled the plan on a ~5-min (Amber tick) stride, and nearly every
+sample landed on a hold-phase plan. ``debug_plan_mode_pending`` recorded the
+wanted charge dozens of times and never committed. A counterfactual replay
+that commits the wanted mode reaches 94.9% instead of 64%.
+
+FIX 1 folds the plan into the decision context: the plan wanting to START
+charging while frozen advances a monotone epoch, which is the 6th fingerprint
+component. The trigger is one-directional (a wanted STOP never grants) and the
+epoch never decrements, which together bound the flap at one extra decision per
+(price context × new wanted-charge mode).
+"""
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.localshift.const import BatteryMode
+from custom_components.localshift.state.machine import StateMachine
+
+_CHARGE_MODES = (BatteryMode.GRID_CHARGING, BatteryMode.BOOST_CHARGING)
+
+
+def dt_aware(year, month, day, hour, minute=0, second=0):
+    """Create a timezone-aware datetime in Australia/Sydney time."""
+    return datetime(
+        year, month, day, hour, minute, second, tzinfo=timezone(timedelta(hours=11))
+    )
+
+
+# =============================================================================
+# FIXTURES (local copies — tests/state has no conftest of its own)
+# =============================================================================
+
+
+@pytest.fixture
+def mock_battery_controller():
+    """Mock BatteryController with all commands succeeding."""
+    controller = MagicMock()
+    controller.set_self_consumption = AsyncMock(return_value=True)
+    controller.set_force_charge = AsyncMock(return_value=True)
+    controller.set_boost_charge = AsyncMock(return_value=True)
+    controller.set_force_discharge = AsyncMock(return_value=True)
+    controller.set_proactive_export = AsyncMock(return_value=True)
+    controller.verify_current_state = AsyncMock(return_value=True)
+    return controller
+
+
+@pytest.fixture
+def mock_notification_service():
+    """Mock NotificationService."""
+    service = MagicMock()
+    service.send_transition_notification = AsyncMock()
+    service.send_transition_failed_notification = AsyncMock()
+    service.send_health_correction_notification = AsyncMock()
+    service.send_manual_override_timeout_notification = AsyncMock()
+    service.send_automation_disabled_notification = AsyncMock()
+    service.send_tesla_override_notification = AsyncMock()
+    return service
+
+
+@pytest.fixture
+def mock_entity_validator():
+    """Mock EntityValidator that always allows automation."""
+    from custom_components.localshift.utils.validation import IntegrationStatus
+
+    validator = MagicMock()
+    validator.should_allow_automation = MagicMock(return_value=True)
+    validator.status = IntegrationStatus.OK
+    validator.errors = []
+    validator.warnings = []
+    return validator
+
+
+@pytest.fixture
+def state_machine(
+    mock_battery_controller, mock_notification_service, mock_entity_validator
+):
+    """StateMachine with live-like options (battery_target defaults to 100)."""
+    return StateMachine(
+        mock_battery_controller,
+        mock_notification_service,
+        lambda key: {"automation_enabled": True, "dry_run": False}.get(key, False),
+        lambda key, default=None: default,
+        mock_entity_validator,
+    )
+
+
+@pytest.fixture
+def coordinator_data():
+    """CoordinatorData seeded with the incident's pre-DW state."""
+    from custom_components.localshift.coordinator import CoordinatorData
+
+    data = CoordinatorData()
+    data.soc = 49.9
+    data.operation_mode = "self_consumption"
+    data.backup_reserve = 10
+    data.general_price = 0.131
+    data.feed_in_price = 0.08
+    data.price_spike = False
+    data.demand_window_active = False
+    data.manual_override = False
+    data.automation_ready = True
+    data.active_mode = BatteryMode.SELF_CONSUMPTION
+    data.decision_log = []
+    return data
+
+
+class FakeFacadeEngine:
+    """Computation-engine stub mimicking the optimizer-facade contract.
+
+    Real flow: compute_derived_values() → facade._assign_active_mode() pins
+    data.active_mode when data.mode_decision_allowed is False (surfacing the
+    would-be plan mode on debug_plan_mode_pending) and re-decides it only when
+    True. ``plan_mode`` is re-assigned by the replay loop each tick, which is
+    how the per-minute plan script is driven.
+    """
+
+    def __init__(self, plan_mode: BatteryMode) -> None:
+        self.plan_mode = plan_mode
+        # data.mode_decision_allowed as observed in-lock on the LAST call (the
+        # flag is transient and already False once evaluate returns).
+        self.last_decision_allowed: bool | None = None
+
+    def compute_derived_values(self, data) -> None:
+        self.last_decision_allowed = data.mode_decision_allowed
+        if data.mode_decision_allowed:
+            data.active_mode = self.plan_mode
+            data.debug_plan_mode_pending = None
+        else:
+            data.debug_plan_mode_pending = (
+                self.plan_mode.value if self.plan_mode != data.active_mode else None
+            )
+
+
+class TestPlanChangeTokenReplay:
+    """FIX 1 — the plan is a decision input; a wanted charge must not starve."""
+
+    # --- Live trace: 13:40-15:00, one entry per simulated minute -------------
+    # Amber publishes on a 5-minute stride, so the price is constant within each
+    # group of five. Anchors from the evidence pack: 14:35 0.115, 14:40 0.113,
+    # 14:45/14:50 0.116. max_pre_charge_price was 0.20 — price never blocked.
+    PRICE_GROUPS = [
+        0.131,  # 13:40
+        0.128,  # 13:45
+        0.134,  # 13:50
+        0.130,  # 13:55
+        0.127,  # 14:00
+        0.133,  # 14:05
+        0.129,  # 14:10
+        0.126,  # 14:15
+        0.124,  # 14:20
+        0.122,  # 14:25
+        0.119,  # 14:30
+        0.115,  # 14:35
+        0.113,  # 14:40
+        0.116,  # 14:45
+        0.116,  # 14:50 (unchanged → no price-driven context change)
+        0.116,  # 14:55 (unchanged)
+    ]
+    PRICES = [p for p in PRICE_GROUPS for _ in range(5)]
+
+    # The incident's exact pathology: the DP's slot-0 action is "hold" at every
+    # 5-minute boundary (the instant the price tick grants a token) and "charge"
+    # on the four intervening minutes. The pre-fix token samples the plan only on
+    # the boundaries, so it never sees the wanted charge.
+    PLAN_SLOT0 = [
+        BatteryMode.SELF_CONSUMPTION if i % 5 == 0 else BatteryMode.GRID_CHARGING
+        for i in range(len(PRICES))
+    ]
+
+    # Live SOC (sensor.my_home_percentage_charged), linearly interpolated between
+    # the recorded anchors. Never near the 95% target, so the sanity gate is open
+    # for the whole replay.
+    SOC_ANCHORS = {0: 49.9, 20: 57.0, 40: 62.6, 70: 60.3, 79: 60.3}
+
+    @classmethod
+    def _soc(cls, minute: int) -> float:
+        keys = sorted(cls.SOC_ANCHORS)
+        lo = max(k for k in keys if k <= minute)
+        hi = min((k for k in keys if k >= minute), default=lo)
+        if hi == lo:
+            return cls.SOC_ANCHORS[lo]
+        span = (minute - lo) / (hi - lo)
+        return cls.SOC_ANCHORS[lo] + span * (cls.SOC_ANCHORS[hi] - cls.SOC_ANCHORS[lo])
+
+    def _replay(self, state_machine, data, engine, minutes=None):
+        """Drive the per-minute replay; return the per-tick committed modes."""
+        committed = []
+        count = len(self.PRICES) if minutes is None else minutes
+        for i in range(count):
+            data.general_price = self.PRICES[i]
+            data.soc = self._soc(i)
+            engine.plan_mode = self.PLAN_SLOT0[i]
+            asyncio.run(state_machine.evaluate_state_machine(data, engine))
+            committed.append(data.active_mode)
+        return committed
+
+    # --- RED anchor ---------------------------------------------------------
+
+    def test_prefix_baseline_no_charge_committed_without_plan_trigger(
+        self, state_machine, coordinator_data
+    ):
+        """Pre-fix behaviour (epoch frozen): the wanted charge never commits.
+
+        This is the incident. Without it the fix test below would be vacuous.
+        """
+        state_machine._update_plan_charge_epoch = lambda data, context=None: None
+        engine = FakeFacadeEngine(BatteryMode.SELF_CONSUMPTION)
+
+        committed = self._replay(state_machine, coordinator_data, engine)
+
+        assert not [m for m in committed if m in _CHARGE_MODES]
+
+    # --- The fix ------------------------------------------------------------
+
+    def test_plan_wanted_charge_is_committed(self, state_machine, coordinator_data):
+        """The plan-change trigger commits the charge the plan kept asking for."""
+        engine = FakeFacadeEngine(BatteryMode.SELF_CONSUMPTION)
+
+        committed = self._replay(state_machine, coordinator_data, engine)
+
+        charge_ticks = [i for i, m in enumerate(committed) if m in _CHARGE_MODES]
+        wanted_ticks = [i for i, m in enumerate(self.PLAN_SLOT0) if m in _CHARGE_MODES]
+
+        # (a) the charge commits at all
+        assert charge_ticks
+        # (b) it commits within 2 evaluations of the first tick that wanted it
+        #     (the pending value carries a 1-tick lag by design)
+        assert charge_ticks[0] - wanted_ticks[0] <= 2
+        # (c) and it stays committed for the bulk of the wanted window rather
+        #     than winning a single tick
+        assert len(charge_ticks) >= 0.6 * len(wanted_ticks)
+
+    def test_no_flap_within_a_price_interval(self, state_machine, coordinator_data):
+        """The §1.8 bound: no charge→hold→charge inside one price context."""
+        engine = FakeFacadeEngine(BatteryMode.SELF_CONSUMPTION)
+
+        transitions = []
+        original = state_machine._execute_mode_transition
+
+        async def _counting(data, target):
+            result = await original(data, target)
+            if result:
+                transitions.append(target)
+            return result
+
+        state_machine._execute_mode_transition = _counting
+
+        committed = self._replay(state_machine, coordinator_data, engine)
+
+        # No charge → non-charge → charge cycle inside a single 5-minute group.
+        for group in range(len(self.PRICE_GROUPS)):
+            window = committed[group * 5 : group * 5 + 5]
+            seen_charge = seen_release = False
+            for mode in window:
+                if mode in _CHARGE_MODES:
+                    assert not seen_release, (
+                        f"charge→hold→charge flap inside price group {group}: {window}"
+                    )
+                    seen_charge = True
+                elif seen_charge:
+                    seen_release = True
+
+        distinct_price_contexts = len([
+            i
+            for i, p in enumerate(self.PRICE_GROUPS)
+            if i == 0 or p != self.PRICE_GROUPS[i - 1]
+        ])
+        rising_edges = state_machine._plan_charge_epoch
+        assert len(transitions) <= distinct_price_contexts + rising_edges
+
+    # --- Guards on the trigger's shape --------------------------------------
+
+    def test_wanted_stop_never_grants_a_token(self, state_machine, coordinator_data):
+        """One-directional: a plan that wants to STOP charging never grants."""
+        engine = FakeFacadeEngine(BatteryMode.GRID_CHARGING)
+
+        # Prime: one granted decision commits GRID_CHARGING.
+        asyncio.run(state_machine.evaluate_state_machine(coordinator_data, engine))
+        assert coordinator_data.active_mode == BatteryMode.GRID_CHARGING
+
+        # The plan now wants to hold, on an otherwise unchanged context.
+        engine.plan_mode = BatteryMode.SELF_CONSUMPTION
+        for _ in range(10):
+            asyncio.run(state_machine.evaluate_state_machine(coordinator_data, engine))
+            assert engine.last_decision_allowed is False
+            assert coordinator_data.mode_decision_allowed is False
+            assert (
+                coordinator_data.debug_plan_mode_pending
+                == BatteryMode.SELF_CONSUMPTION.value
+            )
+
+        assert coordinator_data.active_mode == BatteryMode.GRID_CHARGING
+        assert state_machine._commanded_mode == BatteryMode.GRID_CHARGING
+
+    def test_epoch_does_not_increment_on_resolution(
+        self, state_machine, coordinator_data
+    ):
+        """Monotonicity: the disagreement clearing must not grant a second token."""
+        engine = FakeFacadeEngine(BatteryMode.SELF_CONSUMPTION)
+
+        # Tick 1: establish the context (plan == current, nothing pending).
+        asyncio.run(state_machine.evaluate_state_machine(coordinator_data, engine))
+        assert state_machine._plan_charge_epoch == 0
+
+        # Tick 2: plan wants to charge on an unchanged context → frozen, pending.
+        engine.plan_mode = BatteryMode.GRID_CHARGING
+        asyncio.run(state_machine.evaluate_state_machine(coordinator_data, engine))
+        assert engine.last_decision_allowed is False
+        assert (
+            coordinator_data.debug_plan_mode_pending == BatteryMode.GRID_CHARGING.value
+        )
+        assert state_machine._plan_charge_epoch == 0
+
+        # Tick 3: the rising edge grants exactly one decision; the plan commits.
+        asyncio.run(state_machine.evaluate_state_machine(coordinator_data, engine))
+        assert engine.last_decision_allowed is True
+        assert coordinator_data.active_mode == BatteryMode.GRID_CHARGING
+        assert state_machine._plan_charge_epoch == 1
+        assert coordinator_data.debug_plan_mode_pending is None
+
+        # Tick 4: the disagreement is resolved — the epoch must NOT move again.
+        asyncio.run(state_machine.evaluate_state_machine(coordinator_data, engine))
+        assert state_machine._plan_charge_epoch == 1
+        assert engine.last_decision_allowed is False
+
+    def test_no_grant_at_or_above_battery_target(self, state_machine, coordinator_data):
+        """Sanity gate: nothing to grant when the battery is already at target."""
+        # get_option returns the default → DEFAULT_BATTERY_TARGET (100).
+        coordinator_data.soc = 100.0
+        engine = FakeFacadeEngine(BatteryMode.SELF_CONSUMPTION)
+        asyncio.run(state_machine.evaluate_state_machine(coordinator_data, engine))
+
+        engine.plan_mode = BatteryMode.GRID_CHARGING
+        for _ in range(3):
+            asyncio.run(state_machine.evaluate_state_machine(coordinator_data, engine))
+            assert engine.last_decision_allowed is False
+
+        assert state_machine._plan_charge_epoch == 0
+        assert coordinator_data.active_mode == BatteryMode.SELF_CONSUMPTION
+
+    def test_deferred_redemption_still_dead(
+        self, state_machine, coordinator_data, mock_battery_controller
+    ):
+        """#622 stays fixed: a non-charge plan flip on a stale token never runs."""
+        engine = FakeFacadeEngine(BatteryMode.SELF_CONSUMPTION)
+
+        # Tick 1: price change, plan stable → token spent, no transition.
+        asyncio.run(state_machine.evaluate_state_machine(coordinator_data, engine))
+        mock_battery_controller.set_force_discharge.reset_mock()
+
+        # Ticks 2-3: SAME price, plan flips to a NON-charge mode. Under the old
+        # gate the stale token was redeemed here; the plan-change trigger is
+        # one-directional so it stays frozen.
+        engine.plan_mode = BatteryMode.SPIKE_DISCHARGE
+        for _ in range(2):
+            asyncio.run(state_machine.evaluate_state_machine(coordinator_data, engine))
+            assert engine.last_decision_allowed is False
+
+        assert coordinator_data.active_mode == BatteryMode.SELF_CONSUMPTION
+        assert state_machine._plan_charge_epoch == 0
+        mock_battery_controller.set_force_discharge.assert_not_called()
+
+    def test_backstop_permission_is_confined_to_the_lock(
+        self, state_machine, coordinator_data
+    ):
+        """mode_backstop_allowed is opened in-lock and always closed on exit."""
+        observed = []
+
+        class _Observer(FakeFacadeEngine):
+            def compute_derived_values(self, data):
+                observed.append(data.mode_backstop_allowed)
+                super().compute_derived_values(data)
+
+        engine = _Observer(BatteryMode.SELF_CONSUMPTION)
+        asyncio.run(state_machine.evaluate_state_machine(coordinator_data, engine))
+
+        assert observed == [True]
+        assert coordinator_data.mode_backstop_allowed is False
+
+
+class _DriftingFacade:
+    """The incident's defining case, which no test in the original diff covered.
+
+    Frozen ticks see a plan that wants to charge; the evaluation that is actually
+    GRANTED re-plans from fresh data and its slot-0 says hold — ``first_charge``
+    drifting forward, exactly what ``_update_plan_charge_epoch``'s docstring
+    describes. The committed mode therefore never enters ``_CHARGE_MODES``, so the
+    "committed mode is not already charging" gate never closes the loop.
+    """
+
+    def __init__(self, granted_mode=BatteryMode.SELF_CONSUMPTION):
+        self.granted_mode = granted_mode
+        self.grants = 0
+
+    def compute_derived_values(self, data):
+        if data.mode_decision_allowed:
+            self.grants += 1
+            data.active_mode = self.granted_mode
+            data.debug_plan_mode_pending = None
+        else:
+            wanted = BatteryMode.GRID_CHARGING
+            data.debug_plan_mode_pending = (
+                wanted.value if wanted != data.active_mode else None
+            )
+
+
+class TestPlanChargeGrantIsBounded:
+    """The §1.8 bound must hold as a BUDGET, not as an edge detector."""
+
+    def test_grant_does_not_re_arm_inside_one_price_context(
+        self, state_machine, coordinator_data
+    ):
+        """Regression: commit → pending-clears → re-grant, forever.
+
+        Edge memory cannot bound this. A granted evaluation clears
+        ``debug_plan_mode_pending``, so the memory of "the last qualifying pending
+        value" is reset by the very grant it gates; the next frozen tick re-sets the
+        pending value and the tick after that reads as a fresh rising edge. Measured
+        before the fix, with the price held constant for all 21 ticks: 11 grants and
+        epoch 10 in a SINGLE price context — the #622 flap budget, spent, with the
+        docstring claiming a bound of one.
+        """
+        engine = _DriftingFacade()
+
+        for _ in range(21):  # price/spike/DW/floor constant throughout
+            asyncio.run(state_machine.evaluate_state_machine(coordinator_data, engine))
+
+        # One grant establishes the context, one is the plan-charge grant. The plan
+        # keeps wanting to charge for all 21 ticks and must not keep buying grants.
+        assert engine.grants == 2
+        assert state_machine._plan_charge_epoch == 1
+
+    def test_budget_refills_when_the_price_context_changes(
+        self, state_machine, coordinator_data
+    ):
+        """The bound is per-context, not global — a real price move re-arms it."""
+        engine = _DriftingFacade()
+
+        for _ in range(6):
+            asyncio.run(state_machine.evaluate_state_machine(coordinator_data, engine))
+        epoch_after_first_context = state_machine._plan_charge_epoch
+
+        coordinator_data.general_price = 0.199  # genuine Amber tick
+        for _ in range(6):
+            asyncio.run(state_machine.evaluate_state_machine(coordinator_data, engine))
+
+        assert state_machine._plan_charge_epoch == epoch_after_first_context + 1
+
+    def test_plan_charge_grant_is_flagged_for_the_facade(
+        self, state_machine, coordinator_data
+    ):
+        """A grant on an unchanged price context is attributable to the plan alone,
+        so the facade can refuse to spend it on a non-charge mode."""
+        seen = []
+
+        class _Recorder(_DriftingFacade):
+            def compute_derived_values(self, data):
+                if data.mode_decision_allowed:
+                    seen.append(data.mode_decision_plan_charge_only)
+                super().compute_derived_values(data)
+
+        engine = _Recorder()
+        for _ in range(6):
+            asyncio.run(state_machine.evaluate_state_machine(coordinator_data, engine))
+
+        # First grant establishes the context (not plan-attributable); the second is
+        # the plan-charge grant.
+        assert seen == [False, True]
+        # And the flag is transient — closed with the rest on exit.
+        assert coordinator_data.mode_decision_plan_charge_only is False
+
+
+class TestTokenWindowIntegrity:
+    """The in-lock window must close on every path."""
+
+    def test_flags_close_even_when_compute_derived_values_raises(
+        self, state_machine, coordinator_data
+    ):
+        """``compute_derived_values`` sat OUTSIDE the try whose finally closes the
+        window, so an exception from any post-facade step escaped with the decision
+        token AND the backstop permission still open — leaving the next out-of-lock
+        recompute armed to force a charge."""
+
+        class _Exploding:
+            def compute_derived_values(self, data):
+                raise RuntimeError("post-facade step blew up")
+
+        with pytest.raises(RuntimeError):
+            asyncio.run(
+                state_machine.evaluate_state_machine(coordinator_data, _Exploding())
+            )
+
+        assert coordinator_data.mode_decision_allowed is False
+        assert coordinator_data.mode_backstop_allowed is False
+        assert coordinator_data.mode_decision_plan_charge_only is False
+
+    def test_suppression_blocks_the_reoptimize_path_from_granting(
+        self, state_machine, coordinator_data
+    ):
+        """``async_recompute_and_evaluate(invalidate_decision=False)`` is documented
+        as "may update the plan but must NOT grant a mode change". It runs
+        compute_derived_values OUT OF LOCK first, so the frozen facade writes
+        debug_plan_mode_pending and the evaluation that follows reads it back with
+        ZERO lag and grants — a mode change caused by a load-deviation reoptimize."""
+        engine = _DriftingFacade()
+
+        # Establish the context.
+        asyncio.run(state_machine.evaluate_state_machine(coordinator_data, engine))
+        # A frozen tick leaves a wanted charge pending.
+        asyncio.run(state_machine.evaluate_state_machine(coordinator_data, engine))
+        assert (
+            coordinator_data.debug_plan_mode_pending == BatteryMode.GRID_CHARGING.value
+        )
+        grants_before = engine.grants
+
+        state_machine.suppress_next_plan_charge_grant("reoptimize")
+        asyncio.run(state_machine.evaluate_state_machine(coordinator_data, engine))
+
+        assert engine.grants == grants_before
+        assert state_machine._plan_charge_epoch == 0
+
+    def test_suppression_is_one_shot(self, state_machine, coordinator_data):
+        """It must not leave the trigger disabled for the rest of the day."""
+        engine = _DriftingFacade()
+        asyncio.run(state_machine.evaluate_state_machine(coordinator_data, engine))
+        asyncio.run(state_machine.evaluate_state_machine(coordinator_data, engine))
+
+        state_machine.suppress_next_plan_charge_grant("reoptimize")
+        asyncio.run(state_machine.evaluate_state_machine(coordinator_data, engine))
+        # Next regular evaluation: the trigger works again.
+        asyncio.run(state_machine.evaluate_state_machine(coordinator_data, engine))
+        asyncio.run(state_machine.evaluate_state_machine(coordinator_data, engine))
+
+        assert state_machine._plan_charge_epoch == 1

--- a/tests/state/test_state_machine.py
+++ b/tests/state/test_state_machine.py
@@ -1668,8 +1668,10 @@ class TestDecisionFingerprint:
 
         assert fp1 == fp2
         # #622 gate replacement: fingerprint now enumerates the full discrete
-        # decision context: buy|sell|spike|dw_active|soc_floor_breached.
-        assert fp1 == "0.2500|0.0800|False|False|False"
+        # decision context: buy|sell|spike|dw_active|soc_floor_breached, plus the
+        # plan-charge epoch (2026-07-27 pre-charge incident — the plan is itself a
+        # decision input; the epoch is 0 until a wanted charge is starved).
+        assert fp1 == "0.2500|0.0800|False|False|False|0"
 
 
 class TestModeTransitionGating:
@@ -1974,13 +1976,23 @@ class TestDecisionTokenInvariant:
             coordinator_data.general_price = price
             coordinator_data.price_spike = False
             engine.plan_mode = oscillate[i % 2]
-            distinct_fps.add(state_machine._get_decision_fingerprint(coordinator_data))
             self._run(state_machine, coordinator_data, engine)
+            # Collect the fingerprint the machine actually SPENT a token on
+            # (post-eval), not a pre-eval sample: the plan-charge epoch is
+            # advanced inside _apply_decision_token, so a pre-eval sample would
+            # read the context one update early.
+            distinct_fps.add(state_machine._last_evaluated_fingerprint)
 
         # The crown jewel: at most one transition per distinct decision context.
         assert len(transitions) <= len(distinct_fps)
-        # And concretely: 4 distinct prices → ≤ 4 transitions, not ~12.
-        assert len(distinct_fps) == 4
+        # And concretely: 4 distinct prices plus the 2 plan-charge rising edges
+        # they starve → 6 contexts, so ≤ 6 transitions across 12 evals, not ~12.
+        # The 2 extra contexts are the plan-change trigger doing its job: on two
+        # frozen ticks the plan wanted to START grid charging while a non-charge
+        # mode was committed and SOC was below target (2026-07-27 incident). The
+        # trigger is one-directional and its epoch is monotone, so it can add at
+        # most one context per (price context × new wanted-charge mode).
+        assert len(distinct_fps) == 6
         # Guard against a vacuous pass: the knife-edge MUST have driven some
         # transitions (otherwise the invariant is trivially satisfied).
         assert len(transitions) >= 1
@@ -2085,8 +2097,8 @@ class TestDecisionTokenInvariant:
     def test_none_price_never_grants_transition(
         self, state_machine, coordinator_data, mock_battery_controller
     ):
-        """price → None → same price restores → still frozen; new price → one
-        decision. None must never grant a transition."""
+        """price → None must never grant. The restored price then grants exactly
+        one decision, because the plan's starved charge advanced the epoch."""
         coordinator_data.active_mode = BatteryMode.SELF_CONSUMPTION
         state_machine._commanded_mode = BatteryMode.SELF_CONSUMPTION
         coordinator_data.general_price = 0.25
@@ -2097,7 +2109,8 @@ class TestDecisionTokenInvariant:
         stored_fp = state_machine._last_evaluated_fingerprint
 
         # Tick 2: price unavailable (None) + plan flips. None must freeze and must
-        # NOT overwrite the stored fingerprint.
+        # NOT overwrite the stored fingerprint — this is the assertion the test
+        # exists for and it is unchanged by the plan-change trigger.
         coordinator_data.general_price = None
         engine.plan_mode = BatteryMode.GRID_CHARGING
         self._run(state_machine, coordinator_data, engine)
@@ -2105,18 +2118,57 @@ class TestDecisionTokenInvariant:
         assert state_machine._last_evaluated_fingerprint == stored_fp
         mock_battery_controller.set_force_charge.assert_not_called()
 
+        # Tick 3: the price returns unchanged, but tick 2 left a starved charge
+        # pending (debug_plan_mode_pending=grid_charging). FIX 1: that is a
+        # genuine context change, so this tick grants EXACTLY ONE decision and
+        # the plan's charge finally commits (2026-07-27 incident).
+        coordinator_data.general_price = 0.25
+        self._run(state_machine, coordinator_data, engine)
+        assert engine.last_decision_allowed is True
+        assert coordinator_data.active_mode == BatteryMode.GRID_CHARGING
+        mock_battery_controller.set_force_charge.assert_called_once()
+
+        # Tick 4: same price, disagreement resolved → frozen again (the epoch is
+        # monotone, so the resolution does not grant a second decision).
+        self._run(state_machine, coordinator_data, engine)
+        assert engine.last_decision_allowed is False
+        mock_battery_controller.set_force_charge.assert_called_once()
+
+    def test_none_price_never_grants_transition_non_charge_plan(
+        self, state_machine, coordinator_data, mock_battery_controller
+    ):
+        """Sibling of the above with a NON-charge pending mode: the plan-change
+        trigger is one-directional, so the restored price stays frozen — the
+        original 'None never grants' behaviour, preserved verbatim."""
+        coordinator_data.active_mode = BatteryMode.SELF_CONSUMPTION
+        state_machine._commanded_mode = BatteryMode.SELF_CONSUMPTION
+        coordinator_data.general_price = 0.25
+        engine = FakeFacadeEngine(BatteryMode.SELF_CONSUMPTION)
+
+        # Tick 1: establish context, plan stable.
+        self._run(state_machine, coordinator_data, engine)
+        stored_fp = state_machine._last_evaluated_fingerprint
+
+        # Tick 2: price unavailable (None) + plan flips to a non-charge mode.
+        coordinator_data.general_price = None
+        engine.plan_mode = BatteryMode.SPIKE_DISCHARGE
+        self._run(state_machine, coordinator_data, engine)
+        assert coordinator_data.mode_decision_allowed is False
+        assert state_machine._last_evaluated_fingerprint == stored_fp
+        mock_battery_controller.set_force_discharge.assert_not_called()
+
         # Tick 3: same price returns — still frozen (no context change).
         coordinator_data.general_price = 0.25
         self._run(state_machine, coordinator_data, engine)
-        assert coordinator_data.mode_decision_allowed is False
-        mock_battery_controller.set_force_charge.assert_not_called()
+        assert engine.last_decision_allowed is False
+        mock_battery_controller.set_force_discharge.assert_not_called()
 
         # Tick 4: genuinely new price — exactly one decision.
         coordinator_data.general_price = 0.40
         self._run(state_machine, coordinator_data, engine)
         assert engine.last_decision_allowed is True
-        assert coordinator_data.active_mode == BatteryMode.GRID_CHARGING
-        mock_battery_controller.set_force_charge.assert_called_once()
+        assert coordinator_data.active_mode == BatteryMode.SPIKE_DISCHARGE
+        mock_battery_controller.set_force_discharge.assert_called_once()
 
     def test_spike_onset_grants_one_decision(self, state_machine, coordinator_data):
         """price_spike False→True is a context change → one decision."""

--- a/tests/test_computation_engine.py
+++ b/tests/test_computation_engine.py
@@ -1025,3 +1025,23 @@ def test_refresh_soc_keeps_cached_when_unavailable(
     computation_engine._refresh_soc_for_optimizer(coordinator_data)
 
     assert coordinator_data.soc == 42.0
+
+
+def test_manual_override_clears_a_stale_pending_plan_mode(
+    computation_engine, coordinator_data
+):
+    """The manual-override early return skips the optimizer facade entirely, so a
+    ``debug_plan_mode_pending`` left by an earlier tick was never refreshed or
+    cleared. The state machine's plan-charge trigger keeps reading that frozen value
+    and can grant a token off a plan that is arbitrarily old — the phantom grant
+    ``_mark_mode_debug_fallback`` claims to have closed on the other early-exit
+    paths."""
+    coordinator_data.manual_override = True
+    coordinator_data.debug_plan_mode_pending = BatteryMode.GRID_CHARGING.value
+    coordinator_data.optimizer_precharge_backstop_active = True
+
+    computation_engine.compute_derived_values(coordinator_data)
+
+    assert coordinator_data.active_mode == BatteryMode.MANUAL
+    assert coordinator_data.debug_plan_mode_pending is None
+    assert coordinator_data.optimizer_precharge_backstop_active is False

--- a/tests/test_optimizer_facade.py
+++ b/tests/test_optimizer_facade.py
@@ -866,3 +866,147 @@ def test_log_comparison_mismatch_trims_decision_log_to_50_entries():
     assert len(data.decision_log) == 50
     assert data.decision_log[-1]["old_mode"] == "self_consumption"
     assert data.decision_log[-1]["new_mode"] == "grid_charging"
+
+
+# =============================================================================
+# FIX 3 (2026-07-27) — the DW-entry actual, on the log line and in the summary
+# =============================================================================
+#
+# The projected dw_entry_soc_pct rolls over to *tomorrow's* window the instant
+# today's demand window starts. On 2026-07-27 that rollover meant the 15:00 log
+# line and every sensor read a healthy 98.5% / shortfall 0.0 while the battery
+# had actually entered the window at 64% against a 95% target. The captured
+# actual is a separate, per-day field the rollover cannot touch; the facade's
+# job is only to surface it.
+
+
+def _with_dw_entry_actual(data: CoordinatorData) -> CoordinatorData:
+    """Stamp the live 2026-07-27 capture onto ``data``."""
+    data.dw_entry_actual_soc_pct = 64.0
+    data.dw_entry_actual_at = datetime(2026, 7, 27, 15, 0, tzinfo=UTC)
+    data.dw_entry_actual_date = datetime(2026, 7, 27, 15, 0, tzinfo=UTC).date()
+    data.dw_entry_actual_target_pct = 95.0
+    data.dw_entry_actual_shortfall_pct = 31.0
+    return data
+
+
+def test_summary_carries_dw_entry_actual_alongside_the_projection():
+    """Projected and actual must sit in the same payload and be allowed to
+    disagree — that disagreement is the whole diagnostic."""
+    data = _with_dw_entry_actual(CoordinatorData())
+    data.soc = 64.0
+    result = _summary_mock_result()
+    result.dw_entry_soc_pct = 98.5  # tomorrow's window, post-rollover
+
+    _run_inline_with(result, data, {"demand_window_target_soc_pct": 95.0})
+
+    summary = data.optimizer_summary
+    assert summary["dw_entry_soc_pct"] == 98.5
+    assert summary["dw_entry_actual_soc_pct"] == 64.0
+    assert summary["dw_entry_actual_shortfall_pct"] == 31.0
+    assert summary["dw_entry_actual_target_pct"] == 95.0
+    assert summary["dw_entry_actual_at"] == "2026-07-27T15:00:00+00:00"
+    assert summary["dw_entry_actual_date"] == "2026-07-27"
+
+
+def test_summary_dw_entry_actual_keys_present_before_any_capture():
+    """Before the first capture of the day the keys exist and read null — a
+    missing key would render as 'unknown' rather than 'not yet'."""
+    data = CoordinatorData()
+    data.soc = 50.0
+
+    _run_inline_with(
+        _summary_mock_result(), data, {"demand_window_target_soc_pct": 95.0}
+    )
+
+    summary = data.optimizer_summary
+    assert summary["dw_entry_actual_soc_pct"] is None
+    assert summary["dw_entry_actual_at"] is None
+    assert summary["dw_entry_actual_date"] is None
+
+
+def test_precharge_decision_log_carries_actual_and_backstop(caplog):
+    """One line, diagnosable on its own: projected next to actual, plus whether
+    the execution backstop had to fire."""
+    import logging
+
+    data = _with_dw_entry_actual(CoordinatorData())
+    data.soc = 64.0
+    data.optimizer_precharge_backstop_active = True
+
+    with caplog.at_level(logging.INFO):
+        _log = OptimizerFacade(slot_builder_cls=_StubSlotBuilder)._log_precharge_decision
+        _log(data, _summary_mock_result(), 64.0, SimpleNamespace())
+
+    assert "dw_entry_actual=64.0%@15:00" in caplog.text
+    assert "backstop=True" in caplog.text
+
+
+def test_precharge_decision_log_reports_this_cycle_not_the_last(caplog):
+    """The line is logged AFTER _assign_active_mode, so backstop= is this cycle's
+    state. It used to be logged before, and reported the PREVIOUS cycle's flag on
+    every line — the exact confusion the line exists to remove."""
+    import logging
+
+    data = _with_dw_entry_actual(CoordinatorData())
+    data.soc = 64.0
+    # Stale True left by an earlier cycle. This cycle's safety gate blocks, so the
+    # backstop cannot have fired and the line must not claim it did.
+    data.optimizer_precharge_backstop_active = True
+
+    with caplog.at_level(logging.INFO):
+        _run_inline_with(
+            _summary_mock_result(), data, {"demand_window_target_soc_pct": 95.0}
+        )
+
+    assert "dw_entry_actual=64.0%@15:00" in caplog.text
+    assert "backstop=False" in caplog.text
+    assert "backstop=True" not in caplog.text
+
+
+def test_precharge_decision_log_reads_na_without_a_capture(caplog):
+    import logging
+
+    data = CoordinatorData()
+    data.soc = 50.0
+
+    with caplog.at_level(logging.INFO):
+        _run_inline_with(
+            _summary_mock_result(), data, {"demand_window_target_soc_pct": 95.0}
+        )
+
+    assert "dw_entry_actual=n/a" in caplog.text
+    assert "backstop=False" in caplog.text
+
+
+def test_underprepared_warning_carries_the_captured_entry_soc(caplog):
+    """#889's guardrail line must quote the real entry SOC, not only the live
+    one — by the time it trips the pack may have partly recovered."""
+    import logging
+
+    data = _with_dw_entry_actual(CoordinatorData())
+    data.soc = 70.0
+    data.demand_window_active = True
+
+    with caplog.at_level(logging.WARNING):
+        _run_inline_with(
+            _summary_mock_result(), data, {"demand_window_target_soc_pct": 95.0}
+        )
+
+    assert data.optimizer_soc_underprepared is True
+    assert "SOC UNDERPREPARED" in caplog.text
+    assert "entered at 64.0%@15:00" in caplog.text
+
+
+def test_mark_mode_debug_fallback_clears_stale_plan_pending():
+    """A pending left by an earlier tick must not survive a cycle that produced
+    no decision at all — it would feed the state machine a phantom grant."""
+    facade = OptimizerFacade(slot_builder_cls=_StubSlotBuilder)
+    data = CoordinatorData()
+    data.debug_plan_mode_pending = BatteryMode.GRID_CHARGING.value
+
+    facade._mark_mode_debug_fallback(data)
+
+    assert data.debug_plan_mode_pending is None
+    assert data.debug_mode_source == "fallback"
+    assert data.optimizer_precharge_backstop_active is False


### PR DESCRIPTION
## Incident (2026-07-27)

Battery entered the 15:00–21:00 demand window at **64.0% vs 95% target** despite:
- prices 12–17c all morning (under the 20c pre-charge cap — price never blocked)
- every plan 09:25–13:40 projecting 93–100% DW entry, shortfall ~0

At 15:00 the summary sensor reported `shortfall=0, dw_entry=100` — the metrics rolled to *tomorrow's* window and erased the miss. Only the #889 `SOC UNDERPREPARED` warning caught it.

## Root cause — decision-token phase starvation

The #622-replacement decision token (`state/machine.py:_get_decision_fingerprint`) grants a mode decision only when the price/spike/DW/floor context changes — ~once per 5-min Amber tick. The DP plan's `first_charge` drifts one slot forward on nearly every replan (cheapest-slot chasing), so at token instants the fresh plan's slot-0 action was almost always **hold**. Plan-wanted charging was selected in dozens of frozen evaluations (`debug_plan_mode_pending`) and never committed:

- 12:40–12:50: boost wanted in **14/14** evaluations, **zero** committed
- final hour: tokens at 14:30/14:35/14:45 all landed on hold-plans whose `first_charge` sat 5 min in the future, forever
- all morning charging (~88 min of bursts) came from boost-path phase luck only

**Deterministic replay** (drift inferred from actual SOC, same solar/load/prices/plans):

| scenario | DW entry |
|---|---|
| actual recorded | 64.0% |
| replay of actual commits (sanity) | 64.1% |
| counterfactual: commit plan-wanted mode | **94.9%** |
| continuous charge upper bound | 100.0% |

## Fixes

1. **Token on plan-change** (`state/machine.py`) — a plan wanting to *start* charging is now a decision-context change. One-directional (wanted stop never grants), budgeted per price context to bound flapping (review round measured 11 grants/21 ticks in the naive edge-detect version; budget version: 2), and a plan-charge grant can only be spent on a charge mode — never on a drifted discharge.
2. **Execution backstop** (`engine/optimizer_facade.py`) — urgency window + projected DW-entry shortfall >5pp + pre-DW charge slots in plan ⇒ force the boost path regardless of token phase. `terminal_penalty_idx` is now published on `OptimizerConfig` so the backstop is **reachable in production** (a review pass caught it shipped dead; a reachability test against the real config now pins it).
3. **`dw_entry_actual` telemetry** (`computation_engine.py`, `sensors/optimizer.py`) — real SOC captured at DW start, daily reset, surfaced on the summary sensor; the window-start rollover can no longer erase a miss.

## Review round (3 adversarial lenses + verified fixes)

12 consolidated findings: 9 confirmed + fixed (incl. the flap loop, the dead backstop, a stale-pending leak on manual override, and a log line reporting the previous cycle's backstop state), 3 rejected with reasoning (backstop-timing runway maths, backstop scope, fallback pending-drop).

## Tests

`3284 passed, 1 xfailed` full suite, single process. New: `tests/state/test_precharge_token_replay.py`, `tests/state/test_precharge_execution_replay.py`, `tests/engine/test_precharge_backstop.py` — replaying the incident shape.