### PR TITLE
fix(optimizer): relieve futile-cycling penalty in a recovery day's distinct cheapest window (#918)

### DIFF
--- a/custom_components/localshift/engine/core.py
+++ b/custom_components/localshift/engine/core.py
@@ -33,6 +33,7 @@ from custom_components.localshift.engine.negative_fit import (
     derive_negative_fit_avoidance_context,
 )
 from custom_components.localshift.engine.penalties import (
+    cheap_recovery_charge_relief,
     get_futile_cycling_penalty_factor,
     get_solar_opportunity_penalty_factor,
 )
@@ -156,6 +157,19 @@ def _evaluate_action_cost(
         charge_kwh=charge_kwh,
         terminal_penalty_idx=terminal_penalty_idx,
     )
+    # Issue #918: on a recovery day (hard target floor active) with a genuinely
+    # distinct cheap window, charging at the day's minimum must not be pushed
+    # later by the futile-cycling penalty — that is exactly the mistiming the
+    # issue documents. Relief only fires inside the cheapest window of a day
+    # whose min is clearly below its median; flat-price days keep the full
+    # penalty (the #406 overnight-sawtooth guard).
+    if futile_factor > 0.0 and cheap_recovery_charge_relief(
+        slot_idx=slot_idx,
+        slots=slots,
+        config=config,
+        terminal_penalty_idx=terminal_penalty_idx,
+    ):
+        futile_factor = 0.0
 
     stage = _cost_stage_cost(
         action,
@@ -1577,6 +1591,15 @@ class DPPlanner:
                 charge_kwh=recon_charge_kwh,
                 terminal_penalty_idx=terminal_penalty_idx,
             )
