### PR TITLE
fix(health-check): reactive grid_charging state listener to suppress hourly reversion (#491)

### DIFF
--- a/custom_components/localshift/coordinator/coordinator.py
+++ b/custom_components/localshift/coordinator/coordinator.py
@@ -292,6 +292,7 @@ class LocalShiftCoordinator:
         # This prevents state machine evaluation during startup before entities populate
         # The grace period must be set before ANY computation that might trigger evaluation
         self._state_machine.set_startup_grace(30)
+        self._state_machine.start_grid_charging_listener(self.hass)
 
         self._learning_orchestrator = LearningOrchestrator(
             self.hass,
@@ -476,6 +477,7 @@ class LocalShiftCoordinator:
 
         # Issue #508: remove the temporary physical-response listener
         self._remove_battery_power_listener()
+        self._state_machine.stop_grid_charging_listener()
         # Save all learning data to storage before shutdown
         await self._save_learning_data()
 

--- a/custom_components/localshift/coordinator/coordinator.py
+++ b/custom_components/localshift/coordinator/coordinator.py
@@ -477,7 +477,8 @@ class LocalShiftCoordinator:
 
         # Issue #508: remove the temporary physical-response listener
         self._remove_battery_power_listener()
-        self._state_machine.stop_grid_charging_listener()
+        if self._state_machine is not None:
+            self._state_machine.stop_grid_charging_listener()
         # Save all learning data to storage before shutdown
         await self._save_learning_data()
 

--- a/custom_components/localshift/state/machine.py
+++ b/custom_components/localshift/state/machine.py
@@ -114,6 +114,8 @@ class StateMachine:
         # Cooldown for health-check corrections (prevents command spam when
         # Teslemetry cloud lags in reflecting a legitimate transition)
         self._last_health_correction: datetime | None = None
+        # Listener for reactive grid_charging correction (#491)
+        self._grid_charging_listener: Callable | None = None
         # Decision-token gating (#622 gate replacement): the mode may be
         # re-decided at most once per discrete decision-context change. The
         # fingerprint is consumed by the *evaluation* that observes the change
@@ -1702,3 +1704,99 @@ class StateMachine:
     def in_mode_transition(self) -> bool:
         """Check if currently in a mode transition."""
         return self._in_mode_transition
+
+    def start_grid_charging_listener(self, hass: Any) -> None:
+        """Register a state-change listener on the grid_charging switch.
+
+        The listener corrects the switch immediately when Teslemetry's hourly
+        cloud sync re-enables grid charging while LocalShift expects it off.
+        The 5-minute cooldown on ``_last_health_correction`` is shared with
+        the periodic health check so corrections do not thrash.
+        """
+        if self._grid_charging_listener is not None:
+            return
+
+        entity_id = self._battery_controller._get_entity_id(  # noqa: SLF001
+            "teslemetry_allow_charging_from_grid"
+        )
+
+        def _on_grid_charging_state_change(  # type: ignore[empty-body]
+            _hass: Any,
+            _listener_id: Any,
+            _target: Any,
+            event: Any,
+        ) -> None:
+            new_state = event["new_state"]
+            if new_state is None or new_state.state not in ("on", "off"):
+                return
+            # Only react to the switch turning ON (reversion)
+            if new_state.state != "on":
+                return
+            asyncio.create_task(
+                self._reactive_correct_grid_charging(hass, entity_id)
+            )
+
+        self._grid_charging_listener = hass.async_listen_state(
+            _on_grid_charging_state_change, entity_id
+        )
+        _LOGGER.debug(
+            "Registered grid_charging state listener on %s (#491)", entity_id
+        )
+
+    def stop_grid_charging_listener(self) -> None:
+        """Unregister the reactive grid_charging state listener."""
+        if self._grid_charging_listener is not None:
+            self._grid_charging_listener()
+            self._grid_charging_listener = None
+            _LOGGER.debug("Unregistered grid_charging state listener (#491)")
+
+    async def _reactive_correct_grid_charging(
+        self, hass: Any, entity_id: str
+    ) -> None:
+        """Turn off grid_charging when it was re-enabled unexpectedly.
+
+        Respects the same cooldown as the health check and skips when a
+        Tesla override is active.
+        """
+        now = dt_util.now()
+        if (
+            self._last_health_correction is not None
+            and now - self._last_health_correction < self._MIN_CORRECTION_INTERVAL
+        ):
+            _LOGGER.debug(
+                "[GRID CHARGING LISTENER] Correction blocked by cooldown"
+            )
+            return
+        if self.is_tesla_override_active():
+            _LOGGER.debug(
+                "[GRID CHARGING LISTENER] Skipping — Tesla override active"
+            )
+            return
+        if self._commanded_mode not in (
+            BatteryMode.SELF_CONSUMPTION,
+            BatteryMode.DEMAND_BLOCK,
+            BatteryMode.SPIKE_DISCHARGE,
+            BatteryMode.PROACTIVE_EXPORT,
+            BatteryMode.HOLD,
+        ):
+            return
+
+        _LOGGER.warning(
+            "[GRID CHARGING LISTENER] Grid charging re-enabled while in "
+            "mode %s — correcting immediately",
+            self._commanded_mode.value,
+        )
+        try:
+            await hass.services.async_call(
+                "switch",
+                "turn_off",
+                {"entity_id": entity_id},
+                blocking=True,
+            )
+        except Exception as exc:  # noqa: BLE001
+            _LOGGER.error(
+                "[GRID CHARGING LISTENER] Failed to correct grid_charging: %s",
+                exc,
+                exc_info=True,
+            )
+        self._last_health_correction = now

--- a/custom_components/localshift/state/machine.py
+++ b/custom_components/localshift/state/machine.py
@@ -1732,16 +1732,12 @@ class StateMachine:
             # Only react to the switch turning ON (reversion)
             if new_state.state != "on":
                 return
-            asyncio.create_task(
-                self._reactive_correct_grid_charging(hass, entity_id)
-            )
+            asyncio.create_task(self._reactive_correct_grid_charging(hass, entity_id))
 
         self._grid_charging_listener = hass.async_listen_state(
             _on_grid_charging_state_change, entity_id
         )
-        _LOGGER.debug(
-            "Registered grid_charging state listener on %s (#491)", entity_id
-        )
+        _LOGGER.debug("Registered grid_charging state listener on %s (#491)", entity_id)
 
     def stop_grid_charging_listener(self) -> None:
         """Unregister the reactive grid_charging state listener."""
@@ -1750,9 +1746,7 @@ class StateMachine:
             self._grid_charging_listener = None
             _LOGGER.debug("Unregistered grid_charging state listener (#491)")
 
-    async def _reactive_correct_grid_charging(
-        self, hass: Any, entity_id: str
-    ) -> None:
+    async def _reactive_correct_grid_charging(self, hass: Any, entity_id: str) -> None:
         """Turn off grid_charging when it was re-enabled unexpectedly.
 
         Respects the same cooldown as the health check and skips when a
@@ -1763,14 +1757,10 @@ class StateMachine:
             self._last_health_correction is not None
             and now - self._last_health_correction < self._MIN_CORRECTION_INTERVAL
         ):
-            _LOGGER.debug(
-                "[GRID CHARGING LISTENER] Correction blocked by cooldown"
-            )
+            _LOGGER.debug("[GRID CHARGING LISTENER] Correction blocked by cooldown")
             return
         if self.is_tesla_override_active():
-            _LOGGER.debug(
-                "[GRID CHARGING LISTENER] Skipping — Tesla override active"
-            )
+            _LOGGER.debug("[GRID CHARGING LISTENER] Skipping — Tesla override active")
             return
         if self._commanded_mode not in (
             BatteryMode.SELF_CONSUMPTION,

--- a/tests/state/test_state_machine.py
+++ b/tests/state/test_state_machine.py
@@ -5,7 +5,7 @@ and error handling as specified in backlog-crit-002.
 """
 
 import asyncio
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -1040,6 +1040,181 @@ class TestHealthCheck:
 
 
 # =============================================================================
+# REACTIVE GRID CHARGING LISTENER TESTS (Issue #491)
+# =============================================================================
+
+
+class TestGridChargingListener:
+    """Tests for the reactive grid_charging state-change listener (#491)."""
+
+    def test_start_listener_registers_callback(
+        self, state_machine, mock_hass
+    ):
+        """start_grid_charging_listener should register an async_listen_state call."""
+        mock_hass.async_listen_state.return_value = MagicMock()
+        state_machine.start_grid_charging_listener(mock_hass)
+        mock_hass.async_listen_state.assert_called_once()
+
+    def test_start_listener_is_idempotent(
+        self, state_machine, mock_hass
+    ):
+        """Calling start twice should only register once."""
+        mock_hass.async_listen_state.return_value = MagicMock()
+        state_machine.start_grid_charging_listener(mock_hass)
+        state_machine.start_grid_charging_listener(mock_hass)
+        assert mock_hass.async_listen_state.call_count == 1
+
+    def test_stop_listener_calls_unsubscribe(
+        self, state_machine, mock_hass
+    ):
+        """stop_grid_charging_listener should call the listener handle."""
+        handle = MagicMock()
+        state_machine._grid_charging_listener = handle
+        state_machine.stop_grid_charging_listener()
+        handle.assert_called_once()
+        assert state_machine._grid_charging_listener is None
+
+    def test_stop_listener_noop_when_none(
+        self, state_machine
+    ):
+        """stop_grid_charging_listener should not error when no listener is active."""
+        state_machine._grid_charging_listener = None
+        state_machine.stop_grid_charging_listener()  # should not raise
+
+    @pytest.mark.asyncio
+    async def test_reactive_correction_turns_off_grid_charging(
+        self, state_machine, mock_hass, mock_battery_controller
+    ):
+        """Listener should turn off grid_charging when it flips to on in self_consumption."""
+        from custom_components.localshift.const import BatteryMode
+
+        state_machine._commanded_mode = BatteryMode.SELF_CONSUMPTION
+        mock_battery_controller._get_entity_id.return_value = (
+            "switch.my_home_allow_charging_from_grid"
+        )
+
+        mock_hass.services.async_call = AsyncMock(return_value=True)
+        mock_hass.async_listen_state.return_value = MagicMock()
+        state_machine.start_grid_charging_listener(mock_hass)
+
+        # Fire the listener callback manually
+        listener = mock_hass.async_listen_state.call_args[0][0]
+        event = {
+            "new_state": MagicMock(state="on"),
+            "old_state": MagicMock(state="off"),
+        }
+        listener(mock_hass, None, None, event)
+
+        # Give the task a tick to complete
+        await asyncio.sleep(0)
+
+        mock_hass.services.async_call.assert_called_once_with(
+            "switch",
+            "turn_off",
+            {"entity_id": "switch.my_home_allow_charging_from_grid"},
+            blocking=True,
+        )
+
+    @pytest.mark.asyncio
+    async def test_reactive_correction_respects_cooldown(
+        self, state_machine, mock_hass, mock_battery_controller
+    ):
+        """Listener should skip correction when health-check cooldown is active."""
+        from datetime import datetime, timedelta
+
+        from custom_components.localshift.const import BatteryMode
+
+        state_machine._commanded_mode = BatteryMode.SELF_CONSUMPTION
+        mock_battery_controller._get_entity_id.return_value = (
+            "switch.my_home_allow_charging_from_grid"
+        )
+        # Set last correction to 1 minute ago (within 5-min cooldown)
+        now = datetime.now(UTC)
+        state_machine._last_health_correction = now - timedelta(minutes=1)
+
+        mock_hass.services.async_call = AsyncMock(return_value=True)
+        mock_hass.async_listen_state.return_value = MagicMock()
+        state_machine.start_grid_charging_listener(mock_hass)
+
+        listener = mock_hass.async_listen_state.call_args[0][0]
+        event = {"new_state": MagicMock(state="on"), "old_state": MagicMock(state="off")}
+        listener(mock_hass, None, None, event)
+        await asyncio.sleep(0)
+
+        mock_hass.services.async_call.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_reactive_correction_skips_when_tesla_override_active(
+        self, state_machine, mock_hass, mock_battery_controller
+    ):
+        """Listener should skip correction when Tesla override is active."""
+        from custom_components.localshift.const import BatteryMode
+
+        state_machine._commanded_mode = BatteryMode.SELF_CONSUMPTION
+        state_machine._tesla_override_detected = True
+        mock_battery_controller._get_entity_id.return_value = (
+            "switch.my_home_allow_charging_from_grid"
+        )
+
+        mock_hass.services.async_call = AsyncMock(return_value=True)
+        mock_hass.async_listen_state.return_value = MagicMock()
+        state_machine.start_grid_charging_listener(mock_hass)
+
+        listener = mock_hass.async_listen_state.call_args[0][0]
+        event = {"new_state": MagicMock(state="on"), "old_state": MagicMock(state="off")}
+        listener(mock_hass, None, None, event)
+        await asyncio.sleep(0)
+
+        mock_hass.services.async_call.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_reactive_correction_skips_in_grid_charging_mode(
+        self, state_machine, mock_hass, mock_battery_controller
+    ):
+        """Listener should do nothing when commanded mode is GRID_CHARGING."""
+        from custom_components.localshift.const import BatteryMode
+
+        state_machine._commanded_mode = BatteryMode.GRID_CHARGING
+        mock_battery_controller._get_entity_id.return_value = (
+            "switch.my_home_allow_charging_from_grid"
+        )
+
+        mock_hass.services.async_call = AsyncMock(return_value=True)
+        mock_hass.async_listen_state.return_value = MagicMock()
+        state_machine.start_grid_charging_listener(mock_hass)
+
+        listener = mock_hass.async_listen_state.call_args[0][0]
+        event = {"new_state": MagicMock(state="on"), "old_state": MagicMock(state="off")}
+        listener(mock_hass, None, None, event)
+        await asyncio.sleep(0)
+
+        mock_hass.services.async_call.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_reactive_correction_noop_when_switch_turns_off(
+        self, state_machine, mock_hass, mock_battery_controller
+    ):
+        """Listener should not act when the switch turns off (only on)."""
+        from custom_components.localshift.const import BatteryMode
+
+        state_machine._commanded_mode = BatteryMode.SELF_CONSUMPTION
+        mock_battery_controller._get_entity_id.return_value = (
+            "switch.my_home_allow_charging_from_grid"
+        )
+
+        mock_hass.services.async_call = AsyncMock(return_value=True)
+        mock_hass.async_listen_state.return_value = MagicMock()
+        state_machine.start_grid_charging_listener(mock_hass)
+
+        listener = mock_hass.async_listen_state.call_args[0][0]
+        event = {"new_state": MagicMock(state="off"), "old_state": MagicMock(state="on")}
+        listener(mock_hass, None, None, event)
+        await asyncio.sleep(0)
+
+        mock_hass.services.async_call.assert_not_called()
+
+
+# =============================================================================
 # MANUAL OVERRIDE TESTS
 # =============================================================================
 
@@ -1830,7 +2005,7 @@ class TestModeTransitionGating:
         once debounce is satisfied.
         """
         import asyncio
-        from unittest.mock import patch, MagicMock
+        from unittest.mock import MagicMock, patch
 
         # Set up data with prices
         coordinator_data.general_price = 0.25


### PR DESCRIPTION
## Summary

The Teslemetry integration re-enables `switch.my_home_allow_charging_from_grid` at the top of each hour via cloud sync. The existing 1-min periodic health check with a 5-min correction cooldown meant the switch stayed wrong for up to ~10 min per cycle, producing an hourly `State mismatch` warning and up to 60 min of unintended grid charging per reversion.

This PR adds a reactive `async_listen_state` listener on the grid_charging switch that immediately calls `switch.turn_off` the moment the switch flips to `on` while LocalShift expects it off (self_consumption, demand_block, spike_discharge, proactive_export, hold modes). The same 5-min cooldown on `_last_health_correction` and the same Tesla-override gate protect the reactive path from thrashing.

## Related Issue
Closes #491

## Changes
- `state/machine.py`: add `start_grid_charging_listener` / `stop_grid_charging_listener` and `_reactive_correct_grid_charging`
- `coordinator/coordinator.py`: register listener in `async_start`, tear down in `async_stop`
- `tests/state/test_state_machine.py`: 9 new tests covering registration, idempotency, teardown, correction path, cooldown, Tesla-override gate, mode gate, and off-transition no-op

## Testing
- [x] 3409 existing tests pass
- [x] 9 new tests pass
- [x] ruff clean
- [ ] CI (pending)