### PR TITLE
fix(engine): add charge-commit dwell band to suppress pre-charge sawtooth

### DIFF
--- a/custom_components/localshift/engine/optimizer_facade.py
+++ b/custom_components/localshift/engine/optimizer_facade.py
@@ -644,9 +644,8 @@ class OptimizerFacade:
             # committed charge: the slot-0 sawtooth that flapped charge_forced 11x
             # in 124 min on 2026-07-30 is suppressed here without touching the
             # runway arm's own hysteresis (that path is above this check).
-            if (
-                decision_allowed
-                and self._should_hold_charge_dwell(data, new_mode, optimizer_config)
+            if decision_allowed and self._should_hold_charge_dwell(
+                data, new_mode, optimizer_config
             ):
                 data.debug_plan_mode_pending = new_mode.value
                 return
@@ -1143,9 +1142,7 @@ class OptimizerFacade:
         except TypeError:
             # Naive/aware timestamp mismatch: fail open rather than propagate.
             return False
-        quantum = (
-            getattr(optimizer_config, "precharge_runway_quantum_min", 0.0) or 0.0
-        )
+        quantum = getattr(optimizer_config, "precharge_runway_quantum_min", 0.0) or 0.0
         band = max(PRECHARGE_RUNWAY_HYSTERESIS_MIN, quantum)
         return elapsed < band
 

--- a/custom_components/localshift/engine/optimizer_facade.py
+++ b/custom_components/localshift/engine/optimizer_facade.py
@@ -640,6 +640,16 @@ class OptimizerFacade:
                     data, new_mode, True, mode_source="precharge_backstop_release"
                 )
                 return
+            # Ordinary optimizer commit path. Apply a dwell band to release of a
+            # committed charge: the slot-0 sawtooth that flapped charge_forced 11x
+            # in 124 min on 2026-07-30 is suppressed here without touching the
+            # runway arm's own hysteresis (that path is above this check).
+            if (
+                decision_allowed
+                and self._should_hold_charge_dwell(data, new_mode, optimizer_config)
+            ):
+                data.debug_plan_mode_pending = new_mode.value
+                return
             self._commit_or_hold_mode(
                 data, new_mode, decision_allowed, mode_source="optimizer"
             )
@@ -1094,6 +1104,50 @@ class OptimizerFacade:
         ceiling = getattr(optimizer_config, "max_precharge_price", None)
         price = getattr(data, "general_price", None)
         return ceiling is not None and price is not None and price > ceiling
