### PR TITLE
fix: sweep 7 stale July bug fixes (#892 #894-#899)

### DIFF
--- a/custom_components/localshift/config_flow/__init__.py
+++ b/custom_components/localshift/config_flow/__init__.py
@@ -780,7 +780,7 @@ class LocalShiftOptionsFlow(OptionsFlow):
             ): selector.NumberSelector(
                 selector.NumberSelectorConfig(
                     min=0.000,
-                    max=0.100,
+                    max=0.200,
                     step=0.005,
                     unit_of_measurement="$/%-point",
                     mode=selector.NumberSelectorMode.SLIDER,

--- a/custom_components/localshift/coordinator/coordinator.py
+++ b/custom_components/localshift/coordinator/coordinator.py
@@ -272,7 +272,9 @@ class LocalShiftCoordinator:
             self.hass, self.entry, self._entity_validator, _pricing_provider
         )
         self._cost_tracker = CostTracker(self.hass)
-        self._battery_controller = BatteryController(self.hass, self.get_entity_id)
+        self._battery_controller = BatteryController(
+            self.hass, self.get_entity_id, get_option_func=self.get_option
+        )
         self._notification_service = NotificationService(
             self.hass, self.entry, self.get_entity_id, self.get_switch_state
         )

--- a/custom_components/localshift/engine/slots.py
+++ b/custom_components/localshift/engine/slots.py
@@ -357,7 +357,15 @@ class SlotBuilder:
         if buy_price < 0.001 or sell_price < 0.001:
             counts["defaulted_price"] = 1
 
-        in_demand_window = dw_start_time <= slot_time < dw_end_time
+        # Issue #896: handle cross-midnight (overnight) demand windows where
+        # end <= start (e.g. 22:00 -> 06:00). The naive ``start <= t < end``
+        # comparison is false for every slot of the day in that case, silently
+        # disabling the entire feature. When end <= start, a slot is in the DW
+        # if its time is >= start OR < end (the window wraps past midnight).
+        if dw_end_time <= dw_start_time:
+            in_demand_window = slot_time >= dw_start_time or slot_time < dw_end_time
+        else:
+            in_demand_window = dw_start_time <= slot_time < dw_end_time
         is_demand_window_entry = in_demand_window and not prev_in_demand_window
 
         ctx = SlotContext(

--- a/custom_components/localshift/integration/controller.py
+++ b/custom_components/localshift/integration/controller.py
@@ -6,12 +6,14 @@ import logging
 import time
 from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from homeassistant.util import dt as dt_util
 
 from ..const import (
     BACKUP_RESERVE_MAX_VALID,
+    CONF_MINIMUM_TARGET_SOC,
+    DEFAULT_MINIMUM_TARGET_SOC,
     TESLEMETRY_EXPORT_BATTERY_OK,
     TESLEMETRY_EXPORT_PV_ONLY,
 )
@@ -72,16 +74,22 @@ class BatteryController:
         self,
         hass: HomeAssistant,
         get_entity_id_func: callable,
+        get_option_func: Callable[[str, Any], Any] | None = None,
     ) -> None:
         """Initialize the battery controller.
 
         Args:
             hass: Home Assistant instance
             get_entity_id_func: Function to get entity IDs by config key
+            get_option_func: Optional function to read config_entry options by
+                key (mirrors the state machine's ``_get_option``). Used to read
+                ``minimum_target_soc`` correctly — it is an option, not a data
+                entity, so the entity-id lookup always returned "" (Issue #894).
 
         """
         self.hass = hass
         self._get_entity_id = get_entity_id_func
+        self._get_option = get_option_func
         self._service_client = PowerwallServiceClient(hass, get_entity_id_func)
         self._validator = TransitionValidator(hass, get_entity_id_func)
 
@@ -494,14 +502,28 @@ class BatteryController:
         return True
 
     def _get_minimum_target_soc(self) -> float:
-        """Read the minimum target SOC from the configured entity.
+        """Read the minimum target SOC from the configured option.
+
+        Issue #894: ``minimum_target_soc`` is a config_entry OPTION, not a data
+        entity. The old entity-id lookup always returned "" and read_float
+        silently fell back to a hardcoded 10.0, ignoring the user's configured
+        slider value during SPIKE_DISCHARGE. Read it via the option function
+        instead, falling back to DEFAULT_MINIMUM_TARGET_SOC (20).
 
         Returns:
-            Minimum target SOC percentage (default 10 if entity unavailable).
+            Minimum target SOC percentage.
 
         """
-        entity_id = self._get_entity_id("minimum_target_soc")
-        return self._validator.read_float(entity_id, default=10.0)
+        if self._get_option is not None:
+            try:
+                return float(
+                    self._get_option(
+                        CONF_MINIMUM_TARGET_SOC, DEFAULT_MINIMUM_TARGET_SOC
+                    )
+                )
+            except (TypeError, ValueError):
+                return float(DEFAULT_MINIMUM_TARGET_SOC)
+        return float(DEFAULT_MINIMUM_TARGET_SOC)
 
     async def set_force_discharge(
         self,
@@ -622,7 +644,25 @@ class BatteryController:
 
         # Dynamic reserve for throttling: SOC - 5%, minimum 4%
         current_soc = data.soc
-        reserve = max(4.0, current_soc - 5.0)
+        minimum_target = self._get_minimum_target_soc()
+
+        # Issue #895: when SOC is 0 (unavailable entity, startup, or genuinely
+        # empty), the old ``max(4.0, soc - 5.0)`` formula yielded reserve=4.0,
+        # draining the battery to 4% — well below the configured
+        # minimum_target_soc. Floor the reserve at minimum_target_soc so the
+        # configured protection holds, and warn so the SOC=0 case is
+        # diagnosable (it usually means the SOC entity is not populated).
+        if current_soc <= 0.0:
+            _LOGGER.warning(
+                "Proactive export requested with SOC=%.1f%% (entity unavailable "
+                "or empty); flooring reserve at minimum_target_soc=%.1f%% "
+                "instead of the dynamic SOC-5 formula.",
+                current_soc,
+                minimum_target,
+            )
+            reserve = minimum_target
+        else:
+            reserve = max(4.0, current_soc - 5.0)
 
         if dry_run:
             _LOGGER.info(

--- a/custom_components/localshift/pricing/provider.py
+++ b/custom_components/localshift/pricing/provider.py
@@ -75,7 +75,7 @@ class _ProviderMixin:
         return ForecastSlot(
             start_time=self._parse_timestamp(raw["start_time"]),
             duration=int(duration),
-            per_kwh=raw["per_kwh"],
+            per_kwh=float(raw["per_kwh"]),
             is_spike=self.is_spike(raw),  # type: ignore[attr-defined]
             source_type=self.name,  # type: ignore[attr-defined]
         )

--- a/custom_components/localshift/sensors/solcast.py
+++ b/custom_components/localshift/sensors/solcast.py
@@ -142,12 +142,12 @@ class ForecastAccuracyComparisonSensor(LocalShiftSensorBase):
         # Calculate combined score (weighted average)
         # When both available, weight equally
         # When only one available, use that one
-        if localshift_accuracy and solcast_mape is not None:
+        if localshift_accuracy is not None and solcast_mape is not None:
             # MAPE is error %, so convert to accuracy %
             solcast_accuracy = max(0, 100 - solcast_mape)
             combined = (localshift_accuracy + solcast_accuracy) / 2
             self._attr_native_value = round(combined, 1)
-        elif localshift_accuracy:
+        elif localshift_accuracy is not None:
             self._attr_native_value = round(localshift_accuracy, 1)
         elif solcast_mape is not None:
             # Convert MAPE to accuracy
@@ -163,7 +163,7 @@ class ForecastAccuracyComparisonSensor(LocalShiftSensorBase):
 
         attrs = {
             "localshift_accuracy_pct": round(localshift_accuracy, 1)
-            if localshift_accuracy
+            if localshift_accuracy is not None
             else None,
             "solcast_mape_pct": round(solcast_mape, 1)
             if solcast_mape is not None
@@ -171,7 +171,7 @@ class ForecastAccuracyComparisonSensor(LocalShiftSensorBase):
         }
 
         # Calculate divergence if both available
-        if localshift_accuracy and solcast_mape is not None:
+        if localshift_accuracy is not None and solcast_mape is not None:
             # Both are percentages, but MAPE is error while localshift is accuracy
             # Convert MAPE to accuracy for comparison
             solcast_accuracy = max(0, 100 - solcast_mape)

--- a/custom_components/localshift/utils/costs.py
+++ b/custom_components/localshift/utils/costs.py
@@ -125,6 +125,12 @@ class CostTracker:
         data.battery_charge_cost = 0.0
         data.target_reached_today = False
         self._reset_energy_accumulators(data)
+        # Issue #899: also clear the SOC baseline so the first grid-charge
+        # sample after midnight establishes a fresh baseline. Without this, a
+        # grid charge spanning midnight leaves _last_soc_pct at the
+        # pre-midnight value, and the next sample attributes the entire
+        # overnight gain to the new day's grid-charge-efficiency metric.
+        self._last_soc_pct = None
 
     def _reset_energy_accumulators(self, data: CoordinatorData) -> None:
         """Reset the Issue #868 daily energy accumulators."""

--- a/tests/pricing/test_provider.py
+++ b/tests/pricing/test_provider.py
@@ -517,3 +517,43 @@ def test_normalize_slot_negative_duration_defaults_to_5():
     }
     slot = provider._normalize_slot(raw)
     assert slot.duration == 5  # -30 min: abs diffs = |35|, |45|, |60|; 5 wins
