### PR TITLE
Productize HA data sweep into scripts/ha_data_sweep.py

### DIFF
--- a/custom_components/localshift/engine/parameters.py
+++ b/custom_components/localshift/engine/parameters.py
@@ -516,9 +516,7 @@ class ParameterOptimizer:
             # was made, so scores reflect the value that produced them.
             # Untagged (pre-Issue #913) or out-of-range tags fall back to the
             # current value's bin, preserving legacy behaviour.
-            tagged_value = (decision.adaptive_params_at_decision or {}).get(
-                param_name
-            )
+            tagged_value = (decision.adaptive_params_at_decision or {}).get(param_name)
             if tagged_value is None or not (
                 param_def.min_val <= tagged_value <= param_def.max_val
             ):
@@ -538,7 +536,9 @@ class ParameterOptimizer:
 
         bin_center = param_def.min_val + (best_bin + 0.5) * bin_width
 
-        current_val = self._current_params.values.get(param_name, param_def.default)
+        current_val = self._current_params.values.get(param_name)
+        if current_val is None:
+            current_val = param_def.default
         bin_center = self._apply_step_limit(bin_center, current_val, param_def.step)
 
         bin_center = max(param_def.min_val, min(param_def.max_val, bin_center))

--- a/custom_components/localshift/switch.py
+++ b/custom_components/localshift/switch.py
@@ -101,9 +101,7 @@ class LocalShiftSwitch(SwitchEntity):
                 self.coordinator.optimization_controller.set_learning_enabled(
                     self._is_on
                 )
-                _LOGGER.debug(
-                    "Learning sync at switch load: learning=%s", self._is_on
-                )
+                _LOGGER.debug("Learning sync at switch load: learning=%s", self._is_on)
 
     @property
     def device_info(self) -> DeviceInfo:

--- a/scripts/ha_data_sweep.py
+++ b/scripts/ha_data_sweep.py
@@ -1,0 +1,672 @@
+#!/usr/bin/env python3
+"""ha_data_sweep.py — recorder-DB health and economics sweep for LocalShift.
+
+Pulls a window of history straight out of the Home Assistant recorder
+database (NOT the REST history API, which silently truncates multi-day
+requests) and produces a markdown report: solar forecast accuracy, price
+capture, daily grid/battery flows, battery-mode churn, charge timing vs
+the day's cheapest hours, and learning decision-outcome distributions.
+
+Method
+------
+The recorder DB is COPY-FIRST: the live file cannot be opened read-only
+by sqlite while HA holds it, so both the db and its -wal are copied to a
+temp dir, queried, and deleted (keep with --keep-db). HA records state
+CHANGES ONLY — long gaps in a series usually mean a constant value (e.g.
+overnight zero solar), not an outage.
+
+Usage
+-----
+  scripts/ha_data_sweep.py                    # 7 days, ./tmp output
+  scripts/ha_data_sweep.py --days 14
+  scripts/ha_data_sweep.py --config /path/to/ha/config
+  scripts/ha_data_sweep.py --stdout           # print report, no files
+  scripts/ha_data_sweep.py --keep-db          # keep the DB copy for ad-hoc SQL
+
+Config dir resolution: --config flag > HA_CONFIG env >
+/Volumes/appdata/Home-Assistant-Container (this host's default).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import sqlite3
+import sys
+from collections import Counter, defaultdict
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+AEST = timezone(timedelta(hours=10))
+
+DB_NAME = "home-assistant_v2.db"
+DEFAULT_CONFIG = "/Volumes/appdata/Home-Assistant-Container"
+
+ENTITIES: dict[str, str] = {
+    "general_price": "sensor.amber_express_100h_general_price",
+    "feed_in_price": "sensor.amber_express_100h_feed_in_price",
+    "solar_forecast": "sensor.solcast_pv_forecast_power_now",
+    "solar_power": "sensor.my_home_solar_power",
+    "battery_power": "sensor.my_home_battery_power",
+    "grid_power": "sensor.my_home_grid_power",
+    "load_power": "sensor.my_home_load_power",
+    "grid_imported": "sensor.my_home_grid_imported",
+    "grid_exported": "sensor.my_home_grid_exported",
+    "import_cost": "sensor.my_home_grid_imported_cost",
+    "export_comp": "sensor.my_home_grid_exported_compensation",
+    "batt_charged": "sensor.my_home_battery_charged",
+    "batt_discharged": "sensor.my_home_battery_discharged",
+    "batt_from_grid": "sensor.my_home_battery_imported_from_grid",
+    "batt_to_grid": "sensor.my_home_grid_exported_from_battery",
+}
+MODE_ENTITY = "select.localshift_battery_mode"
+GAP_ENTITIES = [
+    "solar_forecast",
+    "solar_power",
+    "grid_power",
+    "batt_charged",
+    "batt_from_grid",
+    "grid_exported",
+]
+# Forecasts are Watts; my_home_* power sensors are kilowatts.
+SOLAR_ACTUAL_SCALE = 1000.0
+
+
+# --------------------------------------------------------------------------
+# Pure analysis helpers
+# --------------------------------------------------------------------------
+
+def parse_series(rows: list[tuple[float, str | None]]) -> list[tuple[float, float]]:
+    """Keep only float-parseable states, preserving order."""
+    out = []
+    for ts, st in rows:
+        try:
+            out.append((ts, float(st)))
+        except (TypeError, ValueError):
+            pass
+    return out
+
+
+def step_value(s: list[tuple[float, float]], t: float) -> float | None:
+    """State-machine value at time t: last sample with ts <= t, else None."""
+    lo, hi, v = 0, len(s) - 1, None
+    while lo <= hi:
+        mid = (lo + hi) // 2
+        if s[mid][0] <= t:
+            v = s[mid][1]
+            lo = mid + 1
+        else:
+            hi = mid - 1
+    return v
+
+
+def merge_buckets(
+    fc: list[tuple[float, float]],
+    ac: list[tuple[float, float]],
+    bucket_secs: int = 900,
+    actual_scale: float = SOLAR_ACTUAL_SCALE,
+) -> dict[int, dict[str, float]]:
+    """Merge forecast (W) and actual (scaled to W) series into buckets.
+
+    Last write wins within a bucket; a side missing from a bucket is
+    simply absent from that bucket's dict.
+    """
+    buckets: dict[int, dict[str, float]] = {}
+    for ts, v in fc:
+        buckets.setdefault(int(ts // bucket_secs), {})["f"] = v
+    for ts, v in ac:
+        buckets.setdefault(int(ts // bucket_secs), {})["a"] = v * actual_scale
+    return buckets
+
+
+def bucket_pairs(
+    buckets: dict[int, dict[str, float]],
+    tz: timezone,
+    min_w: float = 100.0,
+    bucket_secs: int = 900,
+) -> dict:
+    """Solar bias stats + per-day energy from merged buckets.
+
+    Bias stats use only buckets where either side exceeds min_w (daytime);
+    day energy integrates every bucket so totals are comparable.
+    """
+    n = 0
+    bias_sum = 0.0
+    by_hour: dict[int, list[float]] = defaultdict(list)
+    day_f: dict[str, float] = defaultdict(float)
+    day_a: dict[str, float] = defaultdict(float)
+    kwh = 1.0 * bucket_secs / 3_600_000.0  # W -> kWh per bucket
+    for b in sorted(buckets):
+        d = buckets[b]
+        ts = b * bucket_secs
+        key = datetime.fromtimestamp(ts, tz).strftime("%m-%d")
+        if "a" in d:
+            day_a[key] += d["a"] * kwh
+        if "f" in d:
+            day_f[key] += d["f"] * kwh
+        if "f" in d and "a" in d and (d["f"] > min_w or d["a"] > min_w):
+            n += 1
+            bias_sum += d["f"] - d["a"]
+            by_hour[datetime.fromtimestamp(ts, tz).hour].append(d["f"] - d["a"])
+    tot_f, tot_a = sum(day_f.values()), sum(day_a.values())
+    return {
+        "n_buckets": n,
+        "bias_mean_w": bias_sum / n if n else 0.0,
+        "bias_by_hour": {
+            h: {"n": len(v), "mean_w": sum(v) / len(v)} for h, v in sorted(by_hour.items())
+        },
+        "day_energy": {k: (day_f[k], day_a.get(k, 0.0)) for k in sorted(day_a)},
+        "energy_ratio": tot_f / tot_a if tot_a > 0 else 0.0,
+    }
+
+
+def price_capture(
+    gpow: list[tuple[float, float]],
+    gp: list[tuple[float, float]],
+    fi: list[tuple[float, float]],
+    step: int = 300,
+) -> dict:
+    """Energy-weighted import price vs the average price while importing.
+
+    Capture ratio < 1 means imports were front-loaded into cheaper moments
+    of the import-active periods. Export revenue uses the feed-in price.
+    """
+    imp_e = imp_c = exp_e = exp_rev = 0.0
+    window_prices: list[float] = []
+    if not gpow:
+        return {
+            "import_kwh": 0.0, "export_kwh": 0.0, "avg_paid": 0.0,
+            "import_window_avg_price": 0.0, "capture_ratio": 0.0,
+            "export_revenue": 0.0,
+        }
+    dt = step / 3600.0
+    t = gpow[0][0]
+    while t < gpow[-1][0]:
+        p = step_value(gpow, t) or 0.0
+        pr = step_value(gp, t)
+        fir = step_value(fi, t)
+        if pr is not None:
+            if p > 0:
+                imp_e += p * dt
+                imp_c += p * dt * pr
+                window_prices.append(pr)
+            elif p < 0:
+                exp_e += -p * dt
+                if fir is not None:
+                    exp_rev += -p * dt * fir
+        t += step
+    avg_paid = imp_c / imp_e if imp_e > 0 else 0.0
+    window_avg = (
+        sum(window_prices) / len(window_prices) if window_prices else 0.0
+    )
+    return {
+        "import_kwh": imp_e,
+        "export_kwh": exp_e,
+        "avg_paid": avg_paid,
+        "import_window_avg_price": window_avg,
+        "capture_ratio": avg_paid / window_avg if window_avg > 0 else 0.0,
+        "export_revenue": exp_rev,
+    }
+
+
+def daily_deltas(series: list[tuple[float, float]], tz: timezone) -> dict[str, float]:
+    """Per-local-day max-min on cumulative meters (daily-reset safe)."""
+    byday: dict[str, list[float]] = defaultdict(list)
+    for ts, v in series:
+        byday[datetime.fromtimestamp(ts, tz).strftime("%m-%d")].append(v)
+    return {d: max(vs) - min(vs) for d, vs in sorted(byday.items())}
+
+
+def mode_stats(states: list[tuple[float, str]], tz: timezone) -> dict:
+    """Transition counts, dwell minutes, destination/pair counts, hour hist."""
+    trans = [(b[0], a[1], b[1]) for a, b in zip(states, states[1:], strict=False) if b[1] != a[1]]
+    dest = Counter(new for _, _, new in trans)
+    pairs = Counter((old, new) for _, old, new in trans)
+    hours = Counter(datetime.fromtimestamp(t, tz).hour for t, _, _ in trans)
+    dwells = sorted((b[0] - a[0]) / 60 for a, b in zip(states, states[1:], strict=False)
+                    if b[1] != a[1])
+    return {
+        "n_changes": len(trans),
+        "dest_counts": dict(dest),
+        "pairs": dict(pairs),
+        "hour_hist": dict(sorted(hours.items())),
+        "dwells_min": dwells,
+        "dwell_median_min": dwells[len(dwells) // 2] if dwells else None,
+        "dwell_p10_min": dwells[len(dwells) // 10] if dwells else None,
+        "dwell_min_min": dwells[0] if dwells else None,
+    }
+
+
+def charge_timing(
+    batt: list[tuple[float, float]],
+    gp: list[tuple[float, float]],
+    day_start: float,
+    tz: timezone,
+    step: int = 300,
+    charge_kw: float = -0.05,
+    bulk_kwh: float = 0.3,
+) -> dict:
+    """Charging energy/prices for one local day vs its cheapest hours.
+
+    Battery power convention: negative = charging.
+    """
+    hourly = [step_value(gp, day_start + h * 3600) for h in range(24)]
+    seen = [x for x in hourly if x is not None]
+    charged = paid = 0.0
+    per_hour: dict[int, float] = defaultdict(float)
+    for i in range(0, 86400, step):
+        bp = step_value(batt, day_start + i) or 0.0
+        pr = step_value(gp, day_start + i)
+        if bp < charge_kw and pr is not None:
+            e = -bp * step / 3600.0
+            charged += e
+            paid += e * pr
+            per_hour[datetime.fromtimestamp(day_start + i, tz).hour] += e
+    cheapest = sorted(
+        (p, h) for h, p in enumerate(hourly) if p is not None
+    )[:3]
+    return {
+        "charged_kwh": charged,
+        "avg_paid": paid / charged if charged > 0 else None,
+        "bulk_hours": {h: e for h, e in per_hour.items() if e > bulk_kwh},
+        "cheapest_hours": [h for _, h in cheapest],
+        "day_min_price": min(seen) if seen else None,
+        "day_max_price": max(seen) if seen else None,
+    }
+
+
+def decision_stats(data: dict) -> dict:
+    """Percentiles by mode, worst decisions, field completeness."""
+    comp = data.get("completed_decisions") or []
+    pend = data.get("pending_decisions") or []
+    scored = [r for r in comp if r.get("outcome_score") is not None]
+    by_mode: dict[str, list[float]] = defaultdict(list)
+    for r in scored:
+        by_mode[r.get("mode_chosen")].append(r["outcome_score"])
+    stats = {
+        m: {
+            "n": len(v),
+            "median": pctl(sorted(v), 0.5),
+            "p10": pctl(sorted(v), 0.1),
+            "p90": pctl(sorted(v), 0.9),
+        }
+        for m, v in by_mode.items()
+    }
+    worst = sorted(scored, key=lambda r: r["outcome_score"])[:5]
+    ts_list = sorted(r.get("timestamp", "") for r in comp)
+    return {
+        "completed": len(comp),
+        "scored": len(scored),
+        "pending": len(pend),
+        "by_mode": dict(stats),
+        "worst5": worst,
+        "missing_cost": sum(
+            1 for r in scored if r.get("actual_cost_during_period") is None
+        ),
+        "span_first": ts_list[0] if ts_list else None,
+        "span_last": ts_list[-1] if ts_list else None,
+    }
+
+
+def pctl(sorted_vals: list[float], q: float) -> float:
+    """Order statistic at fraction q (0..1) of a pre-sorted list."""
+    if not sorted_vals:
+        raise ValueError("pctl of empty list")
+    idx = min(int(q * len(sorted_vals)), len(sorted_vals) - 1)
+    return sorted_vals[idx]
+
+
+def gap_windows(
+    series: list[tuple[float, float]], min_gap_s: float = 3600.0
+) -> list[tuple[float, float]]:
+    """Consecutive-sample gaps longer than min_gap_s."""
+    return [(a[0], b[0]) for a, b in zip(series, series[1:], strict=False)
+            if b[0] - a[0] > min_gap_s]
+
+
+# --------------------------------------------------------------------------
+# Markdown rendering
+# --------------------------------------------------------------------------
+
+def _md_solar(solar: dict) -> list[str]:
+    lines = ["## Solar forecast vs actual", ""]
+    if not solar:
+        return lines + ["(no data)", ""]
+    lines.append(
+        f"- daytime buckets: {solar['n_buckets']}, mean bias "
+        f"(fc-ac): {solar['bias_mean_w']:+.0f} W, "
+        f"energy ratio fc/ac: {solar['energy_ratio']:.2f}"
+    )
+    lines.append("")
+    lines.append("| day | forecast kWh | actual kWh |")
+    lines.append("|-----|--------------|------------|")
+    for day, (f, a) in solar["day_energy"].items():
+        lines.append(f"| {day} | {f:.1f} | {a:.1f} |")
+    lines.append("")
+    lines.append("bias by local hour: " + " ".join(
+        f"{h:02d}:{v['mean_w']:+.0f}" for h, v in solar["bias_by_hour"].items()
+    ))
+    return lines + [""]
+
+
+def _md_price(price: dict) -> list[str]:
+    lines = ["## Price capture", ""]
+    if not price:
+        return lines + ["(no data)", ""]
+    lines.append(
+        f"- import: {price['import_kwh']:.1f} kWh, avg paid "
+        f"{price['avg_paid']:.3f} $/kWh vs "
+        f"{price['import_window_avg_price']:.3f} while importing — "
+        f"capture ratio: **{price['capture_ratio']:.2f}** (<1 beats average)"
+    )
+    lines.append(
+        f"- export: {price['export_kwh']:.1f} kWh, revenue "
+        f"${price['export_revenue']:.2f}"
+    )
+    return lines + [""]
+
+
+def _md_meters(daily_meters: dict, days_order: list[str]) -> list[str]:
+    lines = ["## Daily meters (kWh / $, local days, max-min)", ""]
+    cols = list(daily_meters.keys())
+    if not cols:
+        return lines + ["(no data)", ""]
+    header = "| day | " + " | ".join(cols) + " |"
+    sep = "|-----" * (len(cols) + 1) + "|"
+    lines += [header, sep]
+    for day in days_order:
+        vals = " | ".join(
+            f"{daily_meters[c].get(day, 0.0):.1f}" for c in cols
+        )
+        lines.append(f"| {day} | {vals} |")
+    return lines + [""]
+
+
+def _md_mode(mode: dict, days: int) -> list[str]:
+    lines = ["## Battery mode churn", ""]
+    if not mode:
+        return lines + ["(no data)", ""]
+    lines.append(
+        f"- {mode['n_changes']} changes ({mode['n_changes'] / days:.1f}/day), "
+        f"dwell median {mode['dwell_median_min']:.0f}m "
+        f"p10 {mode['dwell_p10_min']:.0f}m"
+    )
+    lines.append(f"- destinations: {mode['dest_counts']}")
+    lines.append(f"- by local hour: {mode['hour_hist']}")
+    return lines + [""]
+
+
+def _md_charge(charge_days: dict) -> list[str]:
+    lines = ["## Charge timing vs day's cheapest hours", ""]
+    if not charge_days:
+        return lines + ["(no charging days)", ""]
+    lines.append("| day | charged kWh | avg paid | day's cheapest hours |")
+    lines.append("|-----|-------------|----------|----------------------|")
+    for day, ct in charge_days.items():
+        paid = f"{ct['avg_paid']:.3f}" if ct["avg_paid"] is not None else "n/a"
+        cheap = ", ".join(str(h) for h in ct["cheapest_hours"])
+        lines.append(f"| {day} | {ct['charged_kwh']:.1f} | {paid} | {cheap} |")
+    return lines + [""]
+
+
+def _md_decisions(decisions: dict) -> list[str]:
+    lines = ["## Learning decision outcomes", ""]
+    if not decisions:
+        return lines + ["(decision store not found)", ""]
+    lines.append(
+        f"- completed: {decisions['completed']} "
+        f"(scored {decisions['scored']}), pending: {decisions['pending']}, "
+        f"missing cost: {decisions['missing_cost']}/{decisions['scored']}"
+    )
+    lines.append(
+        f"- span: {decisions['span_first']} -> {decisions['span_last']}"
+    )
+    lines.append("")
+    lines.append("| mode | n | median | p10 | p90 |")
+    lines.append("|------|---|--------|-----|-----|")
+    for m, st in decisions["by_mode"].items():
+        lines.append(
+            f"| {m} | {st['n']} | {st['median']:+.3f} | "
+            f"{st['p10']:+.3f} | {st['p90']:+.3f} |"
+        )
+    lines.append("")
+    lines.append("worst 5:")
+    for r in decisions["worst5"]:
+        lines.append(
+            f"- {str(r.get('timestamp', ''))[:16]} {r.get('mode_chosen')} "
+            f"score={r['outcome_score']:+.3f} "
+            f"cost=${r.get('actual_cost_during_period') or 0:.2f} "
+            f"imp={r.get('actual_import_kwh') or 0:.1f}"
+        )
+    return lines + [""]
+
+
+def render_markdown(
+    days: int,
+    config_dir: str,
+    coverage: dict[str, dict],
+    solar: dict | None,
+    price: dict | None,
+    daily_meters: dict[str, dict[str, float]],
+    mode: dict | None,
+    charge_days: dict,
+    decisions: dict | None,
+    gaps: list,
+) -> str:
+    """Assemble the full sweep report."""
+    lines = [
+        "# HA data sweep",
+        "",
+        f"- days: {days}",
+        f"- generated: {datetime.now(AEST).isoformat(timespec='seconds')}",
+        f"- config dir: {config_dir}",
+        f"- recorder: copied {DB_NAME} (+ wal) to temp, queried read-only",
+        "",
+    ]
+    lines.append("## Coverage (numeric samples in window)")
+    lines.append("")
+    if coverage:
+        lines.append("| entity | n | max gap min |")
+        lines.append("|--------|---|-------------|")
+        for eid, c in coverage.items():
+            lines.append(f"| {eid} | {c['n']} | {c['max_gap_min']:.0f} |")
+    else:
+        lines.append("(no entities found in window)")
+    lines.append("")
+    if gaps:
+        lines.append("### Gap windows > 60 min (see notes before panicking)")
+        lines.append("")
+        for label, t1, t2 in gaps:
+            lines.append(
+                f"- {label}: "
+                f"{datetime.fromtimestamp(t1, AEST):%m-%d %H:%M} -> "
+                f"{datetime.fromtimestamp(t2, AEST):%m-%d %H:%M} "
+                f"({(t2 - t1) / 3600:.1f}h)"
+            )
+        lines.append("")
+    day_sets = [set(m) for m in daily_meters.values()]
+    days_order = sorted(set().union(*day_sets)) if day_sets else []
+    lines += _md_solar(solar or {})
+    lines += _md_price(price or {})
+    lines += _md_meters(daily_meters, days_order)
+    lines += _md_mode(mode or {}, days)
+    lines += _md_charge(charge_days)
+    lines += _md_decisions(decisions or {})
+    lines += [
+        "## Notes",
+        "",
+        "- HA records state CHANGES ONLY: long gaps usually mean a constant",
+        "  value (overnight zero solar), not an outage.",
+        "- Solcast forecasts in W; my_home_* power sensors in kW",
+        "  (x1000 correction applied).",
+        "- Daily meters use max-min per local day (daily-reset safe).",
+    ]
+    return "\n".join(lines)
+
+
+# --------------------------------------------------------------------------
+# I/O layer
+# --------------------------------------------------------------------------
+
+def snapshot_db(config_dir: str, tmp_dir: str) -> str:
+    """Copy the recorder db + wal into tmp_dir; return the copy path."""
+    src = Path(config_dir) / DB_NAME
+    if not src.exists():
+        sys.exit(f"ERROR: recorder db not found at {src}")
+    dst = str(Path(tmp_dir) / DB_NAME)
+    shutil.copyfile(src, dst)
+    wal = Path(str(src) + "-wal")
+    if wal.exists():
+        shutil.copyfile(wal, dst + "-wal")
+    return dst
+
+
+def load_series(
+    con: sqlite3.Connection, entity_id: str, since: float
+) -> list[tuple[float, str]]:
+    cur = con.execute(
+        "SELECT s.last_updated_ts, s.state FROM states s "
+        "JOIN states_meta m ON s.metadata_id=m.metadata_id "
+        "WHERE m.entity_id=? AND s.last_updated_ts>=? "
+        "ORDER BY s.last_updated_ts",
+        (entity_id, since),
+    )
+    return cur.fetchall()
+
+
+def find_decision_store(config_dir: str) -> Path | None:
+    storage = Path(config_dir) / ".storage"
+    hits = sorted(storage.glob("localshift.decision_outcomes.*"))
+    return hits[-1] if hits else None
+
+
+def day_starts(series: list[tuple[float, float]], tz: timezone) -> list[tuple[str, float]]:
+    """Distinct local days in a series with their midnight timestamps."""
+    seen: dict[str, float] = {}
+    for ts, _ in series:
+        local = datetime.fromtimestamp(ts, tz)
+        key = local.strftime("%m-%d")
+        if key not in seen:
+            midnight = local.replace(hour=0, minute=0, second=0, microsecond=0)
+            seen[key] = midnight.timestamp()
+    return sorted(seen.items(), key=lambda kv: kv[1])
+
+
+def run_sweep(args) -> str:
+    import time as _time
+
+    config_dir = (
+        args.config
+        or os.environ.get("HA_CONFIG")
+        or DEFAULT_CONFIG
+    )
+    since = _time.time() - args.days * 86400
+
+    # Transient DB copy lives under out-dir (gitignored tmp/): the system
+    # temp dir can be sandbox-blocked, and keeping it local to the report
+    # makes --keep-db ad-hoc SQL natural.
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    stamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    tmp_holder = str(out_dir / f"sweep-db-{stamp}")
+    Path(tmp_holder).mkdir()
+    try:
+        db = snapshot_db(config_dir, tmp_holder)
+        con = sqlite3.connect(db)
+
+        raw = {k: load_series(con, eid, since) for k, eid in ENTITIES.items()}
+        num = {k: parse_series(v) for k, v in raw.items()}
+
+        coverage = {}
+        for k in num:
+            gaps = [b[0] - a[0] for a, b in zip(num[k], num[k][1:], strict=False)]
+            coverage[ENTITIES[k]] = {
+                "n": len(num[k]),
+                "max_gap_min": max(gaps) / 60 if gaps else 0.0,
+            }
+        gaps = []
+        for k in GAP_ENTITIES:
+            gaps += [
+                (ENTITIES[k], t1, t2) for t1, t2 in gap_windows(num[k])
+            ]
+
+        solar = bucket_pairs(
+            merge_buckets(num["solar_forecast"], num["solar_power"]),
+            AEST,
+        )
+        price = price_capture(
+            num["grid_power"], num["general_price"], num["feed_in_price"]
+        )
+        meters = {
+            "grid_import_kWh": daily_deltas(num["grid_imported"], AEST),
+            "grid_export_kWh": daily_deltas(num["grid_exported"], AEST),
+            "import_cost": daily_deltas(num["import_cost"], AEST),
+            "export_rev": daily_deltas(num["export_comp"], AEST),
+            "batt_charged_kWh": daily_deltas(num["batt_charged"], AEST),
+            "batt_discharged_kWh": daily_deltas(num["batt_discharged"], AEST),
+            "batt_from_grid_kWh": daily_deltas(num["batt_from_grid"], AEST),
+            "batt_to_grid_kWh": daily_deltas(num["batt_to_grid"], AEST),
+        }
+        mode = mode_stats(load_series(con, MODE_ENTITY, since), AEST)
+        charge_days = {
+            day: charge_timing(num["battery_power"], num["general_price"],
+                               start, AEST)
+            for day, start in day_starts(num["battery_power"], AEST)
+        }
+        decisions = None
+        store = find_decision_store(config_dir)
+        if store:
+            decisions = decision_stats(json.loads(store.read_text())["data"])
+        con.close()
+
+        return render_markdown(
+            days=args.days,
+            config_dir=config_dir,
+            coverage=coverage,
+            solar=solar,
+            price=price,
+            daily_meters=meters,
+            mode=mode,
+            charge_days=charge_days,
+            decisions=decisions,
+            gaps=gaps,
+        )
+    finally:
+        if args.keep_db:
+            print(f"DB copy kept at {tmp_holder}")
+        else:
+            shutil.rmtree(tmp_holder, ignore_errors=True)
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    ap.add_argument("--days", type=int, default=7,
+                    help="window length in days (default: 7)")
+    ap.add_argument("--config", help=f"HA config dir (default: HA_CONFIG env "
+                                     f"or {DEFAULT_CONFIG})")
+    ap.add_argument("--out-dir", default="tmp",
+                    help="output directory (default: ./tmp)")
+    ap.add_argument("--stdout", action="store_true",
+                    help="print the report to stdout instead of writing a file")
+    ap.add_argument("--keep-db", action="store_true",
+                    help="keep the copied recorder DB for ad-hoc SQL")
+    args = ap.parse_args()
+
+    report = run_sweep(args)
+    if args.stdout:
+        print(report)
+        return
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    stamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    path = out_dir / f"ha-data-sweep-{stamp}.md"
+    path.write_text(report)
+    print(f"Wrote {path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/snapshot_charging_plan.py
+++ b/scripts/snapshot_charging_plan.py
@@ -182,7 +182,7 @@ class SnapshotGenerator:
 ---"""
 
     def _current_state(self) -> str:
-        mode = self.state("sensor.localshift_battery_mode")
+        mode = self.state("select.localshift_battery_mode")
         soc = self.state("sensor.my_home_percentage_charged")
         battery_power = self.state("sensor.my_home_battery_power")
         grid_power = self.state("sensor.my_home_grid_power")
@@ -266,7 +266,7 @@ class SnapshotGenerator:
         max_buy = self.attr(
             "binary_sensor.localshift_price_spike_coming", "max_buy_forecast_price", 0
         )
-        mode = self.state("sensor.localshift_battery_mode")
+        mode = self.state("select.localshift_battery_mode")
         can_reach = self.state("binary_sensor.localshift_solar_can_reach_target")
         boost_needed = self.state("binary_sensor.localshift_charge_boost_needed")
 

--- a/tests/test_data_sweep.py
+++ b/tests/test_data_sweep.py
@@ -1,0 +1,348 @@
+"""Unit tests for ha_data_sweep module.
+
+Tests the pure analysis functions of the recorder-DB sweep: series parsing,
+step lookup, forecast bucketing, price capture, daily meter deltas, mode
+churn stats, charge timing, and decision-outcome distributions.
+"""
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+from scripts.ha_data_sweep import (
+    AEST,
+    bucket_pairs,
+    charge_timing,
+    daily_deltas,
+    decision_stats,
+    gap_windows,
+    merge_buckets,
+    mode_stats,
+    parse_series,
+    pctl,
+    price_capture,
+    render_markdown,
+    step_value,
+)
+
+UTC = UTC
+
+
+class TestParseSeries:
+    """Numeric filtering of raw recorder rows."""
+
+    def test_keeps_floats_and_drops_non_numeric(self):
+        rows = [(100, "1.5"), (200, "unavailable"), (300, "2"), (400, None)]
+        assert parse_series(rows) == [(100, 1.5), (300, 2.0)]
+
+    def test_empty(self):
+        assert parse_series([]) == []
+
+
+class TestStepValue:
+    """State-machine value lookup at time t."""
+
+    def test_returns_latest_at_or_before(self):
+        s = [(10, 1.0), (20, 2.0), (30, 3.0)]
+        assert step_value(s, 25) == 2.0
+
+    def test_exact_timestamp(self):
+        s = [(10, 1.0), (20, 2.0)]
+        assert step_value(s, 20) == 2.0
+
+    def test_before_first_is_none(self):
+        assert step_value([(10, 1.0)], 5) is None
+
+    def test_after_last_holds(self):
+        assert step_value([(10, 1.0)], 999) == 1.0
+
+    def test_empty_series(self):
+        assert step_value([], 100) is None
+
+
+class TestMergeBuckets:
+    """15-min forecast/actual bucket merge with unit correction."""
+
+    def test_buckets_and_scales_actual_kw_to_w(self):
+        # 900s buckets; fc already W, ac in kW.
+        fc = [(0, 500.0), (900, 0.0)]
+        ac = [(10, 0.4), (910, 0.0)]  # 0.4 kW = 400 W
+        out = merge_buckets(fc, ac, bucket_secs=900, actual_scale=1000.0)
+        assert out[0] == {"f": 500.0, "a": 400.0}
+        assert out[1] == {"f": 0.0, "a": 0.0}
+
+    def test_last_write_wins_within_bucket(self):
+        fc = [(0, 100.0), (300, 200.0)]
+        out = merge_buckets(fc, [], bucket_secs=900)
+        assert out[0]["f"] == 200.0
+
+    def test_unmatched_sides_omitted(self):
+        out = merge_buckets([(0, 100.0)], [(2000, 1.0)], bucket_secs=900)
+        assert out == {0: {"f": 100.0}, 2: {"a": 1000.0}}
+
+
+class TestBucketPairs:
+    """Solar bias and daily energy from merged buckets."""
+
+    def test_bias_and_day_energy(self):
+        # Two 15-min buckets at 06:00/06:15 AEST 20 Aug, one sub-threshold.
+        t0 = datetime(2026, 8, 20, 6, tzinfo=AEST).timestamp()
+        buckets = {
+            int(t0 // 900): {"f": 800.0, "a": 600.0},
+            int((t0 + 900) // 900): {"f": 600.0, "a": 600.0},
+            int((t0 + 1800) // 900): {"f": 50.0, "a": 50.0},  # below min_w
+        }
+        rep = bucket_pairs(buckets, AEST, min_w=100.0)
+        assert rep["n_buckets"] == 2
+        assert rep["bias_mean_w"] == 100.0  # (200 + 0) / 2
+        hour = rep["bias_by_hour"][6]
+        assert hour["n"] == 2
+        assert hour["mean_w"] == 100.0
+        fc_kwh, ac_kwh = rep["day_energy"]["08-20"]
+        # day energy integrates ALL buckets (incl. below-threshold): 3 x 0.25h
+        assert fc_kwh == (800 + 600 + 50) / 4 / 1000 * 1.0
+        assert ac_kwh == (600 + 600 + 50) / 4 / 1000 * 1.0
+
+    def test_energy_ratio_guard_zero_actual(self):
+        rep = bucket_pairs({}, AEST)
+        assert rep["energy_ratio"] == 0.0
+
+
+class TestPriceCapture:
+    """Energy-weighted import price vs import-window average."""
+
+    def _gp(self):
+        # price 0.10 at t=0, 0.20 at t=300
+        return [(0, 0.10), (300, 0.20)]
+
+    def test_import_export_split_and_capture(self):
+        gpow = [(0, 2.0), (300, -1.0), (600, 0.0)]
+        cap = price_capture(gpow, self._gp(), [(0, 0.02)], step=300)
+        # import 2kW for 5min = 1/6 kWh at 0.10; export 1kW for 5min at FiT 0.02
+        assert abs(cap["import_kwh"] - 2.0 / 12) < 1e-9
+        assert abs(cap["export_kwh"] - 1.0 / 12) < 1e-9
+        assert abs(cap["avg_paid"] - 0.10) < 1e-9
+        assert abs(cap["import_window_avg_price"] - 0.10) < 1e-9
+        assert abs(cap["capture_ratio"] - 1.0) < 1e-9
+        assert abs(cap["export_revenue"] - (1.0 / 12) * 0.02) < 1e-9
+
+    def test_steps_without_price_skipped(self):
+        gpow = [(0, 2.0)]
+        cap = price_capture(gpow, [], [], step=300)
+        assert cap["import_kwh"] == 0.0
+        assert cap["capture_ratio"] == 0.0
+
+
+class TestDailyDeltas:
+    """Per-local-day max-min on cumulative meters."""
+
+    def test_max_minus_min_per_day(self):
+        # Day 1 (AEST): 0->5->3 ; Day 2: 0->2  (daily reset)
+        d1 = datetime(2026, 8, 20, 6, tzinfo=AEST).timestamp()
+        s = [
+            (d1, 0.0),
+            (d1 + 3600, 5.0),
+            (d1 + 7200, 3.0),
+            (d1 + 86400, 0.0),
+            (d1 + 90000, 2.0),
+        ]
+        assert daily_deltas(s, AEST) == {"08-20": 5.0, "08-21": 2.0}
+
+    def test_single_observation_day(self):
+        s = [(datetime(2026, 8, 20, 6, tzinfo=AEST).timestamp(), 4.0)]
+        assert daily_deltas(s, AEST) == {"08-20": 0.0}
+
+
+class TestModeStats:
+    """Transition counts, dwell, destinations, hour histogram."""
+
+    def test_transitions_and_dwell(self):
+        base = datetime(2026, 8, 20, 12, tzinfo=AEST).timestamp()
+        sm = [
+            (base, "self_consumption"),
+            (base + 600, "boost_charging"),
+            (base + 600 + 300, "self_consumption"),
+            (base + 600 + 300 + 1200, "grid_charging"),
+        ]
+        st = mode_stats(sm, AEST)
+        assert st["n_changes"] == 3
+        assert st["dest_counts"] == {
+            "boost_charging": 1,
+            "self_consumption": 1,
+            "grid_charging": 1,
+        }
+        dwells = sorted(st["dwells_min"])
+        assert dwells == [5.0, 10.0, 20.0]
+        assert st["dwell_median_min"] == 10.0
+        assert st["dwell_p10_min"] == 5.0
+        assert st["pairs"][("self_consumption", "boost_charging")] == 1
+        assert st["pairs"][("boost_charging", "self_consumption")] == 1
+        assert st["pairs"][("self_consumption", "grid_charging")] == 1
+        assert st["hour_hist"][12] == 3
+
+    def test_no_changes(self):
+        sm = [(100, "hold"), (200, "hold")]
+        st = mode_stats(sm, AEST)
+        assert st["n_changes"] == 0
+        assert st["dwell_median_min"] is None
+
+
+class TestChargeTiming:
+    """Charging energy, price paid, bulk hours, cheapest hours for a day."""
+
+    def _run(self):
+        d0 = datetime(2026, 8, 20, tzinfo=AEST).timestamp()  # midnight AEST
+        # battery: -5kW (charging) for first two 5-min steps, then 0
+        batt = [(d0, -5.0), (d0 + 600, 0.0)]
+        # price: 0.15 at 00:00, 0.10 at 01:00, 0.20 at 02:00
+        gp = [(d0, 0.15), (d0 + 3600, 0.10), (d0 + 7200, 0.20)]
+        return charge_timing(batt, gp, d0, AEST, step=300), d0
+
+    def test_energy_and_avg_paid(self):
+        ct, _ = self._run()
+        # 5 kW for 10 min = 5/6 kWh at 0.15
+        assert abs(ct["charged_kwh"] - 10.0 / 12) < 1e-9
+        assert abs(ct["avg_paid"] - 0.15) < 1e-9
+
+    def test_bulk_hours_and_cheapest(self):
+        ct, _ = self._run()
+        assert ct["bulk_hours"] == {0: 10.0 / 12}
+        # up to 3 cheapest known hours, ordered by price: 1 (0.10), 0 (0.15), 2 (0.20)
+        assert ct["cheapest_hours"] == [1, 0, 2]
+        assert ct["day_min_price"] == 0.10
+        assert ct["day_max_price"] == 0.20
+
+    def test_no_charging(self):
+        d0 = datetime(2026, 8, 20, tzinfo=AEST).timestamp()
+        ct = charge_timing([(d0, 1.0)], [(d0, 0.1)], d0, AEST, step=300)
+        assert ct["charged_kwh"] == 0.0
+        assert ct["avg_paid"] is None
+
+
+class TestDecisionStats:
+    """Learning store: percentiles by mode, worst-5, completeness."""
+
+    def _data(self):
+        completed = [
+            {
+                "timestamp": "2026-08-20T06:00:00+10:00",
+                "mode_chosen": "hold",
+                "outcome_score": 0.5,
+                "actual_cost_during_period": 0.10,
+                "actual_import_kwh": 1.0,
+                "actual_soc_change": 2.0,
+            },
+            {
+                "timestamp": "2026-08-20T12:00:00+10:00",
+                "mode_chosen": "hold",
+                "outcome_score": 0.7,
+                "actual_cost_during_period": 0.20,
+                "actual_import_kwh": 2.0,
+                "actual_soc_change": 1.0,
+            },
+            {
+                "timestamp": "2026-08-21T06:00:00+10:00",
+                "mode_chosen": "charge_grid_normal",
+                "outcome_score": 0.3,
+                "actual_cost_during_period": None,  # missing cost
+                "actual_import_kwh": 0.0,
+                "actual_soc_change": 8.0,
+            },
+            {  # pending-shaped record (no score) inside completed list
+                "timestamp": "2026-08-21T12:00:00+10:00",
+                "mode_chosen": "hold",
+            },
+        ]
+        pending = [{"timestamp": "2026-08-27T12:00:00+10:00", "mode_chosen": "hold"}]
+        return {"completed_decisions": completed, "pending_decisions": pending}
+
+    def test_counts_and_percentiles(self):
+        st = decision_stats(self._data())
+        assert st["completed"] == 4
+        assert st["scored"] == 3
+        assert st["pending"] == 1
+        hold = st["by_mode"]["hold"]
+        assert hold["n"] == 2
+        assert hold["median"] == 0.7
+        assert hold["p10"] == 0.5
+        assert hold["p90"] == 0.7
+        assert st["missing_cost"] == 1
+
+    def test_worst5(self):
+        st = decision_stats(self._data())
+        assert len(st["worst5"]) == 3
+        assert st["worst5"][0]["mode_chosen"] == "charge_grid_normal"
+        assert st["worst5"][0]["outcome_score"] == 0.3
+
+    def test_span(self):
+        st = decision_stats(self._data())
+        assert st["span_first"].startswith("2026-08-20T06")
+        assert st["span_last"].startswith("2026-08-21T12")
+
+
+class TestPctl:
+    def test_median_even(self):
+        assert pctl([1.0, 2.0, 3.0, 4.0], 0.5) == 3.0  # len//2 index
+
+    def test_median_odd(self):
+        assert pctl([1.0, 2.0, 3.0], 0.5) == 2.0
+
+    def test_bounds(self):
+        assert pctl([5.0], 0.1) == 5.0
+        assert pctl([5.0], 0.9) == 5.0
+
+
+class TestGapWindows:
+    def test_reports_long_gaps_only(self):
+        s = [(0, 1.0), (100, 1.0), (7200, 1.0)]
+        assert gap_windows(s, min_gap_s=3600) == [(100, 7200)]
+
+    def test_none(self):
+        assert gap_windows([(0, 1.0), (60, 1.0)], min_gap_s=3600) == []
+
+
+class TestRenderMarkdown:
+    def test_renders_sections(self, tmp_path: Path):
+        md = render_markdown(
+            days=7,
+            config_dir="/tmp/ha",
+            coverage={"sensor.my_home_grid_power": {"n": 100, "max_gap_min": 5.0}},
+            solar={
+                "n_buckets": 10,
+                "bias_mean_w": 250.0,
+                "energy_ratio": 1.45,
+                "day_energy": {"08-26": (22.9, 12.2)},
+                "bias_by_hour": {12: {"n": 4, "mean_w": 620.0}},
+            },
+            price={
+                "import_kwh": 50.0,
+                "avg_paid": 0.146,
+                "import_window_avg_price": 0.140,
+                "capture_ratio": 1.04,
+                "export_kwh": 14.1,
+                "export_revenue": 0.29,
+            },
+            daily_meters={
+                "grid_import_kWh": {"08-25": 21.77},
+                "batt_from_grid_kWh": {"08-25": 11.11},
+            },
+            mode={"n_changes": 105, "dwell_median_min": 10.0,
+                  "dwell_p10_min": 4.0, "dest_counts": {"boost_charging": 44},
+                  "hour_hist": {12: 22}},
+            charge_days={"08-25": {"charged_kwh": 14.0, "avg_paid": 0.172,
+                                   "cheapest_hours": [8, 9, 10]}},
+            decisions={"completed": 500, "scored": 500, "pending": 1,
+                       "missing_cost": 2, "by_mode": {},
+                       "span_first": "2026-07-29T06", "span_last": "2026-08-27T11",
+                       "worst5": []},
+            gaps=[("sensor.my_home_grid_power", 100.0, 7200.0)],
+        )
+        assert "# HA data sweep" in md
+        assert "- days: 7" in md
+        assert "### Gap windows" in md
+        assert "- sensor.my_home_grid_power:" in md
+        assert "| 08-26 | 22.9 | 12.2 |" in md
+        assert "capture ratio: **1.04**" in md
+        assert "| 08-25 | 21.8 | 11.1 |" in md
+        assert "105 changes" in md
+        assert "| 08-25 | 14.0 | 0.172 | 8, 9, 10 |" in md
+        assert "missing cost: 2/500" in md


### PR DESCRIPTION
## Summary
Turns the /tmp analysis prototypes from the 2026-08-27 data sweep into a repo tool. Snapshots the recorder DB (copy-first: the live file can't be opened read-only and the REST history API silently truncates multi-day requests), then renders a markdown report:

- Solar forecast vs actual (daily kWh ratios, hour-of-day bias; W vs kW corrected)
- Price capture (energy-weighted import price vs import-window average)
- Daily grid/battery meters (per-local-day max-min, daily-reset safe)
- Battery mode churn (transitions, dwell, hour histogram)
- Charge timing vs each day's cheapest hours
- Learning decision-outcome distributions (.storage decision store)
- Coverage + labelled gap windows (with change-only-recording caveat)

## Related Issue
Closes #920

## Changes
- `scripts/ha_data_sweep.py` — CLI: `--days/--config/--out-dir/--stdout/--keep-db`; transient DB copy lives under out-dir and is deleted unless `--keep-db`
- `tests/test_data_sweep.py` — 30 unit tests on the pure analysis functions

## Testing
- [x] `uv run pytest` full suite 3464 passed + 1 xfailed
- [x] `uv run ruff check` clean
- [x] Live run against this host's HA config dir; report reproduces the sweep findings that motivated #915-#919 (Solcast +88% over-forecast on 08-26, cloudy-day grid import ~22 kWh/day, score bands median ~0.47-0.56, worst-5 all +0.280)

## Addition (post-initial PR)
- - Fix `scripts/snapshot_charging_plan.py` querying `sensor.localshift_battery_mode` (404 → Current Mode always 'unknown'); now `select.localshift_battery_mode` (Closes #909)
