### PR TITLE
fix(solar): cap confidence from learned cloudy-day over-forecast ratios

### DIFF
--- a/custom_components/localshift/computation_engine.py
+++ b/custom_components/localshift/computation_engine.py
@@ -237,9 +237,24 @@ class ComputationEngine:
             else 1.0
         )
 
-        # Set absent confidence on data (used by all ConfidenceResolver sites)
-        data.solar_absent_confidence = (
-            DEFAULT_ABSENT_SOLAR_CONFIDENCE if conservative else 1.0
+        # Learned over-forecast cap (issue #916): pulls the median→P10 blend
+        # toward P10 by the recent whole-day over-forecast ratio. 1.0 = dormant.
+        overforecast_cap_getter = (
+            getattr(tracker, "overforecast_confidence_cap", None)
+            if tracker is not None
+            else None
+        )
+        overforecast_cap = (
+            float(overforecast_cap_getter())
+            if overforecast_cap_getter is not None
+            else 1.0
+        )
+
+        # Set absent confidence on data (used by all ConfidenceResolver sites),
+        # bounded by the over-forecast cap.
+        data.solar_absent_confidence = min(
+            DEFAULT_ABSENT_SOLAR_CONFIDENCE if conservative else 1.0,
+            overforecast_cap,
         )
 
         # Stamp ceiling on each analysis object
@@ -247,10 +262,10 @@ class ComputationEngine:
             if analysis is None:
                 continue
             if conservative and analysis.is_stale:
-                resolved = min(ceiling, accuracy_ceiling)
+                resolved = min(ceiling, accuracy_ceiling, overforecast_cap)
             else:
-                # Fresh data: only the accuracy ceiling applies (dormant today → 1.0)
-                resolved = min(1.0, accuracy_ceiling)
+                # Fresh data: only the accuracy ceiling and over-forecast cap apply
+                resolved = min(1.0, accuracy_ceiling, overforecast_cap)
             analysis.confidence_ceiling = resolved
 
     # ========================================================================

--- a/custom_components/localshift/engine/optimizer_facade.py
+++ b/custom_components/localshift/engine/optimizer_facade.py
@@ -11,6 +11,7 @@ from homeassistant.util import dt as dt_util
 
 from ..const import BatteryMode as _BatteryMode
 from ..coordinator.data import CoordinatorData
+from ..forecast.solar import get_solar_for_slot_by_interval
 from .optimizer_dp import DPPlanner, OptimizerInputs
 from .optimizer_runner import (
     OptimizerSafetyGate,
@@ -96,13 +97,19 @@ class OptimizerFacade:
         self._solar_accuracy_tracker = tracker
 
     def _record_forecasts_for_slots(
-        self, slots: list[Any], weather_condition: str, is_boost: bool = False
+        self,
+        slots: list[Any],
+        weather_condition: str,
+        is_boost: bool = False,
+        all_solcast: list[Any] | None = None,
     ) -> None:
         """Record solar forecasts for accuracy tracking.
 
         Args:
             slots: List of time slots with solar forecast data.
             weather_condition: Current weather condition for tracking.
+            all_solcast: Raw Solcast entries, used to capture the pure-P10
+                energy for each period (issue #916 over-forecast learning).
 
         """
         if self._solar_accuracy_tracker is None:
@@ -121,11 +128,19 @@ class OptimizerFacade:
             if not self._is_backfillable_period_start(period_start):
                 continue
 
+            forecast_p10_kwh = (
+                get_solar_for_slot_by_interval(
+                    all_solcast, period_start, 30, confidence=0.0
+                )
+                if all_solcast
+                else 0.0
+            )
             self._solar_accuracy_tracker.record_forecast(
                 period_start=period_start,
                 forecast_kwh=slot.solar_kwh,
                 weather_condition=weather_condition,
                 is_boost=is_boost,
+                forecast_p10_kwh=forecast_p10_kwh,
             )
             recorded += 1
 
@@ -241,6 +256,7 @@ class OptimizerFacade:
                 slots,
                 weather_condition,
                 is_boost=getattr(data, "boost_charge_active", False),
+                all_solcast=getattr(slot_metadata, "all_solcast", None),
             )
             self._apply_bias_correction_to_slots(slots, weather_condition)
             self._apply_cloud_scale_factor_to_slots(slots, data, now_dt)

--- a/custom_components/localshift/forecast/solar_accuracy.py
+++ b/custom_components/localshift/forecast/solar_accuracy.py
@@ -12,7 +12,7 @@ import math
 from collections import defaultdict, deque
 from collections.abc import Callable
 from dataclasses import dataclass, field
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.helpers.storage import Store
@@ -26,6 +26,14 @@ _LOGGER = logging.getLogger(__name__)
 MAX_PERIOD_RECORDS = 1440
 BIAS_HALF_LIFE_DAYS = 7.0
 MIN_SOLAR_CORRECTION_SAMPLES = 20
+
+# Over-forecast cap (issue #916): learned day-level over-forecast ratio drives
+# the median→P10 confidence blend.
+OVERFORECAST_HALF_LIFE_DAYS = 2.0
+OVERFORECAST_LOOKBACK_DAYS = 7.0
+OVERFORECAST_MIN_DAY_FORECAST_KWH = 2.0
+OVERFORECAST_MIN_COMPLETED_DAYS = 2
+OVERFORECAST_MIN_SPREAD = 0.05
 
 
 def _period_key(period_start: datetime) -> str:
@@ -82,6 +90,7 @@ class SolarPeriodRecord:
     bias: float = 0.0
     additive_bias: float = 0.0
     is_boost_period: bool = False
+    forecast_p10_kwh: float = 0.0
 
     def __post_init__(self) -> None:
         """Calculate bias after initialization."""
@@ -108,6 +117,7 @@ class SolarPeriodRecord:
             "bias": self.bias,
             "additive_bias": self.additive_bias,
             "is_boost_period": self.is_boost_period,
+            "forecast_p10_kwh": self.forecast_p10_kwh,
         }
 
     @classmethod