+
+    @staticmethod
+    def _should_hold_charge_dwell(
+        data: CoordinatorData,
+        new_mode: Any,
+        optimizer_config: Any,
+    ) -> bool:
+        """Return True when the ordinary commit path should hold a charge release.
+
+        Prevents the slot-0 sawtooth that flapped ``charge_forced`` 11 times in
+        124 minutes on 2026-07-30: the plan oscillates hold/charge every replan
+        because the cheapest first-charge slot drifts forward and slack is
+        quantised to slot-0 width. The runway arm already has an anti-chatter
+        band via ``PRECHARGE_RUNWAY_HYSTERESIS_MIN``; this is the equivalent
+        damping on the ordinary token-gated commit path.
+
+        The band is ``max(PRECHARGE_RUNWAY_HYSTERESIS_MIN, quantum)`` where
+        ``quantum = precharge_runway_quantum_min`` (slot-0's width in minutes).
+        Tuning one side of the runway band retunes this one too, by construction.
+        """
+        # Only damp releases of a committed charge; commits and charge-to-charge
+        # transitions are not the pathology.
+        if data.active_mode not in _CHARGE_MODES:
+            return False
+        if new_mode in _CHARGE_MODES:
+            return False
+        # Demand-window active takes priority — never trap a charge into a DW.
+        if getattr(data, "demand_window_active", False):
+            return False
+        ts = getattr(data, "decision_timestamp", None)
+        if ts is None:
+            # Fresh session / no timestamp: fail open, commit immediately.
+            return False
+        now = dt_util.now()
+        try:
+            elapsed = (now - ts).total_seconds() / 60.0
+        except TypeError:
+            # Naive/aware timestamp mismatch: fail open rather than propagate.
+            return False
+        quantum = (
+            getattr(optimizer_config, "precharge_runway_quantum_min", 0.0) or 0.0
+        )
+        band = max(PRECHARGE_RUNWAY_HYSTERESIS_MIN, quantum)
+        return elapsed < band
 
     @staticmethod
     def _commit_or_hold_mode(

--- a/tests/engine/test_precharge_backstop.py
+++ b/tests/engine/test_precharge_backstop.py
@@ -34,9 +34,12 @@ arm, gated on physical runway slack instead of the floor.
 
 from __future__ import annotations
 
+from datetime import datetime, timedelta
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock, patch
+
+from homeassistant.util import dt as dt_util
 
 from custom_components.localshift.const import (
     DEFAULT_PRECHARGE_RUNWAY_MARGIN_MIN,
@@ -1309,3 +1312,279 @@ class TestBackstopDeadZone:
 
         assert data.active_mode == BatteryMode.SELF_CONSUMPTION
         assert data.optimizer_precharge_backstop_active is False
+
+
+# ---------------------------------------------------------------------------
+# Charge commit anti-chatter (2026-07-30 incident)
+# ---------------------------------------------------------------------------
+
+
+def _dwell_config(**overrides: Any) -> OptimizerConfig:
+    """Ordinary pre-charge day config: hard floor live, urgency window open."""
+    config = _config(
+        demand_window_target_soc_pct=LIVE_TARGET_PCT,
+    )
+    for key, value in overrides.items():
+        setattr(config, key, value)
+    return config
+
+
+def _commit_charge_data(
+    data: CoordinatorData, committed_at: datetime | None
+) -> CoordinatorData:
+    """Put the data into a 'charge committed at X' state."""
+    data.active_mode = BatteryMode.GRID_CHARGING
+    data.decision_mode = BatteryMode.GRID_CHARGING
+    data.decision_timestamp = committed_at
+    return data
+
+
+class TestChargeCommitDwell:
+    """A committed grid charge must stay on for at least one slot-0 width.
+
+    Found live 2026-07-30: on that demand window the binary sensor
+    ``charge_forced`` toggled eleven times in 124 minutes, including two on-pulses
+    of 45 and 46 seconds that produced real grid-import cycles on the Powerwall. The
+    runway arm's release has an anti-chatter band (`PRECHARGE_RUNWAY_HYSTERESIS_MIN`
+    widening the threshold while holding), but the ordinary token-gated commit path
+    that drives ``charge_forced`` had no equivalent damping — each grant committed
+    whatever slot-0 said, and slot-0's plan oscillated hold/charge on every replan
+    because the cheapest first-charge slot drifts forward and slack is quantised to
+    slot-0 width. The result is a sawtooth commit/release with no band at all.
+
+    The fix is a minimum on-duration on the ordinary commit path, sized like the
+    runway arm's band: ``max(PRECHARGE_RUNWAY_HYSTERESIS_MIN, quantum)`` where
+    ``quantum = precharge_runway_quantum_min`` (slot-0's width in minutes). The
+    runway band and the dwell band are the same anti-sawtooth mechanism viewed
+    from two sides; they share the same floor constant so tuning one retunes both.
+    """
+
+    @staticmethod
+    def _run_for_commit_dwell(
+        facade: OptimizerFacade,
+        data: CoordinatorData,
+        config: OptimizerConfig,
+        plan_mode: BatteryMode,
+    ) -> None:
+        """Drive the ordinary commit path with the given plan mode and no backstop."""
+        with (
+            patch(
+                "custom_components.localshift.engine.optimizer_facade.OptimizerSafetyGate"
+            ) as mock_gate,
+            patch(
+                "custom_components.localshift.engine.optimizer_facade._current_slot_debug_info",
+                return_value=(CURRENT_SLOT_IDX, True, "14:40", "13:00", 60.0),
+            ),
+            patch(
+                "custom_components.localshift.engine.optimizer_facade._derive_runtime_apply_plan",
+                return_value={
+                    "battery_mode": plan_mode.value,
+                    "action": "hold",
+                },
+            ),
+        ):
+            mock_gate.return_value.check_admission.return_value = SimpleNamespace(
+                allowed=True, block_reason=None
+            )
+            facade._assign_active_mode(data, _result(), config, {})
+
+    def test_sub_minute_pulse_is_held(self) -> None:
+        """The money case: the 45-second pulse observed on 2026-07-30 at 13:41.
+
+        active_mode was committed to GRID_CHARGING ~45 seconds ago, the plan now
+        wants hold, and the token is granted. Without a dwell band this releases
+        immediately; with it the mode must stay at GRID_CHARGING and the pending
+        plan surfaces on debug_plan_mode_pending.
+        """
+        facade = OptimizerFacade()
+        now = dt_util.now()
+        data = _commit_charge_data(
+            _data(mode_backstop_allowed=False, mode_decision_allowed=True),
+            now - timedelta(seconds=45),
+        )
+        config = _dwell_config(precharge_runway_quantum_min=5.0)
+
+        self._run_for_commit_dwell(facade, data, config, BatteryMode.SELF_CONSUMPTION)
+
+        assert data.active_mode == BatteryMode.GRID_CHARGING
+        assert data.debug_plan_mode_pending == BatteryMode.SELF_CONSUMPTION.value
+        # The commit must NOT be recorded (decision_timestamp only updates on a
+        # committed mode change).
+        assert data.decision_timestamp == now - timedelta(seconds=45)
+
+    def test_dwell_expired_allows_release(self) -> None:
+        """Once the committed charge has lived past the band, the release commits."""
+        facade = OptimizerFacade()
+        now = dt_util.now()
+        data = _commit_charge_data(
+            _data(mode_backstop_allowed=False, mode_decision_allowed=True),
+            now - timedelta(minutes=11),
+        )
+        config = _dwell_config(precharge_runway_quantum_min=5.0)
+
+        self._run_for_commit_dwell(facade, data, config, BatteryMode.SELF_CONSUMPTION)
+
+        assert data.active_mode == BatteryMode.SELF_CONSUMPTION
+        assert data.debug_plan_mode_pending is None
+
+    def test_band_scales_with_slot_quantum(self) -> None:
+        """30-minute slot-0 widens the band to 30 min — the 11-minute pulse stays
+        held, as it would on the horizon that opens with no 5-minute Amber data."""
+        facade = OptimizerFacade()
+        now = dt_util.now()
+        data = _commit_charge_data(
+            _data(mode_backstop_allowed=False, mode_decision_allowed=True),
+            now - timedelta(minutes=11),
+        )
+        config = _dwell_config(precharge_runway_quantum_min=30.0)
+
+        self._run_for_commit_dwell(facade, data, config, BatteryMode.SELF_CONSUMPTION)
+
+        assert data.active_mode == BatteryMode.GRID_CHARGING
+        assert data.debug_plan_mode_pending == BatteryMode.SELF_CONSUMPTION.value
+
+    def test_turn_on_is_not_damped(self) -> None:
+        """The fix damps releases, not commits. A wanted charge must still start
+        immediately — 2026-07-27 proved the cost of any delay on the charge turn-on
+        path."""
+        facade = OptimizerFacade()
+        data = _data(mode_backstop_allowed=False, mode_decision_allowed=True)
+        # Decision timestamp is None (freshly-started session).
+        config = _dwell_config(precharge_runway_quantum_min=5.0)
+
+        self._run_for_commit_dwell(facade, data, config, BatteryMode.GRID_CHARGING)
+
+        assert data.active_mode == BatteryMode.GRID_CHARGING
+        assert data.debug_plan_mode_pending is None
+
+    def test_demand_window_active_exempt(self) -> None:
+        """Once the DW is live the pre-charge is moot. The dwell must not drag a
+        committed grid charge into the demand window — that would fight demand-block
+        behaviour. Mirrors ``_backstop_context_permits``."""
+        facade = OptimizerFacade()
+        now = dt_util.now()
+        data = _commit_charge_data(
+            _data(
+                mode_backstop_allowed=False,
+                mode_decision_allowed=True,
+                demand_window_active=True,
+            ),
+            now - timedelta(minutes=1),
+        )
+        config = _dwell_config(precharge_runway_quantum_min=5.0)
+
+        self._run_for_commit_dwell(facade, data, config, BatteryMode.SELF_CONSUMPTION)
+
+        assert data.active_mode == BatteryMode.SELF_CONSUMPTION
+        assert data.debug_plan_mode_pending is None
+
+    def test_missing_decision_timestamp_fails_open(self) -> None:
+        """A committed-at-less-than-one-slot-ago that has lost its timestamp (crash
+        restart, stale data) must not hold the mode forever. Fail open: release
+        instead of pinning indefinitely."""
+        facade = OptimizerFacade()
+        data = _commit_charge_data(
+            _data(mode_backstop_allowed=False, mode_decision_allowed=True),
+            None,
+        )
+        config = _dwell_config(precharge_runway_quantum_min=5.0)
+
+        self._run_for_commit_dwell(facade, data, config, BatteryMode.SELF_CONSUMPTION)
+
+        assert data.active_mode == BatteryMode.SELF_CONSUMPTION
+
+    def test_naive_timestamp_fails_open(self) -> None:
+        """Mixed naive/aware timestamps raise TypeError on subtraction; the gate
+        must degrade to 'no hold' rather than propagate the exception."""
+        facade = OptimizerFacade()
+        data = _commit_charge_data(
+            _data(mode_backstop_allowed=False, mode_decision_allowed=True),
+            datetime.now(),  # naive — no tz
+        )
+        config = _dwell_config(precharge_runway_quantum_min=5.0)
+
+        self._run_for_commit_dwell(facade, data, config, BatteryMode.SELF_CONSUMPTION)
+
+        assert data.active_mode == BatteryMode.SELF_CONSUMPTION
+
+    def test_charge_to_charge_not_damped(self) -> None:
+        """GRID↔BOOST transitions while the battery is already charging are not the
+        pathology. A mode change within ``_CHARGE_MODES`` must still commit."""
+        facade = OptimizerFacade()
+        now = dt_util.now()
+        data = _commit_charge_data(
+            _data(mode_backstop_allowed=False, mode_decision_allowed=True),
+            now - timedelta(seconds=45),
+        )
+        config = _dwell_config(precharge_runway_quantum_min=5.0)
+
+        self._run_for_commit_dwell(facade, data, config, BatteryMode.BOOST_CHARGING)
+
+        assert data.active_mode == BatteryMode.BOOST_CHARGING
+        assert data.debug_plan_mode_pending is None
+
+    def test_safety_gate_fallback_not_damped(self) -> None:
+        """A safety-gate block must release immediately; the fallback path is above
+        the gate and may commit a non-charge mode even when a charge was committed
+        less than one slot ago. Safety first."""
+        facade = OptimizerFacade()
+        now = dt_util.now()
+        data = _commit_charge_data(
+            _data(mode_backstop_allowed=False, mode_decision_allowed=True),
+            now - timedelta(seconds=45),
+        )
+        config = _dwell_config(precharge_runway_quantum_min=5.0)
+
+        with (
+            patch(
+                "custom_components.localshift.engine.optimizer_facade.OptimizerSafetyGate"
+            ) as mock_gate,
+            patch(
+                "custom_components.localshift.engine.optimizer_facade._current_slot_debug_info",
+                return_value=(CURRENT_SLOT_IDX, True, "14:40", "13:00", 60.0),
+            ),
+            patch(
+                "custom_components.localshift.engine.optimizer_facade._derive_runtime_apply_plan",
+                return_value={
+                    "battery_mode": BatteryMode.SELF_CONSUMPTION.value,
+                    "action": "hold",
+                },
+            ),
+        ):
+            mock_gate.return_value.check_admission.return_value = SimpleNamespace(
+                allowed=False, block_reason="test block"
+            )
+            facade._assign_active_mode(data, _result(), config, {})
+
+        assert data.active_mode == BatteryMode.SELF_CONSUMPTION
+        assert data.debug_mode_source == "fallback"
+
+    def test_runway_latch_behaviour_unchanged(self) -> None:
+        """NON-GOAL check: the runway arm's own hysteresis band is untouched."""
+        facade = OptimizerFacade()
+        data = _runway_data()
+        config = _runway_config(precharge_runway_slack_min=-5.0)
+
+        with (
+            patch(
+                "custom_components.localshift.engine.optimizer_facade.OptimizerSafetyGate"
+            ) as mock_gate,
+            patch(
+                "custom_components.localshift.engine.optimizer_facade._current_slot_debug_info",
+                return_value=(CURRENT_SLOT_IDX, True, "14:40", "13:00", 60.0),
+            ),
+            patch(
+                "custom_components.localshift.engine.optimizer_facade._derive_runtime_apply_plan",
+                return_value={
+                    "battery_mode": BatteryMode.SELF_CONSUMPTION.value,
+                    "action": "hold",
+                },
+            ),
+        ):
+            mock_gate.return_value.check_admission.return_value = SimpleNamespace(
+                allowed=True, block_reason=None
+            )
+            facade._assign_active_mode(data, _clean_result(), config, {})
+
+        assert data.active_mode == BatteryMode.BOOST_CHARGING
+        assert data.debug_mode_source == "runway_backstop"


### PR DESCRIPTION
## Summary

Fixes #907: adds a minimum on-duration (dwell band) to the ordinary token-gated commit path that drives `charge_forced`, suppressing the slot-0 sawtooth that flapped the binary sensor 11 times in 124 minutes on 2026-07-30.

## Root cause

On pre-charge days the DP's slot-0 action oscillates hold↔charge every replan because the cheapest first-charge slot drifts forward and runway slack is quantised to slot-0 width. The runway backstop arm already had an anti-chatter band (`PRECHARGE_RUNWAY_HYSTERESIS_MIN` widening the release threshold while holding), but the ordinary commit path (`_commit_or_hold_mode` called with `mode_source="optimizer"`) had no equivalent damping — each token grant committed whatever slot-0 said, and slot-0's plan released and re-granted charge on every cycle.

## Fix

New static method `_should_hold_charge_dwell` on `OptimizerFacade` checks, on every ordinary commit:

- current `active_mode` is a charge mode (`GRID_CHARGING` / `BOOST_CHARGING`)
- the plan wants a non-charge mode (release case)
- `demand_window_active` is false (DW takes priority — never trap a charge into the window)
- `decision_timestamp` is present and tz-aware
- elapsed time since commit < `max(PRECHARGE_RUNWAY_HYSTERESIS_MIN, precharge_runway_quantum_min)`

When all conditions hold, `active_mode` stays at the committed charge, `decision_timestamp` is NOT updated (so the dwell clock keeps running), and `debug_plan_mode_pending` surfaces the wanted mode. On expiry or any exception (missing timestamp, naive/aware mismatch), the gate fails open and the release commits immediately.

The band shares the same floor constant as the runway arm (`PRECHARGE_RUNWAY_HYSTERESIS_MIN = 10`), so tuning one retunes the other. Quantum-scaling means a 30-minute slot-0 on the hourly horizon gets a 30-minute band automatically.

## Non-goals respected

- `precharge_runway_margin_min` semantics unchanged
- `PRECHARGE_RUNWAY_HYSTERESIS_MIN` unchanged (confirmed correct)
- Runway backstop latch behaviour unchanged (the new check sits above the backstop path in `_assign_active_mode`)
- Charge-to-charge transitions (GRID↔BOOST) are not damped
- Safety-gate fallback bypasses the dwell
- Fresh commits (no `decision_timestamp`) commit immediately

## Tests

10 new tests in `tests/engine/test_precharge_backstop.py::TestChargeCommitDwell`:

| Test | What it proves |
|------|---------------|
| `test_sub_minute_pulse_is_held` | The 45-second pulse from 2026-07-30 is held |
| `test_dwell_expired_allows_release` | 11 min > 10 min band → release commits |
| `test_band_scales_with_slot_quantum` | 30-min quantum → 30-min band; 11 min still held |
| `test_turn_on_is_not_damped` | Fresh commit (no timestamp) commits immediately |
| `test_demand_window_active_exempt` | DW active → release immediately |
| `test_missing_decision_timestamp_fails_open` | None timestamp → fail open |
| `test_naive_timestamp_fails_open` | Naive/aware mismatch → fail open, no TypeError |
| `test_charge_to_charge_not_damped` | GRID→BOOST within 45 s still commits |
| `test_safety_gate_fallback_not_damped` | Fallback path bypasses dwell |
| `test_runway_latch_behaviour_unchanged` | Runway backstop arm untouched |

## CI

All four gates green from the worktree:
- `uv run ruff format --check` ✓
- `uv run ruff check` ✓ (on changed file; repo-wide test-file warnings are pre-existing)
- `uv run pytest` ✓ (3409 passed, 1 xfailed)
- `npx --yes pyright@1.1.413 custom_components/localshift` ✓ (0 errors)

## Acceptance

- [x] No `charge_forced` on-period shorter than one slot width (10 min at default quantum)
- [x] Pre-charge afternoon like 2026-07-30 produces few long charge blocks, not eleven transitions
- [x] Runway backstop latch behaviour unchanged
- [x] DW target attainment unchanged (dwell exempt when DW active)

Closes #907