+
+
+def test_normalize_slot_coerces_string_per_kwh_to_float():
+    """Issue #897: per_kwh arriving as a JSON string must be coerced to float.
+
+    Same bug family as #887 (which fixed the attribute NAME). HA state
+    attributes aren't guaranteed numeric — Amber/Amber Express slots can
+    arrive with per_kwh as "0.25" (string). Pre-fix the ForecastSlot held the
+    string verbatim, breaking downstream arithmetic and comparison.
+    """
+    from custom_components.localshift.pricing.provider import AmberExpressProvider
+
+    provider = AmberExpressProvider()
+    raw = {
+        "start_time": "2026-03-16T10:00:01+00:00",
+        "end_time": "2026-03-16T10:30:00+00:00",
+        "per_kwh": "0.25",  # string, not float
+        "demand_window": False,
+    }
+    slot = provider._normalize_slot(raw)
+
+    assert isinstance(slot.per_kwh, float)
+    assert slot.per_kwh == 0.25
+
+
+def test_normalize_slot_integer_per_kwh_coerced_to_float():
+    """Issue #897: integer per_kwh (e.g. 0) also coerced to float for consistency."""
+    from custom_components.localshift.pricing.provider import AmberExpressProvider
+
+    provider = AmberExpressProvider()
+    raw = {
+        "start_time": "2026-03-16T10:00:01+00:00",
+        "end_time": "2026-03-16T10:30:00+00:00",
+        "per_kwh": 0,  # int (e.g. negative-price slot clamped to 0)
+        "demand_window": False,
+    }
+    slot = provider._normalize_slot(raw)
+
+    assert isinstance(slot.per_kwh, float)
+    assert slot.per_kwh == 0.0

