### PR TITLE
fix(optimizer): fund pre-charge for forecast price spikes outside the demand window

### DIFF
--- a/custom_components/localshift/engine/constraints.py
+++ b/custom_components/localshift/engine/constraints.py
@@ -167,6 +167,21 @@ def feasible_actions(
                 slot.buy_price <= cheap_threshold * VERY_CHEAP_PRICE_FACTOR
             )
 
+            # Spike-event funding: a slot that pays for a materially dearer future
+            # interval is admitted even when it is above the cheap threshold. Without
+            # this the charge is not merely discouraged, it is ABSENT from the feasible
+            # set, so no penalty or bonus anywhere in the DP can buy it — the failure
+            # behind the 2026-08-05 incident, where a $1.65 spike was met at the floor
+            # because the overnight trough sat two cents above base_cheap_price.
+            # Only the normal rate is unlocked: boost stays gated on the existing
+            # very-cheap/target logic so this can never become #800 in a new costume.
+            if (
+                config.spike_funding_slots is not None
+                and slot_idx in config.spike_funding_slots
+                and not price_is_cheap
+            ):
+                actions.append(PlannerAction.CHARGE_GRID_NORMAL)
+
             if price_is_cheap:
                 actions.append(PlannerAction.CHARGE_GRID_NORMAL)
                 # Shortfall-aware boost (2026-06-11 incident): boost is normally reserved

--- a/custom_components/localshift/engine/core.py
+++ b/custom_components/localshift/engine/core.py
@@ -43,6 +43,7 @@ from custom_components.localshift.engine.solar import (
     get_forecast_accuracy,
     projected_solcast_gain_pct,
 )
