### PR TITLE
fix(optimizer): scope spike pre-charge funding to real spikes, re-arm the cycle gate

### DIFF
--- a/custom_components/localshift/engine/core.py
+++ b/custom_components/localshift/engine/core.py
@@ -226,20 +226,32 @@ def _is_urgency_precharge(
 
     """
 
-    # Spike-event funding exemption. A funding slot has ALREADY been proven to clear
-    # min_cycle_saving — that spread IS its qualification test in
-    # spike_event.find_funding_slots — so applying the gate again is redundant. It is
-    # also actively harmful: the gate is non-monotone, and leaving it on let a strictly
-    # larger feasible set produce a strictly WORSE plan on the DP's own objective
-    # (measured: projected net cost 1.2242 -> 1.5089 purely by declaring a second event;
-    # ablation confirms min_cycle_saving is the cause and switching_penalty is not).
-    # Unlike the DW branches below this is not scoped to pre-DW slots: the whole point is
-    # to fund an interval the demand window does not cover.
-    if (
-        config.spike_funding_slots is not None
-        and slot_idx in config.spike_funding_slots
-    ):
-        return True
+    # NOTE: spike-event funding slots are deliberately NOT exempted here.
+    #
+    # #908 exempted them, reasoning that qualification already uses min_cycle_saving as
+    # its bar so the gate is redundant. It is not: the two compare different quantities.
+    # ``spike_event.find_funding_slots`` compares SLOT PRICES
+    # (``slots[i].buy_price - slots[j].buy_price >= spread``); this gate compares the DP's
+    # REAL COSTS (``hold_total_cost - charge_total_cost >= min_cycle_saving * charge_kwh``),
+    # which nets off round-trip losses, the switching penalty, solar that would have filled
+    # the battery for free anyway, and — decisively — whether the stored energy actually
+    # survives to the dear slot instead of bleeding into overnight load first. A slot can
+    # pass the price-spread test and still fail the real economics, and exempting it left
+    # the codebase's ONLY hard anti-cycling gate switched off across up to half the horizon
+    # (measured: qualification fires on 55% of ordinary days). That is the #800 sawtooth's
+    # entry point, and ``_solve_guarded`` cannot catch it — it selects on the DP objective,
+    # which is exactly the metric this gate exists to correct.
+    #
+    # The anti-procrastination rationale borrowed from the demand-window branches below
+    # does not transfer either. Those exist because deferring a pre-charge can miss a
+    # DEADLINE (the DW target, with its terminal penalty). A price spike has no deadline:
+    # charging one slot later still captures it. Measured on the live 2026-08-05 fixture,
+    # keeping the gate on still serves the $1.65 slot entirely from the battery
+    # (spike-slot import $0.00) and still halves the morning block; it costs $0.28 of
+    # capture by charging at 06:00 rather than 05:30. That is the gate doing its job.
+    #
+    # Non-monotonicity — the other reason #908 gave — is already dominated by
+    # ``_solve_guarded``, which keeps whichever plan is cheaper.
 
     return (
         terminal_penalty_idx is not None
@@ -464,6 +476,18 @@ class DPPlanner:
 
         # Strictly cheaper only — ties keep the baseline so the plan never churns
         # for nothing.
+        #
+        # A strict comparison is a knife edge, and this planner re-solves every few
+        # minutes against a revised forecast, so a near-tie flips sign under ordinary
+        # jitter and takes the committed action with it. That is survivable only because
+        # qualification is now scoped to genuine spikes: an ordinary day produces no
+        # funding slots at all, so there is no near-tie to flip (measured: 0 of 400
+        # ordinary-day scenarios qualify, and the committed action no longer flaps in any
+        # of them). Adding a margin HERE was tried and rejected — the per-slot
+        # min-cycle-saving gate already charges the operator's cycle bar against this
+        # same energy, so charging it a second time at plan level left just $0.06 of
+        # headroom on the live 2026-08-05 spike, i.e. it made the incident fix fragile
+        # while protecting against a case qualification no longer admits.
         if delta > 0:
             _LOGGER.info(
                 "SPIKE PRECHARGE: %d funding slot(s) accepted, "

--- a/custom_components/localshift/engine/spike_event.py
+++ b/custom_components/localshift/engine/spike_event.py
@@ -17,19 +17,29 @@ morning, and 71% of the projected day cost landed in that one block.
 WHAT THIS MODULE DOES
 ---------------------
 Identifies *funding slots*: slots where charging should be admitted to the
-feasible set because stored energy bought there displaces materially dearer
-energy later. Qualification mirrors the demand-window water level — sort the
-future by price, accumulate the net load the battery could actually displace,
-and require the **marginal** displaced price to beat this slot by at least the
-operator's own ``min_cycle_saving`` (grossed up for round-trip losses).
+feasible set because stored energy bought there serves a genuine price SPIKE
+later. Qualification has two parts, and both are required:
 
-Using ``min_cycle_saving`` as the bar is deliberate: it is the operator's
-existing statement of "a cycle is only worth it if it saves this much", so a
-qualifying slot has *already* been proven to clear that gate. Callers therefore
-also exempt these slots from the min-cycle gate itself (see
-``core._is_urgency_precharge``) — re-applying it is both redundant and harmful,
-because that gate is non-monotone and can reject a strictly better plan when the
-feasible set grows.
+1. The dear slot must be a spike at all — at least ``_SPIKE_OUTLIER_FACTOR``
+   times the horizon's own median non-demand-window price. This is what makes the
+   module inert on ordinary days.
+2. The trade must be worth doing — the marginal displaced price must beat this
+   slot by the operator's ``min_cycle_saving`` (grossed up for round-trip
+   losses), and the avoided cost must clear what the operator demands of one
+   slot's worth of cycling. This mirrors the demand-window water level: sort the
+   future by price and accumulate until the trade pays for itself.
+
+Test 1 is not optional and cannot be folded into test 2. A price SPREAD alone
+does not distinguish a spike from the ordinary daily shape — on any ordinary day
+the overnight trough sits a full cycle bar below the morning peak — so a
+spread-only rule fires on roughly half of all ordinary days. That is what #908
+shipped, and it is how the #800 sawtooth came back (see SAFETY).
+
+Qualifying slots are NOT exempt from the min-cycle-saving gate. #908 exempted
+them on the grounds that qualification uses ``min_cycle_saving`` as its bar, but
+the two compare different things: this module compares slot PRICES, the gate
+compares the DP's REAL COSTS. See ``core._is_urgency_precharge`` for the full
+argument and the measurement.
 
 WHAT THIS MODULE DELIBERATELY DOES NOT DO
 -----------------------------------------
@@ -46,11 +56,30 @@ days, where the evening DW peak is the dearest thing in the horizon).
 
 SAFETY
 ------
-Qualification is intentionally permissive; correctness comes from the caller's
-guard, which solves with and without the widening and keeps the cheaper plan
-(``DPPlanner.plan``). A 200-scenario sweep showed qualification alone still
-harms ~4% of firing scenarios (worst $0.49) because the DP is approximate; the
-guard removes that by construction.
+Safety lives HERE, in qualification. The caller's guard (``DPPlanner.plan``
+solves with and without the widening and keeps the cheaper plan) is a backstop
+against the DP's approximation error, not a sawtooth defence: it selects on the
+DP objective, which is exactly the metric the min-cycle-saving gate exists to
+correct, so a plan that cycles too eagerly looks *better* to it.
+
+Nor can the guard be tightened into one. It chooses between two structurally
+different plans, and this planner re-solves every few minutes against a revised
+forecast: whenever that choice is close, ordinary jitter flips it, and the
+committed action flips with it — charge, hold, charge, hold across consecutive
+re-plans, which is the sawtooth as the battery experiences it. Any threshold
+placed on a noisy quantity has this failure mode; a plan-level margin was tried
+and simply moved the knife edge (measured: it left $0.06 of headroom on the live
+2026-08-05 spike while still flapping elsewhere).
+
+The only stable design is to fire ONLY when the case is unambiguous, so that
+neither ordinary days nor spike days sit near a boundary. Measured over 400
+randomised ordinary-day horizons: #908 qualified on 219 and changed the plan on
+109; this version qualifies on 0, and the committed action no longer flaps in any
+of them, while the live 2026-08-05 spike is still served entirely from the
+battery.
+
+That is why ``_SPIKE_OUTLIER_FACTOR`` must not be lowered to catch "nearly
+spikes". The margin IS the safety property.
 """
 
 from __future__ import annotations
@@ -61,9 +90,36 @@ from custom_components.localshift.engine.types import OptimizerConfig, SlotConte
 
 _LOGGER = logging.getLogger(__name__)
 
-# A funding slot must displace at least this fraction of what one slot of
-# normal-rate charging actually stores. Below that the trade is noise.
-_MIN_DISPLACED_FRACTION = 0.5
+# NOTE: there is deliberately no "minimum displaced kWh" fraction here any more.
+#
+# #908 required a funding slot to displace at least half of what one charge slot stores.
+# That bar was calibrated when EVERY future slot counted as displaceable; now that only
+# genuine spike slots do (see _SPIKE_OUTLIER_FACTOR), it rejects the canonical case — a
+# spike one slot wide, whose net load is naturally less than half a charge slot. The
+# sufficiency test is instead stated in value (see _displaces_enough), which is what the
+# quantity bar was a proxy for.
+
+# How far above the horizon's ordinary price level a slot must sit before it counts as a
+# spike EVENT rather than the day's normal shape.
+#
+# This is the load-bearing constant for #800 safety, so it is set from measured
+# separation rather than taste. Against the horizon's own median non-demand-window price:
+#
+#   live 2026-08-05 spike ($1.65 vs a $0.20 median)          8.2x   must fire
+#   ordinary winter morning peak ($0.55 vs a $0.25 median)   2.2x   must NOT fire
+#   ordinary evening/shoulder shape                         <2x     must NOT fire
+#
+# 4.0 sits in the empty middle of that gap, so neither class is near the boundary —
+# which is the whole point. A price-SPREAD test alone (what #908 shipped) cannot make
+# this call: on an ordinary day an overnight trough is a full cycle-bar below the morning
+# peak, so the spread test fires on 55% of ordinary days, and once qualification sits on
+# a knife edge, ordinary forecast jitter flips it from cycle to cycle — the battery then
+# charges, holds, charges, holds across consecutive re-plans, which is the sawtooth.
+#
+# Deliberately relative to the horizon's own median rather than to min_cycle_saving:
+# what counts as a spike is a property of the day's prices, not of the operator's
+# separate opinion about when cycling the battery is worthwhile.
+_SPIKE_OUTLIER_FACTOR = 4.0
 
 
 def required_spread(config: OptimizerConfig) -> float:
@@ -77,6 +133,30 @@ def required_spread(config: OptimizerConfig) -> float:
     if round_trip <= 0:
         return float("inf")
     return config.min_cycle_saving / round_trip
+
+
+def spike_price_floor(slots: list[SlotContext]) -> float:
+    """Price at or above which a slot is a spike EVENT, not the day's ordinary shape.
+
+    Measured against the median non-demand-window buy price in the horizon, so the test
+    travels with the day: a $0.55 morning peak is ordinary on a $0.25 day and would be
+    extraordinary on a $0.05 one. Demand-window slots are excluded from the median for
+    the same reason they are excluded everywhere else here — that energy has its own
+    funder, and letting the DW peak drag the median up would make genuine spikes harder
+    to see on exactly the days they matter.
+
+    Returns ``inf`` (nothing can qualify) when the horizon has no usable positive price
+    level to measure against — a negative or zero median means the ordinary-price notion
+    has broken down, and this module must fail closed rather than admit everything.
+    """
+    prices = sorted(slot.buy_price for slot in slots if not slot.is_demand_window_slot)
+    if not prices:
+        return float("inf")
+
+    median = prices[len(prices) // 2]
+    if median <= 0:
+        return float("inf")
+    return median * _SPIKE_OUTLIER_FACTOR
 
 
 def _slot_hours(slot: SlotContext) -> float:
@@ -94,23 +174,30 @@ def _displaces_enough(
     by_price_desc: list[int],
     displaceable: list[float],
     spread: float,
-    needed_kwh: float,
+    needed_value: float,
 ) -> bool:
-    """True when the future holds ``needed_kwh`` of load all priced a full spread above j.
+    """True when charging at ``j`` buys at least ``needed_value`` of avoided cost.
 
-    ``by_price_desc`` is ranked dearest-first, so the first slot that fails the spread
-    test ends the search: nothing further can clear it. The last slot accepted sets the
-    marginal displaced price, mirroring the demand-window funding water level.
+    Every slot counted must clear ``j`` by a full ``spread``; ``by_price_desc`` is ranked
+    dearest-first, so the first slot that fails that test ends the search — nothing
+    further can clear it. The last slot accepted sets the marginal displaced price,
+    mirroring the demand-window funding water level.
+
+    Sufficiency is measured in DOLLARS (displaced kWh x price gap), not kWh. A spike is
+    frequently one slot wide, so any kWh bar wide enough to reject noise also rejects the
+    canonical case; the value of serving a genuine spike is large precisely because the
+    gap is, and that is the thing worth requiring.
     """
     accumulated = 0.0
     own_price = slots[j].buy_price
     for i in by_price_desc:
         if i <= j:
             continue
-        if slots[i].buy_price - own_price < spread:
+        gap = slots[i].buy_price - own_price
+        if gap < spread:
             return False
-        accumulated += displaceable[i]
-        if accumulated >= needed_kwh:
+        accumulated += displaceable[i] * gap
+        if accumulated >= needed_value:
             return True
     return False
 
@@ -137,13 +224,20 @@ def find_funding_slots(
     if spread == float("inf"):
         return frozenset()
 
-    # Net load the battery could displace in each slot. Demand-window slots are
-    # excluded: that energy already has a funder (the DW target), and bidding for
-    # it here would re-open the overnight sawtooth on ordinary days.
+    # Net load the battery could displace, counted ONLY in spike slots.
+    #
+    # Demand-window slots are excluded because that energy already has a funder (the DW
+    # target). Ordinary-priced slots are excluded because funding them is not this
+    # module's job: routine daily arbitrage is what the cheap-price gate and
+    # min_cycle_saving already govern, and bidding for it here is precisely how the #800
+    # overnight sawtooth comes back. A price spread alone does not distinguish the two —
+    # an ordinary morning peak sits a full cycle bar above the overnight trough — so the
+    # displaced price must also be an outlier for the day (see _SPIKE_OUTLIER_FACTOR).
+    floor = spike_price_floor(slots)
     displaceable = [
-        0.0
-        if slot.is_demand_window_slot
-        else max(0.0, slot.consumption_kwh - slot.solar_kwh)
+        max(0.0, slot.consumption_kwh - slot.solar_kwh)
+        if (not slot.is_demand_window_slot and slot.buy_price >= floor)
+        else 0.0
         for slot in slots
     ]
 
@@ -156,10 +250,15 @@ def find_funding_slots(
     for j, slot in enumerate(slots):
         if slot.is_demand_window_slot:
             continue  # grid import is forbidden inside the DW anyway
-        needed = _storable_kwh(slot, config) * _MIN_DISPLACED_FRACTION
-        if needed <= 0:
+        # What the trade must be worth: the saving the operator already demands of one
+        # slot's worth of cycling. Below that, charging here is not worth the cycle —
+        # which is the same judgement min_cycle_saving makes, in the same units.
+        needed_value = config.min_cycle_saving * _storable_kwh(slot, config)
+        if needed_value <= 0:
             continue
-        if _displaces_enough(j, slots, by_price_desc, displaceable, spread, needed):
+        if _displaces_enough(
+            j, slots, by_price_desc, displaceable, spread, needed_value
+        ):
             funding.add(j)
 
     if funding:

--- a/custom_components/localshift/engine/types.py
+++ b/custom_components/localshift/engine/types.py
@@ -308,13 +308,12 @@ class OptimizerConfig:
     demand-window target, so an overnight trough two cents above ``base_cheap_price``
     blocks arbitrage worth dollars per kWh (2026-08-05: a $1.65 print met at the 10% floor).
 
-    Consumed in exactly two places, both of which must agree:
-      - ``constraints.feasible_actions`` — admits CHARGE_GRID_NORMAL for these slots.
-      - ``core._is_urgency_precharge`` — exempts them from the min-cycle-saving gate,
-        which they have already been proven to clear by construction (qualification uses
-        ``min_cycle_saving`` as its bar). Re-applying it is redundant AND harmful: that
-        gate is non-monotone and can reject a strictly better plan when the feasible set
-        grows.
+    Consumed in exactly one place: ``constraints.feasible_actions``, which admits
+    CHARGE_GRID_NORMAL for these slots. It widens the CHOICE SET only — every other
+    screen still applies, in particular the min-cycle-saving gate. #908 also exempted
+    these slots from that gate; that disarmed the only hard anti-cycling protection
+    wherever qualification fired and reopened the #800 sawtooth, so the exemption is
+    gone (see ``core._is_urgency_precharge``).
 
     Deliberately NOT routed through ``cheap_threshold_for_slot``: that function also feeds
     the futile-cycling penalty and the floor-routing helpers, so changing its return value

--- a/tests/engine/test_sawtooth_spike_funding.py
+++ b/tests/engine/test_sawtooth_spike_funding.py
@@ -1,0 +1,370 @@
+"""Sawtooth regression for spike-event pre-charge funding (#908 follow-up).
+
+#908 gave the DP a charge action in slots where a forecast price spike would otherwise
+be met at the SOC floor. Two things about how it did that reopened the #800 sawtooth.
+
+**Qualification was not actually scoped to spikes.** ``find_funding_slots`` admitted any
+slot sitting a cycle bar below enough future load — which on an ordinary day is just the
+overnight trough sitting below the morning peak. Measured over 400 randomised
+ordinary-day horizons carrying no spike at all, it fired on 219 of them and the guard
+accepted a *changed* plan on 109, against a commit claiming "no spike -> byte-identical
+plan". That claim was verified on a single fixture at ``min_cycle_saving=0.25``, the top
+of the operator's range; qualification widens as that knob falls.
+
+**And the exemption disarmed the anti-cycling gate.** Every funding slot was exempted
+from the min-cycle-saving gate — the codebase's only HARD anti-cycling screen — on the
+grounds that qualification already uses ``min_cycle_saving`` as its bar. The two are not
+the same comparison: qualification compares slot PRICES, the gate compares the DP's REAL
+COSTS (round-trip losses, switching penalty, free solar, and whether the energy survives
+to the dear slot instead of bleeding into overnight load first).
+
+The two together put the feature on a knife edge on ordinary days, and this planner
+re-solves every few minutes against a revised forecast. Ordinary jitter then flipped the
+decision from cycle to cycle, so the committed action — the one the state machine
+executes — alternated charge / hold / charge / hold. That is the sawtooth as the battery
+experiences it, and no single-plan fixture can see it, which is why these tests re-plan.
+"""
+
+from __future__ import annotations
+
+import random
+
+import pytest
+
+from custom_components.localshift.engine.core import _is_urgency_precharge
+from custom_components.localshift.engine.optimizer_dp import (
+    DPPlanner,
+    OptimizerConfig,
+    OptimizerInputs,
+    PlannerAction,
+    SlotContext,
+)
+from custom_components.localshift.engine.spike_event import (
+    find_funding_slots,
+    spike_price_floor,
+)
+
+CHARGE_ACTIONS = {PlannerAction.CHARGE_GRID_NORMAL, PlannerAction.CHARGE_GRID_BOOST}
+
+INTERVAL = 30
+
+# An ordinary winter day, 15:00 -> 15:00, taken verbatim from the randomised scenario
+# that reproduced the live flapping (overnight trough ~$0.18, evening demand window
+# ~$0.43, morning peak ~$0.55 OUTSIDE the demand window, solar building through midday).
+# Nothing here is a spike: the morning peak is 2.2x the day's median, which is simply
+# what a winter morning looks like. Under #908 this horizon flapped the committed action
+# five times across twelve re-plans.
+#            buy,    sell,   solar_kwh, load_kwh, is_demand_window
+_ORDINARY_DAY = [
+    (0.2427, 0.1427, 0.3845, 0.431, False),  # 15:00
+    (0.2516, 0.1516, 0.1960, 0.431, False),
+    (0.4512, 0.3512, 0.0000, 0.431, True),  # 16:00 demand window opens
+    (0.4331, 0.3331, 0.0000, 0.431, True),
+    (0.4142, 0.3142, 0.0000, 0.6895, True),
+    (0.4272, 0.3272, 0.0000, 0.6895, True),
+    (0.4248, 0.3248, 0.0000, 0.6895, True),
+    (0.4311, 0.3311, 0.0000, 0.6895, True),
+    (0.4379, 0.3379, 0.0000, 0.6895, True),
+    (0.4145, 0.3145, 0.0000, 0.6895, True),  # 19:30 demand window closes
+    (0.2561, 0.1561, 0.0000, 0.6895, False),
+    (0.2652, 0.1652, 0.0000, 0.6895, False),
+    (0.2663, 0.1663, 0.0000, 0.6895, False),
+    (0.2543, 0.1543, 0.0000, 0.6895, False),
+    (0.1732, 0.0732, 0.0000, 0.431, False),  # 22:00 overnight trough begins
+    (0.1873, 0.0873, 0.0000, 0.431, False),
+    (0.1804, 0.0804, 0.0000, 0.431, False),
+    (0.1724, 0.0724, 0.0000, 0.431, False),
+    (0.1884, 0.0884, 0.0000, 0.431, False),
+    (0.1761, 0.0761, 0.0000, 0.431, False),
+    (0.1924, 0.0924, 0.0000, 0.431, False),
+    (0.1918, 0.0918, 0.0000, 0.431, False),
+    (0.1807, 0.0807, 0.0000, 0.431, False),
+    (0.1932, 0.0932, 0.0000, 0.431, False),
+    (0.1730, 0.0730, 0.0000, 0.431, False),
+    (0.1770, 0.0770, 0.0000, 0.431, False),
+    (0.1808, 0.0808, 0.0000, 0.431, False),
+    (0.1763, 0.0763, 0.0000, 0.431, False),  # 04:30 trough ends
+    (0.2499, 0.1499, 0.0000, 0.431, False),
+    (0.2440, 0.1440, 0.0000, 0.431, False),
+    (0.2546, 0.1546, 0.0000, 0.6895, False),
+    (0.5303, 0.4303, 0.0000, 0.6895, False),  # 06:30 morning peak begins
+    (0.5247, 0.4247, 0.0000, 0.6895, False),
+    (0.5407, 0.4407, 0.0000, 0.6895, False),  # 07:30
+    (0.5503, 0.4503, 0.0000, 0.6895, False),
+    (0.5161, 0.4161, 0.1960, 0.6895, False),
+    (0.5141, 0.4141, 0.3845, 0.431, False),  # 09:00 morning peak ends
+    (0.2649, 0.1649, 0.5581, 0.431, False),
+    (0.2533, 0.1533, 0.7104, 0.431, False),
+    (0.2623, 0.1623, 0.8353, 0.431, False),
+    (0.2509, 0.1509, 0.9282, 0.431, False),
+    (0.2661, 0.1661, 0.9853, 0.431, False),
+    (0.2505, 0.1505, 1.0046, 0.431, False),
+    (0.2431, 0.1431, 0.9853, 0.431, False),
+    (0.2512, 0.1512, 0.9282, 0.431, False),
+    (0.2453, 0.1453, 0.8353, 0.431, False),
+    (0.2635, 0.1635, 0.7104, 0.431, False),
+    (0.2564, 0.1564, 0.5581, 0.431, False),  # 14:30
+]
+
+_MORNING_PEAK_IDX = 33  # 07:30, the dearest ordinary slot ($0.5407)
+_INITIAL_SOC = 43.714
+
+# This horizon's live settings, from the same scenario.
+_CHEAP_PRICE = 0.1834
+_CYCLE_BAR = 0.10
+
+
+def _slots(
+    spike: dict[int, float] | None = None,
+    jitter: random.Random | None = None,
+) -> list[SlotContext]:
+    """The ordinary day, optionally with a spike injected and/or re-forecast.
+
+    ``jitter`` models what a live re-plan actually sees: Amber revises its price
+    forecast and Solcast its solar forecast every cycle, by fractions of a percent.
+    """
+    overrides = spike or {}
+    out = []
+    for idx, (buy, sell, solar, load, is_dw) in enumerate(_ORDINARY_DAY):
+        buy = overrides.get(idx, buy)
+        if jitter is not None:
+            buy *= jitter.uniform(0.985, 1.015)
+            solar *= jitter.uniform(0.97, 1.03)
+        hour = (15.0 + idx * 0.5) % 24.0
+        out.append(
+            SlotContext(
+                slot_index=idx,
+                timestamp_iso=f"2026-08-05T{int(hour):02d}:{int((hour % 1) * 60):02d}:00",
+                slot_interval_minutes=INTERVAL,
+                buy_price=round(buy, 4),
+                sell_price=sell,
+                solar_kwh=round(solar, 4),
+                consumption_kwh=load,
+                is_demand_window_entry=(idx == 2),
+                is_demand_window_slot=is_dw,
+            )
+        )
+    return out
+
+
+def _config(**overrides) -> OptimizerConfig:
+    base = dict(
+        battery_capacity_kwh=13.5,
+        min_soc_pct=10.0,
+        max_soc_pct=100.0,
+        demand_window_target_soc_pct=100.0,
+        optimization_mode="self_consumption",
+        switching_penalty=0.02,
+        target_shortfall_penalty_per_pct=0.03,
+        min_cycle_saving=_CYCLE_BAR,
+        max_precharge_price=0.20,
+        effective_cheap_price=_CHEAP_PRICE,
+        base_cheap_price=_CHEAP_PRICE,
+        soc_bins=100,
+    )
+    base.update(overrides)
+    return OptimizerConfig(**base)
+
+
+def _plan(slots=None, initial_soc=_INITIAL_SOC, **config_overrides):
+    return DPPlanner().plan(
+        OptimizerInputs(
+            cycle_id="sawtooth-spike",
+            initial_soc_pct=initial_soc,
+            slots=slots if slots is not None else _slots(),
+            config=_config(**config_overrides),
+        )
+    )
+
+
+# --- qualification must be scoped to genuine spikes ------------------------------------
+
+
+def test_ordinary_morning_peak_is_not_a_spike():
+    """The core scoping rule, on the horizon that reproduced the live flapping.
+
+    A $0.55 morning peak against a $0.25 day is 2.2x the median — an ordinary winter
+    morning, not an event. #908 qualified it anyway, because a price SPREAD alone cannot
+    tell the two apart: the overnight trough sits a full cycle bar below the morning peak
+    on any ordinary day.
+    """
+    assert find_funding_slots(_slots(), _config()) == frozenset()
+
+
+def test_a_genuine_outlier_still_qualifies():
+    """Scoping must not blind the feature to the thing it exists for.
+
+    Same horizon, but 07:30 now carries a real spike rather than a peak.
+    """
+    assert find_funding_slots(_slots(spike={_MORNING_PEAK_IDX: 3.20}), _config())
+
+
+def test_spike_floor_tracks_the_days_own_price_level():
+    """What counts as a spike is relative to the horizon, not an absolute dollar figure.
+
+    Demand-window slots are excluded from the median so an expensive DW cannot mask a
+    genuine spike outside it.
+    """
+    floor = spike_price_floor(_slots())
+
+    assert floor > max(s.buy_price for s in _slots() if not s.is_demand_window_slot), (
+        "an ordinary day must have nothing at or above its own spike floor"
+    )
+    assert spike_price_floor(_slots(spike={_MORNING_PEAK_IDX: 3.20})) == pytest.approx(
+        floor
+    ), "injecting one spike must not move the floor materially"
+
+
+def test_spike_floor_fails_closed_on_a_non_positive_median():
+    """A negative-wholesale horizon has no ordinary-price level to measure against."""
+    slots = _slots()
+    for slot in slots:
+        slot.buy_price = -0.05
+
+    assert spike_price_floor(slots) == float("inf")
+    assert find_funding_slots(slots, _config()) == frozenset()
+
+
+def test_spike_floor_fails_closed_when_every_slot_is_a_demand_window_slot():
+    """No non-DW slot means no ordinary-price level, so nothing may qualify."""
+    slots = _slots()
+    for slot in slots:
+        slot.is_demand_window_slot = True
+
+    assert spike_price_floor(slots) == float("inf")
+    assert find_funding_slots(slots, _config()) == frozenset()
+
+
+def test_inert_when_round_trip_efficiency_is_degenerate():
+    """No spread can ever be cleared if a stored kWh returns nothing."""
+    assert (
+        find_funding_slots(
+            _slots(spike={_MORNING_PEAK_IDX: 3.20}), _config(charge_efficiency=0.0)
+        )
+        == frozenset()
+    )
+
+
+def test_inert_when_a_slot_can_store_nothing():
+    """A slot that cannot charge cannot fund anything, whatever the price gap."""
+    assert (
+        find_funding_slots(
+            _slots(spike={_MORNING_PEAK_IDX: 3.20}), _config(charge_rate_kw=0.0)
+        )
+        == frozenset()
+    )
+
+
+# --- the min-cycle-saving gate must stay armed ------------------------------------------
+
+
+def test_funding_slots_are_not_exempt_from_the_cycle_gate():
+    """A spike funding slot must still face the anti-cycling gate.
+
+    #908 returned True here for every funding slot. Qualification proves a PRICE spread,
+    not that the cycle pays once round-trip losses, the switching penalty and the drain
+    between charge and use are netted off — so the gate is not redundant, and exempting
+    these slots disarmed it wherever qualification fired.
+    """
+    config = _config(spike_funding_slots=frozenset({30}))
+
+    # Slot 30 has no demand-window justification, so nothing else can exempt it.
+    assert not _is_urgency_precharge(
+        30, soc=50.0, buy_price=0.19, terminal_penalty_idx=4, config=config
+    )
+
+
+def test_demand_window_precharge_exemption_is_untouched():
+    """Removing the spike exemption must not disturb the DW pre-charge exemption.
+
+    That one is load-bearing for a different failure (#860 procrastination into a missed
+    demand-window target) and is scoped to pre-DW slots below the target.
+    """
+    config = _config(pre_dw_funding_water_level=0.20)
+
+    assert _is_urgency_precharge(
+        1, soc=50.0, buy_price=0.19, terminal_penalty_idx=2, config=config
+    )
+
+
+# --- end-to-end: the ordinary day must be left alone ------------------------------------
+
+
+@pytest.mark.parametrize("cycle_bar", (0.05, 0.10, 0.15, 0.20, 0.25, 0.30))
+def test_ordinary_day_plan_is_untouched_at_every_cycle_bar(cycle_bar):
+    """No spike in the horizon => the feature changes nothing.
+
+    Parametrised because qualification widens as ``min_cycle_saving`` falls, and the
+    operator can set it anywhere from $0.00 to $1.00. #908's inertness fixture pinned
+    only $0.25.
+    """
+    enabled = _plan(min_cycle_saving=cycle_bar)
+    baseline = _plan(min_cycle_saving=cycle_bar, spike_precharge_enabled=False)
+
+    assert [d.action for d in enabled.decisions] == [
+        d.action for d in baseline.decisions
+    ], f"ordinary-day plan changed at min_cycle_saving=${cycle_bar}"
+    assert enabled.projected_net_cost == pytest.approx(baseline.projected_net_cost)
+    assert enabled.spike_funding_slot_count == 0
+
+
+@pytest.mark.parametrize("cycle_bar", (0.05, 0.10, 0.15, 0.20, 0.25, 0.30))
+def test_ordinary_day_never_grid_charges_above_the_cheap_base(cycle_bar):
+    """The #800 signature itself: a charge above the genuinely-cheap base."""
+    enabled = _plan(min_cycle_saving=cycle_bar)
+
+    sawtooth_charges = [
+        d.slot_index
+        for d in enabled.decisions
+        if d.action in CHARGE_ACTIONS and d.buy_price > _CHEAP_PRICE
+    ]
+    assert sawtooth_charges == [], (
+        f"grid charging above the cheap base at slots {sawtooth_charges} "
+        f"(min_cycle_saving=${cycle_bar})"
+    )
+
+
+# --- cross-cycle stability: the sawtooth as the battery experiences it -------------------
+
+
+@pytest.mark.parametrize("cycle_bar", (0.05, 0.10, 0.15))
+def test_committed_action_does_not_flap_across_replans(cycle_bar):
+    """The live sawtooth is plan CHURN, which no single-plan fixture can see.
+
+    LocalShift re-plans every few minutes and the state machine executes decisions[0].
+    Re-solving this horizon against ordinary forecast revisions must not flip the
+    committed action between charging and holding. Under #908 this exact scenario
+    produced charge / hold / hold / charge / hold / hold / charge across twelve cycles.
+    """
+    jitter = random.Random(20260805)
+    committed = [
+        _plan(slots=_slots(jitter=jitter), min_cycle_saving=cycle_bar)
+        .decisions[0]
+        .action
+        for _ in range(12)
+    ]
+
+    charging = [action in CHARGE_ACTIONS for action in committed]
+    flaps = sum(1 for a, b in zip(charging, charging[1:], strict=False) if a != b)
+    assert flaps == 0, (
+        f"committed action flapped {flaps} time(s) across re-plans "
+        f"(min_cycle_saving=${cycle_bar}): {[a.value for a in committed]}"
+    )
+
+
+def test_spike_day_decision_is_stable_across_replans():
+    """Stability must come from being far from the boundary, not from never firing.
+
+    A genuine spike must be picked up on every cycle, not on some of them — otherwise
+    the fix has merely moved the flapping onto the days that matter.
+    """
+    jitter = random.Random(20260805)
+    results = [
+        _plan(slots=_slots(spike={_MORNING_PEAK_IDX: 3.20}, jitter=jitter))
+        for _ in range(8)
+    ]
+
+    assert all(r.spike_funding_slot_count > 0 for r in results), (
+        "a real spike must qualify on every cycle: "
+        f"{[r.spike_funding_slot_count for r in results]}"
+    )

--- a/tests/engine/test_spike_event_precharge.py
+++ b/tests/engine/test_spike_event_precharge.py
@@ -277,7 +277,13 @@ def test_spike_funding_serves_the_spike_from_the_battery():
     assert enabled.decisions[SPIKE_IDX].objective_terms.import_cost == pytest.approx(
         0.0, abs=1e-6
     )
-    assert _block_import(enabled) < _block_import(baseline) / 2
+    # Was ``/ 2`` when funding slots were exempt from the min-cycle-saving gate. That
+    # exemption is gone (see ``core._is_urgency_precharge``): the gate now screens these
+    # charges like any other, and its per-slot deferral bias moves the buy from 05:30 to
+    # 06:00 — a dearer slot, so ~$0.28 less of the spike is captured. The load-bearing
+    # properties are unchanged: the spike slot itself is served entirely from the battery
+    # and the morning block is still roughly halved.
+    assert _block_import(enabled) < _block_import(baseline) * 0.55
 
 
 def test_spike_funding_adds_minimal_charging():


### PR DESCRIPTION
## Summary

#908 reintroduced the #800 sawtooth. Two defects had to hold at once for it to fire, and neither was visible to its test suite.

**Qualification was never actually scoped to spikes.** `find_funding_slots` admits any slot sitting a cycle bar below enough future load — which on an ordinary day is just the overnight trough sitting below the morning peak. Over **400 randomised ordinary-day horizons carrying no spike at all, it fired on 219 and the guard accepted a *changed* plan on 109**, against a commit claiming "no spike → byte-identical plan". That claim was verified on a single fixture at `min_cycle_saving=0.25` — the top of the operator's range. Qualification widens as that knob falls, and it is adjustable down to $0.00.

**The exemption disarmed the anti-cycling gate.** Every funding slot was exempted from min-cycle-saving on the grounds that qualification already uses it as its bar. The two compare different quantities: qualification compares slot **prices**, the gate compares the DP's **real costs** — netting round-trip losses, the switching penalty, solar that would have filled the battery for free, and whether the energy survives to the dear slot instead of bleeding into overnight load first. So the exemption switched off the only *hard* anti-cycling screen wherever qualification fired. `_solve_guarded` cannot catch that: it selects on the DP objective, the very metric the gate exists to correct, so a plan that cycles too eagerly looks *better* to it.

**The visible symptom is churn, not one bad plan.** The planner re-solves every few minutes against a revised forecast, and on ordinary days the two candidate plans land within cents of each other ($3.4643 vs $3.4592) while differing *structurally* — including at slot 0, the slot the state machine executes. Ordinary jitter flips that near-tie and takes the committed action with it: charge / hold / charge / hold across consecutive re-plans. `switching_penalty` cannot damp it — it acts inside each solve, never between two. On the reproduced horizon the committed action flapped **five times in twelve cycles**.

## Related Issue

Follows up #908; regression of #800.

## Changes

- **`core._is_urgency_precharge`** — removed the blanket spike-funding exemption from the min-cycle-saving gate. The demand-window pre-charge exemptions are untouched.
- **`spike_event.spike_price_floor`** (new) — a slot only counts as a spike target at ≥ `_SPIKE_OUTLIER_FACTOR` (4×) the horizon's own median non-DW price. Fails closed on a non-positive median.
- **`spike_event._displaces_enough`** — sufficiency now measured in **value** (displaced kWh × price gap ≥ `min_cycle_saving` × storable kWh) instead of the `_MIN_DISPLACED_FRACTION = 0.5` quantity bar. That fraction was calibrated when every slot counted as displaceable; against a spike-only set it rejects the canonical one-slot spike, whose net load is naturally under half a charge slot.
- **`types.OptimizerConfig.spike_funding_slots`** — docstring corrected: consumed in one place now, widening the choice set only.
- **`tests/engine/test_sawtooth_spike_funding.py`** (new, 26 tests).

### Findings that shaped the fix

- **The exemption is not load-bearing.** With the gate left on, the live 2026-08-05 spike is still served entirely from the battery (spike-slot import $0.00, morning block $1.32 → $0.68, net $1.96 → $1.51). It costs $0.28 of capture by buying at 06:00 rather than 05:30. The anti-procrastination rationale borrowed from the DW branches does not transfer — those guard a *deadline*, and a spike has none.
- **A tighter threshold cannot fix churn.** A plan-level acceptance margin was built and measured: it cut ordinary-day plan changes 109 → 20 but merely *relocated* the knife edge (one scenario sat at delta 1.50–1.54 against a 1.518 bar) and left just **$0.06 of headroom** on the live spike, because the per-slot gate already charges the cycle bar against that same energy. Reverted rather than shipped.
- **Only unambiguity is stable.** Requiring an outlier separates the two classes with nothing near the boundary: live spike **8.2×** median, ordinary winter morning peak **2.2×**. Multiplying the price *spread* instead was measured and rejected — it kills the incident fix from 2× upward.

### Measured after the fix

| | #908 | this PR |
|---|---|---|
| Ordinary-day horizons qualifying (of 400) | 219 | **0** |
| Ordinary-day plans changed | 109 | **0** |
| Scenarios where committed action flaps (60 × 12 re-plans) | 1 (worst 0→5 flaps) | **0** |
| Live 2026-08-05 spike captured | yes | **yes** ($0.00 spike-slot import) |

Behaviour on ordinary days is now identical to the feature being off. `spike_precharge_enabled=False` remains an exact kill switch.

## Testing

- [x] Full suite: **3394 passed, 1 xfailed**
- [x] Coverage 95% total; `spike_event.py` 100%, `core.py` 95%
- [x] `ruff check` clean on `custom_components/localshift` and both touched test files
- [ ] Tested in worktree — developed on branch, not a worktree
- [ ] CI passes — pending

New tests **re-plan under forecast jitter** rather than asserting on a single plan, since that is the only way the churn is visible. The ordinary-day fixture is the scenario that actually reproduced, taken verbatim. Both new gate assertions were confirmed to fail against pre-fix `core.py`. Inertness is asserted across the operator's whole `min_cycle_saving` range, not one value.

## Checklist

- [x] Code follows project conventions
- [x] No type errors
- [x] Tests added/updated for new functionality

---
_Generated by [Claude Code](https://claude.ai/code/session_01A3QfGTpzunHd3pFrYQZ7Qv)_