### PR TITLE
fix(solar): relax backfill guards so accuracy samples land

### DIFF
--- a/custom_components/localshift/coordinator/tick_scheduler.py
+++ b/custom_components/localshift/coordinator/tick_scheduler.py
@@ -32,12 +32,16 @@ class TickScheduler:
     # intervals, else it is discarded rather than recorded as a full actual.
     # Guards the restart case: the baseline re-establishes mid-period, so that
     # period only accumulates partial energy (Issue: partial-coverage poisoning).
-    _MIN_COVERAGE_FRACTION = 0.9
+    # 70% (Issue #893) tolerates one missing 5-min medium tick (~83% covered)
+    # while still discarding the worst partial periods after a restart.
+    _MIN_COVERAGE_FRACTION = 0.7
     # Intervals longer than this (e.g. an event-loop stall or a long gap) are
     # not integrated — one giant trapezoid prorated across many periods would
     # produce several plausible-looking but garbage samples. We re-baseline and
     # skip integration; the spanned periods fall below the coverage gate.
-    _MAX_INTEGRATION_SECONDS = 900.0  # 15 min
+    # 30 min (Issue #893): a single ~20-min stall no longer discards the whole
+    # period — the interval integrates and attributes to the correct period.
+    _MAX_INTEGRATION_SECONDS = 1800.0  # 30 min
 
     def __init__(
         self,
@@ -331,11 +335,12 @@ class TickScheduler:
         record is meaningful is decided at flush time by the tracker.
 
         Two robustness guards keep partial/garbage samples out of the (now
-        persisted) learning store: a period must be >=90% covered by integration
+        persisted) learning store: a period must be >=70% covered by integration
         intervals to be recorded (else it is discarded — handles the restart
-        re-baseline mid-period), and intervals longer than 15 min are not
-        integrated at all (an event-loop stall would otherwise smear one
-        trapezoid across many periods as plausible-looking garbage).
+        re-baseline mid-period; one missing 5-min tick still records, Issue
+        #893), and intervals longer than 30 min are not integrated at all (an
+        event-loop stall would otherwise smear one trapezoid across many
+        periods as plausible-looking garbage).
         """
         tracker = getattr(self._coordinator, "solar_accuracy_tracker", None)
         if tracker is None:

--- a/custom_components/localshift/utils/entity_configs.py
+++ b/custom_components/localshift/utils/entity_configs.py
@@ -381,6 +381,11 @@ LOCALSHIFT_ENTITY_CONFIG: dict[str, dict[str, Any]] = {
         "category": EntityCategory.OPTIONAL,
         "expected_type": float,
         "staleness_minutes": 1440,
+        # Issue #917: 'unknown' during the tracker's 20-sample warmup is
+        # expected, not a failure. While samples_until_active > 0 the sensor
+        # is treated as healthy instead of accumulating consecutive failures
+        # toward BROKEN.
+        "warmup_unknown": True,
     },
     "sensor.localshift_decision_lag": {
         "category": EntityCategory.OPTIONAL,

--- a/custom_components/localshift/utils/validation.py
+++ b/custom_components/localshift/utils/validation.py
@@ -213,6 +213,22 @@ class EntityValidator:
             return (EntityStatus.UNKNOWN, f"Entity '{entity_id}' has unknown state")
         return None
 
+    def _is_expected_warmup(
+        self, config: dict[str, Any], status: EntityStatus, state: Any
+    ) -> bool:
+        """Return True when an UNKNOWN state is configured, expected warmup.
+
+        Configured via ``warmup_unknown`` in LOCALSHIFT_ENTITY_CONFIG (Issue #917):
+        the solar accuracy sensor legitimately reads 'unknown' until the
+        tracker has gathered enough samples, and advertises
+        ``samples_until_active`` > 0 in its attributes for exactly that
+        window. Unknown without that evidence is still treated as a failure.
+        """
+        if not config.get("warmup_unknown") or status is not EntityStatus.UNKNOWN:
+            return False
+        attributes = getattr(state, "attributes", None) or {}
+        return attributes.get("samples_until_active", 0) > 0
+
     def _check_entity_staleness(
         self, entity_id: str, config_key: str, state: Any
     ) -> str | None:
@@ -554,6 +570,17 @@ class EntityValidator:
             )
 
         failure_result = self._check_entity_state(entity_id, state)
+        if failure_result and self._is_expected_warmup(
+            config, failure_result[0], state
+        ):
+            # Issue #917: 'unknown' during the configured warmup window is
+            # expected behaviour, not a failure. Treat as healthy so the
+            # consecutive-failure gate cannot mark the entity BROKEN.
+            health.status = EntityStatus.OK
+            health.error_message = ""
+            health.consecutive_failures = 0
+            health.is_broken = False
+            return health
         if failure_result:
             health.status = failure_result[0]
             health.error_message = failure_result[1]

--- a/tests/coordinator/test_tick_scheduler.py
+++ b/tests/coordinator/test_tick_scheduler.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from custom_components.localshift.coordinator.tick_scheduler import TickScheduler
+from custom_components.localshift.forecast.solar_accuracy import SolarAccuracyTracker
 
 
 async def test_tick_scheduler_initialization(coordinator):
@@ -519,6 +520,20 @@ def _setup_tracker(coordinator, *, power=5.0, boost=False):
     return tracker
 
 
+def _setup_real_tracker(coordinator, *, power=5.0):
+    """Wire a REAL solar accuracy tracker onto the coordinator.
+
+    The tracker's HA Store is only touched by async_load/async_save, so a
+    MagicMock hass suffices (established pattern in test_solar_accuracy.py).
+    """
+    tracker = SolarAccuracyTracker(MagicMock(), "issue_893")
+    coordinator.solar_accuracy_tracker = tracker
+    coordinator.data = MagicMock()
+    coordinator.data.solar_power_kw = power
+    coordinator.data.boost_charge_active = False
+    return tracker
+
+
 def _drive(scheduler, coordinator, ticks):
     """Drive _backfill_solar_actual across a sequence of (time, power[, boost]) ticks.
 
@@ -651,22 +666,81 @@ async def test_backfill_zero_power_still_flushes(coordinator):
 
 
 @pytest.mark.asyncio
+async def test_pending_forecast_converts_to_sample_despite_stall_gap(coordinator):
+    """End-to-end (Issue #893): a pending forecast lands despite a stall gap.
+
+    The scheduler records forecasts as pendings via the tracker, but nothing
+    ever converted them to samples: a single ~20-min gap (event-loop stall,
+    restart) re-baselined the whole interval under the 15-min integration
+    cap, dropping coverage below the 90% gate. The accuracy sensor therefore
+    sat 'unknown' forever. With the relaxed guards the gap integrates, the
+    09:30 period flushes, and the pending converts to a real sample.
+    """
+    scheduler = TickScheduler(coordinator)
+    tracker = _setup_real_tracker(coordinator, power=5.0)
+
+    tracker.record_forecast(_t(9, 30), 2.0, "sunny")
+
+    # Baseline 09:30, two normal ticks, then a 20-min gap to 10:00.
+    _drive(
+        scheduler,
+        coordinator,
+        [(_t(9, 30), 5.0), (_t(9, 35), 5.0), (_t(9, 40), 5.0), (_t(10, 0), 5.0)],
+    )
+
+    assert tracker.metrics.sample_count == 1
+    assert len(tracker._pending_forecasts) == 0
+    record = tracker._period_records[-1]
+    assert record.forecast_kwh == 2.0
+    assert record.actual_kwh == pytest.approx(2.5, rel=1e-3)  # 5 kW x 0.5 h
+
+
+@pytest.mark.asyncio
+async def test_pending_forecast_converts_with_partial_coverage(coordinator):
+    """End-to-end (Issue #893): one missing 5-min tick still records a sample.
+
+    Ticks 09:30-09:55 cover 25 of 30 min (83%); a 35-min gap follows so the
+    tail is never integrated. The old 90% coverage gate discarded the period;
+    70% accepts it, attributing the 25 observed minutes to the 09:30 period.
+    """
+    scheduler = TickScheduler(coordinator)
+    tracker = _setup_real_tracker(coordinator, power=5.0)
+
+    tracker.record_forecast(_t(9, 30), 2.0, "sunny")
+
+    # 5-min ticks 09:30-09:55, then a 35-min gap (never integrated under any cap).
+    _drive(
+        scheduler,
+        coordinator,
+        _five_min_ticks(9, 30, 9, 55, 5.0) + [(_t(10, 30), 5.0)],
+    )
+
+    assert tracker.metrics.sample_count == 1
+    assert len(tracker._pending_forecasts) == 0
+    record = tracker._period_records[-1]
+    # 5 kW for 25 min = 25/12 kWh observed across the covered span.
+    assert record.actual_kwh == pytest.approx(5.0 * 25 / 60, rel=1e-3)
+
+
+@pytest.mark.asyncio
 async def test_backfill_long_interval_rebaselines_without_integrating(coordinator):
-    """An interval longer than the cap (15 min) re-baselines without integrating.
+    """An interval longer than the cap (30 min) re-baselines without integrating.
 
     Guards against an event-loop stall smearing one trapezoid across many periods.
+    (A ~20-min stall now integrates by design — Issue #893 — so this must exceed
+    the cap.)
     """
     scheduler = TickScheduler(coordinator)
     tracker = _setup_tracker(coordinator, power=5.0)
     scheduler._last_solar_power_timestamp = _t(10, 0)
     scheduler._last_solar_power_kw = 5.0
 
-    _drive(scheduler, coordinator, [(_t(10, 20), 5.0)])  # 20-min gap > 15-min cap
+    _drive(scheduler, coordinator, [(_t(10, 35), 5.0)])  # 35-min gap > 30-min cap
 
     tracker.backfill_actual.assert_not_called()
     assert scheduler._period_energy_accum == {}
     # Baseline is advanced so the next normal interval integrates cleanly.
-    assert scheduler._last_solar_power_timestamp == _t(10, 20)
+    assert scheduler._last_solar_power_timestamp == _t(10, 35)
 
 
 @pytest.mark.asyncio

--- a/tests/utils/test_validation_extended.py
+++ b/tests/utils/test_validation_extended.py
@@ -569,6 +569,75 @@ class TestFailureThresholds:
 
         assert health.is_broken is True
 
+    def test_accuracy_sensor_warmup_unknown_not_broken(
+        self, mock_hass: MagicMock
+    ) -> None:
+        """Solar accuracy 'unknown' during warmup must never be marked BROKEN.
+
+        Issue #917 (accuracy half): the sensor legitimately reads 'unknown'
+        while the tracker gathers its first 20 samples, advertising
+        samples_until_active > 0 in its attributes. That is expected warmup,
+        not a validation failure — 10 warmup cycles must not trip the BROKEN
+        gate (a staleness-threshold bump is explicitly rejected by #917).
+        """
+        accuracy_id = "sensor.localshift_solar_forecast_accuracy"
+        now = dt_util.now()
+        states = MockStates({
+            accuracy_id: MockState(
+                entity_id=accuracy_id,
+                state="unknown",
+                attributes={"samples_until_active": 20, "correction_active": False},
+                last_changed=now - timedelta(minutes=5),
+                last_updated=now - timedelta(minutes=5),
+            )
+        })
+        mock_hass.states.get = states.get
+        validator = _create_validator(mock_hass)
+
+        for _ in range(FAILURE_THRESHOLD_ERROR + 2):
+            validator.check_all_localshift_entities()
+        health = validator._localshift_entity_health[accuracy_id]
+
+        assert health.is_broken is False
+        assert health.consecutive_failures == 0
+        assert health.status is EntityStatus.OK
+
+    def test_accuracy_sensor_unknown_without_warmup_still_broken(
+        self, mock_hass: MagicMock
+    ) -> None:
+        """Guard: 'unknown' with no warmup attributes is genuine breakage.
+
+        Also covers the non-warmup-config short-circuit: an unrelated
+        REQUIRED entity that is unavailable still fails normally.
+        """
+        accuracy_id = "sensor.localshift_solar_forecast_accuracy"
+        price_id = "sensor.localshift_price_cheap_effective"
+        now = dt_util.now()
+        states = MockStates({
+            accuracy_id: MockState(
+                entity_id=accuracy_id,
+                state="unknown",
+                attributes={},
+                last_changed=now - timedelta(minutes=5),
+                last_updated=now - timedelta(minutes=5),
+            ),
+            price_id: MockState(
+                entity_id=price_id,
+                state="unavailable",
+                attributes={},
+                last_changed=now - timedelta(minutes=5),
+                last_updated=now - timedelta(minutes=5),
+            ),
+        })
+        mock_hass.states.get = states.get
+        validator = _create_validator(mock_hass)
+
+        for _ in range(FAILURE_THRESHOLD_ERROR):
+            validator.check_all_localshift_entities()
+
+        assert validator._localshift_entity_health[accuracy_id].is_broken is True
+        assert validator._localshift_entity_health[price_id].is_broken is True
+
 
 # =============================================================================
 # Recovery Tests
@@ -1438,9 +1507,7 @@ class TestCheckOrphanedOwnedEntities:
         entry.disabled_by = "user" if disabled else None
         return entry
 
-    def test_no_orphans_when_registry_empty(
-        self, mock_hass: MagicMock
-    ) -> None:
+    def test_no_orphans_when_registry_empty(self, mock_hass: MagicMock) -> None:
         """No orphans when the config entry owns no registry entries."""
         validator = _create_validator(mock_hass)
 
@@ -1476,9 +1543,7 @@ class TestCheckOrphanedOwnedEntities:
 
         assert result == {}
 
-    def test_orphan_detected_for_unknown_entity(
-        self, mock_hass: MagicMock
-    ) -> None:
+    def test_orphan_detected_for_unknown_entity(self, mock_hass: MagicMock) -> None:
         """Registry entry absent from LOCALSHIFT_ENTITY_CONFIG is reported as orphan."""
         orphan_id = "number.localshift_cycle_penalty"
         entry = self._make_registry_entry(orphan_id, "cfg_1")
@@ -1578,7 +1643,9 @@ class TestCheckOrphanedOwnedEntities:
 
         unavailable_state = MagicMock()
         unavailable_state.state = "unavailable"
-        mock_hass.states.get = lambda eid: unavailable_state if eid == orphan_id else None
+        mock_hass.states.get = lambda eid: (
+            unavailable_state if eid == orphan_id else None
+        )
 
         validator = _create_validator(mock_hass)
 
@@ -1620,9 +1687,7 @@ class TestCheckOrphanedOwnedEntities:
             f"User-disabled entry {disabled_id!r} was falsely flagged as orphan"
         )
 
-    def test_multiple_orphans(
-        self, mock_hass: MagicMock
-    ) -> None:
+    def test_multiple_orphans(self, mock_hass: MagicMock) -> None:
         """Multiple orphans are all returned in the dict."""
         orphan_ids = [
             "number.localshift_cycle_penalty",
@@ -1644,9 +1709,7 @@ class TestCheckOrphanedOwnedEntities:
 
         assert set(result.keys()) == set(orphan_ids)
 
-    def test_mix_of_known_and_orphaned(
-        self, mock_hass: MagicMock
-    ) -> None:
+    def test_mix_of_known_and_orphaned(self, mock_hass: MagicMock) -> None:
         """Known entities are filtered out; only orphans are returned."""
         known_id = "sensor.localshift_price_cheap_effective"
         orphan_id = "number.localshift_cycle_penalty"


### PR DESCRIPTION
## Summary
- Pending solar forecasts never converted to samples: the scheduler's coverage gate (0.9) discarded any period with one missing 5-min tick (~83% covered), and the 15-min integration cap re-baselined any period containing a ~20-min stall. Result: 70 pending, 0 samples, accuracy sensor `unknown` forever. Relaxed to 0.7 / 30 min — the partial-coverage poisoning guard is preserved (mid-period restarts still accumulate partial energy and the worst cases are still discarded).
- Covers the accuracy half of #917: the sensor sat `unknown` through its 20-sample warmup (which never completed under the old gates), accruing 10 consecutive validation failures → BROKEN. Warmup is now expected in validation via a `warmup_unknown` config flag — while the sensor advertises `samples_until_active > 0` it counts as healthy; `unknown` without that evidence still trips the gate. No staleness-threshold bumps (explicitly rejected by #917).
- First end-to-end tests for the integration → flush → tracker path, using a real `SolarAccuracyTracker` wired into the scheduler.

## Related Issue
Closes #893
Covers the accuracy-sensor half of #917 (decision-lag half remains with #913).

## Changes
- `coordinator/tick_scheduler.py`: `_MIN_COVERAGE_FRACTION` 0.9 → 0.7, `_MAX_INTEGRATION_SECONDS` 900 → 1800; guard comments/docstring updated to stay accurate.
- `utils/entity_configs.py`: `warmup_unknown: True` on `sensor.localshift_solar_forecast_accuracy`.
- `utils/validation.py`: `_is_expected_warmup()` — UNKNOWN state with live warmup attributes is treated as healthy (resets consecutive failures), in `_check_single_localshift_entity`.
- Tests: two end-to-end scheduler→tracker tests (20-min gap; 83% coverage), two validation tests (warmup not broken; guard that plain `unknown` still breaks), re-baseline test moved to a 35-min gap so it keeps exercising the re-baseline path.

## Testing
- [x] TDD: new tests shown failing before the fix (sample_count 0 == 1; warmup sensor BROKEN after 10 checks)
- [x] `uv run ruff format --check custom_components/localshift`
- [x] `uv run ruff check custom_components/localshift`
- [x] `uv run pytest` — 3468 passed, 1 xfailed
- [x] `npx pyright@1.1.413 custom_components/localshift` — 0 errors
- [x] Coverage on changed files: tick_scheduler 100%, entity_configs 100%, validation 92% (pre-existing gaps; all new lines covered)