### PR TITLE
feat(decision-lag): two-phase command + physical response lag measurement

### DIFF
--- a/custom_components/localshift/coordinator/coordinator.py
+++ b/custom_components/localshift/coordinator/coordinator.py
@@ -12,6 +12,8 @@ from typing import TYPE_CHECKING, Any
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import CALLBACK_TYPE, Event, HomeAssistant, callback
+from homeassistant.helpers.event import async_track_state_change_event
+from homeassistant.util import dt as dt_util
 
 from ..const import (
     CONF_BATTERY_TARGET,
@@ -24,6 +26,7 @@ from ..const import (
     CONF_PRICING_PRICE_SPIKE,
     CONF_SOLCAST_FORECAST_TODAY,
     CONF_SOLCAST_FORECAST_TOMORROW,
+    CONF_TESLEMETRY_BATTERY_POWER,
     CONF_TESLEMETRY_LOAD_POWER,
     DEFAULT_BATTERY_TARGET,
     DEFAULT_DEMAND_WINDOW_END,
@@ -72,6 +75,10 @@ SOLCAST_MAX_STARTUP_RETRIES = 3
 # If price sensor hasn't updated in this time, trigger state machine evaluation
 STALE_PRICE_THRESHOLD = timedelta(minutes=10)
 
+# Issue #508: battery power must cross this magnitude (kW) to count as a
+# physical response. Charging reads negative, discharging positive.
+PHYSICAL_RESPONSE_THRESHOLD_KW = 0.3
+
 
 class LocalShiftCoordinator:
     """Central coordinator: reads external entities, computes state, drives battery.
@@ -87,6 +94,8 @@ class LocalShiftCoordinator:
         self.data = CoordinatorData()
         self._listeners: list[CALLBACK_TYPE] = []
         self._update_callbacks: list[CALLBACK_TYPE] = []
+        # Issue #508: temporary battery-power listener for the active watch
+        self._unsub_battery_power_listener: CALLBACK_TYPE | None = None
 
         # Switch state bridge — switches read/write via these methods
         self._switch_states: dict[str, bool] = dict(SWITCH_DEFAULTS)
@@ -465,6 +474,8 @@ class LocalShiftCoordinator:
         if self._subscription_manager is not None:
             self._subscription_manager.stop()
 
+        # Issue #508: remove the temporary physical-response listener
+        self._remove_battery_power_listener()
         # Save all learning data to storage before shutdown
         await self._save_learning_data()
 
@@ -571,6 +582,8 @@ class LocalShiftCoordinator:
         """Handle FAST tier periodic tasks (1 minute)."""
         if self._tick_scheduler is not None:
             self._tick_scheduler.handle_fast_tick(now)
+        # Issue #508: enforce the physical-response watch timeout between events
+        self._check_physical_response_watch()
 
     @callback
     def _handle_medium_tick(self, now: datetime) -> None:  # pragma: no cover
@@ -811,6 +824,97 @@ class LocalShiftCoordinator:
                 if self._state_reader is not None
                 else None,
             )
+        # Issue #508: start the physical-response listener immediately after a
+        # transition may have set a watch (also enforces timeouts between events).
+        self._check_physical_response_watch()
+
+    # ------------------------------------------------------------------
+    # Physical response watch (Issue #508)
+    # ------------------------------------------------------------------
+
+    def _check_physical_response_watch(self) -> None:
+        """Maintain the temporary battery-power listener for the active watch.
+
+        No watch (including one cleared by a failed transition) removes any
+        lingering listener; an expired watch records the timeout.
+        """
+        watch = self.data.physical_response_watch
+        if watch is None:
+            self._remove_battery_power_listener()
+            return
+        if dt_util.now() >= watch.timeout_at:
+            self._record_physical_response(timed_out=True)
+        elif self._unsub_battery_power_listener is None:
+            self._unsub_battery_power_listener = async_track_state_change_event(
+                self.hass,
+                [self.get_entity_id(CONF_TESLEMETRY_BATTERY_POWER)],
+                self._on_battery_power_change,
+            )
+
+    def _remove_battery_power_listener(self) -> None:
+        """Remove the temporary battery-power listener, if any."""
+        if self._unsub_battery_power_listener is not None:
+            self._unsub_battery_power_listener()
+            self._unsub_battery_power_listener = None
+
+    @callback
+    def _on_battery_power_change(self, event: Event) -> None:
+        """Battery power changed — check for the physical response."""
+        watch = self.data.physical_response_watch
+        if watch is None:
+            return
+        new_state = event.data.get("new_state")
+        try:
+            power = float(new_state.state)
+        except (AttributeError, TypeError, ValueError):
+            return
+        now = dt_util.now()
+        if now >= watch.timeout_at:
+            self._record_physical_response(timed_out=True)
+            return
+        detected = (
+            power <= -PHYSICAL_RESPONSE_THRESHOLD_KW
+            if watch.expected_direction == "charging"
+            else power >= PHYSICAL_RESPONSE_THRESHOLD_KW
+        )
+        if detected:
+            self._record_physical_response(timed_out=False)
+
+    def _record_physical_response(self, *, timed_out: bool) -> None:
+        """Finalize the active watch as detected or timed out."""
+        watch = self.data.physical_response_watch
+        if watch is None:
+            return
+        now = dt_util.now()
+        lag_seconds: float | None = None
+        if timed_out:
+            self.data.physical_response_timed_out = True
+            _LOGGER.info(
+                "Physical response to %s timed out after %.0fs",
+                watch.target_mode.value,
+                (now - watch.decision_timestamp).total_seconds(),
+            )
+        else:
+            lag_seconds = (now - watch.decision_timestamp).total_seconds()
+            self.data.physical_response_timestamp = now
+            self.data.physical_response_lag_seconds = lag_seconds
+            self.data.physical_response_timed_out = False
+            _LOGGER.info(
+                "Physical response to %s observed in %.2fs",
+                watch.target_mode.value,
+                lag_seconds,
+            )
+        # Backfill the history entry this watch belongs to
+        if self.data.decision_lag_history:
+            last = self.data.decision_lag_history[-1]
+            if last.get("decision_time") == watch.decision_timestamp.isoformat():
+                last["timed_out"] = timed_out
+                last["physical_lag"] = (
+                    round(lag_seconds, 2) if lag_seconds is not None else None
+                )
+        self.data.physical_response_watch = None
+        self._remove_battery_power_listener()
+        self.notify_listeners()
 
     # ------------------------------------------------------------------
     # Battery mode control (for select entity - Issue #382)

--- a/custom_components/localshift/coordinator/data.py
+++ b/custom_components/localshift/coordinator/data.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import date, datetime
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 from ..const import BatteryMode
 
@@ -154,6 +154,22 @@ class ChargingDecision:
     charge_amount_kwh: float = 0.0
     price_per_kwh: float = 0.0
     reason: str = ""
+
+
+@dataclass
+class PhysicalResponseWatch:
+    """Active watch for a physical battery response after a mode command.
+
+    Issue #508: created at decision time for modes with an observable power
+    direction; the coordinator watches battery power until it crosses the
+    mode-appropriate threshold or the watch times out.
+    """
+
+    decision_timestamp: datetime
+    expected_direction: Literal["charging", "discharging"]
+    baseline_power_kw: float
+    target_mode: BatteryMode
+    timeout_at: datetime
 
 
 @dataclass
@@ -541,9 +557,11 @@ class CoordinatorData:
     cloud_event_solar_scale_factor: float | None = None
 
     # ---------------------------------------------------------------------------
-    # --- Decision-to-Implementation Lag Tracking (Issue #501) ---
+    # --- Two-phase Decision Lag Tracking (Issues #501, #508) ---
     # ---------------------------------------------------------------------------
-    # Measures time from decision made to hardware validation passed.
+    # Phase 1 (command lag): decision -> control entity command completion.
+    # Phase 2 (physical lag): decision -> battery power physically crossing a
+    # mode-appropriate threshold (cloud propagation excluded).
 
     decision_timestamp: datetime | None = None
     """When active_mode was set to a new value (decision made)."""
@@ -551,17 +569,29 @@ class CoordinatorData:
     decision_mode: BatteryMode | None = None
     """The mode that was decided (for lag tracking)."""
 
-    implementation_timestamp: datetime | None = None
-    """When validation passed for the decision."""
+    command_completion_timestamp: datetime | None = None
+    """Issue #508 phase 1: when the last control entity command completed."""
 
     decision_lag_seconds: float | None = None
-    """Calculated lag from decision to implementation (seconds)."""
+    """Issue #508: command lag, decision -> command completion (seconds)."""
 
     decision_lag_history: list[dict[str, Any]] = field(default_factory=list)
-    """History of recent decision-to-implementation lag measurements.
-    Each entry: {from_mode, to_mode, lag_seconds, decision_time, implementation_time}.
-    Max 50 entries.
+    """History of two-phase lag measurements.
+    Each entry: {from_mode, to_mode, command_lag, physical_lag, decision_time,
+    command_time, observable, timed_out}. Max 50 entries.
     """
+
+    physical_response_watch: PhysicalResponseWatch | None = None
+    """Issue #508 phase 2: active physical-response watch, if any."""
+
+    physical_response_timestamp: datetime | None = None
+    """Issue #508: when the battery physically responded."""
+
+    physical_response_lag_seconds: float | None = None
+    """Issue #508: physical lag, decision -> physical response (seconds)."""
+
+    physical_response_timed_out: bool = False
+    """Issue #508: True when the last physical-response watch timed out."""
 
     # ---------------------------------------------------------------------------
     # --- Decision-token gating (#622 gate replacement) ---

--- a/custom_components/localshift/integration/controller.py
+++ b/custom_components/localshift/integration/controller.py
@@ -8,6 +8,8 @@ from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from homeassistant.util import dt as dt_util
+
 from ..const import (
     BACKUP_RESERVE_MAX_VALID,
     TESLEMETRY_EXPORT_BATTERY_OK,
@@ -109,11 +111,16 @@ class BatteryController:
             pass
         return None
 
-    async def _run_transition(self, recipe: TransitionRecipe) -> bool:
+    async def _run_transition(
+        self, recipe: TransitionRecipe, data: CoordinatorData | None = None
+    ) -> bool:
         """Execute a transition recipe and validate the result.
 
         Args:
             recipe: Transition recipe containing steps and expectations.
+            data: Coordinator data; when given, records the command completion
+                timestamp after the last control command, before validation
+                (Issue #508 phase 1).
 
         Returns:
             True if transition succeeded and validated, False otherwise.
@@ -123,6 +130,9 @@ class BatteryController:
             if not await step.action():
                 _LOGGER.error(step.failure_message)
                 return False
+
+        if data is not None:
+            data.command_completion_timestamp = dt_util.now()
 
         if not await self._validator.validate_transition(
             expected_operation_mode=recipe.expectation.operation_mode,
@@ -236,7 +246,7 @@ class BatteryController:
             on_validation_failure=_log_validation_failure,
         )
 
-        if not await self._run_transition(recipe):
+        if not await self._run_transition(recipe, data):
             return False
 
         _LOGGER.info(
@@ -381,7 +391,7 @@ class BatteryController:
             on_validation_failure=_log_validation_failure,
         )
 
-        if not await self._run_transition(recipe):
+        if not await self._run_transition(recipe, data):
             return False
 
         elapsed = time.monotonic() - transition_start
@@ -476,7 +486,7 @@ class BatteryController:
             on_validation_failure=_log_validation_failure,
         )
 
-        if not await self._run_transition(recipe):
+        if not await self._run_transition(recipe, data):
             return False
 
         elapsed = time.monotonic() - transition_start
@@ -587,7 +597,7 @@ class BatteryController:
             on_validation_failure=_log_validation_failure,
         )
 
-        if not await self._run_transition(recipe):
+        if not await self._run_transition(recipe, data):
             return False
 
         elapsed = time.monotonic() - transition_start
@@ -681,7 +691,7 @@ class BatteryController:
             on_validation_failure=_log_validation_failure,
         )
 
-        if not await self._run_transition(recipe):
+        if not await self._run_transition(recipe, data):
             return False
 
         elapsed = time.monotonic() - transition_start

--- a/custom_components/localshift/sensors/status.py
+++ b/custom_components/localshift/sensors/status.py
@@ -215,42 +215,59 @@ class DecisionLagSensor(LocalShiftSensorBase):
     _attr_state_class = SensorStateClass.MEASUREMENT
 
     def _update_from_coordinator(self) -> None:
-        lag = self.coordinator.data.decision_lag_seconds
-        if lag is not None:
-            self._attr_native_value = round(lag, 2)
+        d = self.coordinator.data
+        # Issue #917: native value is ALWAYS numeric. A None would render the
+        # HA state as "unknown", which the entity validator counts as a
+        # consecutive failure — 10 of them mark the entity broken during quiet
+        # periods. 0.0 means "never measured"; STALE (which does not count) is
+        # then the worst status the sensor can reach.
+        if d.physical_response_lag_seconds is not None:
+            self._attr_native_value = round(d.physical_response_lag_seconds, 2)
+        elif d.decision_lag_seconds is not None:
+            self._attr_native_value = round(d.decision_lag_seconds, 2)
         else:
-            self._attr_native_value = None
+            self._attr_native_value = 0.0
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         d = self.coordinator.data
         history = d.decision_lag_history or []
 
-        if history:
-            lag_values = [h["lag_seconds"] for h in history]
-            avg_lag = sum(lag_values) / len(lag_values)
-            max_lag = max(lag_values)
-            min_lag = min(lag_values)
-        else:
-            avg_lag = None
-            max_lag = None
-            min_lag = None
+        command_lags = [
+            h["command_lag"] for h in history if h.get("command_lag") is not None
+        ]
+        physical_lags = [
+            h["physical_lag"] for h in history if h.get("physical_lag") is not None
+        ]
+
+        def _round_or_none(values: list[float]) -> float | None:
+            return round(sum(values) / len(values), 2) if values else None
 
         return {
+            "command_lag_seconds": round(d.decision_lag_seconds, 2)
+            if d.decision_lag_seconds is not None
+            else None,
+            "physical_lag_seconds": round(d.physical_response_lag_seconds, 2)
+            if d.physical_response_lag_seconds is not None
+            else None,
+            "physical_lag_observable": d.physical_response_watch is not None
+            or bool(history and history[-1].get("observable")),
+            "physical_response_timed_out": d.physical_response_timed_out,
             "current_lag": round(d.decision_lag_seconds, 2)
             if d.decision_lag_seconds is not None
             else None,
             "last_transition": history[-1] if history else None,
             "history": history[-20:],
-            "avg_lag_24h": round(avg_lag, 2) if avg_lag is not None else None,
-            "max_lag_24h": round(max_lag, 2) if max_lag is not None else None,
-            "min_lag_24h": round(min_lag, 2) if min_lag is not None else None,
+            "avg_lag_24h": _round_or_none(command_lags),
+            "max_lag_24h": round(max(command_lags), 2) if command_lags else None,
+            "min_lag_24h": round(min(command_lags), 2) if command_lags else None,
+            "avg_physical_lag": _round_or_none(physical_lags),
             "total_transitions": len(history),
             "decision_timestamp": d.decision_timestamp.isoformat()
             if d.decision_timestamp
             else None,
-            "implementation_timestamp": d.implementation_timestamp.isoformat()
-            if d.implementation_timestamp
+            "command_completion_timestamp": d.command_completion_timestamp.isoformat()
+            if d.command_completion_timestamp
             else None,
         }
 

--- a/custom_components/localshift/state/machine.py
+++ b/custom_components/localshift/state/machine.py
@@ -6,7 +6,7 @@ import asyncio
 import logging
 from collections.abc import Callable
 from datetime import datetime, timedelta
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 from homeassistant.util import dt as dt_util
 
@@ -31,7 +31,7 @@ from ..const import (
     TESLEMETRY_EXPORT_PV_ONLY,
     BatteryMode,
 )
-from ..coordinator.data import CoordinatorData
+from ..coordinator.data import CoordinatorData, PhysicalResponseWatch
 from .mode_configs import MODE_CONFIG_BUILDERS, MODE_EXECUTORS, ModeConfig
 
 if TYPE_CHECKING:
@@ -52,6 +52,21 @@ _LOGGER = logging.getLogger(__name__)
 # flap-free (see _update_plan_charge_epoch).
 _CHARGE_MODES = (BatteryMode.GRID_CHARGING, BatteryMode.BOOST_CHARGING)
 _CHARGE_MODE_VALUES = frozenset(m.value for m in _CHARGE_MODES)
+
+# Issue #508: modes whose physical battery response is observable in the
+# battery power sensor. Charging modes respond by drawing power (negative
+# battery power), discharging modes by exporting it (positive battery power).
+# Modes absent from this table (self-consumption family, HOLD, MANUAL) produce
+# no predictable power signature, so their physical lag is unobservable.
+PHYSICAL_RESPONSE_DIRECTIONS: dict[BatteryMode, Literal["charging", "discharging"]] = {
+    BatteryMode.GRID_CHARGING: "charging",
+    BatteryMode.BOOST_CHARGING: "charging",
+    BatteryMode.SPIKE_DISCHARGE: "discharging",
+    BatteryMode.PROACTIVE_EXPORT: "discharging",
+}
+
+# Issue #508: how long to wait for the physical response before giving up.
+PHYSICAL_RESPONSE_TIMEOUT = timedelta(minutes=10)
 
 
 class StateMachine:
@@ -1096,6 +1111,13 @@ class StateMachine:
         finally:
             _LOGGER.debug("Mode transition flag cleared, allowing re-evaluation")
             self._in_mode_transition = False
+            # Issue #508: a failed transition abandons the pending decision —
+            # clear lag tracking so a stale watch never fires. The coordinator
+            # removes its listener when it sees the watch cleared.
+            if not transition_success and data.decision_mode == target:
+                data.decision_timestamp = None
+                data.decision_mode = None
+                data.physical_response_watch = None
 
         if transition_success:
             self._record_transition_metrics(data, target, dry_run)
@@ -1174,32 +1196,49 @@ class StateMachine:
     def _record_transition_metrics(
         self, data: CoordinatorData, target: BatteryMode, dry_run: bool
     ) -> None:
-        """Record transition timing metrics for telemetry."""
+        """Record two-phase transition timing metrics (Issue #508).
+
+        Phase 1 (command lag): decision -> control command completion.
+        Phase 2 (physical lag): starts a watch here; the coordinator observes
+        the battery power crossing the mode-appropriate threshold.
+        """
         transition_time = dt_util.now()
         if not dry_run:
             self._last_successful_transition = transition_time
 
-        if data.decision_timestamp is not None and data.decision_mode == target:
-            data.implementation_timestamp = transition_time
-            lag_seconds = (transition_time - data.decision_timestamp).total_seconds()
-            data.decision_lag_seconds = lag_seconds
+        # Issue #508: dry runs execute no real commands and drive no physical
+        # change, so neither phase is recorded.
+        if (
+            not dry_run
+            and data.decision_timestamp is not None
+            and data.decision_mode == target
+        ):
+            command_end = data.command_completion_timestamp or transition_time
+            command_lag = (command_end - data.decision_timestamp).total_seconds()
+            data.decision_lag_seconds = command_lag
+
+            observable = self._start_physical_response_watch(data, target, dry_run)
 
             history_entry = {
                 "from_mode": data.active_mode.value if data.active_mode else "unknown",
                 "to_mode": target.value,
-                "lag_seconds": round(lag_seconds, 2),
+                "command_lag": round(command_lag, 2),
+                "physical_lag": None,
                 "decision_time": data.decision_timestamp.isoformat(),
-                "implementation_time": transition_time.isoformat(),
+                "command_time": command_end.isoformat(),
+                "observable": observable,
+                "timed_out": False,
             }
             data.decision_lag_history.append(history_entry)
             if len(data.decision_lag_history) > 50:
                 data.decision_lag_history = data.decision_lag_history[-50:]
 
             _LOGGER.info(
-                "Decision lag: %s → %s completed in %.2fs",
+                "Decision lag: %s → %s commanded in %.2fs (physical watch %s)",
                 data.decision_mode.value if data.decision_mode else "unknown",
                 target.value,
-                lag_seconds,
+                command_lag,
+                "started" if observable else "not started",
             )
             data.decision_timestamp = None
             data.decision_mode = None
@@ -1209,6 +1248,36 @@ class StateMachine:
             target.value,
             transition_time.strftime("%H:%M:%S"),
         )
+
+    def _start_physical_response_watch(
+        self, data: CoordinatorData, target: BatteryMode, dry_run: bool
+    ) -> bool:
+        """Start the phase-2 physical response watch for *target*.
+
+        Returns True when a watch was started (physical lag observable).
+        Skipped for dry runs, unobservable modes, and charging decisions made
+        when the battery is already at its target SOC (no power will flow).
+        """
+        direction = PHYSICAL_RESPONSE_DIRECTIONS.get(target)
+        decision = data.decision_timestamp
+        if dry_run or direction is None or decision is None:
+            return False
+        if direction == "charging" and data.soc >= data.battery_target_soc:
+            _LOGGER.debug(
+                "Physical watch skipped for %s: SOC %.1f%% already at target %.1f%%",
+                target.value,
+                data.soc,
+                data.battery_target_soc,
+            )
+            return False
+        data.physical_response_watch = PhysicalResponseWatch(
+            decision_timestamp=decision,
+            expected_direction=direction,
+            baseline_power_kw=data.battery_power_kw,
+            target_mode=target,
+            timeout_at=decision + PHYSICAL_RESPONSE_TIMEOUT,
+        )
+        return True
 
     def _get_expected_state_for_mode(
         self, mode: BatteryMode

--- a/tests/sensors/test_sensors.py
+++ b/tests/sensors/test_sensors.py
@@ -206,10 +206,13 @@ class Fixtures:
         data.recent_decision_log = [{"time": "2024-01-01T10:00:00", "score": 0.9}]
         data.decision_lag_seconds = 2.5
         data.decision_lag_history = [
-            {"lag_seconds": 2.5, "timestamp": "2024-01-01T10:00:00"}
+            {"command_lag": 2.5, "timestamp": "2024-01-01T10:00:00"}
         ]
         data.decision_timestamp = None
-        data.implementation_timestamp = None
+        data.command_completion_timestamp = None
+        data.physical_response_lag_seconds = None
+        data.physical_response_watch = None
+        data.physical_response_timed_out = False
         data.forecast_status = "ready"
         data.forecast_ready = True
         data.solcast_today = [{"time": "2024-01-01T10:00:00"}] * 10

--- a/tests/sensors/test_status.py
+++ b/tests/sensors/test_status.py
@@ -283,50 +283,85 @@ class TestAutomationReadySensor:
 
 class TestDecisionLagSensor:
     def test_update_with_value(self):
-        sensor = _sensor(DecisionLagSensor, decision_lag_seconds=1.234)
+        sensor = _sensor(
+            DecisionLagSensor,
+            decision_lag_seconds=1.234,
+            physical_response_lag_seconds=None,
+        )
         sensor._update_from_coordinator()
         assert sensor._attr_native_value == pytest.approx(1.23)
 
-    def test_update_with_none(self):
-        sensor = _sensor(DecisionLagSensor, decision_lag_seconds=None)
+    def test_update_with_none_reports_zero(self):
+        # Issue #917: never None — 'unknown' states tripped the validator's
+        # consecutive-failure counter and marked the entity broken.
+        sensor = _sensor(
+            DecisionLagSensor,
+            decision_lag_seconds=None,
+            physical_response_lag_seconds=None,
+        )
         sensor._update_from_coordinator()
-        assert sensor._attr_native_value is None
+        assert sensor._attr_native_value == 0.0
+
+    def test_update_prefers_physical_lag(self):
+        sensor = _sensor(
+            DecisionLagSensor,
+            decision_lag_seconds=1.0,
+            physical_response_lag_seconds=9.5,
+        )
+        sensor._update_from_coordinator()
+        assert sensor._attr_native_value == pytest.approx(9.5)
 
     def test_extra_state_attributes_no_history(self):
         sensor = _sensor(
             DecisionLagSensor,
             decision_lag_seconds=None,
+            physical_response_lag_seconds=None,
+            physical_response_timed_out=False,
+            physical_response_watch=None,
             decision_lag_history=[],
             decision_timestamp=None,
-            implementation_timestamp=None,
+            command_completion_timestamp=None,
         )
         attrs = sensor.extra_state_attributes
         assert attrs["avg_lag_24h"] is None
         assert attrs["max_lag_24h"] is None
         assert attrs["min_lag_24h"] is None
+        assert attrs["avg_physical_lag"] is None
         assert attrs["total_transitions"] == 0
         assert attrs["decision_timestamp"] is None
+        assert attrs["command_completion_timestamp"] is None
         assert attrs["current_lag"] is None
+        assert attrs["command_lag_seconds"] is None
+        assert attrs["physical_lag_seconds"] is None
+        assert attrs["physical_lag_observable"] is False
+        assert attrs["physical_response_timed_out"] is False
 
     def test_extra_state_attributes_with_history(self):
         now = datetime(2026, 3, 12, 12, 0, 0)
         history = [
-            {"lag_seconds": 1.0},
-            {"lag_seconds": 2.0},
-            {"lag_seconds": 3.0},
+            {"command_lag": 1.0, "physical_lag": 5.0},
+            {"command_lag": 2.0, "physical_lag": None},
+            {"command_lag": 3.0, "physical_lag": 7.0},
         ]
         sensor = _sensor(
             DecisionLagSensor,
             decision_lag_seconds=3.0,
+            physical_response_lag_seconds=7.0,
+            physical_response_timed_out=False,
+            physical_response_watch=None,
             decision_lag_history=history,
             decision_timestamp=now,
-            implementation_timestamp=now,
+            command_completion_timestamp=now,
         )
         attrs = sensor.extra_state_attributes
         assert attrs["avg_lag_24h"] == pytest.approx(2.0)
         assert attrs["max_lag_24h"] == pytest.approx(3.0)
         assert attrs["min_lag_24h"] == pytest.approx(1.0)
+        assert attrs["avg_physical_lag"] == pytest.approx(6.0)
         assert attrs["total_transitions"] == 3
+        assert attrs["command_lag_seconds"] == pytest.approx(3.0)
+        assert attrs["physical_lag_seconds"] == pytest.approx(7.0)
+        assert attrs["command_completion_timestamp"] == now.isoformat()
 
     def test_icon_with_decision_timestamp(self):
         sensor = _sensor(DecisionLagSensor, decision_timestamp=MagicMock())

--- a/tests/state/test_state_machine.py
+++ b/tests/state/test_state_machine.py
@@ -1275,8 +1275,10 @@ class TestStateMachineInternalBranches:
         coordinator_data.active_mode = BatteryMode.SELF_CONSUMPTION
         coordinator_data.decision_mode = BatteryMode.GRID_CHARGING
         coordinator_data.decision_timestamp = base - timedelta(seconds=12)
+        coordinator_data.soc = 50.0
+        coordinator_data.battery_target_soc = 80.0
         coordinator_data.decision_lag_history = [
-            {"lag_seconds": float(i)} for i in range(60)
+            {"command_lag": float(i)} for i in range(60)
         ]
 
         with patch(
@@ -1290,11 +1292,16 @@ class TestStateMachineInternalBranches:
             )
 
         assert state_machine._last_successful_transition == base
-        assert coordinator_data.implementation_timestamp == base
+        # No command completion recorded — falls back to transition time
         assert coordinator_data.decision_lag_seconds == 12.0
         assert len(coordinator_data.decision_lag_history) == 50
         assert coordinator_data.decision_timestamp is None
         assert coordinator_data.decision_mode is None
+        # Issue #508: observable mode starts the physical response watch
+        watch = coordinator_data.physical_response_watch
+        assert watch is not None
+        assert watch.expected_direction == "charging"
+        assert watch.timeout_at == watch.decision_timestamp + timedelta(minutes=10)
 
     def test_set_commanded_mode_updates_mode_and_clears_timers(self, state_machine):
         """Direct commanded mode setter should clear pending desired timers."""

--- a/tests/test_decision_lag.py
+++ b/tests/test_decision_lag.py
@@ -1,40 +1,570 @@
-"""Tests for decision-to-implementation lag tracking (Issue #501)."""
+"""Tests for two-phase decision lag tracking (Issues #501, #508, #917).
 
-from custom_components.localshift.coordinator import CoordinatorData
+Phase 1 (command lag): decision -> control entity command completion.
+Phase 2 (physical lag): decision -> battery power crossing a mode-appropriate
+threshold, observed via a temporary state-change listener with a 10-minute
+timeout.
+"""
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from homeassistant.util import dt as dt_util
+
+from custom_components.localshift.const import BatteryMode
+from custom_components.localshift.coordinator.coordinator import LocalShiftCoordinator
+from custom_components.localshift.coordinator.data import (
+    CoordinatorData,
+    PhysicalResponseWatch,
+)
+from custom_components.localshift.sensors.status import DecisionLagSensor
+from custom_components.localshift.state.machine import (
+    PHYSICAL_RESPONSE_DIRECTIONS,
+    StateMachine,
+)
+
+SYDNEY = timezone(timedelta(hours=11))
 
 
-class TestDecisionLagTracking:
-    """Test decision lag tracking in CoordinatorData."""
+def dt_aware(*args):
+    return datetime(*args, tzinfo=SYDNEY)
 
-    def test_initial_state_no_lag(self):
-        """Test initial state has no lag data."""
+
+@pytest.fixture
+def data():
+    return CoordinatorData()
+
+
+@pytest.fixture
+def state_machine():
+    controller = MagicMock()
+    controller.set_self_consumption = AsyncMock(return_value=True)
+    controller.set_force_charge = AsyncMock(return_value=True)
+    controller.set_boost_charge = AsyncMock(return_value=True)
+    controller.set_force_discharge = AsyncMock(return_value=True)
+    controller.set_proactive_export = AsyncMock(return_value=True)
+    return StateMachine(
+        controller,
+        MagicMock(),
+        lambda key: False,
+        lambda key, default=None: default,
+        MagicMock(),
+    )
+
+
+def make_coordinator():
+    hass = MagicMock()
+    entry = MagicMock()
+    entry.data = {}
+    entry.options = {}
+    return LocalShiftCoordinator(hass, entry)
+
+
+def make_event(power):
+    return MagicMock(data={"new_state": SimpleNamespace(state=str(power))})
+
+
+class TestPhysicalResponseWatch:
+    def test_defaults_and_fields(self):
+        decision = dt_aware(2026, 8, 27, 6, 0, 0)
+        watch = PhysicalResponseWatch(
+            decision_timestamp=decision,
+            expected_direction="charging",
+            baseline_power_kw=0.1,
+            target_mode=BatteryMode.GRID_CHARGING,
+            timeout_at=decision + timedelta(minutes=10),
+        )
+        assert watch.decision_timestamp == decision
+        assert watch.expected_direction == "charging"
+        assert watch.baseline_power_kw == 0.1
+        assert watch.target_mode == BatteryMode.GRID_CHARGING
+        assert watch.timeout_at == decision + timedelta(minutes=10)
+
+    def test_coordinator_data_defaults(self):
         data = CoordinatorData()
-
+        assert data.command_completion_timestamp is None
+        assert data.physical_response_watch is None
+        assert data.physical_response_timestamp is None
+        assert data.physical_response_lag_seconds is None
+        assert data.physical_response_timed_out is False
         assert data.decision_timestamp is None
         assert data.decision_mode is None
-        assert data.implementation_timestamp is None
         assert data.decision_lag_seconds is None
         assert len(data.decision_lag_history) == 0
 
-    def test_history_limit(self):
-        """Test history is limited to 50 entries when managed by state machine."""
-        data = CoordinatorData()
 
-        # Simulate what state machine does - adds entries with limit check
-        for i in range(60):
-            entry = {
-                "from_mode": "self_consumption",
-                "to_mode": "grid_charging",
-                "lag_seconds": 5.0 + i,
-                "decision_time": f"2025-01-01T{i:02d}:00:00",
-                "implementation_time": f"2025-01-01T{i:02d}:00:05",
-            }
-            data.decision_lag_history.append(entry)
-            if len(data.decision_lag_history) > 50:
-                data.decision_lag_history = data.decision_lag_history[-50:]
+class TestPhysicalResponseDirections:
+    def test_charging_modes(self):
+        assert PHYSICAL_RESPONSE_DIRECTIONS[BatteryMode.GRID_CHARGING] == "charging"
+        assert PHYSICAL_RESPONSE_DIRECTIONS[BatteryMode.BOOST_CHARGING] == "charging"
 
-        # Should be limited to 50
+    def test_discharging_modes(self):
+        assert (
+            PHYSICAL_RESPONSE_DIRECTIONS[BatteryMode.SPIKE_DISCHARGE] == "discharging"
+        )
+        assert (
+            PHYSICAL_RESPONSE_DIRECTIONS[BatteryMode.PROACTIVE_EXPORT] == "discharging"
+        )
+
+    def test_other_modes_unobservable(self):
+        for mode in (
+            BatteryMode.SELF_CONSUMPTION,
+            BatteryMode.HOLD,
+            BatteryMode.MANUAL,
+            BatteryMode.DEMAND_BLOCK,
+        ):
+            assert mode not in PHYSICAL_RESPONSE_DIRECTIONS
+
+
+class TestRecordTransitionMetrics:
+    """Phase 1 + watch start via StateMachine._record_transition_metrics."""
+
+    def _prime(self, data):
+        data.active_mode = BatteryMode.SELF_CONSUMPTION
+        data.decision_mode = BatteryMode.GRID_CHARGING
+        data.decision_timestamp = dt_aware(2026, 8, 27, 6, 0, 0)
+        data.battery_power_kw = 0.0
+        data.soc = 50.0
+        data.battery_target_soc = 80.0
+
+    def test_command_lag_uses_command_completion(self, state_machine, data):
+        self._prime(data)
+        data.command_completion_timestamp = dt_aware(2026, 8, 27, 6, 0, 7)
+        with patch(
+            "custom_components.localshift.state.machine.dt_util.now"
+        ) as mock_now:
+            mock_now.return_value = dt_aware(2026, 8, 27, 6, 0, 30)
+            state_machine._record_transition_metrics(
+                data, BatteryMode.GRID_CHARGING, dry_run=False
+            )
+        # Command lag is decision -> command completion (7s), not -> validation (30s)
+        assert data.decision_lag_seconds == 7.0
+        assert data.command_completion_timestamp == dt_aware(2026, 8, 27, 6, 0, 7)
+
+    def test_watch_started_for_observable_mode(self, state_machine, data):
+        self._prime(data)
+        completion = dt_aware(2026, 8, 27, 6, 0, 7)
+        data.command_completion_timestamp = completion
+        with patch(
+            "custom_components.localshift.state.machine.dt_util.now"
+        ) as mock_now:
+            mock_now.return_value = completion
+            state_machine._record_transition_metrics(
+                data, BatteryMode.GRID_CHARGING, dry_run=False
+            )
+        watch = data.physical_response_watch
+        assert watch is not None
+        assert watch.decision_timestamp == dt_aware(2026, 8, 27, 6, 0, 0)
+        assert watch.expected_direction == "charging"
+        assert watch.target_mode == BatteryMode.GRID_CHARGING
+        assert watch.baseline_power_kw == 0.0
+        assert watch.timeout_at == dt_aware(2026, 8, 27, 6, 10, 0)
+
+    def test_watch_not_started_dry_run(self, state_machine, data):
+        self._prime(data)
+        with patch(
+            "custom_components.localshift.state.machine.dt_util.now"
+        ) as mock_now:
+            mock_now.return_value = dt_aware(2026, 8, 27, 6, 0, 7)
+            state_machine._record_transition_metrics(
+                data, BatteryMode.GRID_CHARGING, dry_run=True
+            )
+        assert data.physical_response_watch is None
+        assert data.decision_lag_seconds is None
+        # Dry runs record neither phase: no history entry at all.
+        assert data.decision_lag_history == []
+
+    def test_watch_not_started_unobservable_mode(self, state_machine, data):
+        self._prime(data)
+        data.decision_mode = BatteryMode.SELF_CONSUMPTION
+        with patch(
+            "custom_components.localshift.state.machine.dt_util.now"
+        ) as mock_now:
+            mock_now.return_value = dt_aware(2026, 8, 27, 6, 0, 7)
+            state_machine._record_transition_metrics(
+                data, BatteryMode.SELF_CONSUMPTION, dry_run=False
+            )
+        assert data.physical_response_watch is None
+        assert data.decision_lag_history[-1]["observable"] is False
+
+    def test_watch_skipped_when_soc_at_target(self, state_machine, data):
+        self._prime(data)
+        data.soc = 80.0
+        assert data.soc >= data.battery_target_soc
+        with patch(
+            "custom_components.localshift.state.machine.dt_util.now"
+        ) as mock_now:
+            mock_now.return_value = dt_aware(2026, 8, 27, 6, 0, 7)
+            state_machine._record_transition_metrics(
+                data, BatteryMode.GRID_CHARGING, dry_run=False
+            )
+        assert data.physical_response_watch is None
+        assert data.decision_lag_history[-1]["observable"] is False
+
+    def test_no_metrics_when_decision_mode_mismatch(self, state_machine, data):
+        self._prime(data)
+        data.decision_mode = BatteryMode.BOOST_CHARGING
+        with patch(
+            "custom_components.localshift.state.machine.dt_util.now"
+        ) as mock_now:
+            mock_now.return_value = dt_aware(2026, 8, 27, 6, 0, 7)
+            state_machine._record_transition_metrics(
+                data, BatteryMode.GRID_CHARGING, dry_run=False
+            )
+        assert data.decision_lag_seconds is None
+        assert data.physical_response_watch is None
+        assert len(data.decision_lag_history) == 0
+        # Decision state preserved for the matching transition
+        assert data.decision_timestamp is not None
+
+    def test_history_entry_shape_and_cap(self, state_machine, data):
+        self._prime(data)
+        completion = dt_aware(2026, 8, 27, 6, 0, 7)
+        data.command_completion_timestamp = completion
+        data.decision_lag_history = [{"command_lag": float(i)} for i in range(60)]
+        with patch(
+            "custom_components.localshift.state.machine.dt_util.now"
+        ) as mock_now:
+            mock_now.return_value = completion
+            state_machine._record_transition_metrics(
+                data, BatteryMode.GRID_CHARGING, dry_run=False
+            )
         assert len(data.decision_lag_history) == 50
-        # Should keep the most recent (entries 10-59, lag values 15.0-64.0)
-        assert data.decision_lag_history[0]["lag_seconds"] == 15.0
-        assert data.decision_lag_history[-1]["lag_seconds"] == 64.0
+        entry = data.decision_lag_history[-1]
+        assert entry["from_mode"] == "self_consumption"
+        assert entry["to_mode"] == "grid_charging"
+        assert entry["command_lag"] == 7.0
+        assert entry["physical_lag"] is None
+        assert (
+            entry["decision_time"]
+            == data.physical_response_watch.decision_timestamp.isoformat()
+        )
+        assert entry["observable"] is True
+        assert entry["timed_out"] is False
+        assert data.decision_timestamp is None
+        assert data.decision_mode is None
+
+
+class TestFailedTransitionCleanup:
+    def test_failed_transition_clears_tracking(self, data):
+        state_machine = StateMachine(
+            MagicMock(),
+            MagicMock(),
+            lambda key: False,
+            lambda key, default=None: default,
+            MagicMock(),
+        )
+        decision = dt_aware(2026, 8, 27, 6, 0, 0)
+        data.decision_mode = BatteryMode.GRID_CHARGING
+        data.decision_timestamp = decision
+        data.physical_response_watch = PhysicalResponseWatch(
+            decision_timestamp=decision,
+            expected_direction="charging",
+            baseline_power_kw=0.0,
+            target_mode=BatteryMode.GRID_CHARGING,
+            timeout_at=decision + timedelta(minutes=10),
+        )
+        state_machine._get_mode_config = lambda target, d: MagicMock(backup_reserve=10)
+        state_machine._dispatch_mode_transition = AsyncMock(return_value=False)
+
+        ok = asyncio.run(
+            state_machine._execute_mode_transition(data, BatteryMode.GRID_CHARGING)
+        )
+
+        assert ok is False
+        assert data.decision_timestamp is None
+        assert data.decision_mode is None
+        assert data.physical_response_watch is None
+
+
+class TestControllerCommandCompletion:
+    def test_run_transition_records_command_completion_before_validation(
+        self, mock_hass, mock_get_entity_id
+    ):
+        from custom_components.localshift.integration.controller import (
+            BatteryController,
+            TransitionExpectation,
+            TransitionRecipe,
+            TransitionStep,
+        )
+
+        controller = BatteryController(mock_hass, mock_get_entity_id)
+        data = CoordinatorData()
+        recorded = {}
+
+        async def step():
+            return True
+
+        async def validate(**kwargs):
+            recorded["completion_at_validation"] = data.command_completion_timestamp
+            return True
+
+        controller._validator = MagicMock()
+        controller._validator.validate_transition = validate
+        completion_time = dt_aware(2026, 8, 27, 6, 0, 7)
+        recipe = TransitionRecipe(
+            name="test",
+            steps=[TransitionStep(action=step, failure_message="nope")],
+            expectation=TransitionExpectation(
+                operation_mode="self_consumption", backup_reserve=10
+            ),
+        )
+        with patch(
+            "custom_components.localshift.integration.controller.dt_util.now"
+        ) as mock_now:
+            mock_now.return_value = completion_time
+            ok = asyncio.run(controller._run_transition(recipe, data))
+        assert ok is True
+        # Recorded after the last command, BEFORE validation observed None? No:
+        # validation must already see the completion timestamp.
+        assert recorded["completion_at_validation"] == completion_time
+        assert data.command_completion_timestamp == completion_time
+
+    def test_dry_run_skips_command_completion(self, mock_hass, mock_get_entity_id):
+        from custom_components.localshift.integration.controller import (
+            BatteryController,
+        )
+
+        controller = BatteryController(mock_hass, mock_get_entity_id)
+        data = CoordinatorData()
+        ok = asyncio.run(controller.set_self_consumption(data, dry_run=True))
+        assert ok is True
+        assert data.command_completion_timestamp is None
+
+
+class TestCoordinatorPhysicalWatch:
+    def _watch(self, minutes_old=0.0, direction="charging"):
+        # Build relative to the real clock so timeout logic is deterministic:
+        # minutes_old >= 10 means the watch is already expired.
+        decision = dt_util.now() - timedelta(minutes=minutes_old)
+        return PhysicalResponseWatch(
+            decision_timestamp=decision,
+            expected_direction=direction,
+            baseline_power_kw=0.0,
+            target_mode=BatteryMode.GRID_CHARGING
+            if direction == "charging"
+            else BatteryMode.SPIKE_DISCHARGE,
+            timeout_at=decision + timedelta(minutes=10),
+        )
+
+    def test_check_starts_listener_for_active_watch(self):
+        coordinator = make_coordinator()
+        coordinator.data.physical_response_watch = self._watch()
+        with patch(
+            "custom_components.localshift.coordinator.coordinator."
+            "async_track_state_change_event"
+        ) as track:
+            unsub = MagicMock()
+            track.return_value = unsub
+            coordinator._check_physical_response_watch()
+        track.assert_called_once()
+        assert coordinator._unsub_battery_power_listener == unsub
+
+    def test_check_removes_listener_when_watch_cleared(self):
+        coordinator = make_coordinator()
+        unsub = MagicMock()
+        coordinator._unsub_battery_power_listener = unsub
+        coordinator._check_physical_response_watch()
+        unsub.assert_called_once_with()
+        assert coordinator._unsub_battery_power_listener is None
+
+    def test_check_timeout_records_and_cleans_up(self):
+        coordinator = make_coordinator()
+        watch = self._watch(minutes_old=11)
+        coordinator.data.physical_response_watch = watch
+        coordinator.data.decision_lag_history = [
+            {"decision_time": watch.decision_timestamp.isoformat()}
+        ]
+        unsub = MagicMock()
+        coordinator._unsub_battery_power_listener = unsub
+        coordinator._check_physical_response_watch()
+        assert coordinator.data.physical_response_timed_out is True
+        assert coordinator.data.physical_response_watch is None
+        unsub.assert_called_once_with()
+        assert coordinator.data.decision_lag_history[-1]["timed_out"] is True
+        assert coordinator.data.decision_lag_history[-1]["physical_lag"] is None
+
+    def test_listener_detects_charging_threshold(self):
+        coordinator = make_coordinator()
+        watch = self._watch()
+        coordinator.data.physical_response_watch = watch
+        coordinator.data.decision_lag_history = [
+            {"decision_time": watch.decision_timestamp.isoformat()}
+        ]
+        now = watch.decision_timestamp + timedelta(seconds=8)
+        with patch(
+            "custom_components.localshift.coordinator.coordinator.dt_util.now"
+        ) as mock_now:
+            mock_now.return_value = now
+            coordinator._on_battery_power_change(make_event(-0.35))
+        assert coordinator.data.physical_response_lag_seconds == 8.0
+        assert coordinator.data.physical_response_timestamp == now
+        assert coordinator.data.physical_response_watch is None
+        assert coordinator.data.physical_response_timed_out is False
+        assert coordinator.data.decision_lag_history[-1]["physical_lag"] == 8.0
+
+    def test_listener_detects_discharging_threshold(self):
+        coordinator = make_coordinator()
+        watch = self._watch(direction="discharging")
+        coordinator.data.physical_response_watch = watch
+        coordinator.data.decision_lag_history = [
+            {"decision_time": watch.decision_timestamp.isoformat()}
+        ]
+        now = watch.decision_timestamp + timedelta(seconds=12)
+        with patch(
+            "custom_components.localshift.coordinator.coordinator.dt_util.now"
+        ) as mock_now:
+            mock_now.return_value = now
+            coordinator._on_battery_power_change(make_event(1.2))
+        assert coordinator.data.physical_response_lag_seconds == 12.0
+
+    def test_listener_ignores_wrong_direction(self):
+        coordinator = make_coordinator()
+        coordinator.data.physical_response_watch = self._watch()
+        coordinator._on_battery_power_change(make_event(2.0))
+        assert coordinator.data.physical_response_lag_seconds is None
+        assert coordinator.data.physical_response_watch is not None
+
+    def test_listener_ignores_below_threshold(self):
+        coordinator = make_coordinator()
+        coordinator.data.physical_response_watch = self._watch()
+        coordinator._on_battery_power_change(make_event(-0.2))
+        assert coordinator.data.physical_response_lag_seconds is None
+
+    def test_listener_ignores_unavailable_state(self):
+        coordinator = make_coordinator()
+        coordinator.data.physical_response_watch = self._watch()
+        coordinator._on_battery_power_change(make_event("unavailable"))
+        assert coordinator.data.physical_response_lag_seconds is None
+
+    def test_listener_timeout_marks_timed_out(self):
+        coordinator = make_coordinator()
+        watch = self._watch()
+        coordinator.data.physical_response_watch = watch
+        coordinator.data.decision_lag_history = [
+            {"decision_time": watch.decision_timestamp.isoformat()}
+        ]
+        coordinator._unsub_battery_power_listener = MagicMock()
+        with patch(
+            "custom_components.localshift.coordinator.coordinator.dt_util.now"
+        ) as mock_now:
+            mock_now.return_value = watch.timeout_at + timedelta(seconds=1)
+            coordinator._on_battery_power_change(make_event(-1.5))
+        assert coordinator.data.physical_response_timed_out is True
+        assert coordinator.data.physical_response_watch is None
+        assert coordinator.data.decision_lag_history[-1]["timed_out"] is True
+
+    def test_listener_noop_without_watch(self):
+        coordinator = make_coordinator()
+        coordinator._on_battery_power_change(make_event(-1.5))
+        assert coordinator.data.physical_response_lag_seconds is None
+
+    def test_record_physical_response_noop_without_watch(self):
+        coordinator = make_coordinator()
+        coordinator._record_physical_response(timed_out=True)
+        assert coordinator.data.physical_response_timed_out is False
+        assert coordinator.data.physical_response_lag_seconds is None
+
+    def test_evaluate_state_machine_starts_listener(self):
+        coordinator = make_coordinator()
+        coordinator.data.physical_response_watch = self._watch()
+        coordinator._state_machine = MagicMock()
+        coordinator._state_machine.evaluate_state_machine = AsyncMock()
+        coordinator._computation_engine = MagicMock()
+        coordinator._state_reader = MagicMock()
+        with patch(
+            "custom_components.localshift.coordinator.coordinator."
+            "async_track_state_change_event"
+        ) as track:
+            track.return_value = MagicMock()
+            asyncio.run(coordinator._evaluate_state_machine())
+        track.assert_called_once()
+        coordinator._state_machine.evaluate_state_machine.assert_awaited_once()
+
+    def test_fast_tick_enforces_timeout(self):
+        coordinator = make_coordinator()
+        coordinator.data.physical_response_watch = self._watch(minutes_old=15)
+        coordinator._tick_scheduler = MagicMock()
+        now = dt_util.now()
+        coordinator._handle_fast_tick(now)
+        coordinator._tick_scheduler.handle_fast_tick.assert_called_once()
+        assert coordinator.data.physical_response_timed_out is True
+
+
+class TestDecisionLagSensor:
+    def _sensor(self, **data_attrs):
+        coordinator = MagicMock()
+        entry = MagicMock()
+        for key, val in data_attrs.items():
+            setattr(coordinator.data, key, val)
+        return DecisionLagSensor(coordinator, entry)
+
+    def test_native_value_zero_when_never_measured(self):
+        sensor = self._sensor(
+            decision_lag_seconds=None,
+            physical_response_lag_seconds=None,
+        )
+        sensor._update_from_coordinator()
+        assert sensor._attr_native_value == 0.0
+
+    def test_native_value_prefers_physical_lag(self):
+        sensor = self._sensor(
+            decision_lag_seconds=7.0,
+            physical_response_lag_seconds=42.0,
+        )
+        sensor._update_from_coordinator()
+        assert sensor._attr_native_value == 42.0
+
+    def test_native_value_falls_back_to_command_lag(self):
+        sensor = self._sensor(
+            decision_lag_seconds=7.0,
+            physical_response_lag_seconds=None,
+        )
+        sensor._update_from_coordinator()
+        assert sensor._attr_native_value == 7.0
+
+    def test_attributes_expose_both_phases(self):
+        now = dt_aware(2026, 8, 27, 6, 0, 0)
+        sensor = self._sensor(
+            decision_lag_seconds=7.0,
+            physical_response_lag_seconds=42.0,
+            physical_response_timed_out=False,
+            physical_response_watch=None,
+            decision_lag_history=[
+                {
+                    "command_lag": 7.0,
+                    "physical_lag": 42.0,
+                    "observable": True,
+                    "timed_out": False,
+                }
+            ],
+            decision_timestamp=now,
+            command_completion_timestamp=now,
+        )
+        attrs = sensor.extra_state_attributes
+        assert attrs["command_lag_seconds"] == 7.0
+        assert attrs["physical_lag_seconds"] == 42.0
+        assert attrs["physical_lag_observable"] is True
+        assert attrs["physical_response_timed_out"] is False
+        assert attrs["avg_lag_24h"] == 7.0
+        assert attrs["avg_physical_lag"] == 42.0
+        assert attrs["command_completion_timestamp"] == now.isoformat()
+
+    def test_attributes_when_no_history(self):
+        sensor = self._sensor(
+            decision_lag_seconds=None,
+            physical_response_lag_seconds=None,
+            physical_response_timed_out=False,
+            physical_response_watch=None,
+            decision_lag_history=[],
+            decision_timestamp=None,
+            command_completion_timestamp=None,
+        )
+        attrs = sensor.extra_state_attributes
+        assert attrs["avg_lag_24h"] is None
+        assert attrs["avg_physical_lag"] is None
+        assert attrs["physical_lag_observable"] is False
+        assert attrs["command_completion_timestamp"] is None


### PR DESCRIPTION
## Summary

The decision lag sensor measured decision -> cloud-validated completion, which reflects cloud propagation rather than how fast the Powerwall physically responds (#508). This PR splits it into two phases:

- **Phase 1 — command lag**: decision -> control entity command completion, recorded after the last control command and before validation (`BatteryController._run_transition`). Dry runs record neither phase.
- **Phase 2 — physical lag**: decision -> `sensor.my_home_battery_power` crossing a mode-appropriate 0.3 kW threshold, observed via a temporary `async_track_state_change_event` listener registered at decision time with a 10-minute timeout. Charging modes detect <= -0.3 kW, discharging modes >= +0.3 kW; unobservable modes (self-consumption, hold, manual, demand block) and charging decisions already at target SOC are skipped and reported as unobservable.

New `PhysicalResponseWatch` dataclass on `CoordinatorData`; `implementation_timestamp` renamed to `command_completion_timestamp`; history entries (capped 50) now carry `{from_mode, to_mode, command_lag, physical_lag, decision_time, command_time, observable, timed_out}`. Failed transitions clear all tracking and the listener self-heals on the next check.

Also fixes the decision_lag half of #917: `native_value` is now always numeric (0.0 when never measured) instead of `None`, so overnight quiet periods and restarts no longer accrue consecutive UNKNOWN validation failures that BROKE the sensor. STALE remains acceptable and never increments failures.

## Related Issue

Closes #508
Refs #917 (decision_lag sensor half)

## Changes

- `coordinator/data.py`: `PhysicalResponseWatch` dataclass; rename + new physical-response fields
- `state/machine.py`: `PHYSICAL_RESPONSE_DIRECTIONS` map, watch start in `_record_transition_metrics`, SOC-at-target / dry-run / unobservable skips, failed-transition cleanup
- `integration/controller.py`: command completion timestamp recorded before validation
- `coordinator/coordinator.py`: battery-power listener lifecycle, threshold detection, timeout enforcement on evaluate + fast tick
- `sensors/status.py`: `DecisionLagSensor` exposes both phases, never-None native value, `avg_physical_lag`
- Tests: new `tests/test_decision_lag.py` (33 tests); updated status/sensor/state-machine suites

## Testing

- [x] TDD RED captured (ImportError: cannot import name 'PhysicalResponseWatch')
- [x] uv run pytest — 3496 passed, 1 xfailed
- [x] uv run ruff check — clean on changed files
- [x] uv run ruff format --check — clean on changed files (25 pre-existing failures elsewhere, verified identical on baseline)
- [x] npx pyright@1.1.413 custom_components/localshift — 0 errors
- [ ] CI passes