+            # Issue #918: mirror the DP-pass relief here so the reconstructed
+            # plan's stage costs agree with the value function that chose them.
+            if recon_futile_factor > 0.0 and cheap_recovery_charge_relief(
+                slot_idx=slot_idx,
+                slots=slots,
+                config=config,
+                terminal_penalty_idx=terminal_penalty_idx,
+            ):
+                recon_futile_factor = 0.0
 
             stage = _cost_stage_cost(
                 action,

--- a/custom_components/localshift/engine/penalties.py
+++ b/custom_components/localshift/engine/penalties.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime
+from statistics import median
 from typing import Any
 
 from custom_components.localshift.engine.types import (
@@ -10,6 +11,56 @@ from custom_components.localshift.engine.types import (
     PlannerAction,
     SlotContext,
 )
+
+# Issue #918: a pre-DW price window counts as "distinct cheapest" only when the
+# day minimum sits at least this far below the pre-DW median — flat-price days
+# (the #406 sawtooth world) must NOT qualify, or the futile-cycling penalty that
+# suppresses overnight sawtooth charging would be disarmed.
+RECOVERY_WINDOW_SEPARATION = 0.03  # $/kWh below the pre-DW median
+# ...and relief applies only within this margin of the day minimum, matching the
+# issue's acceptance criterion (bulk charging within ~1c of the day-min).
+RECOVERY_WINDOW_PRICE_MARGIN = 0.01  # $/kWh above the day minimum
+
+
+def cheap_recovery_charge_relief(
+    *,
+    slot_idx: int,
+    slots: list[SlotContext],
+    config: OptimizerConfig,
+    terminal_penalty_idx: int | None,
+) -> bool:
+    """Issue #918: should the futile-cycling penalty stand down for this slot?
+
+    On a recovery day (``hard_target_floor`` set — grid charging is mandatory to
+    reach the demand-window target), charging at the day's cheapest hours is the
+    *right* plan, yet the futile-cycling penalty can price it as wasteful and push
+    the bulk charge 2-4 hours later at materially higher prices.
+
+    Relief is granted only when BOTH hold:
+
+    1. A **distinct cheapest window** exists: the pre-DW minimum is at least
+       ``RECOVERY_WINDOW_SEPARATION`` below the pre-DW median. Flat-price days
+       fail this test, so the #406 overnight-sawtooth guard stays armed.
+    2. This slot sits within ``RECOVERY_WINDOW_PRICE_MARGIN`` of that minimum.
+
+    Returns False when the hard target floor is dormant (solar can reach target),
+    leaving the penalty untouched in the normal self-consumption world.
+    """
+    if config.hard_target_floor is None or not slots:
+        return False
+    horizon_end = (
+        terminal_penalty_idx if terminal_penalty_idx is not None else len(slots)
+    )
+    prices = [
+        slot.buy_price for slot in slots[:horizon_end] if not slot.is_demand_window_slot
+    ]
+    if len(prices) < 2:
+        return False
+    day_min = min(prices)
+    day_median = median(prices)
+    if day_min > day_median - RECOVERY_WINDOW_SEPARATION:
+        return False  # no distinct cheap window (flat day) — penalty stays armed
+    return slots[slot_idx].buy_price <= day_min + RECOVERY_WINDOW_PRICE_MARGIN
 
 
 def get_solar_opportunity_penalty_factor(

--- a/tests/test_futile_cycling_penalty.py
+++ b/tests/test_futile_cycling_penalty.py
@@ -18,6 +18,7 @@ import pytest
 
 from custom_components.localshift.engine.cost import stage_cost
 from custom_components.localshift.engine.penalties import (
+    cheap_recovery_charge_relief,
     get_futile_cycling_penalty_factor,
 )
 from custom_components.localshift.engine.optimizer_dp import (
@@ -840,4 +841,101 @@ class TestLaterCheaperWindow:
         assert factor > 0.7, (
             f"Expected high futile factor (>0.7) when battery drains to min_soc "
             f"before cheaper window, got {factor:.3f}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Issue #918: recovery-mode suppression of futile cycling penalty
+# ---------------------------------------------------------------------------
+
+
+class TestRecoveryModeSuppression:
+    """Issue #918: on recovery days, charging in the day's distinct cheapest window
+    must not be punished as futile.
+
+    The relief is TARGETED: it fires only when a hard target floor is active AND the
+    pre-DW price profile has a *distinct* cheapest window (day-min well below the
+    median). On flat-price days — the #406 sawtooth world — there is no distinct
+    window, so the penalty stays fully armed and overnight sawtooth charging stays
+    suppressed.
+    """
+
+    def test_relief_in_distinct_cheapest_window(self):
+        """Recovery day with a real cheap window: slots at day-min get relief."""
+        config = OptimizerConfig(
+            battery_capacity_kwh=13.5,
+            demand_window_target_soc_pct=95.0,
+            min_soc_pct=10.0,
+            effective_cheap_price=0.14,
+            charge_efficiency=0.92,
+            discharge_efficiency=0.95,
+            hard_target_floor=85.0,  # recovery day: grid charge is mandatory
+        )
+        # Morning cheap window 0.13-0.14 vs afternoon 0.19-0.20 — the 25 Aug pattern.
+        # Enough afternoon slots that the day median (0.19) sits clearly above the
+        # cheap window; a 5-slot fixture leaves the median at 0.14 and the window
+        # is not "distinct".
+        slots = [
+            make_slot(0, 8, 0, buy_price=0.13, consumption_kwh=0.30),
+            make_slot(1, 8, 30, buy_price=0.13, consumption_kwh=0.30),
+            make_slot(2, 9, 0, buy_price=0.14, consumption_kwh=0.30),
+            make_slot(3, 12, 0, buy_price=0.19, consumption_kwh=0.30),
+            make_slot(4, 12, 30, buy_price=0.19, consumption_kwh=0.30),
+            make_slot(5, 13, 0, buy_price=0.20, consumption_kwh=0.30),
+            make_slot(6, 13, 30, buy_price=0.20, consumption_kwh=0.30),
+        ]
+        assert cheap_recovery_charge_relief(
+            slot_idx=0, slots=slots, config=config, terminal_penalty_idx=7
+        )
+        assert cheap_recovery_charge_relief(
+            slot_idx=2, slots=slots, config=config, terminal_penalty_idx=7
+        )
+        # Outside the cheapest window (12:00 at 0.19): no relief.
+        assert not cheap_recovery_charge_relief(
+            slot_idx=3, slots=slots, config=config, terminal_penalty_idx=7
+        )
+
+    def test_no_relief_on_flat_price_day(self):
+        """Flat prices (the #406 sawtooth world): no distinct window, no relief.
+
+        This is the guard that keeps overnight sawtooth charging suppressed —
+        blanket relief here would reopen #406.
+        """
+        config = OptimizerConfig(
+            battery_capacity_kwh=13.5,
+            demand_window_target_soc_pct=95.0,
+            min_soc_pct=10.0,
+            effective_cheap_price=0.16,
+            charge_efficiency=0.92,
+            discharge_efficiency=0.95,
+            hard_target_floor=85.0,
+        )
+        slots = [
+            make_slot(0, 22, 0, buy_price=0.16, consumption_kwh=0.25),
+            make_slot(1, 22, 30, buy_price=0.16, consumption_kwh=0.25),
+            make_slot(2, 23, 0, buy_price=0.16, consumption_kwh=0.25),
+            make_slot(3, 23, 30, buy_price=0.16, consumption_kwh=0.25),
+        ]
+        assert not cheap_recovery_charge_relief(
+            slot_idx=0, slots=slots, config=config, terminal_penalty_idx=4
+        )
+
+    def test_no_relief_when_floor_dormant(self):
+        """hard_target_floor None (solar can reach target): relief inactive —
+        the existing penalty behaviour is untouched."""
+        config = OptimizerConfig(
+            battery_capacity_kwh=13.5,
+            demand_window_target_soc_pct=95.0,
+            min_soc_pct=10.0,
+            effective_cheap_price=0.14,
+            charge_efficiency=0.92,
+            discharge_efficiency=0.95,
+            hard_target_floor=None,
+        )
+        slots = [
+            make_slot(0, 8, 0, buy_price=0.13, consumption_kwh=0.30),
+            make_slot(1, 12, 0, buy_price=0.19, consumption_kwh=0.30),
+        ]
+        assert not cheap_recovery_charge_relief(
+            slot_idx=0, slots=slots, config=config, terminal_penalty_idx=2
         )


### PR DESCRIPTION
## Summary

On recovery days (hard target floor active) the DP was deferring mandatory grid charging out of the day's cheapest window — 25 Aug charged 12:00-14:00 at 16-20c while the day's cheapest window sat at 13-14c. The futile-cycling penalty was punishing *early* cheap charging because the forward simulation sees the charge draining before a "useful period", pushing the charge later into more expensive slots.

## Fix

Targeted relief, not blanket suppression:

- **`penalties.py`** — new `cheap_recovery_charge_relief(...)`: returns True only when (a) `hard_target_floor` is active (recovery day), (b) the pre-DW price profile has a *distinct* cheapest window (day-min at least 3c below day-median), and (c) the slot's buy price is within 1c of the day-min (the issue's acceptance bar).
- **`core.py`** — wired at both futile-factor call sites (DP pass + forward reconstruction) so the value function and the realized plan agree.

Why targeted: a first attempt suppressed the penalty whenever the hard floor was set. That reopened #406 — flat-price overnight sawtooth charging — because the #406 world also sets the floor, and the futile penalty is the only guard there. The flat-day discriminator (min vs median) keeps that guard armed: on a flat day there is no distinct cheapest window, so no relief.

## Verification

- 3,544 tests green (3 new: distinct-window relief, flat-day no-relief (#406 guard), dormant-floor no-relief).
- `penalties.py` 97%, `core.py` 96% coverage; ruff clean.
- Risk files all pass: sawtooth/futile suite (28), soc_discretization (6), min_cycle_saving_gate (6).

## Relationship to other PRs

- PR #937 (#933 + #905 combined) is open against `test`; this PR is independent (penalties.py/core.py vs negative_fit.py/types.py) and based directly on current `test`.
- Root driver of mistimed recovery charging is solar over-forecast on cloudy days (#916, merged via #925) — this PR fixes the residual timing penalty once the charge is genuinely needed.

Closes #918