### PR TITLE
fix(learning): metered outcome attribution + rate-based cost scoring

### DIFF
--- a/custom_components/localshift/engine/outcomes.py
+++ b/custom_components/localshift/engine/outcomes.py
@@ -5,6 +5,12 @@ a ground-truth dataset for optimization. This phase is observation-only —
 no behavioral changes.
 
 Issue #449 Phase 7: Updated to use DP-native PlannerAction instead of legacy BatteryMode.
+
+Issue #915: Outcome attribution is metered. Import/export/cost come from the
+CostTracker fast-tick accumulators differenced over the exact decision window
+(snapshot at decision time), replacing the old SOC-derived estimates that
+recorded import 0.0 for successful charges. The cost score is rate-based
+(average price per kWh vs the price threshold).
 """
 
 from __future__ import annotations
@@ -52,6 +58,34 @@ MAX_COMPLETED_DECISIONS = 500
 # Maximum duration for a decision period before it's considered complete
 MAX_DECISION_DURATION = timedelta(minutes=30)
 
+# Meter accumulators snapshotted at decision time and differenced at backfill
+# to attribute energy/cost to the exact decision window (Issue #915). These
+# run on CoordinatorData and are integrated from instantaneous power on every
+# fast tick by CostTracker.
+_ENERGY_METER_KEYS = (
+    "grid_import_kwh_today",
+    "grid_export_kwh_today",
+    "grid_import_cost",
+    "grid_export_revenue",
+)
+
+
+def _snapshot_energy_meters(data: CoordinatorData) -> dict[str, float]:
+    """Copy the current meter accumulator values (never live references)."""
+    return {key: float(getattr(data, key)) for key in _ENERGY_METER_KEYS}
+
+
+def _meter_delta(current: float, snapshot: float) -> float:
+    """Meter accrual over the decision window, daily-reset aware.
+
+    The accumulators reset to 0 at midnight. If a reset fell inside the
+    window, ``current`` is smaller than the snapshot and equals the energy
+    accrued since midnight — all of which lies inside the window. The
+    pre-midnight portion of the window is unknowable after the reset, so the
+    delta is conservative (never negative, never fabricated).
+    """
+    return current - snapshot if current >= snapshot else current
+
 
 @dataclass
 class DecisionRecord:
@@ -93,6 +127,12 @@ class DecisionRecord:
     # was actually applied. None on records persisted before Issue #913.
     adaptive_params_at_decision: dict[str, float] | None = None
 
+    # Issue #915: meter accumulator values copied at decision time, differenced
+    # at backfill to attribute import/export/cost to this decision's window.
+    # None on records persisted before Issue #915 (outcome fields are then
+    # populated with 0.0 rather than estimated from SOC).
+    energy_at_decision: dict[str, float] | None = None
+
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary for serialization."""
         return {
@@ -118,6 +158,7 @@ class DecisionRecord:
             "next_mode": self.next_mode.value if self.next_mode else None,
             "outcome_score": self.outcome_score,
             "adaptive_params_at_decision": self.adaptive_params_at_decision,
+            "energy_at_decision": self.energy_at_decision,
         }
 
     @classmethod
@@ -174,6 +215,7 @@ class DecisionRecord:
             else None,
             outcome_score=data.get("outcome_score"),
             adaptive_params_at_decision=data.get("adaptive_params_at_decision"),
+            energy_at_decision=data.get("energy_at_decision"),
         )
 
 
@@ -205,15 +247,6 @@ class DecisionOutcomeTracker:
         self._completed_decisions: deque[DecisionRecord] = deque(
             maxlen=MAX_COMPLETED_DECISIONS
         )
-
-        # Track SOC and energy at last decision for outcome computation
-        self._last_decision_soc: float | None = None
-        self._last_decision_time: datetime | None = None
-        self._energy_at_last_decision: dict[str, float] = {
-            "import_kwh": 0.0,
-            "export_kwh": 0.0,
-            "cost": 0.0,
-        }
 
         # Track if save is needed (after backfill)
         self._save_pending: bool = False
@@ -282,18 +315,10 @@ class DecisionOutcomeTracker:
             adaptive_params_at_decision=dict(adaptive.values)
             if adaptive is not None
             else None,
+            energy_at_decision=_snapshot_energy_meters(data),
         )
 
         self._pending_decisions.append(record)
-
-        # Track state for outcome computation
-        self._last_decision_soc = data.soc
-        self._last_decision_time = now
-        self._energy_at_last_decision = {
-            "import_kwh": 0.0,  # Reset for next period
-            "export_kwh": 0.0,
-            "cost": 0.0,
-        }
 
         _LOGGER.info(
             "Decision recorded: %s → %s at %s (SOC=%.1f%%, price=%.2f, weather=%s)",
@@ -304,6 +329,42 @@ class DecisionOutcomeTracker:
             data.general_price,
             data.weather_condition,
         )