--- a/tests/sensors/test_solcast.py
+++ b/tests/sensors/test_solcast.py
@@ -238,3 +238,47 @@ class TestForecastAccuracyComparisonSensor:
 
         sensor = ForecastAccuracyComparisonSensor(coordinator_with_analysis, Mock())
         assert sensor.entity_category == EntityCategory.DIAGNOSTIC
+
+    def test_zero_accuracy_is_not_treated_as_missing(self):
+        """Issue #892: accuracy of exactly 0.0 must NOT be collapsed to None.
+
+        ``if localshift_accuracy:`` treats 0.0 the same as None (unavailable),
+        so a genuinely-0% accuracy (terrible forecast, all samples wrong) is
+        misreported as the Solcast-only value or None. Use ``is not None``.
+        """
+        coordinator = Mock()
+        coordinator.data = Mock()
+        coordinator.data.solar_forecast_accuracy = 0.0  # Genuinely 0%
+        coordinator.data.solcast_mape = None
+        coordinator.data.low_confidence_periods = []
+
+        sensor = ForecastAccuracyComparisonSensor(coordinator, Mock())
+        sensor._update_from_coordinator()
+
+        # Must report 0.0 (the LocalShift value), NOT None or a Solcast fallback.
+        assert sensor.native_value == 0.0
+
+        attrs = sensor.extra_state_attributes
+        assert attrs["localshift_accuracy_pct"] == 0.0
+
+    def test_zero_accuracy_blended_with_solcast(self):
+        """Issue #892: 0.0 LocalShift + Solcast MAPE blends correctly.
+
+        Pre-fix the 0.0 was truthy-false so the blend branch was skipped and
+        only Solcast was reported. Post-fix both contribute.
+        """
+        coordinator = Mock()
+        coordinator.data = Mock()
+        coordinator.data.solar_forecast_accuracy = 0.0
+        coordinator.data.solcast_mape = 10.0  # 90% accuracy
+        coordinator.data.low_confidence_periods = []
+
+        sensor = ForecastAccuracyComparisonSensor(coordinator, Mock())
+        sensor._update_from_coordinator()
+
+        # Combined = (0.0 + 90.0) / 2 = 45.0
+        assert sensor.native_value == 45.0
+
+        attrs = sensor.extra_state_attributes
+        assert attrs["localshift_accuracy_pct"] == 0.0
+        assert attrs["divergence_pct"] == 90.0  # |0 - 90|

