### PR TITLE
fix(optimizer): stop the DW-entry floor collapsing on a negative-net-load runway (#903)

### DIFF
--- a/custom_components/localshift/engine/constraints.py
+++ b/custom_components/localshift/engine/constraints.py
@@ -560,6 +560,12 @@ def compute_max_feasible_terminal_soc(
     charge in) contributes a boost-rate charge; every other slot evolves on solar/load
     only. The result is clamped to the charge ceiling (target in self-consumption mode).
 
+    A charge slot is simulated the way ``_transition_charge_grid`` actually moves SOC
+    (issue #903): the house load is served from the grid during a grid charge, so the
+    battery does not drain and the net-load drift MUST NOT be applied on top of the boost
+    credit. Applying both under-reported the reachable SOC by the whole pre-DW load on any
+    negative-net-load runway, which degraded the hard floor below a reachable target.
+
     The simulation is measured at the SOC ENTERING the DW-entry slot (before that slot's
     own consumption drift) — matching how the DP applies the terminal penalty in
     ``_backward_induction`` (to ``dp[terminal_penalty_idx][bin]``, keyed by the SOC at the
@@ -591,31 +597,59 @@ def compute_max_feasible_terminal_soc(
     for i in range(terminal_penalty_idx):
         slot = slots[i]
         slot_hours = slot.slot_interval_minutes / 60.0
-        # Solar/load drift first (mirrors the solar-only simulation shape).
         net_kwh = slot.solar_kwh - slot.consumption_kwh
-        max_solar_transfer = config.solar_charge_rate_kw * slot_hours
-        if net_kwh >= 0:
+        # No ``soc < charge_ceiling`` guard: the clamp below already refuses to credit
+        # anything above the ceiling, and gating on it made the trajectory oscillate —
+        # a slot that arrived AT the ceiling took the drift branch and fell back under
+        # it, so a HIGHER initial SOC could report a LOWER max feasible (67.15 -> 95.0
+        # but 69.77 -> 93.88). A plan that has reached the ceiling can always keep
+        # trickling to hold there, so the optimistic trajectory must be sticky at it.
+        charging = (
+            not slot.is_demand_window_slot
+            and slot.buy_price
+            <= cheap_threshold_for_slot(config, i, terminal_penalty_idx)
+        )
+        if charging:
+            # Issue #903: a charge slot must be simulated the way the DP's own charge
+            # transition moves SOC, not as "drift, then charge". While the battery is
+            # grid-charging, a load deficit is imported from the grid rather than drawn
+            # from the battery (``_charge_grid_with_deficit`` in transitions.py), so SOC
+            # does NOT drain in a charge slot. Subtracting the net-load drift here AND
+            # crediting the boost double-counted the deficit, under-reporting the
+            # reachable SOC on every negative-net-load pre-DW runway (live 2026-07-29:
+            # 88.67 reported vs 95.0 actually reachable) and degrading the hard floor
+            # below a target that was physically attainable.
             soc += (
-                min(net_kwh, max_solar_transfer)
+                config.boost_charge_rate_kw
+                * slot_hours
                 * config.charge_efficiency
                 / config.battery_capacity_kwh
                 * 100.0
             )
-        else:
-            soc += (
-                max(net_kwh, -max_solar_transfer)
-                / config.discharge_efficiency
-                / config.battery_capacity_kwh
-                * 100.0
-            )
-        # Then the most optimistic eligible grid charge (boost) in this pre-DW slot.
-        if not slot.is_demand_window_slot and soc < charge_ceiling:
-            threshold = cheap_threshold_for_slot(config, i, terminal_penalty_idx)
-            if slot.buy_price <= threshold:
+            if net_kwh > 0:
+                # Solar surplus stacks on top of the grid charge, exactly as
+                # ``_charge_grid_with_solar`` does (uncapped by solar_charge_rate_kw —
+                # that cap governs the solar-only path, not a grid-charge slot).
                 soc += (
-                    config.boost_charge_rate_kw
-                    * slot_hours
+                    net_kwh
                     * config.charge_efficiency
+                    / config.battery_capacity_kwh
+                    * 100.0
+                )
+        else:
+            # No eligible grid charge: evolve on solar/load only.
+            max_solar_transfer = config.solar_charge_rate_kw * slot_hours
+            if net_kwh >= 0:
+                soc += (
+                    min(net_kwh, max_solar_transfer)
+                    * config.charge_efficiency
+                    / config.battery_capacity_kwh
+                    * 100.0
+                )
+            else:
+                soc += (
+                    max(net_kwh, -max_solar_transfer)
+                    / config.discharge_efficiency
                     / config.battery_capacity_kwh
                     * 100.0
                 )

--- a/custom_components/localshift/engine/core.py
+++ b/custom_components/localshift/engine/core.py
@@ -1105,8 +1105,19 @@ class DPPlanner:
                 # The penalty is monotonic in the gap, so among below-floor states the DP
                 # still prefers the highest reachable SOC (no infeasible/empty plan).
                 if hard_target_floor is not None and effective_soc < hard_target_floor:
-                    shortfall = hard_target_floor - effective_soc
-                    shortfall_penalty = shortfall * hard_constraint_penalty
+                    # Issue #903: measure the gap to TARGET, then ADD the floor breach —
+                    # never the gap to the floor alone. The floor is min(target, max
+                    # feasible), so when it degrades below target a gap-to-floor penalty
+                    # is SMALLER than the gap-to-target penalty applied just above the
+                    # floor: the schedule stepped UP at the boundary (measured $3.24 just
+                    # below vs $615.60 just above) and made the degraded floor an
+                    # attractor the DP deliberately parked under, forgoing reachable cheap
+                    # SOC. Summing keeps the penalty non-increasing in SOC across the
+                    # whole below-target range and continuous at the floor (the breach
+                    # term vanishes there), while still making a breach strictly worse.
+                    shortfall = target - effective_soc
+                    breach = hard_target_floor - effective_soc
+                    shortfall_penalty = (shortfall + breach) * hard_constraint_penalty
                 elif use_hard_constraint and effective_soc < target:
                     shortfall = target - effective_soc
                     shortfall_penalty = shortfall * hard_constraint_penalty

--- a/tests/engine/test_dw_floor_negative_net_load_runway.py
+++ b/tests/engine/test_dw_floor_negative_net_load_runway.py
@@ -1,0 +1,399 @@
+"""DW-entry floor on a negative-net-load pre-DW runway (issue #903).
+
+Two coupled defects, both observed live on 2026-07-29 (masked at the hardware by the
+#901 execution backstop, so the battery reached target while the *plan* said ``hold``):
+
+1. ``compute_max_feasible_terminal_soc`` subtracted the forecast net-load drift in every
+   pre-DW slot, INCLUDING the slots where it also credited a boost grid charge. The DP's
+   own charge transition imports the load deficit from the grid instead of draining the
+   battery (``_charge_grid_with_deficit``), so the function's documented upper-bound
+   property was false whenever net load was negative. Live: 88.67 reported against a
+   physically reachable 95.0, which degraded ``hard_target_floor`` below a reachable
+   target.
+
+2. The terminal penalty was non-monotone at the floor boundary — below the floor it
+   measured the gap to the FLOOR, at/above it the gap to the TARGET. Since the floor is
+   ``min(target, max_feasible)``, a degraded floor made below-floor states strictly
+   CHEAPER than states just above it ($3.24 vs $615.60 across the boundary in replay), so
+   the DP deliberately parked under the degraded floor rather than charging past it.
+
+The test gap that let this survive: no test covered a pre-DW runway with negative net
+load. These fixtures are that shape.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+import pytest
+
+from custom_components.localshift.engine.constraints import (
+    compute_max_feasible_terminal_soc,
+)
+from custom_components.localshift.engine.core import DPPlanner
+from custom_components.localshift.engine.types import (
+    OptimizerConfig,
+    OptimizerInputs,
+    PlannerAction,
+    SlotContext,
+)
+
+_CHARGE = (PlannerAction.CHARGE_GRID_NORMAL, PlannerAction.CHARGE_GRID_BOOST)
+
+# --- The 2026-07-29 live shape ---------------------------------------------
+#
+# 12 remaining pre-DW 5-minute slots, mid-morning cloud collapse (solar 0.6 kW), a load
+# spike leaving ~1.73 kW of net load, live buy price 0.06 against a 0.12 cheap-effective
+# threshold — i.e. every remaining slot comfortably eligible.
+_LIVE_INTERVAL = 5
+_LIVE_DW_ENTRY_IDX = 12
+_LIVE_N_SLOTS = 24
+_LIVE_INITIAL_SOC = 67.15
+_LIVE_SOLAR_KW = 0.6
+_LIVE_NET_LOAD_KW = 1.73
+
+
+def _config(**overrides) -> OptimizerConfig:
+    defaults = dict(
+        min_soc_pct=10.0,
+        max_soc_pct=100.0,
+        demand_window_target_soc_pct=95.0,
+        allow_dw_entry_under_target=False,
+        optimization_mode="self_consumption",
+        battery_capacity_kwh=13.5,
+        charge_rate_kw=3.3,
+        boost_charge_rate_kw=5.0,
+        solar_charge_rate_kw=5.0,
+        charge_efficiency=0.92,
+        discharge_efficiency=0.95,
+        effective_cheap_price=0.12,
+        base_cheap_price=0.12,
+        max_precharge_price=0.20,
+        target_shortfall_penalty_per_pct=0.10,
+        soc_bins=100,
+    )
+    defaults.update(overrides)
+    return OptimizerConfig(**defaults)
+
+
+def _live_slots(
+    n_slots: int = _LIVE_N_SLOTS,
+    dw_entry_idx: int = _LIVE_DW_ENTRY_IDX,
+    solar_kw: float = _LIVE_SOLAR_KW,
+    net_load_kw: float = _LIVE_NET_LOAD_KW,
+) -> list[SlotContext]:
+    """Pre-DW runway with NEGATIVE net load — the shape no prior test covered."""
+    start = datetime(2026, 7, 29, 14, 4)
+    hours = _LIVE_INTERVAL / 60.0
+    solar_kwh = solar_kw * hours
+    consumption_kwh = (solar_kw + net_load_kw) * hours
+    slots: list[SlotContext] = []
+    for i in range(n_slots):
+        t = start + timedelta(minutes=_LIVE_INTERVAL * i)
+        is_dw = i >= dw_entry_idx
+        slots.append(
+            SlotContext(
+                slot_index=i,
+                timestamp_iso=t.isoformat(),
+                slot_interval_minutes=_LIVE_INTERVAL,
+                buy_price=0.30 if is_dw else 0.06,
+                sell_price=0.03,
+                solar_kwh=0.0 if is_dw else solar_kwh,
+                consumption_kwh=consumption_kwh,
+                is_demand_window_entry=(i == dw_entry_idx),
+                is_demand_window_slot=is_dw,
+            )
+        )
+    return slots
+
+
+def _plan(slots, initial_soc_pct, **overrides):
+    config = _config(**overrides)
+    result = DPPlanner(config).plan(
+        OptimizerInputs(
+            cycle_id="repro-903",
+            initial_soc_pct=initial_soc_pct,
+            slots=slots,
+            config=config,
+            all_solcast=[],
+        )
+    )
+    return result, config
+
+
+def _boost_gain_pct(config: OptimizerConfig, interval_min: int) -> float:
+    """Untapered boost SOC gain for one slot — the credit max-feasible applies."""
+    return (
+        config.boost_charge_rate_kw
+        * (interval_min / 60.0)
+        * config.charge_efficiency
+        / config.battery_capacity_kwh
+        * 100.0
+    )
+
+
+# ---------------------------------------------------------------------------
+# Defect 1 — drift must not be double-counted in a credited charge slot.
+# ---------------------------------------------------------------------------
+
+
+def test_max_feasible_does_not_subtract_drift_in_charge_slots():
+    """12 cheap boost slots reach the 95 ceiling; the old code reported ~88.
+
+    Each 5-minute boost slot stores ~2.84 SOC points. Twelve of them is ~34 points, so
+    from 67.15 the ceiling clamp at target is hit well before the DW entry. The pre-fix
+    code subtracted ~1.12 points of load drift in each of those same slots, cutting the
+    per-slot gain to ~1.72 and landing ~21.5 points above initial — the fixed "+21.5
+    regardless of SOC" signature seen live.
+    """
+    config = _config()
+    slots = _live_slots()
+
+    max_feasible = compute_max_feasible_terminal_soc(
+        slots, config, _LIVE_DW_ENTRY_IDX, _LIVE_INITIAL_SOC
+    )
+
+    assert max_feasible == pytest.approx(config.demand_window_target_soc_pct)
+    # Guard the specific regression: the old value sat ~6.3 points under target.
+    assert max_feasible > 94.0
+
+    # And the per-slot credit really is the full untapered boost gain, undrifted.
+    short_runway = _live_slots(n_slots=4, dw_entry_idx=2)
+    two_slot = compute_max_feasible_terminal_soc(short_runway, config, 2, 40.0)
+    assert two_slot == pytest.approx(40.0 + 2 * _boost_gain_pct(config, _LIVE_INTERVAL))
+
+
+def test_max_feasible_is_a_true_upper_bound_on_the_dp():
+    """The documented contract: no feasible plan may exceed the reported max.
+
+    This is the property the drift double-count broke — the DP's own transitions reached
+    94.37 while max-feasible claimed 88.67. Charging is the most this trajectory ever
+    does, and it ignores the CV taper the DP pays, so it must bound the DP from above.
+    """
+    slots = _live_slots()
+    result, config = _plan(slots, _LIVE_INITIAL_SOC)
+    max_feasible = compute_max_feasible_terminal_soc(
+        slots, config, _LIVE_DW_ENTRY_IDX, _LIVE_INITIAL_SOC
+    )
+
+    assert result.success
+    assert result.dw_entry_soc_pct is not None
+    assert max_feasible is not None
+    assert result.dw_entry_soc_pct <= max_feasible + 1e-9, (
+        f"DP reached {result.dw_entry_soc_pct} above the claimed max {max_feasible}"
+    )
+
+
+def test_max_feasible_still_drifts_in_non_charging_slots():
+    """The undrifted path is scoped to credited charge slots only.
+
+    With every pre-DW price above ``max_precharge_price`` nothing is eligible, so the
+    trajectory must fall on pure solar/load drift and LOSE SOC. A blanket "never drift"
+    would have made this rise.
+    """
+    config = _config()
+    slots = _live_slots()
+    for slot in slots:
+        if not slot.is_demand_window_slot:
+            slot.buy_price = 0.50  # above max_precharge_price -> ineligible
+
+    max_feasible = compute_max_feasible_terminal_soc(
+        slots, config, _LIVE_DW_ENTRY_IDX, _LIVE_INITIAL_SOC
+    )
+    assert max_feasible is not None
+    assert max_feasible < _LIVE_INITIAL_SOC, (
+        "with no eligible slot the runway must drain on net load, not hold flat"
+    )
+
+
+def test_max_feasible_stacks_solar_surplus_on_a_charge_slot():
+    """Positive net load in a charge slot mirrors ``_charge_grid_with_solar``.
+
+    Grid charge and solar surplus both land in the battery; the solar side is not capped
+    by ``solar_charge_rate_kw`` here because that cap governs the solar-ONLY path.
+    """
+    config = _config()
+    slots = _live_slots(n_slots=4, dw_entry_idx=2, solar_kw=3.0, net_load_kw=-2.0)
+    surplus_kwh = slots[0].solar_kwh - slots[0].consumption_kwh
+    assert surplus_kwh > 0
+
+    max_feasible = compute_max_feasible_terminal_soc(slots, config, 2, 40.0)
+    per_slot = (
+        _boost_gain_pct(config, _LIVE_INTERVAL)
+        + surplus_kwh * config.charge_efficiency / config.battery_capacity_kwh * 100.0
+    )
+    assert max_feasible == pytest.approx(40.0 + 2 * per_slot)
+
+
+# ---------------------------------------------------------------------------
+# Defect 2 — the terminal penalty must be monotone through the floor.
+# ---------------------------------------------------------------------------
+
+
+def _terminal_penalties(slots, initial_soc_pct, **overrides):
+    """``(soc_grid, penalty_by_bin, config)`` from a real solve's terminal costs."""
+    config = _config(**overrides)
+    planner = DPPlanner(config)
+    inputs = OptimizerInputs(
+        cycle_id="penalty-903",
+        initial_soc_pct=initial_soc_pct,
+        slots=slots,
+        config=config,
+        all_solcast=[],
+    )
+    # Run a full solve first so the solver-derived floor is on the config.
+    planner.plan(inputs)
+    dw_entry_idx = next(
+        i for i, slot in enumerate(slots) if slot.is_demand_window_entry
+    )
+    soc_grid = [
+        config.min_soc_pct
+        + (config.max_soc_pct - config.min_soc_pct) * i / (config.soc_bins - 1)
+        for i in range(config.soc_bins)
+    ]
+    _dp, penalty_by_bin = planner._initialize_dp_tables(
+        len(slots),
+        soc_grid,
+        config,
+        dw_entry_idx,
+        False,
+        inputs,
+        config.hard_target_floor,
+    )
+    return soc_grid, penalty_by_bin, config
+
+
+def _degraded_floor_slots() -> list[SlotContext]:
+    """A runway too short to reach target, so the floor degrades below it.
+
+    Three 5-minute boost slots store ~8.5 points; from 40% that is nowhere near 95%, so
+    ``hard_target_floor`` lands well under target — the regime where the old gap-to-floor
+    penalty inverted against gap-to-target.
+    """
+    return _live_slots(n_slots=12, dw_entry_idx=3)
+
+
+def test_floor_degrades_below_target_in_this_fixture():
+    """Guard the fixture itself: the boundary only exists when floor < target."""
+    _result, config = _plan(_degraded_floor_slots(), 40.0)
+    assert config.hard_target_floor is not None
+    assert config.hard_target_floor < config.demand_window_target_soc_pct
+
+
+def test_terminal_penalty_is_monotone_non_increasing_in_soc():
+    """No SOC may be penalized MORE than a lower SOC — the attractor's root cause."""
+    soc_grid, penalties, config = _terminal_penalties(_degraded_floor_slots(), 40.0)
+    assert penalties, "strict mode must populate the DW-entry penalty"
+    assert config.hard_target_floor is not None
+
+    for bin_idx in range(1, len(soc_grid)):
+        lower, higher = penalties[bin_idx - 1], penalties[bin_idx]
+        assert higher <= lower + 1e-9, (
+            f"penalty rose with SOC: {soc_grid[bin_idx - 1]:.2f}% -> ${lower:.2f} but "
+            f"{soc_grid[bin_idx]:.2f}% -> ${higher:.2f}"
+        )
+
+
+def test_terminal_penalty_is_continuous_across_the_floor():
+    """The breach term must vanish at the floor, not step by (target - floor).
+
+    Measured pre-fix across the boundary: $3.24 just below, $615.60 just above.
+    """
+    soc_grid, penalties, config = _terminal_penalties(_degraded_floor_slots(), 40.0)
+    floor = config.hard_target_floor
+    assert floor is not None
+
+    below = max(i for i, soc in enumerate(soc_grid) if soc < floor)
+    above = below + 1
+    step = penalties[above] - penalties[below]
+    bin_width = soc_grid[above] - soc_grid[below]
+    # Slope is at most 2x the per-point penalty (gap-to-target + breach), so the step
+    # across one bin can never approach the (target - floor) cliff the old code had.
+    max_step = 2.0 * bin_width * (config.battery_capacity_kwh * 0.30 * 2) * 10
+    assert abs(step) <= max_step + 1e-9, (
+        f"discontinuity at the floor: ${penalties[below]:.2f} -> ${penalties[above]:.2f}"
+    )
+
+
+def test_below_floor_is_strictly_worse_than_the_floor():
+    """The floor still prunes: breaching it must cost more than clearing it."""
+    soc_grid, penalties, config = _terminal_penalties(_degraded_floor_slots(), 40.0)
+    floor = config.hard_target_floor
+    assert floor is not None
+
+    below = max(i for i, soc in enumerate(soc_grid) if soc < floor)
+    above = below + 1
+    assert penalties[below] > penalties[above]
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: the coupled fix on the live 2026-07-29 regime.
+# ---------------------------------------------------------------------------
+
+
+def test_live_20260729_plan_charges_the_cheap_runway_to_target():
+    """The planner must want the charge the hardware was already doing.
+
+    Live, the plan said ``hold`` at a 0.06 buy price with 12 eligible pre-DW slots while
+    the #901 execution backstop drove the battery at -5.0 kW. Both defects had to go: the
+    drift fix restores a 95 floor, and the monotone penalty stops the DP parking under it.
+    """
+    result, config = _plan(_live_slots(), _LIVE_INITIAL_SOC)
+
+    assert result.success
+    assert config.hard_target_floor == pytest.approx(95.0)
+    assert result.dw_entry_soc_pct is not None
+    assert result.dw_entry_soc_pct >= 93.0, (
+        f"DW entry {result.dw_entry_soc_pct}% — planner still parking under the floor"
+    )
+    pre_dw_charges = [
+        d
+        for d in result.decisions
+        if d.action in _CHARGE and d.slot_index < _LIVE_DW_ENTRY_IDX
+    ]
+    assert pre_dw_charges, (
+        "every pre-DW slot was cheap and eligible; plan charged in none"
+    )
+
+
+def test_dp_does_not_park_under_a_degraded_floor():
+    """The attractor itself, end to end: DW entry must CLEAR the floor, not sit under it.
+
+    With the old gap-to-floor penalty the DP settled one bin BELOW the floor (44.55
+    against a 45.15 floor) because every state above it was priced against the
+    DP-unreachable target and therefore cost more. Stated against the solver's own floor
+    rather than a pinned SOC, so it survives any legitimate move in the floor's value.
+    """
+    result, config = _plan(_degraded_floor_slots(), 40.0)
+    assert result.success
+    assert config.hard_target_floor is not None
+    assert config.hard_target_floor < config.demand_window_target_soc_pct, (
+        "fixture guard: this only tests anything while the floor is degraded"
+    )
+    assert result.dw_entry_soc_pct is not None
+    assert result.dw_entry_soc_pct >= config.hard_target_floor - 1e-9, (
+        f"DP parked at {result.dw_entry_soc_pct}% under its own floor "
+        f"{config.hard_target_floor}%"
+    )
+
+
+def test_max_feasible_is_monotone_in_initial_soc():
+    """More SOC in hand can never mean less SOC reachable.
+
+    A ``soc < charge_ceiling`` guard on the charge credit made a slot that arrived AT the
+    ceiling fall back through the drift branch, so 69.77 reported a LOWER max feasible
+    (93.88) than 67.15 did (95.0) — and the floor with it.
+    """
+    config = _config()
+    slots = _live_slots()
+    previous = None
+    for soc in (60.0, 65.0, 67.15, 69.77, 75.0, 90.0, 95.0):
+        value = compute_max_feasible_terminal_soc(
+            slots, config, _LIVE_DW_ENTRY_IDX, soc
+        )
+        assert value is not None
+        if previous is not None:
+            assert value >= previous - 1e-9, (
+                f"max feasible fell from {previous} to {value} as initial SOC rose"
+            )
+        previous = value

--- a/tests/engine/test_hard_dw_target_gate.py
+++ b/tests/engine/test_hard_dw_target_gate.py
@@ -352,11 +352,19 @@ def _expected_slack(config: OptimizerConfig, dw_entry_idx: int, soc: float) -> f
 # Captured from the code BEFORE the telemetry fields were added. Stage A is purely
 # additive; if any of these move, the DP's own input changed and the change is not
 # additive after all.
+#
+# The ``unreachable`` baseline was deliberately re-captured for #903 (34.697855750487335
+# -> 37.03703703703704). That fixture's single pre-DW slot is a CHARGE slot with negative
+# net load, and ``compute_max_feasible_terminal_soc`` used to subtract the slot's load
+# drift on top of the boost credit — double-counting a deficit the DP's own charge
+# transition imports from the grid. The new value is `20.0 + one untapered boost slot`,
+# with no drift. Every other baseline is unchanged, which is the point: the correction is
+# scoped to charge slots on a negative-net-load runway.
 _FLOOR_BASELINES = [
     # (case name, slots factory, initial SOC, config overrides, expected floor)
     ("repro", _repro_slots, 66.0, {}, 95.0),
     ("solar_sufficient", _solar_sufficient_slots, 66.0, {}, None),
-    ("unreachable", _unreachable_slots, 20.0, {}, 34.697855750487335),
+    ("unreachable", _unreachable_slots, 20.0, {}, 37.03703703703704),
     (
         "allow_under_target",
         _repro_slots,


### PR DESCRIPTION
Fixes #903.

## What was wrong

`compute_max_feasible_terminal_soc` under-reported the reachable DW-entry SOC on any day with negative net load before the demand window, degrading `hard_target_floor` below a physically reachable target. A non-monotone terminal penalty then turned that degraded floor into an *attractor*, so the DP deliberately parked under it rather than charging past it.

Observed live 2026-07-29 at a 0.06 $/kWh buy price with 12 eligible pre-DW slots: the plan said `hold` while the #901 execution backstop drove the hardware at −5.0 kW. The battery reached target anyway, which is why this went unnoticed — but the planner defect is real, and `terminal_shortfall_pct` reported a shortfall the controller was already fixing.

## Defect 1 — drift double-count (`engine/constraints.py`)

The simulation subtracted forecast net load in **every** pre-DW slot, including the slots where it also credited a boost grid charge. The DP's own charge transition imports the load deficit from the grid rather than draining the battery (`_charge_grid_with_deficit`), so the documented upper-bound property was false whenever net load was negative — max-feasible returned 88.67 while the DP's own transitions reached 94.37.

A charge slot is now simulated the way `_transition_charge_grid` actually moves SOC: boost credit with no drift, solar surplus stacked on top exactly as `_charge_grid_with_solar` does. Ineligible slots keep the solar/load drift path.

## Defect 2 — non-monotone terminal penalty (`engine/core.py`)

Below the floor the penalty measured the gap to the **floor**; at or above it, the gap to the **target**. Because the floor is `min(target, max_feasible)`, a degraded floor made below-floor states strictly cheaper than states just above it:

| SOC | penalty (pre-fix) |
|---|---|
| just below floor | $48.66 |
| just above floor | $4013.18 |

The below-floor branch now charges gap-to-target **plus** the floor breach. Non-increasing in SOC across the whole below-target range, continuous at the floor (the breach term vanishes there), and still strictly worse for a breach.

## Also fixed: max-feasible was non-monotone in initial SOC

Found while verifying. The `soc < charge_ceiling` guard sent a slot that arrived *at* the ceiling down the drift branch, so it fell back under — a higher initial SOC could report a lower max feasible (67.15 → 95.0 but 69.77 → 93.88). The guard is removed; the existing clamp already refuses to credit anything above the ceiling.

## Tests

New `tests/engine/test_dw_floor_negative_net_load_runway.py` — 11 tests on the negative-net-load pre-DW runway, the shape that had no coverage at all, which is how this survived a green suite. **Seven fail on pre-fix code**, including:

- `test_max_feasible_does_not_subtract_drift_in_charge_slots` — 87.73 → 95.0
- `test_max_feasible_is_a_true_upper_bound_on_the_dp` — the broken contract
- `test_dp_does_not_park_under_a_degraded_floor` — end-to-end attractor: DP parked at 44.55 under its own 45.15 floor
- `test_terminal_penalty_is_monotone_non_increasing_in_soc` / `_is_continuous_across_the_floor` / `test_below_floor_is_strictly_worse_than_the_floor`

`_FLOOR_BASELINES["unreachable"]` is deliberately re-captured (34.697855750487335 → 37.03703703703704). That fixture's single pre-DW slot is a charge slot with negative net load; the new value is `20.0 + one untapered boost slot`, with no drift. Every other baseline is unchanged, which scopes the correction to exactly the affected shape.

Full suite: **3354 passed, 1 xfailed**. `ruff check` and `ruff format --check` clean on all touched files.

## Not addressed

SOC bin quantization still leaves ~1 point of residual `terminal_shortfall_pct` on the live fixture. #903 lists it as contributory rather than a fix target, so it is not folded in here.

## Verification to watch after deploy

- DW entry vs the 95% target on the next negative-net-load afternoon.
- `hard_target_floor` should sit at 95 (not a degraded value) whenever the runway is genuinely cheap and eligible.
- Sawtooth guard: no charging inside or after the DW. The wider boost unlock (`hard_floor_needs_boost` fires more often now that the floor stops degrading) is still scoped to pre-DW slots.