@@ -132,6 +142,7 @@ class SolarPeriodRecord:
             bias=data.get("bias", 0.0),
             additive_bias=data.get("additive_bias", 0.0),
             is_boost_period=data.get("is_boost_period", False),
+            forecast_p10_kwh=data.get("forecast_p10_kwh", 0.0),
         )
 
 
@@ -312,6 +323,7 @@ class SolarAccuracyTracker:
         forecast_kwh: float,
         weather_condition: str,
         is_boost: bool = False,
+        forecast_p10_kwh: float = 0.0,
     ) -> None:
         """Record a solar forecast for a 30-min period.
 
@@ -330,6 +342,7 @@ class SolarAccuracyTracker:
             time_of_day=time_of_day,
             season=season,
             is_boost_period=is_boost,
+            forecast_p10_kwh=forecast_p10_kwh,
         )
         self._pending_forecasts[key] = record
         self._save_pending = True
@@ -639,6 +652,92 @@ class SolarAccuracyTracker:
             return high
         # Linear interpolation between (50, low) and (85, high)
         return low + (high - low) * (accuracy - 50.0) / 35.0
+
+    def _aggregate_completed_days(self, today: date) -> dict[date, dict[str, float]]:
+        """Group non-boost records into per-local-day forecast/actual/P10 totals.
+
+        Only completed days (date < today) are returned; today's partial
+        history must not feed the cap.
+        """
+        days: dict[date, dict[str, float]] = defaultdict(
+            lambda: {"forecast": 0.0, "actual": 0.0, "p10": 0.0}
+        )
+        for record in self._period_records:
+            if record.is_boost_period:
+                continue
+            day = record.period_start.date()
+            if day >= today:
+                continue
+            totals = days[day]
+            totals["forecast"] += record.forecast_kwh
+            totals["actual"] += record.actual_kwh
+            totals["p10"] += record.forecast_p10_kwh
+        return days
+
+    def overforecast_confidence_cap(self) -> float:
+        """Confidence cap learned from recent whole-day over-forecast ratios.
+
+        Issue #916: Solcast over-forecasts cloudy days (median high, P10
+        closer to reality). This measures the energy-weighted actual/forecast
+        ratio R over recent completed local days, plus the P10/forecast ratio
+        P̄, and returns a confidence cap ``1 - w`` where
+        ``w = clamp((1-R)/(1-P̄), 0, 1)``. Flowing ``1-w`` through the
+        existing median→P10 blend lands the blended forecast at ~R of median
+        on days whose spread matches the learned P̄ — while never scaling up
+        and leaving narrow-spread (clear) days untouched.
+
+        Guards (all return 1.0 — no correction): fewer than
+        OVERFORECAST_MIN_COMPLETED_DAYS qualifying days, no P10 data, spread
+        ``1-P̄`` below OVERFORECAST_MIN_SPREAD, or R ≥ 1.0 (no over-forecast).
+
+        Returns:
+            Confidence ceiling in [0, 1]; 1.0 means no correction.
+        """
+        now = dt_util.now()
+        today = now.date()
+
+        days = self._aggregate_completed_days(today)
+
+        weighted_forecast = 0.0
+        weighted_actual = 0.0
+        weighted_p10 = 0.0
+        qualifying_days = 0
+        for day, totals in days.items():
+            age_days = (today - day).days
+            if age_days > OVERFORECAST_LOOKBACK_DAYS:
+                continue
+            if totals["forecast"] < OVERFORECAST_MIN_DAY_FORECAST_KWH:
+                continue
+            weight = 0.5 ** (age_days / OVERFORECAST_HALF_LIFE_DAYS)
+            weighted_forecast += weight * totals["forecast"]
+            weighted_actual += weight * totals["actual"]
+            weighted_p10 += weight * totals["p10"]
+            qualifying_days += 1
+
+        if qualifying_days < OVERFORECAST_MIN_COMPLETED_DAYS:
+            return 1.0
+        if weighted_forecast <= 0.0 or weighted_p10 <= 0.0:
+            return 1.0
+
+        ratio = weighted_actual / weighted_forecast
+        p10_ratio = weighted_p10 / weighted_forecast
+        if ratio >= 1.0:
+            return 1.0
+        spread = 1.0 - p10_ratio
+        if spread < OVERFORECAST_MIN_SPREAD:
+            return 1.0
+
+        w_blend = (1.0 - ratio) / spread
+        w_blend = max(0.0, min(1.0, w_blend))
+        cap = 1.0 - w_blend
+        _LOGGER.debug(
+            "Over-forecast cap: ratio=%.3f, p10_ratio=%.3f, cap=%.3f (%d days)",
+            ratio,
+            p10_ratio,
+            cap,
+            qualifying_days,
+        )
+        return cap
 
     def get_bias_correction(
         self,

--- a/tests/forecast/test_solar_accuracy.py
+++ b/tests/forecast/test_solar_accuracy.py
@@ -1,6 +1,6 @@
 """Tests for forecast/solar_accuracy.py - Solar forecast accuracy tracking."""
 
-from datetime import UTC, datetime, timedelta, timezone
+from datetime import UTC, date, datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -1037,6 +1037,310 @@ def _fill_tracker_with_bias(tracker, forecast: float, actual: float, count: int)
         period = datetime(2026, 1, 1, 6 + i // 2, (i % 2) * 30, tzinfo=UTC)
         tracker.record_forecast(period, forecast, "sunny")
         tracker.backfill_actual(period, actual)
+
+
+# ─── forecast_p10_kwh recording (issue #916) ────────────────────────────────
+
+
+class TestForecastP10Recording:
+    """Tests for the forecast_p10_kwh field carried on period records."""
+
+    @pytest.fixture
+    def mock_hass(self):
+        hass = MagicMock()
+        hass.data = {}
+        return hass
+
+    @pytest.fixture
+    def tracker(self, mock_hass):
+        return SolarAccuracyTracker(mock_hass, "test_entry")
+
+    def test_record_forecast_stores_p10(self, tracker):
+        """record_forecast captures the P10 energy alongside the median."""
+        period_start = datetime(2026, 8, 26, 10, 0, tzinfo=UTC)
+        tracker.record_forecast(
+            period_start, 2.5, "cloudy", forecast_p10_kwh=1.25
+        )
+
+        record = tracker._pending_forecasts[period_start.isoformat()]
+        assert record.forecast_p10_kwh == pytest.approx(1.25)
+
+    def test_record_forecast_p10_defaults_to_zero(self, tracker):
+        """Omitting forecast_p10_kwh keeps old callers working (0.0)."""
+        period_start = datetime(2026, 8, 26, 10, 0, tzinfo=UTC)
+        tracker.record_forecast(period_start, 2.5, "cloudy")
+
+        record = tracker._pending_forecasts[period_start.isoformat()]
+        assert record.forecast_p10_kwh == 0.0
+
+    def test_backfill_preserves_p10(self, tracker):
+        """The P10 forecast survives the pending → record transition."""
+        period_start = datetime(2026, 8, 26, 10, 0, tzinfo=UTC)
+        tracker.record_forecast(
+            period_start, 2.5, "cloudy", forecast_p10_kwh=1.25
+        )
+        tracker.backfill_actual(period_start, 1.6)
+
+        assert tracker._period_records[-1].forecast_p10_kwh == pytest.approx(1.25)
+
+    def test_p10_round_trips_through_storage(self):
+        """forecast_p10_kwh serializes and deserializes; missing field → 0.0."""
+        record = SolarPeriodRecord(
+            period_start=datetime(2026, 8, 26, 10, 0, tzinfo=UTC),
+            forecast_kwh=2.5,
+            actual_kwh=1.6,
+            weather_condition="cloudy",
+            time_of_day="morning",
+            season="winter",
+            forecast_p10_kwh=1.25,
+        )
+        data = record.to_dict()
+        assert data["forecast_p10_kwh"] == pytest.approx(1.25)
+
+        restored = SolarPeriodRecord.from_dict(data)
+        assert restored.forecast_p10_kwh == pytest.approx(1.25)
+
+        legacy = SolarPeriodRecord.from_dict(
+            {
+                "period_start": "2026-08-26T10:00:00+00:00",
+                "forecast_kwh": 2.5,
+                "actual_kwh": 1.6,
+            }
+        )
+        assert legacy.forecast_p10_kwh == 0.0
+
+
+# ─── overforecast_confidence_cap (issue #916) ───────────────────────────────
+
+
+def _seed_completed_day(
+    tracker,
+    day: date,
+    forecast_kwh: float,
+    actual_ratio: float,
+    p10_ratio: float,
+    periods: int = 4,
+    boost: bool = False,
+) -> None:
+    """Seed one completed local day of uniform 30-min records into the tracker.
+
+    Daily totals: F = periods * forecast_kwh, A = F * actual_ratio,
+    P = F * p10_ratio.
+    """
+    for i in range(periods):
+        tracker._period_records.append(
+            SolarPeriodRecord(
+                period_start=datetime(
+                    day.year,
+                    day.month,
+                    day.day,
+                    9 + i // 2,
+                    (i % 2) * 30,
+                    tzinfo=UTC,
+                ),
+                forecast_kwh=forecast_kwh,
+                actual_kwh=forecast_kwh * actual_ratio,
+                forecast_p10_kwh=forecast_kwh * p10_ratio,
+                weather_condition="cloudy",
+                time_of_day="morning",
+                season="winter",
+                is_boost_period=boost,
+            )
+        )
+
+
+@pytest.fixture
+def cap_now():
+    """Fixed 'now' so completed-day logic is deterministic (today = 2026-08-28)."""
+    return datetime(2026, 8, 28, 12, 0, tzinfo=UTC)
+
+
+class TestOverforecastConfidenceCap:
+    """Tests for overforecast_confidence_cap — issue #916 cloudy-day correction."""
+
+    @pytest.fixture
+    def mock_hass(self):
+        hass = MagicMock()
+        hass.data = {}
+        return hass
+
+    @pytest.fixture
+    def tracker(self, mock_hass):
+        return SolarAccuracyTracker(mock_hass, "test_entry")
+
+    def test_empty_tracker_returns_one(self, tracker, cap_now):
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(
+                "custom_components.localshift.forecast.solar_accuracy.dt_util.now",
+                lambda: cap_now,
+            )
+            assert tracker.overforecast_confidence_cap() == 1.0
+
+    def test_single_day_returns_one(self, tracker, cap_now):
+        """Needs at least 2 qualifying completed days to correct."""
+        _seed_completed_day(tracker, date(2026, 8, 27), 1.5, 0.6, 0.5)
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(
+                "custom_components.localshift.forecast.solar_accuracy.dt_util.now",
+                lambda: cap_now,
+            )
+            assert tracker.overforecast_confidence_cap() == 1.0
+
+    def test_missing_p10_returns_one(self, tracker, cap_now):
+        """Legacy records without P10 data cannot express a blend correction."""
+        _seed_completed_day(tracker, date(2026, 8, 27), 1.5, 0.6, 0.0)
+        _seed_completed_day(tracker, date(2026, 8, 26), 1.5, 0.6, 0.0)
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(
+                "custom_components.localshift.forecast.solar_accuracy.dt_util.now",
+                lambda: cap_now,
+            )
+            assert tracker.overforecast_confidence_cap() == 1.0
+
+    def test_narrow_spread_returns_one(self, tracker, cap_now):
+        """Clear-sky-like days with almost no median/P10 spread are left alone."""
+        _seed_completed_day(tracker, date(2026, 8, 27), 1.5, 0.6, 0.97)
+        _seed_completed_day(tracker, date(2026, 8, 26), 1.5, 0.6, 0.97)
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(
+                "custom_components.localshift.forecast.solar_accuracy.dt_util.now",
+                lambda: cap_now,
+            )
+            assert tracker.overforecast_confidence_cap() == 1.0
+
+    def test_today_is_not_a_completed_day(self, tracker, cap_now):
+        """Only full days count — today's partial history must not feed the cap."""
+        _seed_completed_day(tracker, date(2026, 8, 28), 1.5, 0.6, 0.5)
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(
+                "custom_components.localshift.forecast.solar_accuracy.dt_util.now",
+                lambda: cap_now,
+            )
+            assert tracker.overforecast_confidence_cap() == 1.0
+
+    def test_days_beyond_lookback_excluded(self, tracker, cap_now):
+        """Days older than the lookback window carry no weight."""
+        _seed_completed_day(tracker, date(2026, 8, 18), 1.5, 0.6, 0.5)
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(
+                "custom_components.localshift.forecast.solar_accuracy.dt_util.now",
+                lambda: cap_now,
+            )
+            assert tracker.overforecast_confidence_cap() == 1.0
+
+    def test_low_energy_days_skipped(self, tracker, cap_now):
+        """Days under the minimum forecast energy are not qualifying days."""
+        _seed_completed_day(tracker, date(2026, 8, 27), 0.2, 0.6, 0.5, periods=4)
+        _seed_completed_day(tracker, date(2026, 8, 26), 1.5, 0.6, 0.5)
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(
+                "custom_components.localshift.forecast.solar_accuracy.dt_util.now",
+                lambda: cap_now,
+            )
+            assert tracker.overforecast_confidence_cap() == 1.0
+
+    def test_boost_days_excluded(self, tracker, cap_now):
+        """Boost periods are excluded from learning (same rule as metrics)."""
+        _seed_completed_day(
+            tracker, date(2026, 8, 27), 1.5, 0.6, 0.5, boost=True
+        )
+        _seed_completed_day(tracker, date(2026, 8, 26), 1.5, 0.6, 0.5)
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(
+                "custom_components.localshift.forecast.solar_accuracy.dt_util.now",
+                lambda: cap_now,
+            )
+            assert tracker.overforecast_confidence_cap() == 1.0
+
+    def test_underforecast_returns_one(self, tracker, cap_now):
+        """Never scales UP: actual above forecast → cap exactly 1.0."""
+        _seed_completed_day(tracker, date(2026, 8, 27), 1.5, 1.2, 0.5)
+        _seed_completed_day(tracker, date(2026, 8, 26), 1.5, 1.3, 0.5)
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(
+                "custom_components.localshift.forecast.solar_accuracy.dt_util.now",
+                lambda: cap_now,
+            )
+            assert tracker.overforecast_confidence_cap() == 1.0
+
+    def test_clear_day_regression_returns_one(self, tracker, cap_now):
+        """THE clear-day acceptance: recent ratios ≈ 1.0 → cap exactly 1.0."""
+        _seed_completed_day(tracker, date(2026, 8, 27), 1.5, 1.02, 0.5)
+        _seed_completed_day(tracker, date(2026, 8, 26), 1.5, 1.01, 0.5)
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(
+                "custom_components.localshift.forecast.solar_accuracy.dt_util.now",
+                lambda: cap_now,
+            )
+            assert tracker.overforecast_confidence_cap() == 1.0
+
+    def test_clear_day_within_ten_percent(self, tracker, cap_now):
+        """Clear days stay ±10%: slightly-under ratios produce a near-1 cap, so
+        the blended forecast on a narrow-spread (clear) day barely moves."""
+        from custom_components.localshift.forecast.solar import (
+            _blend_solar_estimate,
+        )
+
+        _seed_completed_day(tracker, date(2026, 8, 27), 1.5, 0.98, 0.95)
+        _seed_completed_day(tracker, date(2026, 8, 26), 1.5, 1.02, 0.95)
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(
+                "custom_components.localshift.forecast.solar_accuracy.dt_util.now",
+                lambda: cap_now,
+            )
+            cap = tracker.overforecast_confidence_cap()
+            # Clear-day spread is narrow: P10 = 0.95 * median.
+            effective = _blend_solar_estimate(1.0, 0.95, cap)
+            assert abs(effective - 1.0) <= 0.10
+
+    def test_cloudy_days_track_actuals_within_20_percent(self, tracker, cap_now):
+        """THE cloudy-day acceptance: with recent ratios at the issue's observed
+        0.68/0.53/0.66, the blend through the cap must land within ±20% of the
+        realized actual/forecast ratio on a wide-spread (cloudy) day."""
+        from custom_components.localshift.forecast.solar import (
+            _blend_solar_estimate,
+        )
+
+        _seed_completed_day(tracker, date(2026, 8, 27), 1.5, 0.68, 0.50)
+        _seed_completed_day(tracker, date(2026, 8, 26), 1.5, 0.53, 0.50)
+        _seed_completed_day(tracker, date(2026, 8, 25), 1.5, 0.66, 0.50)
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(
+                "custom_components.localshift.forecast.solar_accuracy.dt_util.now",
+                lambda: cap_now,
+            )
+            cap = tracker.overforecast_confidence_cap()
+
+        assert cap < 1.0
+        # Half-life 2 days: weights 0.7071 / 0.5 / 0.3536 over ratios above.
+        weights = [0.7071, 0.5, 0.3536]
+        ratios = [0.68, 0.53, 0.66]
+        expected_ratio = sum(w * r for w, r in zip(weights, ratios, strict=True)) / sum(weights)
+        # Cloudy-day spread: P10 = 0.5 * median.
+        effective = _blend_solar_estimate(1.0, 0.5, cap)
+        assert abs(effective - expected_ratio) / expected_ratio <= 0.20
+
+    def test_recent_days_dominate(self, tracker, cap_now):
+        """Half-life weighting: an old clear day barely dilutes a recent cloudy pair."""
+        _seed_completed_day(tracker, date(2026, 8, 27), 1.5, 0.60, 0.50)
+        _seed_completed_day(tracker, date(2026, 8, 26), 1.5, 0.60, 0.50)
+        # 6 days old: weight 2^-3 = 0.125 vs 0.5/0.707 for the recent pair.
+        _seed_completed_day(tracker, date(2026, 8, 22), 1.5, 1.30, 0.50)
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(
+                "custom_components.localshift.forecast.solar_accuracy.dt_util.now",
+                lambda: cap_now,
+            )
+            cap = tracker.overforecast_confidence_cap()
+
+        assert cap < 1.0
+        # Weighted ratio stays well under 1.0 despite the clear old day.
+        weights = [0.7071, 0.5, 0.125]
+        ratios = [0.60, 0.60, 1.30]
+        expected_ratio = sum(w * r for w, r in zip(weights, ratios, strict=True)) / sum(weights)
+        assert expected_ratio < 0.85
 
 
 class TestComputeContextBias:

--- a/tests/test_computation_engine.py
+++ b/tests/test_computation_engine.py
@@ -1,12 +1,17 @@
 """Unit tests for ComputationEngine."""
 
 from datetime import datetime, time
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from custom_components.localshift.computation_engine import BatteryMode
-from custom_components.localshift.const import CONF_WEATHER_LEARNING_ENABLED
+from custom_components.localshift.const import (
+    CONF_STALE_SOLAR_CONFIDENCE_CEILING,
+    CONF_WEATHER_LEARNING_ENABLED,
+    SWITCH_STALE_SOLAR_CONSERVATIVE,
+)
 
 
 @pytest.mark.parametrize(
@@ -1045,3 +1050,111 @@ def test_manual_override_clears_a_stale_pending_plan_mode(
     assert coordinator_data.active_mode == BatteryMode.MANUAL
     assert coordinator_data.debug_plan_mode_pending is None
     assert coordinator_data.optimizer_precharge_backstop_active is False
+
+
+# ─── _stamp_confidence_ceilings: over-forecast cap (issue #916) ─────────────
+
+
+class TestStampConfidenceOverforecastCap:
+    """The learned over-forecast cap folds into every ceiling branch."""
+
+    @staticmethod
+    def _make_tracker(cap: float, accuracy_ceiling: float = 1.0) -> MagicMock:
+        tracker = MagicMock()
+        tracker.overforecast_confidence_cap.return_value = cap
+        tracker.accuracy_confidence_ceiling.return_value = accuracy_ceiling
+        return tracker
+
+    @staticmethod
+    def _make_analysis(is_stale: bool = False) -> SimpleNamespace:
+        return SimpleNamespace(is_stale=is_stale, confidence_ceiling=1.0)
+
+    def _stamp(self, computation_engine, coordinator_data, tracker) -> None:
+        computation_engine._optimizer_facade = SimpleNamespace(
+            _solar_accuracy_tracker=tracker
+        )
+        computation_engine._stamp_confidence_ceilings(coordinator_data)
+
+    def test_no_tracker_leaves_ceilings_uncapped(
+        self, computation_engine, coordinator_data
+    ):
+        analysis = self._make_analysis()
+        coordinator_data.solcast_analysis_today = analysis
+        coordinator_data.solcast_analysis_tomorrow = None
+
+        self._stamp(computation_engine, coordinator_data, tracker=None)
+
+        assert analysis.confidence_ceiling == 1.0
+        assert coordinator_data.solar_absent_confidence == 1.0
+
+    def test_cap_applies_to_fresh_analysis(
+        self, computation_engine, coordinator_data
+    ):
+        analysis = self._make_analysis(is_stale=False)
+        coordinator_data.solcast_analysis_today = analysis
+        coordinator_data.solcast_analysis_tomorrow = None
+
+        self._stamp(
+            computation_engine, coordinator_data, self._make_tracker(cap=0.24)
+        )
+
+        assert analysis.confidence_ceiling == pytest.approx(0.24)
+
+    def test_cap_bounds_absent_confidence(
+        self, computation_engine, coordinator_data
+    ):
+        """No analysis at all → absent_confidence is THE confidence, so the cap
+        must bound it too (non-conservative default is 1.0)."""
+        coordinator_data.solcast_analysis_today = None
+        coordinator_data.solcast_analysis_tomorrow = None
+
+        self._stamp(
+            computation_engine, coordinator_data, self._make_tracker(cap=0.24)
+        )
+
+        assert coordinator_data.solar_absent_confidence == pytest.approx(0.24)
+
+    def test_cap_composes_with_stale_conservative_knob(
+        self, computation_engine, coordinator_data
+    ):
+        """Stale + conservative: resolved = min(knob, accuracy, cap)."""
+        analysis = self._make_analysis(is_stale=True)
+        coordinator_data.solcast_analysis_today = analysis
+        coordinator_data.solcast_analysis_tomorrow = None
+        computation_engine._get_switch_state = lambda key: key == (
+            SWITCH_STALE_SOLAR_CONSERVATIVE
+        )
+        computation_engine.entry = SimpleNamespace(
+            options={CONF_STALE_SOLAR_CONFIDENCE_CEILING: 0.3}
+        )
+
+        # Cap tighter than the knob → cap wins.
+        self._stamp(
+            computation_engine, coordinator_data, self._make_tracker(cap=0.24)
+        )
+        assert analysis.confidence_ceiling == pytest.approx(0.24)
+
+        # Cap dormant (1.0) → knob wins.
+        self._stamp(
+            computation_engine, coordinator_data, self._make_tracker(cap=1.0)
+        )
+        assert analysis.confidence_ceiling == pytest.approx(0.3)
+
+    def test_absent_confidence_conservative_floor_respected(
+        self, computation_engine, coordinator_data
+    ):
+        """Conservative switch on with no analysis: absent confidence takes the
+        conservative default, still bounded by the (tighter) cap."""
+        coordinator_data.solcast_analysis_today = None
+        coordinator_data.solcast_analysis_tomorrow = None
+        computation_engine._get_switch_state = lambda key: key == (
+            SWITCH_STALE_SOLAR_CONSERVATIVE
+        )
+
+        self._stamp(
+            computation_engine,
+            coordinator_data,
+            self._make_tracker(cap=0.24),
+        )
+
+        assert coordinator_data.solar_absent_confidence == pytest.approx(0.24)

--- a/tests/test_optimizer_facade.py
+++ b/tests/test_optimizer_facade.py
@@ -1,6 +1,6 @@
 """Unit tests for OptimizerFacade."""
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta, timezone
 from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import MagicMock, patch
@@ -329,12 +329,14 @@ def test_record_forecasts_for_slots_records_only_backfillable_timestamps():
         forecast_kwh=0.0,
         weather_condition="sunny",
         is_boost=False,
+        forecast_p10_kwh=0.0,
     )
     tracker.record_forecast.assert_any_call(
         period_start=datetime(2026, 1, 15, 10, 30, tzinfo=UTC),
         forecast_kwh=0.2,
         weather_condition="sunny",
         is_boost=False,
+        forecast_p10_kwh=0.0,
     )
 
 
@@ -383,6 +385,38 @@ def test_record_forecasts_for_slots_passes_boost_flag():
         forecast_kwh=0.2,
         weather_condition="sunny",
         is_boost=True,
+        forecast_p10_kwh=0.0,
+    )
+
+
+def test_record_forecasts_for_slots_captures_p10_energy():
+    """Issue #916: with all_solcast provided, each recorded slot also carries
+    the pure-P10 energy (confidence=0.0 blend) so the tracker can learn the
+    median/P10 spread it needs for the over-forecast cap."""
+    tracker = MagicMock()
+    tz = timezone(timedelta(hours=11))
+    slots = [
+        SimpleNamespace(solar_kwh=0.5, timestamp_iso="2026-08-26T10:00:00+11:00"),
+    ]
+    all_solcast = [
+        {
+            "period_start": "2026-08-26T10:00:00+11:00",
+            "pv_estimate": 1.0,
+            "pv_estimate10": 0.4,
+        },
+    ]
+
+    facade = OptimizerFacade(slot_builder_cls=_StubSlotBuilder)
+    facade.set_solar_accuracy_tracker(tracker)
+    facade._record_forecasts_for_slots(slots, "cloudy", all_solcast=all_solcast)
+
+    tracker.record_forecast.assert_called_once_with(
+        period_start=datetime(2026, 8, 26, 10, 0, tzinfo=tz),
+        forecast_kwh=0.5,
+        weather_condition="cloudy",
+        is_boost=False,
+        # P10 = 0.4 kW over 30 min = 0.2 kWh.
+        forecast_p10_kwh=pytest.approx(0.2),
     )
 
 