--- a/tests/test_battery_controller.py
+++ b/tests/test_battery_controller.py
@@ -6,6 +6,8 @@ import pytest
 
 from custom_components.localshift.integration.controller import BatteryController
 from custom_components.localshift.const import (
+    CONF_MINIMUM_TARGET_SOC,
+    DEFAULT_MINIMUM_TARGET_SOC,
     TESLEMETRY_EXPORT_BATTERY_OK,
     TESLEMETRY_EXPORT_PV_ONLY,
 )
@@ -42,8 +44,20 @@ def mock_get_entity_id():
 
 @pytest.fixture
 def battery_controller(mock_hass, mock_get_entity_id):
-    """Create a BatteryController instance."""
-    return BatteryController(mock_hass, mock_get_entity_id)
+    """Create a BatteryController instance.
+
+    Wired with a get_option_func so minimum_target_soc reads work (Issue #894).
+    Individual tests can override the option value by constructing their own
+    controller with a custom get_option_func.
+    """
+    options = {CONF_MINIMUM_TARGET_SOC: DEFAULT_MINIMUM_TARGET_SOC}
+
+    def get_option(key, default=None):
+        return options.get(key, default)
+
+    return BatteryController(
+        mock_hass, mock_get_entity_id, get_option_func=get_option
+    )
 
 
 @pytest.fixture
@@ -346,11 +360,9 @@ class TestSetForceDischarge:
             if "operation_mode" in entity_id:
                 state.state = "autonomous"
             elif "backup_reserve" in entity_id:
-                state.state = "10"
+                state.state = str(DEFAULT_MINIMUM_TARGET_SOC)
             elif "allow_export" in entity_id:
                 state.state = TESLEMETRY_EXPORT_BATTERY_OK
-            elif "minimum_target_soc" in entity_id:
-                state.state = "10"
             return state
 
         mock_hass.states.get = mock_get_state
@@ -415,9 +427,14 @@ class TestSetForceDischarge:
     @pytest.mark.asyncio
     @pytest.mark.usefixtures("mock_battery_sleep")
     async def test_set_force_discharge_uses_minimum_target_soc(
-        self, battery_controller, coordinator_data, mock_hass
+        self, coordinator_data, mock_hass, mock_get_entity_id
     ):
-        """Test that force discharge uses minimum_target_soc when no override."""
+        """Issue #894: force discharge reads minimum_target_soc from config option."""
+        controller = BatteryController(
+            mock_hass,
+            mock_get_entity_id,
+            get_option_func=lambda key, default=None: 15.0,
+        )
         mock_hass.services.async_call.return_value = None
 
         def mock_get_state(entity_id):