+
+    @staticmethod
+    def _compute_period_energy(
+        pending: DecisionRecord, data: CoordinatorData
+    ) -> tuple[float, float, float]:
+        """Attribute grid energy and net cost to the decision window (Issue #915).
+
+        Diffs the fast-tick meter accumulators (integrated from instantaneous
+        power by CostTracker) between the snapshot taken at decision time and
+        the current values at backfill time. This replaces the old SOC-derived
+        estimates, which recorded import 0.0 for successful charges (import
+        was tied to an SOC *drop*) and fabricated "export" from SOC rises.
+
+        Returns:
+            (import_kwh, export_kwh, net_cost) where net_cost is import cost
+            minus export revenue (negative = the period earned money).
+
+        """
+        snapshot = pending.energy_at_decision
+        if snapshot is None:
+            # Record persisted before Issue #915 (no baseline). Populate with
+            # 0.0 rather than guessing from SOC — see issue evidence on
+            # fabricated attribution.
+            return 0.0, 0.0, 0.0
+
+        import_kwh = _meter_delta(
+            data.grid_import_kwh_today, snapshot["grid_import_kwh_today"]
+        )
+        export_kwh = _meter_delta(
+            data.grid_export_kwh_today, snapshot["grid_export_kwh_today"]
+        )
+        import_cost = _meter_delta(data.grid_import_cost, snapshot["grid_import_cost"])
+        export_revenue = _meter_delta(
+            data.grid_export_revenue, snapshot["grid_export_revenue"]
+        )
+        return import_kwh, export_kwh, import_cost - export_revenue
 
     def _backfill_pending_decision(
         self,
@@ -331,25 +392,8 @@ class DecisionOutcomeTracker:
         # Compute SOC change
         soc_change = data.soc - pending.soc_at_decision
 
-        # Estimate import/export during period (simplified for now)
-        # In Phase 2+, we'll integrate with cost_tracker for precise values
-        import_kwh = max(0.0, -soc_change / 100.0 * 13.5)  # Approximate from SOC change
-        export_kwh = max(0.0, soc_change / 100.0 * 13.5)
-
-        # Compute cost (simplified - will integrate with cost_tracker later)
-        # For now, use current prices as approximation
-        if soc_change < 0:  # Battery discharged
-            cost = 0.0  # Discharging is "free"
-        else:  # Battery charged
-            if pending.mode_chosen in (
-                PlannerAction.CHARGE_GRID_NORMAL,
-                PlannerAction.CHARGE_GRID_BOOST,
-            ):
-                cost = (
-                    -soc_change / 100.0 * 13.5 * pending.general_price_at_decision / 100
-                )
-            else:
-                cost = 0.0  # Solar charging
+        # Attribute energy/cost from meter deltas over the decision window
+        import_kwh, export_kwh, cost = self._compute_period_energy(pending, data)
 
         # Set outcome fields
         pending.actual_soc_change = soc_change
@@ -426,23 +470,8 @@ class DecisionOutcomeTracker:
         # Compute SOC change
         soc_change = data.soc - pending.soc_at_decision
 
-        # Estimate import/export during period (same logic as _backfill_pending_decision)
-        import_kwh = max(0.0, -soc_change / 100.0 * 13.5)
-        export_kwh = max(0.0, soc_change / 100.0 * 13.5)
-
-        # Compute cost (simplified - same logic as _backfill_pending_decision)
-        if soc_change < 0:
-            cost = 0.0
-        else:
-            if pending.mode_chosen in (
-                PlannerAction.CHARGE_GRID_NORMAL,
-                PlannerAction.CHARGE_GRID_BOOST,
-            ):
-                cost = (
-                    -soc_change / 100.0 * 13.5 * pending.general_price_at_decision / 100
-                )
-            else:
-                cost = 0.0
+        # Attribute energy/cost from meter deltas (same as the transition path)
+        import_kwh, export_kwh, cost = self._compute_period_energy(pending, data)
 
         # Set outcome fields
         pending.actual_soc_change = soc_change
@@ -478,32 +507,57 @@ class DecisionOutcomeTracker:
         mode-based scores. Scores higher when actual cost is well below
         the cheap price threshold for grid charges, and higher revenue
         for exports.
+
+        Issue #915: with metered attribution the score is rate-based — the
+        average price actually paid per imported kWh (or earned per exported
+        kWh) is compared against the price threshold, like-for-like. The old
+        formula divided a dollar total by a price threshold, which clamped
+        every real cost onto a band edge and quantised the scores. Records
+        without metered energy (pre-#915) keep the legacy dollar-ratio path.
         """
         if record.actual_cost_during_period is None:
             return None
 
         cost = record.actual_cost_during_period
         threshold = record.cheap_price_threshold or 0.10  # fallback
+        import_kwh = record.actual_import_kwh or 0.0
+        export_kwh = record.actual_export_kwh or 0.0
 
         mode = record.mode_chosen
 
         # Grid charge: score based on how cheap relative to threshold
         if mode in (PlannerAction.CHARGE_GRID_NORMAL, PlannerAction.CHARGE_GRID_BOOST):
             if record.actual_export_kwh and record.actual_export_kwh > 0.5:
-                return 0.2  # charged then exported — still bad
-            # Excellent if cost < 50% of threshold, poor if cost > 150%
-            ratio = cost / max(threshold, 0.01)
+                return 0.2  # imported while exporting — still bad
+            if import_kwh > 0.05:
+                # Average price paid per kWh vs threshold (like-for-like)
+                avg_price = max(cost, 0.0) / import_kwh
+                ratio = avg_price / max(threshold, 0.01)
+            else:
+                # Legacy records: dollar total vs threshold
+                ratio = cost / max(threshold, 0.01)
             return max(0.2, min(0.9, 1.0 - ratio * 0.4))
 
         # Export: score based on revenue (negative cost = good)
         if mode == PlannerAction.EXPORT_PROACTIVE:
             if cost < 0:
-                # Earned money — scale by how much relative to threshold
-                revenue_ratio = abs(cost) / max(threshold, 0.01)
-                return min(0.95, 0.6 + revenue_ratio * 0.2)
+                if export_kwh > 0.05:
+                    # Average sell price captured vs feed-in price at decision
+                    avg_sell = abs(cost) / export_kwh
+                    ratio = avg_sell / max(record.feed_in_price_at_decision, 0.01)
+                else:
+                    # Legacy records: dollar total vs threshold
+                    ratio = abs(cost) / max(threshold, 0.01)
+                return min(0.95, 0.6 + ratio * 0.2)
             return 0.3  # exported but didn't earn — poor
 
         # Hold/Solar charge: mild score, slightly better if low cost
+        if import_kwh > 0.05:
+            # Imported to serve load while holding — penalise by avg price
+            avg_price = max(cost, 0.0) / import_kwh
+            ratio = avg_price / max(threshold, 0.01)
+            return max(0.35, min(0.75, 0.75 - ratio * 0.15))
+        # Self-sufficient hold (no grid import), or legacy dollar-ratio path
         ratio = cost / max(threshold, 0.01)
         return max(0.4, min(0.7, 0.65 - ratio * 0.1))
 
@@ -844,10 +898,16 @@ class DecisionOutcomeTracker:
                     self._pending_decisions.append(record)
                 else:
                     # Decision timed out while HA was down - mark as completed
-                    # with partial outcome (we don't have the actual data)
+                    # with partial outcome (we don't have the actual data).
+                    # Outcome fields are populated (0.0) rather than left
+                    # None so completed records always carry a cost (Issue
+                    # #915: 2/500 completed decisions had cost missing).
                     record.duration_minutes = (
                         MAX_DECISION_DURATION.total_seconds() / 60.0
                     )
+                    record.actual_cost_during_period = 0.0
+                    record.actual_import_kwh = 0.0
+                    record.actual_export_kwh = 0.0
                     record.outcome_score = 0.5  # Neutral score (unknown outcome)
                     self._completed_decisions.append(record)
                     _LOGGER.info(

--- a/docs/LEARNING_SYSTEM.md
+++ b/docs/LEARNING_SYSTEM.md
@@ -32,8 +32,8 @@ The learning system operates in the background, observing your battery's behavio
 └─────────────────────────────────────────────────────────────────┘
 ```
 
-1. **Decision Made**: When the battery mode changes, the system records the context (SOC, prices, forecasts, weather)
-2. **Outcome Tracking**: After the decision period ends, actual costs and results are measured
+1. **Decision Made**: When the battery mode changes, the system records the context (SOC, prices, forecasts, weather) plus a snapshot of the grid meter accumulators (import/export kWh and cost/revenue, integrated from instantaneous power on every fast tick)
+2. **Outcome Tracking**: After the decision period ends (next mode change or 30 min), import/export/cost are attributed by differencing the meter snapshot over the exact decision window (Issue #915; daily-reset aware)
 3. **Parameter Optimization**: Parameters are adjusted to improve future decisions
 4. **Improved Decisions**: Next time, the system uses learned parameters
 
@@ -74,6 +74,16 @@ score = max(0.0, min(1.0, score))        # clamp to [0, 1]
 | Cycling Penalty | Additive | 0.0 or 0.10 | Rapid mode change penalty |
 
 **Note:** This is NOT a weighted average. The base+cost blend creates the foundation, then additive components adjust the score up or down.
+
+### Cost Attribution and Rate-Based Scoring (Issue #915)
+
+Energy and cost are attributed from real meters, not SOC estimates:
+
+- `actual_import_kwh` / `actual_export_kwh`: meter deltas over the decision window (never derived from SOC change)
+- `actual_cost_during_period`: net dollars — grid import cost minus export revenue (negative = the period earned money)
+- A daily accumulator reset falling inside the window is handled conservatively (post-reset accrual only, never negative)
+
+The cost score compares **average price per kWh actually paid/earned** against the cheap-price threshold (charge/hold) or the feed-in price at decision (export) — like-for-like, which keeps the score continuous instead of clamped onto band edges. Records persisted before Issue #915 (no metered energy) keep the legacy dollar-ratio scoring.
 
 ### Interpreting the Score
 

--- a/tests/test_outcomes.py
+++ b/tests/test_outcomes.py
@@ -14,9 +14,9 @@ from custom_components.localshift.engine.optimizer_dp import (
     PlannerAction,
 )
 from custom_components.localshift.engine.outcomes import (
+    MAX_DECISION_DURATION,
     DecisionOutcomeTracker,
     DecisionRecord,
-    MAX_DECISION_DURATION,
 )
 
 
@@ -481,7 +481,12 @@ class TestDecisionOutcomeTracker:
     def test_backfill_pending_decision_discharge_cost_zero(
         self, mock_hass, coordinator_data
     ):
-        """Discharging backfill should record zero cost and import-only energy."""
+        """Discharge backfill with no grid meter movement records zeroed energy.
+
+        Issue #915: the SOC drop must not be converted into a fabricated
+        import figure. With the grid meters idle, import/export/cost are all
+        0.0 (populated, not None).
+        """
         tracker = DecisionOutcomeTracker(mock_hass, "test_entry_id")
         start = datetime(2026, 1, 1, 10, 0, 0)
         end = start + timedelta(minutes=5)
@@ -496,7 +501,7 @@ class TestDecisionOutcomeTracker:
                 BatteryMode.GRID_CHARGING,
             )
 
-        coordinator_data.soc = 45.0
+        coordinator_data.soc = 45.0  # discharged 5%, no grid flow
         tracker._backfill_pending_decision(
             coordinator_data,
             PlannerAction.HOLD,
@@ -506,8 +511,9 @@ class TestDecisionOutcomeTracker:
         assert tracker.pending_count == 0
         completed = tracker._completed_decisions[0]
         assert completed.actual_cost_during_period == 0.0
-        assert completed.actual_import_kwh > 0.0
+        assert completed.actual_import_kwh == 0.0
         assert completed.actual_export_kwh == 0.0
+        assert completed.actual_soc_change == -5.0
 
     def test_save_pending_flag_clears(self, mock_hass, coordinator_data):
         """save_pending should flip to False after clear_save_pending."""
@@ -823,6 +829,402 @@ class TestOutcomeScoringBranches:
         assert costs == {}
 
 
+class TestIssue915MeteredAttribution:
+    """Issue #915: import/cost attribution from real meter deltas.
+
+    The old backfill derived import/export/cost from the SOC delta with
+    inverted semantics (import tied to an SOC *drop*, "export" tied to an
+    SOC *rise*), so a successful charge decision recorded import 0.0 while
+    labelling the charge as export. These tests pin the new behaviour:
+    energy and cost come from the coordinator's fast-tick meter
+    accumulators, differenced over the exact decision window.
+    """
+
+    CHARGE = (BatteryMode.GRID_CHARGING, BatteryMode.SELF_CONSUMPTION)
+    EXPORT = (BatteryMode.PROACTIVE_EXPORT, BatteryMode.SELF_CONSUMPTION)
+
+    def _record(self, tracker, data, now, modes=CHARGE):
+        with patch(
+            "custom_components.localshift.engine.outcomes.dt_util.now"
+        ) as mock_now:
+            mock_now.return_value = now
+            tracker.record_decision(data, *modes)
+
+    def test_charge_with_soc_rise_records_import_and_cost(
+        self, mock_hass, coordinator_data
+    ):
+        """The issue's defect signature: SOC rise + real import must not be $0.00/0.0."""
+        tracker = DecisionOutcomeTracker(mock_hass, "test_entry_id")
+        start = datetime(2026, 1, 1, 6, 0, 0)
+        end = start + timedelta(minutes=15)
+
+        self._record(tracker, coordinator_data, start)
+
+        # Charging happened: SOC rose +8% and the meters advanced.
+        coordinator_data.soc = 58.0
+        coordinator_data.grid_import_kwh_today = 1.2
+        coordinator_data.grid_import_cost = 0.18
+
+        tracker._backfill_pending_decision(coordinator_data, PlannerAction.HOLD, end)
+
+        completed = tracker._completed_decisions[0]
+        assert completed.actual_import_kwh == pytest.approx(1.2)
+        assert completed.actual_cost_during_period == pytest.approx(0.18)
+        assert completed.actual_export_kwh == pytest.approx(0.0)
+        assert completed.actual_soc_change == pytest.approx(8.0)
+
+    def test_soc_change_alone_does_not_fabricate_energy(
+        self, mock_hass, coordinator_data
+    ):
+        """SOC movement without meter movement attributes zero energy (populated)."""
+        tracker = DecisionOutcomeTracker(mock_hass, "test_entry_id")
+        start = datetime(2026, 1, 1, 10, 0, 0)
+        end = start + timedelta(minutes=5)
+
+        self._record(
+            tracker,
+            coordinator_data,
+            start,
+            modes=(BatteryMode.SELF_CONSUMPTION, BatteryMode.GRID_CHARGING),
+        )
+
+        # Battery discharged 5% but no grid flow at all (solar-buffered home).
+        coordinator_data.soc = 45.0
+
+        tracker._backfill_pending_decision(coordinator_data, PlannerAction.HOLD, end)
+
+        completed = tracker._completed_decisions[0]
+        assert completed.actual_import_kwh == pytest.approx(0.0)
+        assert completed.actual_export_kwh == pytest.approx(0.0)
+        assert completed.actual_cost_during_period == pytest.approx(0.0)
+        assert completed.actual_soc_change == pytest.approx(-5.0)
+
+    def test_attribution_window_spans_exactly_decision_period(
+        self, mock_hass, coordinator_data
+    ):
+        """Energy is the meter delta between decision and backfill instants."""
+        tracker = DecisionOutcomeTracker(mock_hass, "test_entry_id")
+        start = datetime(2026, 1, 1, 14, 0, 0)
+        end = start + timedelta(minutes=30)
+
+        # Meters already carried earlier-day energy when the decision was made.
+        coordinator_data.grid_import_kwh_today = 4.0
+        coordinator_data.grid_export_kwh_today = 2.0
+        coordinator_data.grid_import_cost = 0.80
+        coordinator_data.grid_export_revenue = 0.10
+        self._record(tracker, coordinator_data, start)
+
+        # During the period: +1.5 kWh import, +0.5 kWh export.
+        coordinator_data.grid_import_kwh_today = 5.5
+        coordinator_data.grid_export_kwh_today = 2.5
+        coordinator_data.grid_import_cost = 1.10
+        coordinator_data.grid_export_revenue = 0.125
+
+        tracker._backfill_pending_decision(coordinator_data, PlannerAction.HOLD, end)
+
+        completed = tracker._completed_decisions[0]
+        assert completed.actual_import_kwh == pytest.approx(1.5)
+        assert completed.actual_export_kwh == pytest.approx(0.5)
+        # Net cost: import cost delta (0.30) minus export revenue delta (0.025).
+        assert completed.actual_cost_during_period == pytest.approx(0.275)
+
+    def test_meter_reset_mid_period_is_reset_aware(self, mock_hass, coordinator_data):
+        """A daily accumulator reset during the window must not zero attribution.
+
+        Snapshot at 23:58 with 5.0 kWh already imported today; midnight reset
+        zeroes the accumulator; backfill at 00:12 sees 0.8 kWh on the new day.
+        The period's import is the post-reset accrual (0.8), never a negative
+        delta and never the pre-midnight total.
+        """
+        tracker = DecisionOutcomeTracker(mock_hass, "test_entry_id")
+        start = datetime(2026, 1, 1, 23, 58, 0)
+        end = start + timedelta(minutes=14)
+
+        coordinator_data.grid_import_kwh_today = 5.0
+        coordinator_data.grid_import_cost = 1.00
+        self._record(tracker, coordinator_data, start)
+
+        # Midnight reset happened; the new day has accrued since.
+        coordinator_data.grid_import_kwh_today = 0.8
+        coordinator_data.grid_import_cost = 0.16
+
+        tracker._backfill_pending_decision(coordinator_data, PlannerAction.HOLD, end)
+
+        completed = tracker._completed_decisions[0]
+        assert completed.actual_import_kwh == pytest.approx(0.8)
+        assert completed.actual_cost_during_period == pytest.approx(0.16)
+
+    def test_export_decision_records_revenue_as_negative_cost(
+        self, mock_hass, coordinator_data
+    ):
+        """Export periods attribute export kWh and net-earn (negative) cost."""
+        tracker = DecisionOutcomeTracker(mock_hass, "test_entry_id")
+        start = datetime(2026, 1, 1, 18, 0, 0)
+        end = start + timedelta(minutes=15)
+
+        coordinator_data.grid_export_kwh_today = 5.0
+        coordinator_data.grid_export_revenue = 0.10
+        self._record(tracker, coordinator_data, start, modes=self.EXPORT)
+
+        coordinator_data.soc = 40.0  # battery drained into the export
+        coordinator_data.grid_export_kwh_today = 7.5
+        coordinator_data.grid_export_revenue = 0.35
+
+        tracker._backfill_pending_decision(coordinator_data, PlannerAction.HOLD, end)
+
+        completed = tracker._completed_decisions[0]
+        assert completed.actual_export_kwh == pytest.approx(2.5)
+        assert completed.actual_import_kwh == pytest.approx(0.0)
+        assert completed.actual_cost_during_period == pytest.approx(-0.25)
+
+    def test_timeout_backfill_uses_meters_too(self, mock_hass, coordinator_data):
+        """The 30-minute timeout path shares the metered attribution."""
+        tracker = DecisionOutcomeTracker(mock_hass, "test_entry_id")
+        start = datetime(2026, 1, 1, 6, 0, 0)
+        end = start + timedelta(minutes=31)
+
+        with patch(
+            "custom_components.localshift.engine.outcomes.dt_util.now"
+        ) as mock_now:
+            mock_now.side_effect = [start, end]
+            tracker.record_decision(
+                coordinator_data, BatteryMode.BOOST_CHARGING, BatteryMode.HOLD
+            )
+            coordinator_data.soc = 62.0
+            coordinator_data.grid_import_kwh_today = 1.7
+            coordinator_data.grid_import_cost = 0.85
+            tracker.backfill_outcomes(coordinator_data)
+
+        completed = tracker._completed_decisions[0]
+        assert completed.actual_import_kwh == pytest.approx(1.7)
+        assert completed.actual_cost_during_period == pytest.approx(0.85)
+        assert completed.actual_export_kwh == pytest.approx(0.0)
+
+    def test_snapshot_survives_serialization_roundtrip(
+        self, mock_hass, coordinator_data
+    ):
+        """The meter snapshot persists so restart-crossing decisions keep a baseline."""
+        coordinator_data.grid_import_kwh_today = 3.25
+        coordinator_data.grid_export_kwh_today = 1.5
+        coordinator_data.grid_import_cost = 0.65
+        coordinator_data.grid_export_revenue = 0.075
+        tracker = DecisionOutcomeTracker(mock_hass, "test_entry_id")
+        now = datetime(2026, 1, 1, 12, 0, 0)
+        with patch(
+            "custom_components.localshift.engine.outcomes.dt_util.now"
+        ) as mock_now:
+            mock_now.return_value = now
+            tracker.record_decision(
+                coordinator_data, BatteryMode.GRID_CHARGING, BatteryMode.HOLD
+            )
+        pending = tracker._pending_decisions[0]
+
+        restored = DecisionRecord.from_dict(pending.to_dict())
+
+        assert restored.energy_at_decision == pending.energy_at_decision
+        assert restored.energy_at_decision is not None
+        assert restored.energy_at_decision["grid_import_kwh_today"] == pytest.approx(
+            3.25
+        )
+
+    def test_missing_snapshot_populates_zero_not_none(
+        self, mock_hass, coordinator_data
+    ):
+        """Pre-change pending records (no snapshot) still get populated outcomes."""
+        tracker = DecisionOutcomeTracker(mock_hass, "test_entry_id")
+        start = datetime(2026, 1, 1, 10, 0, 0)
+        end = start + timedelta(minutes=10)
+
+        self._record(tracker, coordinator_data, start)
+        tracker._pending_decisions[0].energy_at_decision = None  # legacy record
+
+        coordinator_data.soc = 55.0
+        coordinator_data.grid_import_kwh_today = 0.9  # no baseline to diff against
+
+        tracker._backfill_pending_decision(coordinator_data, PlannerAction.HOLD, end)
+
+        completed = tracker._completed_decisions[0]
+        assert completed.actual_cost_during_period is not None
+        assert completed.actual_import_kwh is not None
+        assert completed.actual_export_kwh is not None
+
+    @pytest.mark.asyncio
+    async def test_downtime_timeout_populates_cost(self, mock_hass):
+        """Records completed during HA downtime must not have missing cost.
+
+        Issue evidence: 2/500 completed decisions had cost missing entirely —
+        the async_load downtime path left outcome fields at None.
+        """
+        now = datetime(2026, 1, 1, 12, 0, 0)
+        old_timestamp = now - timedelta(minutes=31)
+        pending_record = DecisionRecord(
+            timestamp=old_timestamp,
+            mode_chosen=PlannerAction.CHARGE_GRID_NORMAL,
+            previous_mode=PlannerAction.HOLD,
+            soc_at_decision=50.0,
+            general_price_at_decision=0.25,
+            feed_in_price_at_decision=0.05,
+            forecast_solar_remaining_kwh=5.0,
+            forecast_consumption_remaining_kwh=8.0,
+            cheap_price_threshold=0.10,
+            battery_target_soc=80.0,
+            weather_condition="sunny",
+            day_of_week=2,
+            hour_of_day=12,
+            is_demand_window=False,
+        )
+
+        mock_store = MagicMock()
+        mock_store.async_load = AsyncMock(
+            return_value={"pending_decisions": [pending_record.to_dict()]}
+        )
+
+        with (
+            patch(
+                "custom_components.localshift.engine.outcomes.Store",
+                return_value=mock_store,
+            ),
+            patch(
+                "custom_components.localshift.engine.outcomes.dt_util.now"
+            ) as mock_now,
+        ):
+            mock_now.return_value = now
+            tracker = DecisionOutcomeTracker(mock_hass, "test_entry_id")
+
+            await tracker.async_load()
+
+        completed = tracker._completed_decisions[0]
+        assert completed.outcome_score is not None
+        assert completed.actual_cost_during_period is not None
+        assert completed.actual_import_kwh is not None
+        assert completed.actual_export_kwh is not None
+
+
+class TestIssue915ScoreSpread:
+    """Issue #915: outcome scores must discriminate decision quality.
+
+    With metered attribution the cost score compares the average price
+    actually paid per kWh against the cheap-price threshold (like-for-like),
+    not dollars against a price threshold (the old dimensional mismatch that
+    clamped every real cost onto a band edge).
+    """
+
+    @pytest.fixture
+    def tracker(self, mock_hass):
+        return DecisionOutcomeTracker(mock_hass, "test_entry_id")
+
+    def _metered_record(
+        self,
+        tracker: DecisionOutcomeTracker,
+        mode: PlannerAction,
+        import_kwh: float,
+        export_kwh: float,
+        cost: float,
+        soc_at_decision: float = 50.0,
+        soc_change: float = 8.0,
+    ) -> DecisionRecord:
+        record = DecisionRecord(
+            timestamp=datetime.now(),
+            mode_chosen=mode,
+            previous_mode=PlannerAction.HOLD,
+            soc_at_decision=soc_at_decision,
+            general_price_at_decision=0.25,
+            feed_in_price_at_decision=0.10,
+            forecast_solar_remaining_kwh=5.0,
+            forecast_consumption_remaining_kwh=8.0,
+            cheap_price_threshold=0.15,
+            battery_target_soc=soc_at_decision + soc_change,  # on-target
+            weather_condition="sunny",
+            day_of_week=0,
+            hour_of_day=14,
+            is_demand_window=False,
+            actual_soc_change=soc_change,
+            actual_import_kwh=import_kwh,
+            actual_export_kwh=export_kwh,
+            actual_cost_during_period=cost,
+            duration_minutes=15.0,
+        )
+        return record
+
+    def test_charge_score_discriminates_price_levels(self, tracker):
+        """Same charge mode, different average prices -> strictly ordered scores."""
+        cheap = self._metered_record(
+            tracker, PlannerAction.CHARGE_GRID_NORMAL, 2.0, 0.0, 0.10
+        )  # avg 0.05 = 0.33x threshold
+        mid = self._metered_record(
+            tracker, PlannerAction.CHARGE_GRID_NORMAL, 2.0, 0.0, 0.30
+        )  # avg 0.15 = 1x threshold
+        pricey = self._metered_record(
+            tracker, PlannerAction.CHARGE_GRID_NORMAL, 2.0, 0.0, 0.60
+        )  # avg 0.30 = 2x threshold
+
+        score_cheap = tracker.compute_outcome_score(cheap)
+        score_mid = tracker.compute_outcome_score(mid)
+        score_pricey = tracker.compute_outcome_score(pricey)
+
+        assert score_cheap > score_mid > score_pricey
+
+    def test_charge_scores_not_quantised(self, tracker):
+        """A price sweep yields many distinct scores, not a handful of bands."""
+        scores = []
+        for avg_price in (0.03, 0.06, 0.09, 0.12, 0.15, 0.18, 0.21, 0.24, 0.27, 0.30):
+            record = self._metered_record(
+                tracker,
+                PlannerAction.CHARGE_GRID_NORMAL,
+                2.0,
+                0.0,
+                round(avg_price * 2.0, 6),
+            )
+            scores.append(tracker.compute_outcome_score(record))
+
+        assert len(set(scores)) >= 8, f"scores collapsed to {sorted(set(scores))}"
+
+    def test_hold_import_penalised_versus_self_sufficient(self, tracker):
+        """A hold that imports at 2x threshold scores below a self-sufficient hold."""
+        importing = self._metered_record(
+            tracker, PlannerAction.HOLD, 1.5, 0.0, 0.45, soc_change=0.0
+        )  # avg 0.30 = 2x threshold
+        self_sufficient = self._metered_record(
+            tracker, PlannerAction.HOLD, 0.0, 0.0, 0.0, soc_change=0.0
+        )
+
+        assert tracker.compute_outcome_score(importing) < tracker.compute_outcome_score(
+            self_sufficient
+        )
+
+    def test_charge_cost_score_rate_based(self, tracker):
+        """Cost score uses avg price vs threshold, not dollars vs threshold."""
+        record = self._metered_record(
+            tracker, PlannerAction.CHARGE_GRID_NORMAL, 2.0, 0.0, 0.30
+        )
+        # avg price 0.15 == threshold 0.15 -> ratio 1.0 -> 1.0 - 0.4 = 0.6
+        assert tracker._compute_cost_score(record) == pytest.approx(0.6)
+
+    def test_free_import_charge_scores_high(self, tracker):
+        """Import at ~$0 (price-spike credit or free window) scores near the cap."""
+        record = self._metered_record(
+            tracker, PlannerAction.CHARGE_GRID_NORMAL, 2.0, 0.0, 0.0
+        )
+        # avg price 0 -> ratio 0 -> 0.9 (band cap)
+        assert tracker._compute_cost_score(record) == pytest.approx(0.9)
+
+    def test_export_revenue_rate_scored(self, tracker):
+        """Export scoring compares avg sell price captured vs feed-in at decision."""
+        at_fit = self._metered_record(
+            tracker, PlannerAction.EXPORT_PROACTIVE, 0.0, 2.0, -0.20, soc_change=-8.0
+        )  # avg sell 0.10 == FiT 0.10
+        spike = self._metered_record(
+            tracker, PlannerAction.EXPORT_PROACTIVE, 0.0, 2.0, -0.80, soc_change=-8.0
+        )  # avg sell 0.40 = 4x FiT
+
+        at_fit_score = tracker._compute_cost_score(at_fit)
+        spike_score = tracker._compute_cost_score(spike)
+
+        assert at_fit_score == pytest.approx(0.8)
+        assert spike_score == pytest.approx(0.95)
+        assert spike_score > at_fit_score
+
+
 class TestOutcomeScoringEdgeCases:
     """Additional coverage for scoring edge cases."""
 
@@ -959,9 +1361,7 @@ class TestEnergyPerformanceMetrics:
 
         assert summary.unnecessary_grid_charge_kwh == pytest.approx(2.35)
 
-    def test_metrics_present_when_decisions_exist(
-        self, mock_hass, coordinator_data
-    ):
+    def test_metrics_present_when_decisions_exist(self, mock_hass, coordinator_data):
         """Energy metrics are computed on the with-decisions return path too."""
         tracker = DecisionOutcomeTracker(mock_hass, "test_entry_id")
         tracker.record_decision(


### PR DESCRIPTION
## Summary

Fixes the two defects behind #915's flat outcome_score signal and the $0.00 + SOC-rise charge rows. Closes #915.

## Root-cause findings

**Defect 1 — attribution was SOC-derived with inverted semantics.** `engine/outcomes.py` backfill estimated `import_kwh = max(0, -soc_change/100*13.5)` and `export_kwh = max(0, soc_change/100*13.5)` — import tied to an SOC **drop**, "export" tied to an SOC **rise**. So every successful charge (SOC +8–11.5%) recorded `actual_import_kwh = 0.0` while the charge itself was labelled an export (which the cost scorer then punished as "charged then exported"). Cost was fabricated as `price × SOC-delta`, landing at $0.00 or negative. The meters named in the issue don't exist in this codebase — nothing read them; the attribution window was also SOC-proxy-based, not meter-based.

**Fix:** the CostTracker fast-tick accumulators (`grid_import_kwh_today`, `grid_export_kwh_today`, `grid_import_cost`, `grid_export_revenue` — instantaneous power integration, much finer than the 5-min medium tick) are snapshotted at decision time, persisted on the record (`energy_at_decision`), and differenced at backfill over the exact decision window. Net cost = import cost − export revenue (negative = earned). Daily-reset aware: a midnight reset inside the window attributes the post-reset accrual (conservative, never negative, never fabricated). The dead `_energy_at_last_decision` tracker scaffolding is deleted. Since the snapshot persists, restart-crossing decisions keep a valid baseline; pre-#915 pending records (no snapshot) get populated 0.0 rather than SOC guesses.

**Defect 2 — the cost score divided dollars by a price threshold.** `ratio = cost / threshold` is dimensionally $ ÷ ($/kWh); it only produced a spread because costs were fabricated tiny. With real dollars it would pin every score to a clamp edge (same quantisation, different band). The score is now **rate-based**: average price actually paid per imported kWh vs the cheap-price threshold (charge/hold), and average sell price captured vs feed-in-at-decision (export). Like-for-like comparison keeps scores continuous. The hold-with-import band widens ([0.35, 0.75], slope 0.15) so importing holds discriminate; records without metered energy keep the legacy dollar-ratio path, so all pre-existing scoring semantics that were right are preserved.

**Also:** records timed out during HA downtime now get cost/import/export populated (0.0 + neutral 0.5 score) — the 2/500 missing-cost rows.

## Changes

- `custom_components/localshift/engine/outcomes.py` — meter snapshot + reset-aware deltas (`_snapshot_energy_meters`, `_meter_delta`, `_compute_period_energy`), both backfill paths metered, `energy_at_decision` on the record (serialized), downtime path populated, rate-based `_compute_cost_score`
- `tests/test_outcomes.py` — 15 new tests; `test_backfill_pending_decision_discharge_cost_zero` updated (it asserted the defect: fabricated import from a bare SOC drop)
- `docs/LEARNING_SYSTEM.md` — attribution + rate-based scoring documented

## Test evidence

- TDD: new tests written RED first (old code fabricated 0.675 kWh import from a 5% SOC drop with zero meter movement, score pinned at the exact 0.560 median from the issue), then GREEN after implementation
- Regression coverage: attribution window (exact decision-period delta), meter-source (real accumulators, not SOC), mid-window daily reset, SOC-rise charge signature, export revenue, timeout path, serialization round-trip, downtime populate, price-level discrimination, non-quantised sweep
- `uv run pytest`: **3515 passed, 1 xfailed**
- Coverage `engine/outcomes.py`: **96%** (uncovered lines are pre-existing branches; repo TOTAL 95%)
- `pyright@1.1.413 custom_components/localshift`: **0 errors**
- `ruff format --check` + `ruff check`: clean on all files touched by this PR

### Pre-existing (verified on base — files not touched by this PR)

- `ruff format --check .` fails on ~23 files (scripts/, various tests/) — present on base `1732aea`
- `ruff check .` reports 269 errors in untouched files — present on base

## Overlap with #899

#899 touches `utils/costs.py` (midnight reset also clears `_last_soc_pct`) and `tick_scheduler.py`. Complementary, not conflicting: it fixes the **daily** accumulator baseline; this PR consumes those accumulators for **per-decision** windows and independently handles the reset-inside-window case. No shared hunks; not rebased or merged.

## Residual limitation (documented, deliberate)

Mode-transition lag (#924 instrumentation) can still shift physical charging into the *next* decision period when a period is shorter than the lag — inherent to the decision-window model, second-order vs the total attribution failure fixed here. The conservative midnight rule under-counts the pre-midnight sliver of a window spanning reset.