### PR DESCRIPTION
Closes #916

## Problem

Solcast over-forecasts cloudy days (+88% on 26 Aug: 12.2 actual vs 22.9 forecast kWh; cloudy-day ratios 0.53–0.68, clear days within ±10%). The optimistic plan then forces midday grid charging (~$1/day avoidable) to recover from solar that never arrives.

## Approach chosen and why

Two options were on the table: (1) a rolling bias from recent-day actual/forecast ratios, (2) day-type-aware conservative scaling via Solcast percentile fields. This PR is **option 1's signal driving option 2's mechanism**: a learned over-forecast ratio expressed as a confidence cap that flows through the existing median→P10 blend machinery (`_blend_solar_estimate`).

Why not flat day-ratio scaling alone: a cloudy yesterday would degrade a clear today by 25–38%, failing the clear-day ±10% acceptance criterion. The P10-blend self-protects structurally — the cap only expresses through the per-period median/P10 spread, which is wide on cloudy days and narrow on clear ones. It also never scales up (ratio ≥ 1.0 → cap exactly 1.0).

Mechanics:

- `SolarAccuracyTracker.overforecast_confidence_cap()`: energy-weighted actual/forecast ratio over completed local days (2-day half-life, 7-day lookback, days < 2 kWh forecast excluded, boost periods excluded). Guards return no correction (cap 1.0) for <2 qualifying days, missing P10 data, spread too narrow to express (<0.05), or no over-forecast.
- `SolarPeriodRecord.forecast_p10_kwh` (backward-compatible, `.get` default): the facade now records the pure-P10 energy per 30-min slot alongside the median forecast, via the existing `get_solar_for_slot_by_interval(confidence=0.0)`.
- The cap folds into the existing `min()` at the single central stamping site (`_stamp_confidence_ceilings`), so it composes with the stale-conservative ceiling and the accuracy ceiling rather than adding a parallel path, and every `ConfidenceResolver` consumer (slots, fallback boost path, sensors) inherits it automatically. It also bounds `solar_absent_confidence` for the absent-analysis path.