@@ -430,13 +447,11 @@ class TestSetForceDischarge:
                 state.state = "15"
             elif "allow_export" in entity_id:
                 state.state = TESLEMETRY_EXPORT_BATTERY_OK
-            elif "minimum_target_soc" in entity_id:
-                state.state = "15"
             return state
 
         mock_hass.states.get = mock_get_state
 
-        result = await battery_controller.set_force_discharge(coordinator_data)
+        result = await controller.set_force_discharge(coordinator_data)
 
         assert result is True
         # Should have used minimum_target_soc (15) for reserve
@@ -608,6 +623,41 @@ class TestSetProactiveExport:
                 break
         assert reserve_call is not None
         assert reserve_call[0][2]["value"] == 4  # max(4, 5-5) = max(4, 0) = 4
+
+    @pytest.mark.asyncio
+    @pytest.mark.usefixtures("mock_battery_sleep")
+    async def test_set_proactive_export_floors_reserve_at_minimum_target_when_soc_zero(
+        self, battery_controller, coordinator_data, mock_hass
+    ):
+        """Issue #895: SOC=0 floors reserve at minimum_target_soc, not 4%."""
+        mock_hass.services.async_call.return_value = None
+        coordinator_data.soc = 0.0  # Unavailable/empty SOC
+
+        def mock_get_state(entity_id):
+            if entity_id is None:
+                return None
+            state = MagicMock()
+            if "operation_mode" in entity_id:
+                state.state = "autonomous"
+            elif "backup_reserve" in entity_id:
+                state.state = str(DEFAULT_MINIMUM_TARGET_SOC)
+            elif "allow_export" in entity_id:
+                state.state = TESLEMETRY_EXPORT_BATTERY_OK
+            return state
+
+        mock_hass.states.get = mock_get_state
+
+        await battery_controller.set_proactive_export(coordinator_data)
+
+        calls = mock_hass.services.async_call.call_args_list
+        reserve_call = None
+        for call in calls:
+            if call[0][0] == "number" and call[0][1] == "set_value":
+                reserve_call = call
+                break
+        assert reserve_call is not None
+        # SOC=0 must floor at minimum_target_soc (20), not the dynamic 4.0.
+        assert reserve_call[0][2]["value"] == DEFAULT_MINIMUM_TARGET_SOC
 
     @pytest.mark.asyncio
     @pytest.mark.usefixtures("mock_battery_sleep")
@@ -1118,22 +1168,46 @@ class TestHelperMethods:
         assert result == "default"
 
     def test_get_minimum_target_soc(self, battery_controller, mock_hass):
-        """Test _get_minimum_target_soc reads from entity."""
-        state = MagicMock()
-        state.state = "15"
-        mock_hass.states.get = MagicMock(return_value=state)
-
+        """Issue #894: _get_minimum_target_soc reads the config option value."""
         result = battery_controller._get_minimum_target_soc()
 
-        assert result == 15.0
+        assert result == float(DEFAULT_MINIMUM_TARGET_SOC)
 
-    def test_get_minimum_target_soc_default(self, battery_controller, mock_hass):
-        """Test _get_minimum_target_soc returns default when unavailable."""
-        mock_hass.states.get = MagicMock(return_value=None)
+    def test_get_minimum_target_soc_uses_configured_option(
+        self, mock_hass, mock_get_entity_id
+    ):
+        """Issue #894: _get_minimum_target_soc returns the configured option."""
+        controller = BatteryController(
+            mock_hass,
+            mock_get_entity_id,
+            get_option_func=lambda key, default=None: 25.0,
+        )
 
-        result = battery_controller._get_minimum_target_soc()
+        assert controller._get_minimum_target_soc() == 25.0
 
