### PR TITLE
fix(optimizer): repair the four faults blocking negative-FIT avoidance (#719)

### DIFF
--- a/custom_components/localshift/engine/constraints.py
+++ b/custom_components/localshift/engine/constraints.py
@@ -50,9 +50,15 @@ def _determine_export_actions(
     if not can_discharge:
         return actions
 
+    # Avoidance applies through the *end* of the risk window, not just ahead of
+    # its start. The spill runs for the whole window, so a positive-FIT slot
+    # inside it is still a chance to make room; restricting to slots before the
+    # start meant a horizon that opens mid-spill (slot 0 already negative) had no
+    # avoidance slots at all. Slots past the window revert to normal mode rules —
+    # exporting after the spill has passed does nothing for avoidance.
     use_avoidance = (
         negative_fit_avoidance_context is not None
-        and slot_idx < negative_fit_avoidance_context.risk_window_start_idx
+        and slot_idx <= negative_fit_avoidance_context.risk_window_end_idx
     )
 
     if use_avoidance and negative_fit_avoidance_context is not None:
@@ -69,7 +75,32 @@ def _determine_export_actions(
             floor_pct = negative_fit_avoidance_context.recoverability_floor_pct_by_slot[
                 slot_idx
             ]
-            if soc_pct > floor_pct + 2.0:
+            # The floor has to bound the OUTCOME, not just admission. Testing
+            # ``soc_pct > floor + 2`` only asks whether we start the slot above
+            # the floor; a full-rate export slot moves SOC far further than that
+            # margin, so the planner could clear the check at 51.5% and land at
+            # 32.3% — sixteen points under its own floor — and repeat it next
+            # slot.
+            #
+            # Bound the landing point instead. A slot can shed at most
+            # ``discharge_rate_kw`` worth of SOC and the transition clamps at
+            # ``min_soc_pct``, so the worst case the DP can reach is the larger
+            # of the two; that is what has to clear the floor. Deriving the
+            # first term from the discharge rate keeps the guarantee true at any
+            # slot length or pack size, and honouring the clamp keeps the test
+            # from double-counting a floor the transitions already enforce —
+            # without it, export is refused whenever SOC sits within one slot's
+            # discharge of the floor, which silently forbids the *chain* of
+            # small exports that a spill day is made of.
+            slot_hours = slot.slot_interval_minutes / 60.0
+            max_export_pp = (
+                config.discharge_rate_kw
+                * slot_hours
+                / config.battery_capacity_kwh
+                * 100.0
+            )
+            landing_soc_pct = max(soc_pct - max_export_pp, config.min_soc_pct)
+            if landing_soc_pct >= floor_pct:
                 actions.append(PlannerAction.EXPORT_PROACTIVE)
     else:
         if config.optimization_mode == "self_consumption":

--- a/custom_components/localshift/engine/constraints.py
+++ b/custom_components/localshift/engine/constraints.py
@@ -34,13 +34,23 @@ def _determine_export_actions(
 
     Issue #719: Recoverability-based negative-FIT avoidance.
 
-    Allows proactive export at positive FIT before the risk window when:
-    - SOC is above the recoverability floor + buffer
-    - The slot is before the risk window starts
+    Allows proactive export at positive FIT through the *end* of the risk window
+    when:
+    - The slot is at or before ``risk_window_end_idx`` (the window spans
+      first-to-last bad-FIT slot, so it may contain positive-FIT slots, and those
+      are exactly the chances to make room before the rest of the spill)
     - The slot has positive sell price
+    - The projected landing SOC — what a full-rate export could leave, floored by
+      the transition's own ``min_soc_pct`` clamp — still clears the
+      recoverability floor
+
+    Slots past the window revert to normal mode rules; exporting after the spill
+    has passed does nothing for avoidance.
 
     The recoverability floor ensures we only discharge energy that can be
     recovered via future solar before the deadline, avoiding later grid import.
+    Bounding the *landing* SOC rather than the entry SOC is what makes that
+    guarantee hold across a chain of exports.
     """
     from custom_components.localshift.engine.types import PlannerAction
 

--- a/custom_components/localshift/engine/core.py
+++ b/custom_components/localshift/engine/core.py
@@ -226,20 +226,32 @@ def _is_urgency_precharge(
 
     """
 
-    # Spike-event funding exemption. A funding slot has ALREADY been proven to clear
-    # min_cycle_saving — that spread IS its qualification test in
-    # spike_event.find_funding_slots — so applying the gate again is redundant. It is
-    # also actively harmful: the gate is non-monotone, and leaving it on let a strictly
-    # larger feasible set produce a strictly WORSE plan on the DP's own objective
-    # (measured: projected net cost 1.2242 -> 1.5089 purely by declaring a second event;
-    # ablation confirms min_cycle_saving is the cause and switching_penalty is not).
-    # Unlike the DW branches below this is not scoped to pre-DW slots: the whole point is
-    # to fund an interval the demand window does not cover.
-    if (
-        config.spike_funding_slots is not None
-        and slot_idx in config.spike_funding_slots
-    ):
-        return True
+    # NOTE: spike-event funding slots are deliberately NOT exempted here.
+    #
+    # #908 exempted them, reasoning that qualification already uses min_cycle_saving as
+    # its bar so the gate is redundant. It is not: the two compare different quantities.
+    # ``spike_event.find_funding_slots`` compares SLOT PRICES
+    # (``slots[i].buy_price - slots[j].buy_price >= spread``); this gate compares the DP's
+    # REAL COSTS (``hold_total_cost - charge_total_cost >= min_cycle_saving * charge_kwh``),
+    # which nets off round-trip losses, the switching penalty, solar that would have filled
+    # the battery for free anyway, and — decisively — whether the stored energy actually
+    # survives to the dear slot instead of bleeding into overnight load first. A slot can
+    # pass the price-spread test and still fail the real economics, and exempting it left
+    # the codebase's ONLY hard anti-cycling gate switched off across up to half the horizon
+    # (measured: qualification fires on 55% of ordinary days). That is the #800 sawtooth's
+    # entry point, and ``_solve_guarded`` cannot catch it — it selects on the DP objective,
+    # which is exactly the metric this gate exists to correct.
+    #
+    # The anti-procrastination rationale borrowed from the demand-window branches below
+    # does not transfer either. Those exist because deferring a pre-charge can miss a
+    # DEADLINE (the DW target, with its terminal penalty). A price spike has no deadline:
+    # charging one slot later still captures it. Measured on the live 2026-08-05 fixture,
+    # keeping the gate on still serves the $1.65 slot entirely from the battery
+    # (spike-slot import $0.00) and still halves the morning block; it costs $0.28 of
+    # capture by charging at 06:00 rather than 05:30. That is the gate doing its job.
+    #
+    # Non-monotonicity — the other reason #908 gave — is already dominated by
+    # ``_solve_guarded``, which keeps whichever plan is cheaper.
 
     return (
         terminal_penalty_idx is not None
@@ -464,6 +476,18 @@ class DPPlanner:
 
         # Strictly cheaper only — ties keep the baseline so the plan never churns
         # for nothing.
+        #
+        # A strict comparison is a knife edge, and this planner re-solves every few
+        # minutes against a revised forecast, so a near-tie flips sign under ordinary
+        # jitter and takes the committed action with it. That is survivable only because
+        # qualification is now scoped to genuine spikes: an ordinary day produces no
+        # funding slots at all, so there is no near-tie to flip (measured: 0 of 400
+        # ordinary-day scenarios qualify, and the committed action no longer flaps in any
+        # of them). Adding a margin HERE was tried and rejected — the per-slot
+        # min-cycle-saving gate already charges the operator's cycle bar against this
+        # same energy, so charging it a second time at plan level left just $0.06 of
+        # headroom on the live 2026-08-05 spike, i.e. it made the incident fix fragile
+        # while protecting against a case qualification no longer admits.
         if delta > 0:
             _LOGGER.info(
                 "SPIKE PRECHARGE: %d funding slot(s) accepted, "

--- a/custom_components/localshift/engine/negative_fit.py
+++ b/custom_components/localshift/engine/negative_fit.py
@@ -9,25 +9,35 @@ from custom_components.localshift.engine.types import (
 )
 
 
-def find_risk_window(slots: list) -> tuple[int | None, int | None]:
-    """Find the spill-risk window (first bad-FIT through end of bad window)."""
+def find_risk_window(
+    slots: list, limit_idx: int | None = None
+) -> tuple[int | None, int | None]:
+    """Find the spill-risk window (first through last bad-FIT slot in the horizon).
+
+    The window spans the whole bad-price period rather than only its first
+    contiguous run. Real horizons interleave short positive blips through a
+    negative middle — a single afternoon can flip sign a dozen times — and a
+    first-run-only scan sizes the window off one slot, under-reading the day's
+    spill by an order of magnitude and leaving ``required_headroom_kwh`` far too
+    small to justify any pre-discharge.
+
+    Positive slots inside the span are export *opportunities*, not window
+    terminators; ``_determine_export_actions`` is what decides which of them are
+    usable, gated on the recoverability floor.
+
+    ``limit_idx`` bounds the scan (inclusive), so the window ends on the last bad
+    slot at or before the recovery deadline rather than on the deadline itself —
+    which would otherwise pull trailing positive slots into the headroom sum.
+    """
     risk_start_idx = None
-    n_slots = len(slots)
+    risk_end_idx = None
+    last_idx = len(slots) - 1 if limit_idx is None else min(limit_idx, len(slots) - 1)
 
-    for idx, slot in enumerate(slots):
-        if slot.sell_price <= 0:
-            risk_start_idx = idx
-            break
-
-    if risk_start_idx is None:
-        return None, None
-
-    risk_end_idx = risk_start_idx
-    for idx in range(risk_start_idx, n_slots):
+    for idx in range(last_idx + 1):
         if slots[idx].sell_price <= 0:
+            if risk_start_idx is None:
+                risk_start_idx = idx
             risk_end_idx = idx
-        else:
-            break
 
     return risk_start_idx, risk_end_idx
 
@@ -76,24 +86,32 @@ def compute_recovery_by_slot(
 
 def compute_floor_by_slot(
     n_slots: int,
-    current_kwh: float,
     target_kwh: float,
     min_floor_kwh: float,
     battery_capacity_kwh: float,
     recovery_by_slot: list[float],
 ) -> list[float]:
-    """Precompute recoverability floor for each slot."""
+    """Precompute the recoverability floor for each slot.
+
+    The floor is the lowest level from which conservative future solar still
+    reaches *target* by the deadline: ``target - recoverable``, never below the
+    configured minimum SOC.
+
+    It is deliberately anchored on the target rather than on present SOC. Asking
+    "how far can I discharge and get back to where I am now" is the wrong
+    question whenever current SOC is below target — which is most of a pre-demand
+    -window day — and on a weak-solar day with a low starting SOC it collapses
+    the floor onto ``min_soc_pct`` and lets the planner sell down to it, arriving
+    at the demand window tens of points short.
+
+    Because the answer depends only on the recovery available from each slot, it
+    is the same for every SOC the DP explores and can safely be precomputed.
+    """
     floor_by_slot = []
     for slot_idx in range(n_slots):
         recoverable_kwh = recovery_by_slot[slot_idx]
 
-        max_discharge_kwh = min(
-            current_kwh - min_floor_kwh,
-            recoverable_kwh,
-        )
-        max_discharge_kwh = max(max_discharge_kwh, 0.0)
-
-        floor_kwh = current_kwh - max_discharge_kwh
+        floor_kwh = target_kwh - recoverable_kwh
         floor_kwh = max(floor_kwh, min_floor_kwh)
         floor_kwh = min(floor_kwh, target_kwh)
 
@@ -113,7 +131,8 @@ def derive_negative_fit_avoidance_context(
 
     Returns None if any of:
     - No negative-FIT window within horizon
-    - No earlier positive-FIT slots
+    - No bad-FIT slot at or before the recovery deadline
+    - No positive-FIT slot to sell into at or before the window ends
     - No recovery path to target (cannot safely pre-discharge)
     """
     slots = inputs.slots
@@ -124,12 +143,32 @@ def derive_negative_fit_avoidance_context(
     if n_slots == 0:
         return None
 
-    risk_start_idx, risk_end_idx = find_risk_window(slots)
+    recovery_deadline_idx = None
+    for idx, slot in enumerate(slots):
+        if slot.is_demand_window_slot:
+            recovery_deadline_idx = idx
+            break
+    if recovery_deadline_idx is None:
+        recovery_deadline_idx = n_slots - 1
+
+    # Bound the scan at the recovery deadline. A 24h+ horizon usually carries
+    # tomorrow's negative middle as well, and sizing today's pre-discharge off a
+    # spill that lands after the battery has to be back at target overstates the
+    # headroom needed and stretches the window past anything this mechanism can
+    # act on.
+    risk_start_idx, risk_end_idx = find_risk_window(slots, recovery_deadline_idx)
     if risk_start_idx is None or risk_end_idx is None:
         return None
 
-    has_positive_before = any(s.sell_price > 0 for s in slots[:risk_start_idx])
-    if not has_positive_before:
+    # An export opportunity is any positive-FIT slot at or before the end of the
+    # risk window. Requiring one strictly *before* ``risk_start_idx`` made the
+    # feature disable itself in exactly the situation it exists for: once slot 0
+    # is already negative, ``risk_start_idx`` is 0, the "before" slice is empty,
+    # and the planner loses its export action for the whole horizon. On a
+    # scattered-negative afternoon the usable slots are the positive blips
+    # *inside* the window, so scan through ``risk_end_idx`` instead.
+    has_export_opportunity = any(s.sell_price > 0 for s in slots[: risk_end_idx + 1])
+    if not has_export_opportunity:
         return None
 
     min_floor_kwh = config.min_soc_pct / 100.0 * battery_capacity_kwh
@@ -152,21 +191,12 @@ def derive_negative_fit_avoidance_context(
     if existing_headroom_kwh >= required_headroom_kwh:
         return None
 
-    recovery_deadline_idx = None
-    for idx, slot in enumerate(slots):
-        if slot.is_demand_window_slot:
-            recovery_deadline_idx = idx
-            break
-    if recovery_deadline_idx is None:
-        recovery_deadline_idx = n_slots - 1
-
     recovery_by_slot = compute_recovery_by_slot(
         slots, recovery_deadline_idx, config.charge_efficiency
     )
 
     floor_by_slot = compute_floor_by_slot(
         n_slots,
-        current_kwh,
         target_kwh,
         min_floor_kwh,
         battery_capacity_kwh,
@@ -185,17 +215,18 @@ def derive_negative_fit_avoidance_context(
 
 def compute_recoverability_floor_pct(
     *,
-    current_soc_pct: float,
     slot_idx: int,
     context: NegativeFitAvoidanceContext,
     config: OptimizerConfig,
-    inputs: OptimizerInputs,
 ) -> float:
     """Compute the minimum SOC that still allows recovery to target.
 
     The recoverability floor is how low SOC can go now while still being
     able to recover to demand_window_target_soc_pct by the deadline using
     conservative future solar estimates.
+
+    Kept in step with ``compute_floor_by_slot`` — same ``target - recoverable``
+    anchor — so the scalar and precomputed forms cannot disagree.
 
     This is the planner-side guardrail. The Tesla-side PROACTIVE_EXPORT
     throttling (SOC - 5%, min 4%) remains the actuator guardrail.
@@ -204,20 +235,12 @@ def compute_recoverability_floor_pct(
     target_kwh = config.demand_window_target_soc_pct / 100.0 * battery_capacity_kwh
     min_floor_kwh = config.min_soc_pct / 100.0 * battery_capacity_kwh
 
-    current_kwh = current_soc_pct / 100.0 * battery_capacity_kwh
-
     if slot_idx >= len(context.conservative_recovery_kwh_by_slot):
         return config.demand_window_target_soc_pct
 
     recoverable_kwh = context.conservative_recovery_kwh_by_slot[slot_idx]
 
-    max_discharge_kwh = min(
-        current_kwh - min_floor_kwh,
-        recoverable_kwh,
-    )
-    max_discharge_kwh = max(max_discharge_kwh, 0.0)
-
-    floor_kwh = current_kwh - max_discharge_kwh
+    floor_kwh = target_kwh - recoverable_kwh
     floor_kwh = max(floor_kwh, min_floor_kwh)
     floor_kwh = min(floor_kwh, target_kwh)
 

--- a/custom_components/localshift/engine/reason_codes.py
+++ b/custom_components/localshift/engine/reason_codes.py
@@ -136,10 +136,13 @@ def classify_export_reason(
     negative_fit_avoidance_context: NegativeFitAvoidanceContext | None = None,
 ) -> PlannerReasonCode:
     """Classify EXPORT action reason."""
+    # Mirrors the ``use_avoidance`` window in ``_determine_export_actions`` — the
+    # two must agree or an export chosen for avoidance reasons gets reported under
+    # the wrong reason code.
     if (
         negative_fit_avoidance_context is not None
         and slot_idx is not None
-        and slot_idx < negative_fit_avoidance_context.risk_window_start_idx
+        and slot_idx <= negative_fit_avoidance_context.risk_window_end_idx
     ):
         return PlannerReasonCode.NEGATIVE_FIT_AVOIDANCE
 

--- a/custom_components/localshift/engine/spike_event.py
+++ b/custom_components/localshift/engine/spike_event.py
@@ -17,19 +17,29 @@ morning, and 71% of the projected day cost landed in that one block.
 WHAT THIS MODULE DOES
 ---------------------
 Identifies *funding slots*: slots where charging should be admitted to the
-feasible set because stored energy bought there displaces materially dearer
-energy later. Qualification mirrors the demand-window water level — sort the
-future by price, accumulate the net load the battery could actually displace,
-and require the **marginal** displaced price to beat this slot by at least the
-operator's own ``min_cycle_saving`` (grossed up for round-trip losses).
+feasible set because stored energy bought there serves a genuine price SPIKE
+later. Qualification has two parts, and both are required:
 
-Using ``min_cycle_saving`` as the bar is deliberate: it is the operator's
-existing statement of "a cycle is only worth it if it saves this much", so a
-qualifying slot has *already* been proven to clear that gate. Callers therefore
-also exempt these slots from the min-cycle gate itself (see
-``core._is_urgency_precharge``) — re-applying it is both redundant and harmful,
-because that gate is non-monotone and can reject a strictly better plan when the
-feasible set grows.
+1. The dear slot must be a spike at all — at least ``_SPIKE_OUTLIER_FACTOR``
+   times the horizon's own median non-demand-window price. This is what makes the
+   module inert on ordinary days.
+2. The trade must be worth doing — the marginal displaced price must beat this
+   slot by the operator's ``min_cycle_saving`` (grossed up for round-trip
+   losses), and the avoided cost must clear what the operator demands of one
+   slot's worth of cycling. This mirrors the demand-window water level: sort the
+   future by price and accumulate until the trade pays for itself.
+
+Test 1 is not optional and cannot be folded into test 2. A price SPREAD alone
+does not distinguish a spike from the ordinary daily shape — on any ordinary day
+the overnight trough sits a full cycle bar below the morning peak — so a
+spread-only rule fires on roughly half of all ordinary days. That is what #908
+shipped, and it is how the #800 sawtooth came back (see SAFETY).
+
+Qualifying slots are NOT exempt from the min-cycle-saving gate. #908 exempted
+them on the grounds that qualification uses ``min_cycle_saving`` as its bar, but
+the two compare different things: this module compares slot PRICES, the gate
+compares the DP's REAL COSTS. See ``core._is_urgency_precharge`` for the full
+argument and the measurement.
 
 WHAT THIS MODULE DELIBERATELY DOES NOT DO
 -----------------------------------------
@@ -46,11 +56,30 @@ days, where the evening DW peak is the dearest thing in the horizon).
 
 SAFETY
 ------
-Qualification is intentionally permissive; correctness comes from the caller's
-guard, which solves with and without the widening and keeps the cheaper plan
-(``DPPlanner.plan``). A 200-scenario sweep showed qualification alone still
-harms ~4% of firing scenarios (worst $0.49) because the DP is approximate; the
-guard removes that by construction.
+Safety lives HERE, in qualification. The caller's guard (``DPPlanner.plan``
+solves with and without the widening and keeps the cheaper plan) is a backstop
+against the DP's approximation error, not a sawtooth defence: it selects on the
+DP objective, which is exactly the metric the min-cycle-saving gate exists to
+correct, so a plan that cycles too eagerly looks *better* to it.
+
+Nor can the guard be tightened into one. It chooses between two structurally
+different plans, and this planner re-solves every few minutes against a revised
+forecast: whenever that choice is close, ordinary jitter flips it, and the
+committed action flips with it — charge, hold, charge, hold across consecutive
+re-plans, which is the sawtooth as the battery experiences it. Any threshold
+placed on a noisy quantity has this failure mode; a plan-level margin was tried
+and simply moved the knife edge (measured: it left $0.06 of headroom on the live
+2026-08-05 spike while still flapping elsewhere).
+
+The only stable design is to fire ONLY when the case is unambiguous, so that
+neither ordinary days nor spike days sit near a boundary. Measured over 400
+randomised ordinary-day horizons: #908 qualified on 219 and changed the plan on
+109; this version qualifies on 0, and the committed action no longer flaps in any
+of them, while the live 2026-08-05 spike is still served entirely from the
+battery.
+
+That is why ``_SPIKE_OUTLIER_FACTOR`` must not be lowered to catch "nearly
+spikes". The margin IS the safety property.
 """
 
 from __future__ import annotations
@@ -61,9 +90,36 @@ from custom_components.localshift.engine.types import OptimizerConfig, SlotConte
 
 _LOGGER = logging.getLogger(__name__)
 
-# A funding slot must displace at least this fraction of what one slot of
-# normal-rate charging actually stores. Below that the trade is noise.
-_MIN_DISPLACED_FRACTION = 0.5
+# NOTE: there is deliberately no "minimum displaced kWh" fraction here any more.
+#
+# #908 required a funding slot to displace at least half of what one charge slot stores.
+# That bar was calibrated when EVERY future slot counted as displaceable; now that only
+# genuine spike slots do (see _SPIKE_OUTLIER_FACTOR), it rejects the canonical case — a
+# spike one slot wide, whose net load is naturally less than half a charge slot. The
+# sufficiency test is instead stated in value (see _displaces_enough), which is what the
+# quantity bar was a proxy for.
+
+# How far above the horizon's ordinary price level a slot must sit before it counts as a
+# spike EVENT rather than the day's normal shape.
+#
+# This is the load-bearing constant for #800 safety, so it is set from measured
+# separation rather than taste. Against the horizon's own median non-demand-window price:
+#
+#   live 2026-08-05 spike ($1.65 vs a $0.20 median)          8.2x   must fire
+#   ordinary winter morning peak ($0.55 vs a $0.25 median)   2.2x   must NOT fire
+#   ordinary evening/shoulder shape                         <2x     must NOT fire
+#
+# 4.0 sits in the empty middle of that gap, so neither class is near the boundary —
+# which is the whole point. A price-SPREAD test alone (what #908 shipped) cannot make
+# this call: on an ordinary day an overnight trough is a full cycle-bar below the morning
+# peak, so the spread test fires on 55% of ordinary days, and once qualification sits on
+# a knife edge, ordinary forecast jitter flips it from cycle to cycle — the battery then
+# charges, holds, charges, holds across consecutive re-plans, which is the sawtooth.
+#
+# Deliberately relative to the horizon's own median rather than to min_cycle_saving:
+# what counts as a spike is a property of the day's prices, not of the operator's
+# separate opinion about when cycling the battery is worthwhile.
+_SPIKE_OUTLIER_FACTOR = 4.0
 
 
 def required_spread(config: OptimizerConfig) -> float:
@@ -77,6 +133,30 @@ def required_spread(config: OptimizerConfig) -> float:
     if round_trip <= 0:
         return float("inf")
     return config.min_cycle_saving / round_trip
+
+
+def spike_price_floor(slots: list[SlotContext]) -> float:
+    """Price at or above which a slot is a spike EVENT, not the day's ordinary shape.
+
+    Measured against the median non-demand-window buy price in the horizon, so the test
+    travels with the day: a $0.55 morning peak is ordinary on a $0.25 day and would be
+    extraordinary on a $0.05 one. Demand-window slots are excluded from the median for
+    the same reason they are excluded everywhere else here — that energy has its own
+    funder, and letting the DW peak drag the median up would make genuine spikes harder
+    to see on exactly the days they matter.
+
+    Returns ``inf`` (nothing can qualify) when the horizon has no usable positive price
+    level to measure against — a negative or zero median means the ordinary-price notion
+    has broken down, and this module must fail closed rather than admit everything.
+    """
+    prices = sorted(slot.buy_price for slot in slots if not slot.is_demand_window_slot)
+    if not prices:
+        return float("inf")
+
+    median = prices[len(prices) // 2]
+    if median <= 0:
+        return float("inf")
+    return median * _SPIKE_OUTLIER_FACTOR
 
 
 def _slot_hours(slot: SlotContext) -> float:
@@ -94,23 +174,30 @@ def _displaces_enough(
     by_price_desc: list[int],
     displaceable: list[float],
     spread: float,
-    needed_kwh: float,
+    needed_value: float,
 ) -> bool:
-    """True when the future holds ``needed_kwh`` of load all priced a full spread above j.
+    """True when charging at ``j`` buys at least ``needed_value`` of avoided cost.
 
-    ``by_price_desc`` is ranked dearest-first, so the first slot that fails the spread
-    test ends the search: nothing further can clear it. The last slot accepted sets the
-    marginal displaced price, mirroring the demand-window funding water level.
+    Every slot counted must clear ``j`` by a full ``spread``; ``by_price_desc`` is ranked
+    dearest-first, so the first slot that fails that test ends the search — nothing
+    further can clear it. The last slot accepted sets the marginal displaced price,
+    mirroring the demand-window funding water level.
+
+    Sufficiency is measured in DOLLARS (displaced kWh x price gap), not kWh. A spike is
+    frequently one slot wide, so any kWh bar wide enough to reject noise also rejects the
+    canonical case; the value of serving a genuine spike is large precisely because the
+    gap is, and that is the thing worth requiring.
     """
     accumulated = 0.0
     own_price = slots[j].buy_price
     for i in by_price_desc:
         if i <= j:
             continue
-        if slots[i].buy_price - own_price < spread:
+        gap = slots[i].buy_price - own_price
+        if gap < spread:
             return False
-        accumulated += displaceable[i]
-        if accumulated >= needed_kwh:
+        accumulated += displaceable[i] * gap
+        if accumulated >= needed_value:
             return True
     return False
 
@@ -137,13 +224,20 @@ def find_funding_slots(
     if spread == float("inf"):
         return frozenset()
 
-    # Net load the battery could displace in each slot. Demand-window slots are
-    # excluded: that energy already has a funder (the DW target), and bidding for
-    # it here would re-open the overnight sawtooth on ordinary days.
+    # Net load the battery could displace, counted ONLY in spike slots.
+    #
+    # Demand-window slots are excluded because that energy already has a funder (the DW
+    # target). Ordinary-priced slots are excluded because funding them is not this
+    # module's job: routine daily arbitrage is what the cheap-price gate and
+    # min_cycle_saving already govern, and bidding for it here is precisely how the #800
+    # overnight sawtooth comes back. A price spread alone does not distinguish the two —
+    # an ordinary morning peak sits a full cycle bar above the overnight trough — so the
+    # displaced price must also be an outlier for the day (see _SPIKE_OUTLIER_FACTOR).
+    floor = spike_price_floor(slots)
     displaceable = [
-        0.0
-        if slot.is_demand_window_slot
-        else max(0.0, slot.consumption_kwh - slot.solar_kwh)
+        max(0.0, slot.consumption_kwh - slot.solar_kwh)
+        if (not slot.is_demand_window_slot and slot.buy_price >= floor)
+        else 0.0
         for slot in slots
     ]
 
@@ -156,10 +250,15 @@ def find_funding_slots(
     for j, slot in enumerate(slots):
         if slot.is_demand_window_slot:
             continue  # grid import is forbidden inside the DW anyway
-        needed = _storable_kwh(slot, config) * _MIN_DISPLACED_FRACTION
-        if needed <= 0:
+        # What the trade must be worth: the saving the operator already demands of one
+        # slot's worth of cycling. Below that, charging here is not worth the cycle —
+        # which is the same judgement min_cycle_saving makes, in the same units.
+        needed_value = config.min_cycle_saving * _storable_kwh(slot, config)
+        if needed_value <= 0:
             continue
-        if _displaces_enough(j, slots, by_price_desc, displaceable, spread, needed):
+        if _displaces_enough(
+            j, slots, by_price_desc, displaceable, spread, needed_value
+        ):
             funding.add(j)
 
     if funding:

--- a/custom_components/localshift/engine/types.py
+++ b/custom_components/localshift/engine/types.py
@@ -778,10 +778,13 @@ class NegativeFitAvoidanceContext:
     """Index of the first slot in the spill-risk window (first sell_price <= 0)."""
 
     risk_window_end_idx: int
-    """Index of the last slot with sell_price <= 0 in the horizon (inclusive).
+    """Index of the last non-positive-FIT slot at or before the recovery deadline
+    (inclusive).
 
-    The window spans first-to-last bad-FIT slot, so it may contain positive-FIT
-    slots; those are the export opportunities the avoidance branch acts on.
+    The window spans first-to-last bad-FIT slot within that bound, so it may
+    contain positive-FIT slots; those are the export opportunities the avoidance
+    branch acts on. Bounding at the deadline keeps a 24h+ horizon from sizing
+    today's pre-discharge off tomorrow's negative middle.
     """
 
     required_headroom_kwh: float

--- a/custom_components/localshift/engine/types.py
+++ b/custom_components/localshift/engine/types.py
@@ -308,13 +308,12 @@ class OptimizerConfig:
     demand-window target, so an overnight trough two cents above ``base_cheap_price``
     blocks arbitrage worth dollars per kWh (2026-08-05: a $1.65 print met at the 10% floor).
 
-    Consumed in exactly two places, both of which must agree:
-      - ``constraints.feasible_actions`` — admits CHARGE_GRID_NORMAL for these slots.
-      - ``core._is_urgency_precharge`` — exempts them from the min-cycle-saving gate,
-        which they have already been proven to clear by construction (qualification uses
-        ``min_cycle_saving`` as its bar). Re-applying it is redundant AND harmful: that
-        gate is non-monotone and can reject a strictly better plan when the feasible set
-        grows.
+    Consumed in exactly one place: ``constraints.feasible_actions``, which admits
+    CHARGE_GRID_NORMAL for these slots. It widens the CHOICE SET only — every other
+    screen still applies, in particular the min-cycle-saving gate. #908 also exempted
+    these slots from that gate; that disarmed the only hard anti-cycling protection
+    wherever qualification fired and reopened the #800 sawtooth, so the exemption is
+    gone (see ``core._is_urgency_precharge``).
 
     Deliberately NOT routed through ``cheap_threshold_for_slot``: that function also feeds
     the futile-cycling penalty and the floor-routing helpers, so changing its return value

--- a/custom_components/localshift/engine/types.py
+++ b/custom_components/localshift/engine/types.py
@@ -778,7 +778,11 @@ class NegativeFitAvoidanceContext:
     """Index of the first slot in the spill-risk window (first sell_price <= 0)."""
 
     risk_window_end_idx: int
-    """Index of the last slot in the spill-risk window (inclusive)."""
+    """Index of the last slot with sell_price <= 0 in the horizon (inclusive).
+
+    The window spans first-to-last bad-FIT slot, so it may contain positive-FIT
+    slots; those are the export opportunities the avoidance branch acts on.
+    """
 
     required_headroom_kwh: float
     """Estimated storage space (kWh) needed to absorb spill during risk window."""

--- a/tests/engine/test_core.py
+++ b/tests/engine/test_core.py
@@ -314,11 +314,9 @@ class TestNegativeFitAvoidanceContext:
         ctx = derive_negative_fit_avoidance_context(inputs)
         assert ctx is not None
         floor_pct = compute_recoverability_floor_pct(
-            current_soc_pct=58.0,
             slot_idx=5,
             context=ctx,
             config=config,
-            inputs=inputs,
         )
         assert floor_pct < config.demand_window_target_soc_pct
         assert floor_pct >= config.min_soc_pct
@@ -348,11 +346,9 @@ class TestNegativeFitAvoidanceContext:
         ctx = derive_negative_fit_avoidance_context(inputs)
         assert ctx is not None
         floor_pct = compute_recoverability_floor_pct(
-            current_soc_pct=95.0,
             slot_idx=5,
             context=ctx,
             config=config,
-            inputs=inputs,
         )
         assert floor_pct >= 80.0
 

--- a/tests/engine/test_sawtooth_spike_funding.py
+++ b/tests/engine/test_sawtooth_spike_funding.py
@@ -1,0 +1,370 @@
+"""Sawtooth regression for spike-event pre-charge funding (#908 follow-up).
+
+#908 gave the DP a charge action in slots where a forecast price spike would otherwise
+be met at the SOC floor. Two things about how it did that reopened the #800 sawtooth.
+
+**Qualification was not actually scoped to spikes.** ``find_funding_slots`` admitted any
+slot sitting a cycle bar below enough future load — which on an ordinary day is just the
+overnight trough sitting below the morning peak. Measured over 400 randomised
+ordinary-day horizons carrying no spike at all, it fired on 219 of them and the guard
+accepted a *changed* plan on 109, against a commit claiming "no spike -> byte-identical
+plan". That claim was verified on a single fixture at ``min_cycle_saving=0.25``, the top
+of the operator's range; qualification widens as that knob falls.
+
+**And the exemption disarmed the anti-cycling gate.** Every funding slot was exempted
+from the min-cycle-saving gate — the codebase's only HARD anti-cycling screen — on the
+grounds that qualification already uses ``min_cycle_saving`` as its bar. The two are not
+the same comparison: qualification compares slot PRICES, the gate compares the DP's REAL
+COSTS (round-trip losses, switching penalty, free solar, and whether the energy survives
+to the dear slot instead of bleeding into overnight load first).
+
+The two together put the feature on a knife edge on ordinary days, and this planner
+re-solves every few minutes against a revised forecast. Ordinary jitter then flipped the
+decision from cycle to cycle, so the committed action — the one the state machine
+executes — alternated charge / hold / charge / hold. That is the sawtooth as the battery
+experiences it, and no single-plan fixture can see it, which is why these tests re-plan.
+"""
+
+from __future__ import annotations
+
+import random
+
+import pytest
+
+from custom_components.localshift.engine.core import _is_urgency_precharge
+from custom_components.localshift.engine.optimizer_dp import (
+    DPPlanner,
+    OptimizerConfig,
+    OptimizerInputs,
+    PlannerAction,
+    SlotContext,
+)
+from custom_components.localshift.engine.spike_event import (
+    find_funding_slots,
+    spike_price_floor,
+)
+
+CHARGE_ACTIONS = {PlannerAction.CHARGE_GRID_NORMAL, PlannerAction.CHARGE_GRID_BOOST}
+
+INTERVAL = 30
+
+# An ordinary winter day, 15:00 -> 15:00, taken verbatim from the randomised scenario
+# that reproduced the live flapping (overnight trough ~$0.18, evening demand window
+# ~$0.43, morning peak ~$0.55 OUTSIDE the demand window, solar building through midday).
+# Nothing here is a spike: the morning peak is 2.2x the day's median, which is simply
+# what a winter morning looks like. Under #908 this horizon flapped the committed action
+# five times across twelve re-plans.
+#            buy,    sell,   solar_kwh, load_kwh, is_demand_window
+_ORDINARY_DAY = [
+    (0.2427, 0.1427, 0.3845, 0.431, False),  # 15:00
+    (0.2516, 0.1516, 0.1960, 0.431, False),
+    (0.4512, 0.3512, 0.0000, 0.431, True),  # 16:00 demand window opens
+    (0.4331, 0.3331, 0.0000, 0.431, True),
+    (0.4142, 0.3142, 0.0000, 0.6895, True),
+    (0.4272, 0.3272, 0.0000, 0.6895, True),
+    (0.4248, 0.3248, 0.0000, 0.6895, True),
+    (0.4311, 0.3311, 0.0000, 0.6895, True),
+    (0.4379, 0.3379, 0.0000, 0.6895, True),
+    (0.4145, 0.3145, 0.0000, 0.6895, True),  # 19:30 demand window closes
+    (0.2561, 0.1561, 0.0000, 0.6895, False),
+    (0.2652, 0.1652, 0.0000, 0.6895, False),
+    (0.2663, 0.1663, 0.0000, 0.6895, False),
+    (0.2543, 0.1543, 0.0000, 0.6895, False),
+    (0.1732, 0.0732, 0.0000, 0.431, False),  # 22:00 overnight trough begins
+    (0.1873, 0.0873, 0.0000, 0.431, False),
+    (0.1804, 0.0804, 0.0000, 0.431, False),
+    (0.1724, 0.0724, 0.0000, 0.431, False),
+    (0.1884, 0.0884, 0.0000, 0.431, False),
+    (0.1761, 0.0761, 0.0000, 0.431, False),
+    (0.1924, 0.0924, 0.0000, 0.431, False),
+    (0.1918, 0.0918, 0.0000, 0.431, False),
+    (0.1807, 0.0807, 0.0000, 0.431, False),
+    (0.1932, 0.0932, 0.0000, 0.431, False),
+    (0.1730, 0.0730, 0.0000, 0.431, False),
+    (0.1770, 0.0770, 0.0000, 0.431, False),
+    (0.1808, 0.0808, 0.0000, 0.431, False),
+    (0.1763, 0.0763, 0.0000, 0.431, False),  # 04:30 trough ends
+    (0.2499, 0.1499, 0.0000, 0.431, False),
+    (0.2440, 0.1440, 0.0000, 0.431, False),
+    (0.2546, 0.1546, 0.0000, 0.6895, False),
+    (0.5303, 0.4303, 0.0000, 0.6895, False),  # 06:30 morning peak begins
+    (0.5247, 0.4247, 0.0000, 0.6895, False),
+    (0.5407, 0.4407, 0.0000, 0.6895, False),  # 07:30
+    (0.5503, 0.4503, 0.0000, 0.6895, False),
+    (0.5161, 0.4161, 0.1960, 0.6895, False),
+    (0.5141, 0.4141, 0.3845, 0.431, False),  # 09:00 morning peak ends
+    (0.2649, 0.1649, 0.5581, 0.431, False),
+    (0.2533, 0.1533, 0.7104, 0.431, False),
+    (0.2623, 0.1623, 0.8353, 0.431, False),
+    (0.2509, 0.1509, 0.9282, 0.431, False),
+    (0.2661, 0.1661, 0.9853, 0.431, False),
+    (0.2505, 0.1505, 1.0046, 0.431, False),
+    (0.2431, 0.1431, 0.9853, 0.431, False),
+    (0.2512, 0.1512, 0.9282, 0.431, False),
+    (0.2453, 0.1453, 0.8353, 0.431, False),
+    (0.2635, 0.1635, 0.7104, 0.431, False),
+    (0.2564, 0.1564, 0.5581, 0.431, False),  # 14:30
+]
+
+_MORNING_PEAK_IDX = 33  # 07:30, the dearest ordinary slot ($0.5407)
+_INITIAL_SOC = 43.714
+
+# This horizon's live settings, from the same scenario.
+_CHEAP_PRICE = 0.1834
+_CYCLE_BAR = 0.10
+
+
+def _slots(
+    spike: dict[int, float] | None = None,
+    jitter: random.Random | None = None,
+) -> list[SlotContext]:
+    """The ordinary day, optionally with a spike injected and/or re-forecast.
+
+    ``jitter`` models what a live re-plan actually sees: Amber revises its price
+    forecast and Solcast its solar forecast every cycle, by fractions of a percent.
+    """
+    overrides = spike or {}
+    out = []
+    for idx, (buy, sell, solar, load, is_dw) in enumerate(_ORDINARY_DAY):
+        buy = overrides.get(idx, buy)
+        if jitter is not None:
+            buy *= jitter.uniform(0.985, 1.015)
+            solar *= jitter.uniform(0.97, 1.03)
+        hour = (15.0 + idx * 0.5) % 24.0
+        out.append(
+            SlotContext(
+                slot_index=idx,
+                timestamp_iso=f"2026-08-05T{int(hour):02d}:{int((hour % 1) * 60):02d}:00",
+                slot_interval_minutes=INTERVAL,
+                buy_price=round(buy, 4),
+                sell_price=sell,
+                solar_kwh=round(solar, 4),
+                consumption_kwh=load,
+                is_demand_window_entry=(idx == 2),
+                is_demand_window_slot=is_dw,
+            )
+        )
+    return out
+
+
+def _config(**overrides) -> OptimizerConfig:
+    base = dict(
+        battery_capacity_kwh=13.5,
+        min_soc_pct=10.0,
+        max_soc_pct=100.0,
+        demand_window_target_soc_pct=100.0,
+        optimization_mode="self_consumption",
+        switching_penalty=0.02,
+        target_shortfall_penalty_per_pct=0.03,
+        min_cycle_saving=_CYCLE_BAR,
+        max_precharge_price=0.20,
+        effective_cheap_price=_CHEAP_PRICE,
+        base_cheap_price=_CHEAP_PRICE,
+        soc_bins=100,
+    )
+    base.update(overrides)
+    return OptimizerConfig(**base)
+
+
+def _plan(slots=None, initial_soc=_INITIAL_SOC, **config_overrides):
+    return DPPlanner().plan(
+        OptimizerInputs(
+            cycle_id="sawtooth-spike",
+            initial_soc_pct=initial_soc,
+            slots=slots if slots is not None else _slots(),
+            config=_config(**config_overrides),
+        )
+    )
+
+
+# --- qualification must be scoped to genuine spikes ------------------------------------
+
+
+def test_ordinary_morning_peak_is_not_a_spike():
+    """The core scoping rule, on the horizon that reproduced the live flapping.
+
+    A $0.55 morning peak against a $0.25 day is 2.2x the median — an ordinary winter
+    morning, not an event. #908 qualified it anyway, because a price SPREAD alone cannot
+    tell the two apart: the overnight trough sits a full cycle bar below the morning peak
+    on any ordinary day.
+    """
+    assert find_funding_slots(_slots(), _config()) == frozenset()
+
+
+def test_a_genuine_outlier_still_qualifies():
+    """Scoping must not blind the feature to the thing it exists for.
+
+    Same horizon, but 07:30 now carries a real spike rather than a peak.
+    """
+    assert find_funding_slots(_slots(spike={_MORNING_PEAK_IDX: 3.20}), _config())
+
+
+def test_spike_floor_tracks_the_days_own_price_level():
+    """What counts as a spike is relative to the horizon, not an absolute dollar figure.
+
+    Demand-window slots are excluded from the median so an expensive DW cannot mask a
+    genuine spike outside it.
+    """
+    floor = spike_price_floor(_slots())
+
+    assert floor > max(s.buy_price for s in _slots() if not s.is_demand_window_slot), (
+        "an ordinary day must have nothing at or above its own spike floor"
+    )
+    assert spike_price_floor(_slots(spike={_MORNING_PEAK_IDX: 3.20})) == pytest.approx(
+        floor
+    ), "injecting one spike must not move the floor materially"
+
+
+def test_spike_floor_fails_closed_on_a_non_positive_median():
+    """A negative-wholesale horizon has no ordinary-price level to measure against."""
+    slots = _slots()
+    for slot in slots:
+        slot.buy_price = -0.05
+
+    assert spike_price_floor(slots) == float("inf")
+    assert find_funding_slots(slots, _config()) == frozenset()
+
+
+def test_spike_floor_fails_closed_when_every_slot_is_a_demand_window_slot():
+    """No non-DW slot means no ordinary-price level, so nothing may qualify."""
+    slots = _slots()
+    for slot in slots:
+        slot.is_demand_window_slot = True
+
+    assert spike_price_floor(slots) == float("inf")
+    assert find_funding_slots(slots, _config()) == frozenset()
+
+
+def test_inert_when_round_trip_efficiency_is_degenerate():
+    """No spread can ever be cleared if a stored kWh returns nothing."""
+    assert (
+        find_funding_slots(
+            _slots(spike={_MORNING_PEAK_IDX: 3.20}), _config(charge_efficiency=0.0)
+        )
+        == frozenset()
+    )
+
+
+def test_inert_when_a_slot_can_store_nothing():
+    """A slot that cannot charge cannot fund anything, whatever the price gap."""
+    assert (
+        find_funding_slots(
+            _slots(spike={_MORNING_PEAK_IDX: 3.20}), _config(charge_rate_kw=0.0)
+        )
+        == frozenset()
+    )
+
+
+# --- the min-cycle-saving gate must stay armed ------------------------------------------
+
+
+def test_funding_slots_are_not_exempt_from_the_cycle_gate():
+    """A spike funding slot must still face the anti-cycling gate.
+
+    #908 returned True here for every funding slot. Qualification proves a PRICE spread,
+    not that the cycle pays once round-trip losses, the switching penalty and the drain
+    between charge and use are netted off — so the gate is not redundant, and exempting
+    these slots disarmed it wherever qualification fired.
+    """
+    config = _config(spike_funding_slots=frozenset({30}))
+
+    # Slot 30 has no demand-window justification, so nothing else can exempt it.
+    assert not _is_urgency_precharge(
+        30, soc=50.0, buy_price=0.19, terminal_penalty_idx=4, config=config
+    )
+
+
+def test_demand_window_precharge_exemption_is_untouched():
+    """Removing the spike exemption must not disturb the DW pre-charge exemption.
+
+    That one is load-bearing for a different failure (#860 procrastination into a missed
+    demand-window target) and is scoped to pre-DW slots below the target.
+    """
+    config = _config(pre_dw_funding_water_level=0.20)
+
+    assert _is_urgency_precharge(
+        1, soc=50.0, buy_price=0.19, terminal_penalty_idx=2, config=config
+    )
+
+
+# --- end-to-end: the ordinary day must be left alone ------------------------------------
+
+
+@pytest.mark.parametrize("cycle_bar", (0.05, 0.10, 0.15, 0.20, 0.25, 0.30))
+def test_ordinary_day_plan_is_untouched_at_every_cycle_bar(cycle_bar):
+    """No spike in the horizon => the feature changes nothing.
+
+    Parametrised because qualification widens as ``min_cycle_saving`` falls, and the
+    operator can set it anywhere from $0.00 to $1.00. #908's inertness fixture pinned
+    only $0.25.
+    """
+    enabled = _plan(min_cycle_saving=cycle_bar)
+    baseline = _plan(min_cycle_saving=cycle_bar, spike_precharge_enabled=False)
+
+    assert [d.action for d in enabled.decisions] == [
+        d.action for d in baseline.decisions
+    ], f"ordinary-day plan changed at min_cycle_saving=${cycle_bar}"
+    assert enabled.projected_net_cost == pytest.approx(baseline.projected_net_cost)
+    assert enabled.spike_funding_slot_count == 0
+
+
+@pytest.mark.parametrize("cycle_bar", (0.05, 0.10, 0.15, 0.20, 0.25, 0.30))
+def test_ordinary_day_never_grid_charges_above_the_cheap_base(cycle_bar):
+    """The #800 signature itself: a charge above the genuinely-cheap base."""
+    enabled = _plan(min_cycle_saving=cycle_bar)
+
+    sawtooth_charges = [
+        d.slot_index
+        for d in enabled.decisions
+        if d.action in CHARGE_ACTIONS and d.buy_price > _CHEAP_PRICE
+    ]
+    assert sawtooth_charges == [], (
+        f"grid charging above the cheap base at slots {sawtooth_charges} "
+        f"(min_cycle_saving=${cycle_bar})"
+    )
+
+
+# --- cross-cycle stability: the sawtooth as the battery experiences it -------------------
+
+
+@pytest.mark.parametrize("cycle_bar", (0.05, 0.10, 0.15))
+def test_committed_action_does_not_flap_across_replans(cycle_bar):
+    """The live sawtooth is plan CHURN, which no single-plan fixture can see.
+
+    LocalShift re-plans every few minutes and the state machine executes decisions[0].
+    Re-solving this horizon against ordinary forecast revisions must not flip the
+    committed action between charging and holding. Under #908 this exact scenario
+    produced charge / hold / hold / charge / hold / hold / charge across twelve cycles.
+    """
+    jitter = random.Random(20260805)
+    committed = [
+        _plan(slots=_slots(jitter=jitter), min_cycle_saving=cycle_bar)
+        .decisions[0]
+        .action
+        for _ in range(12)
+    ]
+
+    charging = [action in CHARGE_ACTIONS for action in committed]
+    flaps = sum(1 for a, b in zip(charging, charging[1:], strict=False) if a != b)
+    assert flaps == 0, (
+        f"committed action flapped {flaps} time(s) across re-plans "
+        f"(min_cycle_saving=${cycle_bar}): {[a.value for a in committed]}"
+    )
+
+
+def test_spike_day_decision_is_stable_across_replans():
+    """Stability must come from being far from the boundary, not from never firing.
+
+    A genuine spike must be picked up on every cycle, not on some of them — otherwise
+    the fix has merely moved the flapping onto the days that matter.
+    """
+    jitter = random.Random(20260805)
+    results = [
+        _plan(slots=_slots(spike={_MORNING_PEAK_IDX: 3.20}, jitter=jitter))
+        for _ in range(8)
+    ]
+
+    assert all(r.spike_funding_slot_count > 0 for r in results), (
+        "a real spike must qualify on every cycle: "
+        f"{[r.spike_funding_slot_count for r in results]}"
+    )

--- a/tests/engine/test_spike_event_precharge.py
+++ b/tests/engine/test_spike_event_precharge.py
@@ -277,7 +277,13 @@ def test_spike_funding_serves_the_spike_from_the_battery():
     assert enabled.decisions[SPIKE_IDX].objective_terms.import_cost == pytest.approx(
         0.0, abs=1e-6
     )
-    assert _block_import(enabled) < _block_import(baseline) / 2
+    # Was ``/ 2`` when funding slots were exempt from the min-cycle-saving gate. That
+    # exemption is gone (see ``core._is_urgency_precharge``): the gate now screens these
+    # charges like any other, and its per-slot deferral bias moves the buy from 05:30 to
+    # 06:00 — a dearer slot, so ~$0.28 less of the spike is captured. The load-bearing
+    # properties are unchanged: the spike slot itself is served entirely from the battery
+    # and the morning block is still roughly halved.
+    assert _block_import(enabled) < _block_import(baseline) * 0.55
 
 
 def test_spike_funding_adds_minimal_charging():

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -141,6 +141,61 @@ def test_feasible_actions_positive_fit_inside_risk_window(default_config):
     assert PlannerAction.EXPORT_PROACTIVE in actions
 
 
+def _max_export_pp(config, slot) -> float:
+    """SOC a single full-rate export slot can shed, in percentage points."""
+    return (
+        config.discharge_rate_kw
+        * (slot.slot_interval_minutes / 60.0)
+        / config.battery_capacity_kwh
+        * 100.0
+    )
+
+
+def _export_offered(config, slot, soc_pct, context) -> bool:
+    return PlannerAction.EXPORT_PROACTIVE in feasible_actions(
+        soc_pct=soc_pct,
+        slot=slot,
+        config=config,
+        slot_idx=0,
+        slots=None,
+        terminal_penalty_idx=None,
+        negative_fit_avoidance_context=context,
+    )
+
+
+def test_feasible_actions_landing_soc_boundary(default_config):
+    """Export is admitted iff the projected LANDING SOC clears the floor.
+
+    Entry SOC is not the test — a full-rate export slot sheds far more than the
+    old fixed 2pp margin, so the boundary sits one slot's discharge above the
+    floor.
+    """
+    slot = _make_test_slot(sell_price=0.08)
+    floor = 40.0
+    context = _make_context(risk_start=0, risk_end=10, floor_by_slot=[floor] * 15)
+    shed = _max_export_pp(default_config, slot)
+
+    assert _export_offered(default_config, slot, floor + shed + 0.1, context)
+    assert not _export_offered(default_config, slot, floor + shed - 0.1, context)
+
+
+def test_feasible_actions_landing_soc_honours_min_soc_clamp(default_config):
+    """Below floor + one slot, export still stands when the floor is min_soc.
+
+    The transition clamps at ``min_soc_pct``, so when the recoverability floor has
+    collapsed onto that clamp the landing point cannot breach it and the chain of
+    small exports a spill day needs must stay available.
+    """
+    slot = _make_test_slot(sell_price=0.08)
+    floor = default_config.min_soc_pct
+    context = _make_context(risk_start=0, risk_end=10, floor_by_slot=[floor] * 15)
+    shed = _max_export_pp(default_config, slot)
+    soc = floor + shed - 0.1  # would fail a naive soc - shed >= floor test
+
+    assert soc > default_config.min_soc_pct
+    assert _export_offered(default_config, slot, soc, context)
+
+
 def test_feasible_actions_normal_rules_after_risk_window(default_config):
     """Uses normal mode rules for slots past the end of the risk window."""
     slot = _make_test_slot(sell_price=0.08)

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -120,15 +120,36 @@ def test_feasible_actions_recoverability_floor_enforced(default_config):
     assert PlannerAction.EXPORT_PROACTIVE not in actions
 
 
-def test_feasible_actions_normal_rules_during_risk_window(default_config):
-    """Uses normal rules for slots during risk window (at/after risk start)."""
+def test_feasible_actions_positive_fit_inside_risk_window(default_config):
+    """Allows EXPORT_PROACTIVE at a positive-FIT blip inside the risk window.
+
+    The window spans first-to-last bad-FIT slot and may contain positive slots.
+    Those are the chances to make room before the rest of the spill, so avoidance
+    applies to them rather than falling back to the (unreachable) mode rules.
+    """
     slot = _make_test_slot(sell_price=0.08)
-    context = _make_context(risk_start=2)
+    context = _make_context(risk_start=2, risk_end=10)
     actions = feasible_actions(
         soc_pct=90.0,
         slot=slot,
         config=default_config,
-        slot_idx=2,
+        slot_idx=5,
+        slots=None,
+        terminal_penalty_idx=None,
+        negative_fit_avoidance_context=context,
+    )
+    assert PlannerAction.EXPORT_PROACTIVE in actions
+
+
+def test_feasible_actions_normal_rules_after_risk_window(default_config):
+    """Uses normal mode rules for slots past the end of the risk window."""
+    slot = _make_test_slot(sell_price=0.08)
+    context = _make_context(risk_start=2, risk_end=10)
+    actions = feasible_actions(
+        soc_pct=90.0,
+        slot=slot,
+        config=default_config,
+        slot_idx=11,
         slots=None,
         terminal_penalty_idx=None,
         negative_fit_avoidance_context=context,

--- a/tests/test_optimizer_dp_solve.py
+++ b/tests/test_optimizer_dp_solve.py
@@ -2860,3 +2860,94 @@ def test_negative_fit_context_computes_floor(default_config):
     assert all(
         f >= default_config.min_soc_pct for f in ctx.recoverability_floor_pct_by_slot
     )
+
+
+def test_negative_fit_window_spans_scattered_negatives(default_config):
+    """Window spans first-to-last bad slot, not just the first contiguous run.
+
+    A real spill afternoon flips sign repeatedly. Scanning only the first run
+    sized the window at one slot and under-read the spill.
+    """
+    default_config.demand_window_target_soc_pct = 80.0
+    sells = [0.08, 0.08, -0.01, 0.02, -0.01, 0.01, -0.02, -0.02, 0.03, 0.06]
+    slots = [
+        _make_slot_for_neg_fit(i, sell_price=s, solar_kwh=3.0, consumption_kwh=0.5)
+        for i, s in enumerate(sells)
+    ]
+    inputs = OptimizerInputs(
+        cycle_id="test",
+        initial_soc_pct=95.0,
+        slots=slots,
+        config=default_config,
+    )
+    ctx = derive_negative_fit_avoidance_context(inputs)
+    assert ctx is not None
+    assert ctx.risk_window_start_idx == 2
+    assert ctx.risk_window_end_idx == 7
+
+
+def test_negative_fit_context_survives_horizon_opening_mid_spill(default_config):
+    """Context is still derived when slot 0 is already at negative FIT.
+
+    Previously the "positive slot before the window" test emptied its slice and
+    returned None, so a horizon recomputed mid-spill lost its export action for
+    the entire day — the exact condition the feature exists to handle.
+    """
+    default_config.demand_window_target_soc_pct = 80.0
+    sells = [-0.01, 0.02, -0.01, 0.03, -0.02, -0.01, 0.05, 0.08, 0.08, 0.08]
+    slots = [
+        _make_slot_for_neg_fit(i, sell_price=s, solar_kwh=3.0, consumption_kwh=0.5)
+        for i, s in enumerate(sells)
+    ]
+    inputs = OptimizerInputs(
+        cycle_id="test",
+        initial_soc_pct=95.0,
+        slots=slots,
+        config=default_config,
+    )
+    ctx = derive_negative_fit_avoidance_context(inputs)
+    assert ctx is not None
+    assert ctx.risk_window_start_idx == 0
+    assert ctx.risk_window_end_idx == 5
+    assert ctx.required_headroom_kwh > 0
+
+
+def test_negative_fit_window_bounded_by_recovery_deadline(default_config):
+    """Window stops at the recovery deadline, ignoring tomorrow's negative middle."""
+    default_config.demand_window_target_soc_pct = 80.0
+    sells = [0.08, -0.01, 0.02, -0.01, 0.06, 0.06, -0.05, -0.05, -0.05, -0.05]
+    slots = [
+        _make_slot_for_neg_fit(i, sell_price=s, solar_kwh=3.0, consumption_kwh=0.5)
+        for i, s in enumerate(sells)
+    ]
+    # Demand window opens at slot 5; the negatives from slot 6 are past the
+    # deadline and must not size today's pre-discharge.
+    slots[5].is_demand_window_slot = True
+    inputs = OptimizerInputs(
+        cycle_id="test",
+        initial_soc_pct=95.0,
+        slots=slots,
+        config=default_config,
+    )
+    ctx = derive_negative_fit_avoidance_context(inputs)
+    assert ctx is not None
+    assert ctx.risk_window_start_idx == 1
+    assert ctx.risk_window_end_idx == 3
+    assert ctx.recovery_deadline_idx == 5
+
+
+def test_negative_fit_context_none_when_no_positive_slot_in_window(default_config):
+    """Still returns None when the window offers no positive-FIT slot to sell into."""
+    default_config.demand_window_target_soc_pct = 80.0
+    sells = [-0.01, -0.02, -0.01, -0.03, 0.08, 0.08]
+    slots = [
+        _make_slot_for_neg_fit(i, sell_price=s, solar_kwh=3.0, consumption_kwh=0.5)
+        for i, s in enumerate(sells)
+    ]
+    inputs = OptimizerInputs(
+        cycle_id="test",
+        initial_soc_pct=95.0,
+        slots=slots,
+        config=default_config,
+    )
+    assert derive_negative_fit_avoidance_context(inputs) is None


### PR DESCRIPTION
## Why

The question that started this: on a day where feed-in went negative from mid-morning, why did the optimizer never export beforehand?

Because in `self_consumption` mode it cannot. The gate in `engine/constraints.py` asks for `sell_price >= buy_price + export_price_margin` — feed-in exceeding import by 10c, in a market where import structurally sits ~8c *above* feed-in (same spot price, plus network and retail margin). It is not a strict gate, it is unsatisfiable, and it is unsatisfiable at the 0.02 default too.

So the #719 negative-FIT avoidance branch is the only path that can ever emit `EXPORT_PROACTIVE`. It had four defects stacked in it, each hidden by the one above.

## The four faults

**1 — `find_risk_window` stopped at the first contiguous run of `sell <= 0`.** A real spill afternoon flips sign repeatedly. Replaying the live 11:30–13:55 series: window `[6, 7]`, spill sized at 0.48 kWh against 4.11 kWh of existing headroom, so the mechanism concluded there was room and returned `None`. First-to-last gives `[6, 29]` and 5.74 kWh. Bounded at the recovery deadline so tomorrow's negative middle cannot inflate today's estimate.

**2 — the feature disabled itself once prices were already negative.** The guard required a positive-FIT slot strictly *before* `risk_start_idx`. Once slot 0 is negative that slice is empty and the planner loses its export action for the entire horizon — switching itself off in precisely the condition it exists to handle. The opportunity scan now runs through `risk_end_idx`; the feasibility and reason-code windows move to `<= risk_window_end_idx` to match.

**3 — the recoverability floor was anchored on current SOC, not target.** Both implementations computed `current - recoverable`, which answers "how low can I go and get back to where I am now?" The question is "how low can I go and still reach *target*?" Whenever SOC sits below target — most of a pre-DW day — the old form is too permissive; at a 60% start it collapsed onto `min_soc_pct` and let the planner sell down to it, reaching the demand window at 67.9%.

**4 — the floor gated admission, never the outcome.** `soc_pct > floor_pct + 2.0` only asks whether the slot *starts* above the floor:

```
idx time   sell    action            soc   floor
  1 06:30 +0.1250 hold               51.5   48.6
  2 07:00 +0.1200 export_proactive   32.3   48.6
```

Cleared at 51.5%, landed at 32.3% — sixteen points under its own floor, free to repeat next slot. The landing point is now bounded, derived from `discharge_rate_kw` rather than a fixed constant and honouring the transition's own `min_soc_pct` clamp.

## Verification

972-scenario sweep across solar peak, forecast confidence, spill depth, positive-blip frequency, starting SOC and evening peak. Deterministic product, both arms run from one script, baseline taken from stashed HEAD.

| | HEAD | this PR |
|---|---|---|
| DW-entry regressions | — | **0** |
| DW entries below 95% target | 81 | **54** |
| pre-DW floor touches | 489 | **309** |
| spill at `sell <= 0` | 6,666 kWh | **3,236 kWh** |
| aggregate cash | −$598.25 | **−$840.75** |

Net **+$242.51** across the set. Zero solver failures. 3407 tests pass, 1 xfail. Ruff findings byte-identical to HEAD.

Correctly declines where it should: on the live 14:07 horizon the negatives run to the demand window with no positive slot left to sell into, and the context returns `None`. Overnight is inert by construction — no solar means recovery is ~0, the floor sits at current SOC, no export is feasible. That is what keeps this clear of the sawtooth.

## The 318 that earn less

45 are the floor refusing to buy revenue with demand-window readiness:

```
HEAD    cash=-0.5630  exports=3  dw_entry= 67.9%
this PR cash=-0.1391  exports=0  dw_entry=100.0%
```

The other 273 cost **$81.01 total, mean $0.26**, and are understood rather than open. `compute_recovery_by_slot` already discounts future solar by 0.8; the floor then treats that discounted figure as inviolable. HEAD's sloppier floor collapsed to `min_soc` exactly and got away with marginal violations that only worked because the recovery estimate is deliberately pessimistic — it exported to 10.0% against its own 10.8% floor and finished at 100% on luck.

**Follow-up, not in this PR:** that 0.8 factor was tuned when the floor was effectively advisory. Now that it is a hard constraint the factor is doing double duty and should be revisited on its own evidence.

## Not included

A solar-confidence gate was considered as a backstop and deliberately left out. `engine/types.py` already records the 2026-07-27 incident — a blended "high" 0.87 confidence against a 52% Solcast day-confidence — and concludes solar confidence is unreliable, pointing at `precharge_runway_slack_min` as the quantity that matters. With fault 4 fixed there is nothing left for such a gate to catch: DW regressions are zero and floor touches sit below HEAD.

## Test changes

`test_feasible_actions_normal_rules_during_risk_window` asserted the behaviour fault 2 changes; replaced with inside-window and after-window cases. Four new context tests cover scattered negatives, a horizon opening mid-spill, deadline bounding, and the still-returns-`None` case.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Positive-price exports can now occur during negative-price avoidance windows when battery recovery remains feasible.
  - Spike-event charging now requires a genuine price spike and sufficient economic value.
  - Spike charging remains subject to minimum cycle-savings protections.

- **Bug Fixes**
  - Improved risk-window detection, recovery-floor calculations, and post-window behavior.
  - Prevented unnecessary charge/hold changes across forecast updates.

- **Tests**
  - Added coverage for negative-price avoidance, recovery limits, spike qualification, and planning stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->