+from custom_components.localshift.engine.spike_event import find_funding_slots
 from custom_components.localshift.engine.transitions import _tapered_stored_kwh
 from custom_components.localshift.engine.transitions import transition as _transition
 from custom_components.localshift.engine.types import (
@@ -225,6 +226,21 @@ def _is_urgency_precharge(
 
     """
 
+    # Spike-event funding exemption. A funding slot has ALREADY been proven to clear
+    # min_cycle_saving — that spread IS its qualification test in
+    # spike_event.find_funding_slots — so applying the gate again is redundant. It is
+    # also actively harmful: the gate is non-monotone, and leaving it on let a strictly
+    # larger feasible set produce a strictly WORSE plan on the DP's own objective
+    # (measured: projected net cost 1.2242 -> 1.5089 purely by declaring a second event;
+    # ablation confirms min_cycle_saving is the cause and switching_penalty is not).
+    # Unlike the DW branches below this is not scoped to pre-DW slots: the whole point is
+    # to fund an interval the demand window does not cover.
+    if (
+        config.spike_funding_slots is not None
+        and slot_idx in config.spike_funding_slots
+    ):
+        return True
+
     return (
         terminal_penalty_idx is not None
         and slot_idx < terminal_penalty_idx
@@ -374,7 +390,7 @@ class DPPlanner:
         start = time.monotonic()
 
         try:
-            result = self._solve(inputs)
+            result = self._solve_guarded(inputs)
 
         except Exception as exc:  # noqa: BLE001
             _LOGGER.error(
@@ -391,6 +407,94 @@ class DPPlanner:
         result.solve_time_seconds = time.monotonic() - start
 
         return result
+
+    def _solve_guarded(self, inputs: OptimizerInputs) -> OptimizerResult:
+        """Solve with and without spike funding, keeping the cheaper plan.
+
+        WHY A GUARD RATHER THAN A BETTER GATE
+        -------------------------------------
+        This DP is approximate: the min-cycle-saving gate prunes actions using a
+        comparison that is not part of the (slot, soc_bin) state, so enlarging the
+        feasible set is NOT guaranteed to improve the optimum. A 200-scenario sweep
+        of the qualification rule on its own found ~4% of firing scenarios came out
+        WORSE than the unmodified planner (worst case $0.49) — the same shape as the
+        long tail of anti-cycling regressions (#800/#804/#816).
+
+        Rather than chase monotonicity in an approximate solver, dominate it: solve
+        both ways and keep the winner on projected net cost. Harm becomes impossible
+        by construction, and the sweep's no-harm and monotonicity properties both go
+        from FAIL to PASS. Cost is one extra solve (~0.04 s live) and it is only paid
+        on days where something actually qualifies.
+
+        Falls back to the baseline plan on any failure in the spike path, so a bug
+        here can degrade the feature but never the planner.
+        """
+        baseline = self._solve(inputs)
+
+        config = inputs.config
+        if not getattr(config, "spike_precharge_enabled", True):
+            return baseline
+
+        try:
+            funding = find_funding_slots(inputs.slots, config)
+        except Exception as exc:  # noqa: BLE001
+            _LOGGER.warning("Spike funding detection failed, using baseline: %s", exc)
+            return baseline
+
+        if not funding:
+            return baseline
+
+        try:
+            config.spike_funding_slots = funding
+            candidate = self._solve(inputs)
+        except Exception as exc:  # noqa: BLE001
+            _LOGGER.warning("Spike-funded solve failed, using baseline: %s", exc)
+            return baseline
+        finally:
+            config.spike_funding_slots = None
+
+        if not candidate.success:
+            return baseline
+
+        # Positive => the widening would save money. Recorded either way: the common
+        # outcome is a dead-on tie (qualification fires, the DP declines to use the
+        # extra option, plans are identical), and lumping ties in with genuine
+        # rejections makes a benign 40%-of-firing-cycles look like a 40% failure rate.
+        delta = baseline.projected_net_cost - candidate.projected_net_cost
+
+        # Strictly cheaper only — ties keep the baseline so the plan never churns
+        # for nothing.
+        if delta > 0:
+            _LOGGER.info(
+                "SPIKE PRECHARGE: %d funding slot(s) accepted, "
+                "projected net cost $%.4f -> $%.4f (saves $%.4f)",
+                len(funding),
+                baseline.projected_net_cost,
+                candidate.projected_net_cost,
+                delta,
+            )
+            candidate.spike_funding_slot_count = len(funding)
+            candidate.spike_funding_accepted = True
+            candidate.spike_funding_net_cost_delta = delta
+            return candidate
+
+        if delta < 0:
+            _LOGGER.debug(
+                "SPIKE PRECHARGE: %d funding slot(s) REJECTED by guard — "
+                "$%.4f would have been worse than $%.4f",
+                len(funding),
+                candidate.projected_net_cost,
+                baseline.projected_net_cost,
+            )
+        else:
+            _LOGGER.debug(
+                "SPIKE PRECHARGE: %d funding slot(s) qualified but changed nothing",
+                len(funding),
+            )
+        baseline.spike_funding_slot_count = len(funding)
+        baseline.spike_funding_accepted = False
+        baseline.spike_funding_net_cost_delta = delta
+        return baseline
 
     # ------------------------------------------------------------------
 

--- a/custom_components/localshift/engine/optimizer_runner.py
+++ b/custom_components/localshift/engine/optimizer_runner.py
@@ -639,6 +639,17 @@ def _build_summary(
     summary["peak_soc_pct"] = result.peak_soc_pct
     summary["dw_entry_soc_pct"] = result.dw_entry_soc_pct
 
+    # Spike-event pre-charge funding. Read the count and the delta together: a zero
+    # count means nothing qualified (the ordinary day), while a non-zero count with
+    # accepted=False is USUALLY a benign tie (delta == 0), not a guard rejection
+    # (delta < 0). Without the delta the two are indistinguishable and a normal ~40%
+    # tie rate reads as a 40% failure rate.
+    summary["spike_funding_slot_count"] = result.spike_funding_slot_count
+    summary["spike_funding_accepted"] = result.spike_funding_accepted
+    summary["spike_funding_net_cost_delta"] = round(
+        result.spike_funding_net_cost_delta, 4
+    )
+
     return summary
 
 

--- a/custom_components/localshift/engine/spike_event.py
+++ b/custom_components/localshift/engine/spike_event.py
@@ -1,0 +1,171 @@
+"""Spike-event pre-charge funding (issue: forecast spike hit at the SOC floor).
+
+WHY THIS EXISTS
+---------------
+``feasible_actions`` omits every CHARGE_* action when a slot's buy price exceeds
+its cheap threshold, so the DP never *prices* a charge in those slots — it cannot
+choose one at any cost. The only thing that ever raises that threshold is
+``compute_pre_dw_charge_thresholds``, which is scoped to pre-demand-window slots
+and sized from the demand-window target deficit.
+
+A forecast price spike outside a demand window therefore has **no funder**: on
+2026-08-05 the horizon carried a $1.65 print at 07:30 while the overnight trough
+sat at $0.17–0.21 and ``base_cheap_price`` was $0.16. Two cents of threshold
+blocked a $1.45/kWh trade, the plan held at the 10% floor through the whole
+morning, and 71% of the projected day cost landed in that one block.
+
+WHAT THIS MODULE DOES
+---------------------
+Identifies *funding slots*: slots where charging should be admitted to the
+feasible set because stored energy bought there displaces materially dearer
+energy later. Qualification mirrors the demand-window water level — sort the
+future by price, accumulate the net load the battery could actually displace,
+and require the **marginal** displaced price to beat this slot by at least the
+operator's own ``min_cycle_saving`` (grossed up for round-trip losses).
+
+Using ``min_cycle_saving`` as the bar is deliberate: it is the operator's
+existing statement of "a cycle is only worth it if it saves this much", so a
+qualifying slot has *already* been proven to clear that gate. Callers therefore
+also exempt these slots from the min-cycle gate itself (see
+``core._is_urgency_precharge``) — re-applying it is both redundant and harmful,
+because that gate is non-monotone and can reject a strictly better plan when the
+feasible set grows.
+
+WHAT THIS MODULE DELIBERATELY DOES NOT DO
+-----------------------------------------
+It does not hold a reserve. Measured 2026-08-05: given only a feasible charge
+action the DP's own economics buy immediately before the spike and hold through
+it unaided (spike-slot import $0.635 -> $0.00). No second terminal index, no
+time-varying floor, no reserve-hold machinery is required — and none should be
+added without first re-measuring that result.
+
+Demand-window slots are excluded from the *event* side: energy inside the DW is
+already funded by the DW target machinery, and letting this module bid for it
+would re-litigate a solved problem (and re-open the #800 sawtooth on ordinary
+days, where the evening DW peak is the dearest thing in the horizon).
+
+SAFETY
+------
+Qualification is intentionally permissive; correctness comes from the caller's
+guard, which solves with and without the widening and keeps the cheaper plan
+(``DPPlanner.plan``). A 200-scenario sweep showed qualification alone still
+harms ~4% of firing scenarios (worst $0.49) because the DP is approximate; the
+guard removes that by construction.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from custom_components.localshift.engine.types import OptimizerConfig, SlotContext
+
+_LOGGER = logging.getLogger(__name__)
+
+# A funding slot must displace at least this fraction of what one slot of
+# normal-rate charging actually stores. Below that the trade is noise.
+_MIN_DISPLACED_FRACTION = 0.5
+
+
+def required_spread(config: OptimizerConfig) -> float:
+    """Price gap a funding slot must beat, grossed up for round-trip losses.
+
+    ``min_cycle_saving`` is stated per kWh *cycled*; a kWh bought from the grid
+    only returns ``charge_efficiency * discharge_efficiency`` of itself, so the
+    raw threshold understates the gap the arbitrage must clear.
+    """
+    round_trip = config.charge_efficiency * config.discharge_efficiency
+    if round_trip <= 0:
+        return float("inf")
+    return config.min_cycle_saving / round_trip
+
+
+def _slot_hours(slot: SlotContext) -> float:
+    return slot.slot_interval_minutes / 60.0
+
+
+def _storable_kwh(slot: SlotContext, config: OptimizerConfig) -> float:
+    """Energy one slot of normal-rate grid charging actually puts in the battery."""
+    return config.charge_rate_kw * _slot_hours(slot) * config.charge_efficiency
+
+
+def _displaces_enough(
+    j: int,
+    slots: list[SlotContext],
+    by_price_desc: list[int],
+    displaceable: list[float],
+    spread: float,
+    needed_kwh: float,
+) -> bool:
+    """True when the future holds ``needed_kwh`` of load all priced a full spread above j.
+
+    ``by_price_desc`` is ranked dearest-first, so the first slot that fails the spread
+    test ends the search: nothing further can clear it. The last slot accepted sets the
+    marginal displaced price, mirroring the demand-window funding water level.
+    """
+    accumulated = 0.0
+    own_price = slots[j].buy_price
+    for i in by_price_desc:
+        if i <= j:
+            continue
+        if slots[i].buy_price - own_price < spread:
+            return False
+        accumulated += displaceable[i]
+        if accumulated >= needed_kwh:
+            return True
+    return False
+
+
+def find_funding_slots(
+    slots: list[SlotContext],
+    config: OptimizerConfig,
+) -> frozenset[int]:
+    """Slots whose grid charge should be admitted to fund a later expensive interval.
+
+    A slot ``j`` qualifies when the future contains enough displaceable net load,
+    all of it priced at least ``required_spread`` above ``slots[j].buy_price``, to
+    absorb a meaningful share of one slot's worth of charging.
+
+    Returns an empty set (feature fully inert) when the mode is not
+    self-consumption, ``min_cycle_saving`` is unset, or nothing qualifies.
+    """
+    if config.optimization_mode != "self_consumption":
+        return frozenset()
+    if not slots or config.min_cycle_saving <= 0:
+        return frozenset()
+
+    spread = required_spread(config)
+    if spread == float("inf"):
+        return frozenset()
+
+    # Net load the battery could displace in each slot. Demand-window slots are
+    # excluded: that energy already has a funder (the DW target), and bidding for
+    # it here would re-open the overnight sawtooth on ordinary days.
+    displaceable = [
+        0.0
+        if slot.is_demand_window_slot
+        else max(0.0, slot.consumption_kwh - slot.solar_kwh)
+        for slot in slots
+    ]
+
+    # Future slots ranked dearest-first: the battery discharges into whichever
+    # slots it likes, so the value of a stored kWh is set by the dearest load it
+    # can displace, and the marginal price is the one that has to clear the gap.
+    by_price_desc = sorted(range(len(slots)), key=lambda i: (-slots[i].buy_price, i))
+
+    funding: set[int] = set()
+    for j, slot in enumerate(slots):
+        if slot.is_demand_window_slot:
+            continue  # grid import is forbidden inside the DW anyway
+        needed = _storable_kwh(slot, config) * _MIN_DISPLACED_FRACTION
+        if needed <= 0:
+            continue
+        if _displaces_enough(j, slots, by_price_desc, displaceable, spread, needed):
+            funding.add(j)
+
+    if funding:
+        _LOGGER.debug(
+            "Spike funding: %d slot(s) qualified at spread $%.3f/kWh",
+            len(funding),
+            spread,
+        )
+    return frozenset(funding)

--- a/custom_components/localshift/engine/types.py
+++ b/custom_components/localshift/engine/types.py
@@ -293,6 +293,35 @@ class OptimizerConfig:
     ``base_cheap_price`` — the #800 overnight-sawtooth protection is untouched).
     None ⇒ legacy behaviour."""
 
+    spike_precharge_enabled: bool = True
+    """Operator kill switch for spike-event pre-charge funding.
+
+    False ⇒ ``DPPlanner.plan`` never computes funding slots and the planner behaves
+    exactly as it did before the feature existed."""
+
+    spike_funding_slots: frozenset[int] | None = None
+    """Solver-derived (set by ``DPPlanner.plan``): slots whose grid charge is admitted to
+    the feasible set so it can fund a later expensive interval outside the demand window.
+
+    Computed by ``spike_event.find_funding_slots``. Without this, a forecast price spike
+    has no funder at all: ``cheap_threshold_for_slot`` only ever widens for the
+    demand-window target, so an overnight trough two cents above ``base_cheap_price``
+    blocks arbitrage worth dollars per kWh (2026-08-05: a $1.65 print met at the 10% floor).
+
+    Consumed in exactly two places, both of which must agree:
+      - ``constraints.feasible_actions`` — admits CHARGE_GRID_NORMAL for these slots.
+      - ``core._is_urgency_precharge`` — exempts them from the min-cycle-saving gate,
+        which they have already been proven to clear by construction (qualification uses
+        ``min_cycle_saving`` as its bar). Re-applying it is redundant AND harmful: that
+        gate is non-monotone and can reject a strictly better plan when the feasible set
+        grows.
+
+    Deliberately NOT routed through ``cheap_threshold_for_slot``: that function also feeds
+    the futile-cycling penalty and the floor-routing helpers, so changing its return value
+    would mutate the objective function rather than only the choice set.
+
+    None ⇒ feature inert (legacy behaviour)."""
+
     hard_target_floor: float | None = None
     """Solver-derived (set by ``DPPlanner._solve``): the hard DW-target feasibility floor
     (issue #885) — ``min(target, max feasible/eligible SOC at DW entry)``.
@@ -681,6 +710,30 @@ class OptimizerResult:
 
     terminal_shortfall_pct: float = 0.0
     """Residual SOC shortfall (%) at demand window entry, if any."""
+
+    spike_funding_slot_count: int = 0
+    """How many slots qualified as spike-event pre-charge funding this cycle.
+
+    0 means nothing qualified — the common case on an ordinary day, and the signal
+    that the feature stayed fully inert."""
+
+    spike_funding_accepted: bool = False
+    """True when the spike-funded plan beat the baseline and was kept.
+
+    Read this together with ``spike_funding_net_cost_delta`` — False alone does NOT
+    mean the guard caught a bad plan. Measured over a 200-scenario sweep, ~40% of
+    cycles that qualify end in a dead tie (the DP simply declines the extra option),
+    and those are indistinguishable from genuine rejections on this flag alone."""
+
+    spike_funding_net_cost_delta: float = 0.0
+    """Baseline minus spike-funded projected net cost ($), when funding slots existed.
+
+    > 0  the widening saved money and was adopted.
+    == 0 it qualified but changed nothing — the common, benign case.
+    < 0  the guard REJECTED it as worse. A persistent run of these means the
+         qualification rule is too permissive and should be tightened; an occasional
+         one is expected, because the min-cycle-saving gate makes this DP
+         non-monotone."""
 
     can_solar_reach_target: bool = False
     """True if solar alone can reach DW target (no grid charge, no export). Phase 4, #441."""

--- a/custom_components/localshift/sensors/optimizer.py
+++ b/custom_components/localshift/sensors/optimizer.py
@@ -149,6 +149,12 @@ class OptimizerSummarySensor(LocalShiftSensorBase):
             "initial_soc_pct": summary.get("initial_soc_pct"),
             "peak_soc_pct": summary.get("peak_soc_pct"),
             "dw_entry_soc_pct": summary.get("dw_entry_soc_pct"),
+            # Spike-event pre-charge. slot_count == 0 is the ordinary day (nothing
+            # qualified); a non-zero count with accepted False is usually a benign
+            # tie — the delta is what separates that from a real guard rejection.
+            "spike_funding_slot_count": summary.get("spike_funding_slot_count"),
+            "spike_funding_accepted": summary.get("spike_funding_accepted"),
+            "spike_funding_net_cost_delta": summary.get("spike_funding_net_cost_delta"),
             # Projected (above) and actual (below) sit together deliberately. These
             # five read from `d`, not `summary`: the summary is rebuilt every cycle
             # and is empty on a failed cycle — precisely when the real entry SOC

--- a/tests/engine/test_spike_event_precharge.py
+++ b/tests/engine/test_spike_event_precharge.py
@@ -1,0 +1,363 @@
+"""Spike-event pre-charge funding.
+
+Built from the live 2026-08-05 horizon, where a forecast $1.65/kWh print at 07:30
+was met at the 10% SOC floor: the plan imported straight through the whole
+05:30-09:00 block, which carried 71% of the projected day cost. Root cause was
+not a bad price signal — it was that ``feasible_actions`` never offered the DP a
+charge action in those overnight slots, because the only thing that widens the
+cheap-price gate is the demand-window funder and a morning spike is not a demand
+window.
+
+The flat-morning case is the load-bearing test. A naive widening (admit charging
+ahead of any dearer interval) reproduces the #800 overnight sawtooth exactly —
+measured on this fixture: six consecutive overnight charge slots plus proactive
+export, import $1.08 -> $2.51. Everything here that asserts inertness exists to
+stop that shipping.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from custom_components.localshift.engine.optimizer_dp import (
+    DPPlanner,
+    OptimizerConfig,
+    OptimizerInputs,
+    PlannerAction,
+    SlotContext,
+)
+from custom_components.localshift.engine.spike_event import (
+    find_funding_slots,
+    required_spread,
+)
+
+CHARGE_ACTIONS = {PlannerAction.CHARGE_GRID_NORMAL, PlannerAction.CHARGE_GRID_BOOST}
+
+# Live buy prices, 2026-08-05 13:17 Sydney (sensor.localshift_forecast_prices).
+# 10 x 5-min slots from 13:15, then 30-min slots through to 13:00 next day.
+_BUY = [
+    0.12,
+    0.12,
+    0.12,
+    0.12,
+    0.12,
+    0.12,
+    0.12,
+    0.12,
+    0.12,
+    0.12,
+    0.13,
+    0.13,
+    0.13,
+    0.14,
+    0.19,
+    0.25,
+    0.29,
+    0.33,
+    0.26,
+    0.29,
+    0.35,
+    0.34,
+    0.41,
+    0.34,
+    0.40,
+    0.27,
+    0.36,
+    0.23,
+    0.24,
+    0.21,
+    0.20,
+    0.21,
+    0.20,
+    0.19,
+    0.18,
+    0.17,
+    0.18,
+    0.19,
+    0.18,
+    0.19,
+    0.21,
+    0.31,
+    0.61,
+    0.76,
+    1.65,
+    0.63,
+    0.26,
+    0.40,
+    0.20,
+    0.17,
+    0.15,
+    0.14,
+    0.12,
+    0.12,
+    0.11,
+    0.20,
+]
+SPIKE_IDX = 44  # 07:30, $1.65
+MORNING_BLOCK = range(40, 48)  # 05:30-09:00
+DW_ENTRY, DW_EXIT = 11, 23  # today's 15:00-21:00 demand window
+
+# Load/solar back-derived from the live plan's objective terms; cross-checks
+# against the observed 100% -> 10% battery excursion (12.15 kWh) to within 4%.
+_LOAD_KW = {
+    0: 0.64,
+    1: 0.64,
+    2: 0.62,
+    3: 0.62,
+    4: 0.62,
+    5: 0.64,
+    6: 0.64,
+    7: 0.82,
+    8: 0.62,
+    9: 0.60,
+    10: 0.60,
+    11: 0.60,
+    12: 0.60,
+    13: 0.70,
+    14: 0.70,
+    15: 0.90,
+    16: 1.10,
+    17: 1.45,
+    18: 1.35,
+    19: 1.50,
+    20: 1.45,
+    21: 1.40,
+    22: 1.30,
+    23: 0.90,
+}
+_SOLAR_KW = {
+    6: 0.0,
+    7: 0.05,
+    8: 0.55,
+    9: 1.40,
+    10: 2.40,
+    11: 3.10,
+    12: 3.30,
+    13: 3.10,
+    14: 2.40,
+    15: 1.50,
+    16: 0.70,
+    17: 0.10,
+}
+_FLAT_MORNING = {41: 0.22, 42: 0.24, 43: 0.26, 44: 0.25, 45: 0.23}
+
+
+def _hour_of(idx: int) -> int:
+    """Wall-clock hour for a slot index, matching the live slot schedule."""
+    if idx < 10:
+        return 13
+    minutes = 14 * 60 + 30 + (idx - 10) * 30
+    return (minutes // 60) % 24
+
+
+def _slots(price_overrides: dict[int, float] | None = None) -> list[SlotContext]:
+    overrides = price_overrides or {}
+    out = []
+    for idx, base in enumerate(_BUY):
+        buy = overrides.get(idx, base)
+        minutes = 5 if idx < 10 else 30
+        hours = minutes / 60.0
+        hour = _hour_of(idx)
+        out.append(
+            SlotContext(
+                slot_index=idx,
+                timestamp_iso=f"2026-08-05T{hour:02d}:00:00",
+                slot_interval_minutes=minutes,
+                buy_price=buy,
+                sell_price=round(max(0.0, min(buy - 0.08, buy * 0.87)), 4),
+                solar_kwh=round(_SOLAR_KW.get(hour, 0.0) * hours, 4),
+                consumption_kwh=round(_LOAD_KW[hour] * hours, 4),
+                is_demand_window_entry=(idx == DW_ENTRY),
+                is_demand_window_slot=(DW_ENTRY <= idx <= DW_EXIT),
+            )
+        )
+    return out
+
+
+def _config(**overrides) -> OptimizerConfig:
+    base = dict(
+        battery_capacity_kwh=13.5,
+        min_soc_pct=10.0,
+        max_soc_pct=100.0,
+        demand_window_target_soc_pct=95.0,
+        optimization_mode="self_consumption",
+        switching_penalty=0.08,
+        target_shortfall_penalty_per_pct=0.10,
+        min_cycle_saving=0.25,
+        max_precharge_price=0.20,
+        effective_cheap_price=0.16,
+        base_cheap_price=0.16,
+        soc_bins=100,
+    )
+    base.update(overrides)
+    return OptimizerConfig(**base)
+
+
+def _plan(price_overrides=None, initial_soc=57.225, **config_overrides):
+    return DPPlanner().plan(
+        OptimizerInputs(
+            cycle_id="spike-test",
+            initial_soc_pct=initial_soc,
+            slots=_slots(price_overrides),
+            config=_config(**config_overrides),
+        )
+    )
+
+
+def _charges(result):
+    return [d.slot_index for d in result.decisions if d.action in CHARGE_ACTIONS]
+
+
+def _block_import(result):
+    return sum(
+        result.decisions[i].objective_terms.import_cost
+        for i in MORNING_BLOCK
+        if result.decisions[i].objective_terms
+    )
+
+
+# --- detection -----------------------------------------------------------------------
+
+
+def test_required_spread_grosses_up_for_round_trip_losses():
+    """min_cycle_saving is per kWh cycled; a bought kWh only returns ~87% of itself."""
+    cfg = _config(
+        min_cycle_saving=0.25, charge_efficiency=0.92, discharge_efficiency=0.95
+    )
+    assert required_spread(cfg) == pytest.approx(0.25 / (0.92 * 0.95), rel=1e-9)
+    assert required_spread(cfg) > 0.25
+
+
+def test_detects_funding_slots_on_the_live_spike_horizon():
+    assert find_funding_slots(_slots(), _config())
+
+
+def test_detects_nothing_when_the_morning_is_ordinary():
+    """The #800 guard: an ordinary morning must qualify NOTHING."""
+    assert find_funding_slots(_slots(_FLAT_MORNING), _config()) == frozenset()
+
+
+def test_demand_window_slots_are_never_funding_slots():
+    """Grid import is forbidden inside the DW, and DW energy has its own funder."""
+    funding = find_funding_slots(_slots(), _config())
+    assert not any(DW_ENTRY <= i <= DW_EXIT for i in funding)
+
+
+def test_inert_outside_self_consumption_mode():
+    assert (
+        find_funding_slots(_slots(), _config(optimization_mode="arbitrage"))
+        == frozenset()
+    )
+
+
+def test_inert_when_min_cycle_saving_is_disabled():
+    """Without an operator-stated cycle bar there is no qualification test to apply."""
+    assert find_funding_slots(_slots(), _config(min_cycle_saving=0.0)) == frozenset()
+
+
+# --- planning ------------------------------------------------------------------------
+
+
+def test_baseline_reproduces_the_incident():
+    """Without the feature the plan sits at the floor and imports through the spike."""
+    result = _plan(spike_precharge_enabled=False)
+    assert result.success
+    assert result.decisions[SPIKE_IDX].action == PlannerAction.HOLD
+    assert result.decisions[SPIKE_IDX].predicted_soc_pct == pytest.approx(10.0, abs=0.5)
+    assert result.decisions[SPIKE_IDX].objective_terms.import_cost > 0.5
+
+
+def test_spike_funding_serves_the_spike_from_the_battery():
+    enabled = _plan()
+    baseline = _plan(spike_precharge_enabled=False)
+
+    assert enabled.spike_funding_accepted
+    assert enabled.projected_net_cost < baseline.projected_net_cost
+    # The battery, not the grid, covers the $1.65 slot.
+    assert enabled.decisions[SPIKE_IDX].objective_terms.import_cost == pytest.approx(
+        0.0, abs=1e-6
+    )
+    assert _block_import(enabled) < _block_import(baseline) / 2
+
+
+def test_spike_funding_adds_minimal_charging():
+    """Widening eligibility must not turn into promiscuous overnight charging.
+
+    Many slots qualify; the DP is expected to take very few. A regression here is
+    the #800 sawtooth returning.
+    """
+    added = set(_charges(_plan())) - set(_charges(_plan(spike_precharge_enabled=False)))
+    assert len(added) <= 2, f"expected a minimal top-up, got {sorted(added)}"
+    assert all(i < SPIKE_IDX for i in added)
+
+
+def test_ordinary_morning_plan_is_untouched():
+    """The regression that matters: no spike -> byte-identical plan."""
+    enabled = _plan(_FLAT_MORNING)
+    baseline = _plan(_FLAT_MORNING, spike_precharge_enabled=False)
+    assert [d.action for d in enabled.decisions] == [
+        d.action for d in baseline.decisions
+    ]
+    assert enabled.projected_net_cost == pytest.approx(baseline.projected_net_cost)
+    assert enabled.spike_funding_slot_count == 0
+    assert not enabled.spike_funding_accepted
+
+
+def test_kill_switch_restores_legacy_behaviour_exactly():
+    off = _plan(spike_precharge_enabled=False)
+    assert off.spike_funding_slot_count == 0
+    assert not off.spike_funding_accepted
+    assert off.decisions[SPIKE_IDX].objective_terms.import_cost > 0.5
+
+
+def test_guard_never_accepts_a_worse_plan():
+    """The core safety property.
+
+    Qualification alone is not safe — a 200-scenario sweep found ~4% of firing
+    scenarios came out WORSE than the baseline (worst $0.49), because the
+    min-cycle-saving gate makes this DP non-monotone: enlarging the feasible set can
+    change which plan wins. The guard removes that by construction, so this must hold
+    for every scenario, not merely the happy path.
+    """
+    for overrides in (None, _FLAT_MORNING, {SPIKE_IDX: 0.30}, {SPIKE_IDX: 5.00}):
+        for soc in (15.0, 57.225, 90.0):
+            enabled = _plan(overrides, initial_soc=soc)
+            baseline = _plan(overrides, initial_soc=soc, spike_precharge_enabled=False)
+            assert enabled.projected_net_cost <= baseline.projected_net_cost + 1e-9, (
+                f"guard admitted a worse plan (overrides={overrides}, soc={soc})"
+            )
+
+
+def test_low_soc_does_not_trigger_panic_buying():
+    """Starting near the floor must not turn the widening into indiscriminate charging."""
+    enabled = _plan(initial_soc=12.0)
+    baseline = _plan(initial_soc=12.0, spike_precharge_enabled=False)
+    assert enabled.projected_net_cost <= baseline.projected_net_cost
+    added = set(_charges(enabled)) - set(_charges(baseline))
+    assert len(added) <= 2, f"expected a bounded top-up, got {sorted(added)}"
+
+
+def test_tie_is_distinguishable_from_a_guard_rejection():
+    """``accepted=False`` alone must not be read as "the guard caught a bad plan".
+
+    ~40% of qualifying cycles end in a dead tie (the DP declines the extra option).
+    Conflating those with genuine rejections turns a benign outcome into what looks
+    like a 40% failure rate in the field, so the delta carries the real signal.
+    """
+    accepted = _plan()
+    assert accepted.spike_funding_accepted
+    assert accepted.spike_funding_net_cost_delta > 0
+
+    # Nothing qualifies -> no verdict to report at all.
+    inert = _plan(_FLAT_MORNING)
+    assert inert.spike_funding_slot_count == 0
+    assert inert.spike_funding_net_cost_delta == 0.0
+
+
+def test_guard_records_a_non_positive_delta_when_it_declines():
+    """Whenever the guard keeps the baseline, the delta must justify that choice."""
+    for overrides in (None, _FLAT_MORNING, {SPIKE_IDX: 0.30}):
+        for soc in (15.0, 57.225, 90.0):
+            result = _plan(overrides, initial_soc=soc)
+            if result.spike_funding_slot_count and not result.spike_funding_accepted:
+                assert result.spike_funding_net_cost_delta <= 0

--- a/tests/test_min_cycle_saving_gate.py
+++ b/tests/test_min_cycle_saving_gate.py
@@ -14,6 +14,8 @@ Runs ENTIRELY OFFLINE. Two worlds:
 
 from __future__ import annotations
 
+import pytest
+
 from custom_components.localshift.engine.optimizer_dp import (
     DPPlanner,
     OptimizerConfig,
@@ -45,6 +47,7 @@ def _restore_406_double_credit(monkeypatch):
         "net_cost",
         property(lambda self: orig(self) - self.self_consumption_value),
     )
+
 
 PROD_DEFAULT = 0.25  # production DEFAULT_MIN_CYCLE_SAVING
 
@@ -186,17 +189,28 @@ def test_gate_blocks_micro_overnight_arbitrage(monkeypatch):
 def test_gate_preserves_spike_capture():
     """A forecast morning spike saves far more than 25c/kWh -> charging returns.
 
-    With the spike the optimizer charges in the run-up to it (just-in-time, to minimise
-    drain) rather than at the far-overnight trough — both capture the spike; what matters
-    is that the gate does NOT suppress it (cf. test_gate_blocks_micro, same threshold and
-    no spike -> no charge at all).
+    What matters is that the gate does NOT suppress the capture (cf.
+    test_gate_blocks_micro, same threshold and no spike -> no charge at all), and that
+    the battery — not the grid — serves the spike slot.
+
+    This deliberately does NOT pin which slot charges. It used to assert a 30-35 window,
+    on the reasoning that the optimizer charges just-in-time to minimise drain. Spike
+    funding legitimately moves it earlier (measured: charges [34] -> [8, 27], projected
+    net cost $0.6297 -> $0.5703), and that plan is only ever adopted because
+    ``_solve_guarded`` proved it cheaper. Pinning the window tested an implementation
+    detail the docstring already disclaimed; the properties below are the real contract.
     """
     rows = list(_LIVE_ROWS)
     rows[35] = (2.00, 1.90, 0.012, 0.821, 30)  # $2/kWh spike at 07:00
-    charges = _charge_slots(_plan_live(PROD_DEFAULT, rows=rows))
+    result = _plan_live(PROD_DEFAULT, rows=rows)
+    charges = _charge_slots(result)
     assert charges, "a $2 spike (huge saving) must still be captured"
-    assert any(30 <= c <= 35 for c in charges), (
-        f"charge should be positioned to reach the 07:00 spike, got {charges}"
+    assert all(c < 35 for c in charges), (
+        f"charging must precede the 07:00 spike to be able to serve it, got {charges}"
+    )
+    spike_import = result.decisions[35].objective_terms.import_cost
+    assert spike_import == pytest.approx(0.0, abs=1e-6), (
+        f"the battery, not the grid, must serve the $2 spike slot (import ${spike_import})"
     )
 
 


### PR DESCRIPTION
## The incident

Live 2026-08-05 13:17: the horizon carried a forecast **$1.65/kWh** print at 07:30 and the plan met it at the **10% SOC floor**, importing straight through 05:30–09:00. That block was **$1.52 of a $2.13 projected day cost** — 71% of the day in one morning.

```
idx  time    buy  action   soc   import$
 40 05:30   0.21  hold   10.00   0.0672
 41 06:00   0.31  hold   10.00   0.0992
 42 06:30   0.61  hold   10.00   0.1952
 43 07:00   0.76  hold   10.00   0.2926
 44 07:30   1.65  hold   10.00   0.6352   <-- SOC_FLOOR_CONSTRAINT
```

## Root cause

Not the price signal. `feasible_actions` omits every `CHARGE_*` action when a slot's buy price exceeds its cheap threshold, so the DP never *prices* the trade — it cannot choose it at any cost. The codebase already states the principle at `constraints.py:289`: *no penalty can buy an action that is not in the feasible set*.

The only thing that ever widens that threshold is `compute_pre_dw_charge_thresholds`, scoped to pre-demand-window slots and sized from the DW target deficit. **A spike outside a demand window has no funder at all.** Two cents of threshold ($0.16 base vs a $0.17–0.21 trough) blocked arbitrage worth $1.45/kWh.

The control philosophy at `constraints.py:107` endorses the outcome — *"If battery runs out overnight, grid import is the correct outcome"* — which is true right up until the morning costs $1.65.

## What this does

`spike_event.find_funding_slots`: a slot qualifies when the future holds enough displaceable load, all priced at least `min_cycle_saving` (grossed up for round-trip losses) above it, to absorb a meaningful share of one slot's charge. Qualifying slots are added to the feasible set and given the existing `_is_urgency_precharge` exemption.

Using `min_cycle_saving` as the bar is deliberate — it is the operator's existing statement of when a cycle is worth it, so a qualifying slot has *already* been proven to clear that gate.

## Three findings that shaped it

**1. No reserve-hold machinery is needed.** Given only a feasible charge action, the DP's own economics buy immediately before the spike and hold through it unaided (spike-slot import $0.635 → $0.00). A second terminal index was prototyped and proved unnecessary. `_backward_induction`'s penalty injection *is* already index-generic if that ever changes.

**2. A naive widening reproduces the #800 sawtooth exactly.** Negative control on a flat-morning fixture: six consecutive overnight charge slots plus proactive export, import **$1.08 → $2.51**. Qualifying on price *spread* rather than *level* is what keeps it inert on ordinary days.

**3. The spread rule alone is still not safe.** A 200-scenario sweep found ~4% of firing scenarios came out **worse** than baseline (worst $0.49). Cause isolated by ablation: `min_cycle_saving` prunes using a comparison absent from the DP state, so the solver is **non-monotone** — enlarging the feasible set can change which plan wins. (`switching_penalty=0` does not fix it; `min_cycle_saving=0` does.)

So `_solve_guarded` solves both ways and keeps the cheaper plan. Harm becomes impossible by construction rather than probable-but-rare. Cost is one extra solve — measured live at 0.0357s → 0.0579s.

## Verification

- **3369 tests pass**, 15 new. Lint and format clean.
- **150 randomised scenarios against the real implementation**: inertness and no-harm both hold. 77 saved ($72.48 total), 62 qualified without changing the plan, **2 blocked by the guard**.
- Live horizon: projected net cost **$1.9667 → $1.2382**, adds exactly **one** charge slot (05:30), spike slot served from the battery.
- Flat-morning control: **byte-identical** plan.

## Deployed

Live since 2026-08-05 ~14:24. First cycle reported `spike_funding_slot_count=8, accepted=false, delta=0` — a benign tie, exactly the case the delta field exists to distinguish from a guard rejection.

**Not yet exercised in anger.** Between snapshot and deploy, Amber revised 07:30 from $1.65 to $0.56 and lifted the trough to $0.20, so the spread no longer clears $0.286 and the feature correctly stands down. An accepted widening still needs a real qualifying event — an 18h-out peak collapsing 66% in an hour is itself the forecast-volatility caveat in the flesh.

## Notes for review

- Deliberately **not** routed through `cheap_threshold_for_slot` — that function also feeds the futile-cycling penalty and floor-routing helpers, so changing its return value would mutate the objective function, not only the choice set.
- Demand-window slots are excluded on both sides: DW energy already has a funder, and bidding for it re-opens the sawtooth on ordinary days.
- `spike_precharge_enabled=False` restores previous behaviour exactly.
- One existing test changed: `test_gate_preserves_spike_capture` pinned charging to slots 30–35, which its own docstring disclaimed as irrelevant. The new plan charges [8, 27] at a **lower** net cost ($0.6297 → $0.5703); the slot pin is replaced with the properties it was protecting (charging precedes the spike; spike slot import ≈ 0).
- A new module means a config-entry reload cannot pick it up — deploys need a full HA restart.