-        assert result == 10.0
+    def test_get_minimum_target_soc_default(self, mock_hass, mock_get_entity_id):
+        """Issue #894: default is DEFAULT_MINIMUM_TARGET_SOC (20) without option func."""
+        controller = BatteryController(mock_hass, mock_get_entity_id)
+
+        result = controller._get_minimum_target_soc()
+
+        assert result == float(DEFAULT_MINIMUM_TARGET_SOC)
+
+    def test_get_minimum_target_soc_option_func_raises_falls_back(
+        self, mock_hass, mock_get_entity_id
+    ):
+        """Issue #894: a raising option func falls back to DEFAULT_MINIMUM_TARGET_SOC."""
+
+        def raising_option(key, default=None):
+            raise ValueError("uncoercible option")
+
+        controller = BatteryController(
+            mock_hass,
+            mock_get_entity_id,
+            get_option_func=raising_option,
+        )
+
+        assert controller._get_minimum_target_soc() == float(DEFAULT_MINIMUM_TARGET_SOC)
 
     def test_read_fresh_soc_success(self, battery_controller, mock_hass):
         """Issue #559 Phase 4: test read_fresh_soc() returns float on valid state."""

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -24,6 +24,7 @@ from custom_components.localshift.const import (
     CONF_SOLCAST_FORECAST_TODAY,
     CONF_SOLCAST_FORECAST_TOMORROW,
     CONF_SWITCHING_PENALTY_PER_KWH,
+    CONF_TARGET_PENALTY,
     CONF_TESLEMETRY_BACKUP_RESERVE,
     CONF_TESLEMETRY_BATTERY_POWER,
     CONF_TESLEMETRY_GRID_POWER,
@@ -616,6 +617,27 @@ class TestStaticMethods:
         flow = LocalShiftOptionsFlow()
         schema = flow._build_advanced_schema({})
         assert CONF_SWITCHING_PENALTY_PER_KWH in schema.schema
+
+    def test_advanced_schema_target_penalty_max_matches_threshold_ranges(self):
+        """Issue #898: the target_penalty slider max must match THRESHOLD_RANGES.
+
+        The options-flow NumberSelector capped at 0.100 while THRESHOLD_RANGES
+        (used by the NumberEntity) allowed 0.200. A user who set 0.15 via the
+        number entity was silently clamped to 0.100 on re-opening the options
+        flow. Assert the selector max matches the const.
+        """
+        from custom_components.localshift.const import THRESHOLD_RANGES
+
+        flow = LocalShiftOptionsFlow()
+        schema = flow._build_advanced_schema({})
+
+        expected_max = THRESHOLD_RANGES[CONF_TARGET_PENALTY]["max"]
+        for field, selector_obj in schema.schema.items():
+            field_key = getattr(field, "schema", field)
+            if field_key == CONF_TARGET_PENALTY:
+                assert selector_obj.config["max"] == expected_max
+                return
+        pytest.fail("target_penalty not found in advanced schema")
 
 
 # =============================================================================

--- a/tests/test_slots.py
+++ b/tests/test_slots.py
@@ -717,3 +717,77 @@ class TestProcessSingleSlot:
 
         assert ctx.is_demand_window_entry is True
         assert ctx.is_demand_window_slot is True
+
+    def test_process_single_slot_cross_midnight_demand_window(self, builder):
+        """Issue #896: overnight (cross-midnight) demand windows must match.
+
+        With start=22:00, end=06:00 the naive ``start <= t < end`` comparison is
+        false for every slot of the day, silently disabling the entire feature.
+        A 23:00 slot must be flagged in the window (>= start wraps past midnight).
+        """
+        from datetime import timezone
+        from zoneinfo import ZoneInfo
+
+        now = datetime.now(timezone.utc).replace(hour=23, minute=0)
+        slot = {
+            "start": now,
+            "interval_minutes": 30,
+            "price": 0.10,
+            "price_source": "30min",
+        }
+
+        data = MagicMock()
+        data.feed_in_forecast = []
+        data.load_forecast_slots = [0.5] * 96
+
+        ctx, _, in_dw = builder._process_single_slot(
+            i=0,
+            slot=slot,
+            data=data,
+            all_solcast=[],
+            solar_confidence_factor=1.0,
+            base_slot=now,
+            local_tz=ZoneInfo("UTC"),
+            dw_start_time=time(22, 0),
+            dw_end_time=time(6, 0),
+            prev_in_demand_window=False,
+        )
+
+        assert in_dw is True
+        assert ctx.is_demand_window_slot is True
+
+    def test_process_single_slot_normal_window_unaffected(self, builder):
+        """Issue #896: a non-wrapping window (start < end) is unaffected.
+
+        23:00 is outside the 18:00->22:00 window and must NOT be flagged.
+        """
+        from datetime import timezone
+        from zoneinfo import ZoneInfo
+
+        now = datetime.now(timezone.utc).replace(hour=23, minute=0)
+        slot = {
+            "start": now,
+            "interval_minutes": 30,
+            "price": 0.10,
+            "price_source": "30min",
+        }
+
+        data = MagicMock()
+        data.feed_in_forecast = []
+        data.load_forecast_slots = [0.5] * 96
+
+        ctx, _, in_dw = builder._process_single_slot(
+            i=0,
+            slot=slot,
+            data=data,
+            all_solcast=[],
+            solar_confidence_factor=1.0,
+            base_slot=now,
+            local_tz=ZoneInfo("UTC"),
+            dw_start_time=time(18, 0),
+            dw_end_time=time(22, 0),
+            prev_in_demand_window=False,
+        )
+
+        assert in_dw is False
+        assert ctx.is_demand_window_slot is False

--- a/tests/utils/test_costs.py
+++ b/tests/utils/test_costs.py
@@ -344,3 +344,18 @@ class TestAccumulateEnergyKwh:
         assert data.grid_to_battery_kwh_today == 0.0
         assert data.soc_gain_during_grid_charge_kwh_today == 0.0
         assert data.export_while_battery_not_full_kwh_today == 0.0
+
+    def test_reset_daily_accumulators_clears_last_soc_pct(self, cost_tracker):
+        """Issue #899: reset must clear _last_soc_pct to avoid cross-day smear.
+
+        Without this, a grid charge spanning midnight leaves _last_soc_pct at
+        the pre-midnight value, so the first post-midnight sample attributes
+        the overnight SOC gain to the new day's grid-charge-efficiency metric.
+        """
+        data = self._make_data(grid_power_kw=3.0, battery_power_kw=-2.0, soc=40.0)
+        cost_tracker.accumulate_costs(data)
+        assert cost_tracker._last_soc_pct == 40.0
+
+        cost_tracker.reset_daily_accumulators(data)
+
+        assert cost_tracker._last_soc_pct is None


### PR DESCRIPTION
## Summary

Re-implements 7 bug fixes that were originally PR'd in July (the #891-#900 batch) but never merged. Each was verified still-broken on current `test` before re-landing; the two that were already in-tree (#891, #900) were closed as superseded.

| Issue | Bug | Fix |
|-------|-----|-----|
| #894 | `minimum_target_soc` read from a phantom entity → silently fell back to 10% instead of the configured 20% | read via `get_option_func` (config option) |
| #895 | proactive-export reserve `max(4.0, SOC-5)` drained to 4% when SOC=0/unavailable | floor reserve at `minimum_target_soc` when SOC ≤ 0 |
| #896 | cross-midnight demand windows never matched (naive `start ≤ t < end` false all day) | wrap comparison for `end ≤ start` |
| #897 | `per_kwh` not coerced to float (string value broke downstream arithmetic) | `float(raw["per_kwh"])` |
| #898 | target_penalty slider capped at 0.100 while `THRESHOLD_RANGES` allows 0.200 | max → 0.200 |
| #899 | daily reset didn't clear `_last_soc_pct` → midnight grid-charge-efficiency smear | clear on reset |
| #892 | genuine 0.0% solar accuracy collapsed to "unavailable" (truthiness) | `is not None` checks |

## Changes

- 7 source files (`integration/controller.py`, `coordinator/coordinator.py`, `engine/slots.py`, `pricing/provider.py`, `config_flow/__init__.py`, `utils/costs.py`, `sensors/solcast.py`)
- 6 test files, ~12 new tests

## Testing

- [x] `ruff check` + `ruff format --check` (source) pass
- [x] `pyright` 0 errors
- [x] `pytest` 3583 passed, 1 xfailed, 96% coverage

## Related Issues

Closes #892, #894, #895, #896, #897, #898, #899