Accepted trade-off: one-day response lag (completed days only), with the 2-day half-life making yesterday dominant.

## Is the `forecast_corrections` wire live?

**Structurally live, functionally dead.** `ForecastCorrectionProvider` loads, saves, and is applied by load forecasting (`forecast/load.py`), but `record_error()` is never called anywhere in the codebase — sample count stays 0, so it always returns 1.0 and has never corrected anything. Not revived here; `SolarAccuracyTracker` is the live ratio source (warming since #923 fixed the tz-key bug).

## Test evidence

22 new tests across three suites:

- Acceptance tests: cloudy-day tracking using the issue's ratios (0.68/0.53/0.66, P̄=0.5) lands within ±20% of the weighted actual; clear-day regression (ratios ≈1.0) returns cap exactly 1.0; clear-day within ±10% with near-correct ratios.
- Guards: empty tracker, single day, missing P10, narrow spread, today excluded, lookback window, low-energy day, boost-only, under-forecast, recency weighting.
- P10 recording: stored on pending records, survives backfill, storage round-trip incl. legacy records without the field.
- Stamping integration: no tracker → uncapped; cap on fresh analysis and absent-analysis confidence; composes with the stale-conservative knob.

Full suite: `3523 passed, 1 xfailed`.

## Verification

- `uv run ruff format --check custom_components/localshift` — 98 files already formatted
- `uv run ruff check custom_components/localshift` — all checks passed
- `uv run pytest -q` — 3523 passed, 1 xfailed
- `npx --yes pyright@1.1.413 custom_components/localshift` — 0 errors, 0 warnings
- Coverage on modified files: computation_engine.py 98%, optimizer_facade.py 99%, solar_accuracy.py 98% (all ≥95%)