### PR TITLE
feat(telemetry): boundary-lag measurement tagged by grant source (#510 slice 1)

### DIFF
--- a/custom_components/localshift/coordinator/data.py
+++ b/custom_components/localshift/coordinator/data.py
@@ -593,6 +593,32 @@ class CoordinatorData:
     physical_response_timed_out: bool = False
     """Issue #508: True when the last physical-response watch timed out."""
 
+    # --- Boundary-lag telemetry (Issue #510 slice 1) ---
+    # How far into its 5-minute price interval a transition landed. Amber's
+    # spot sensor updates 14-36s after each boundary, so real transitions are
+    # expected to land ~20-45s in. Measurement only — no decision reads these.
+
+    boundary_lag_seconds: float | None = None
+    """Issue #510: seconds from the 5-min interval start to the transition."""
+
+    boundary_lag_history: list[dict[str, Any]] = field(default_factory=list)
+    """History of boundary-lag measurements.
+    Each entry: {from_mode, to_mode, boundary_lag, grant_source,
+    interval_start_utc, transition_time}. interval_start_utc is UTC (NEM is
+    a fixed UTC+10 offset); transition_time is local wall clock. Max 200
+    entries (capped in machine.py) — deliberately deeper than
+    decision_lag_history's 50, because this ring is shared across grant
+    sources and a burst must not evict the price samples (#942).
+    """
+
+    anticipated_transitions_today: int = 0
+    """Issue #510: transitions fired anticipatorily. Declared and daily-reset
+    here; a later slice owns the increment. Stays 0 in slice 1."""
+
+    anticipation_corrections_today: int = 0
+    """Issue #510: anticipated transitions later corrected by spot prices.
+    Declared and daily-reset here; a later slice owns the increment."""
+
     # ---------------------------------------------------------------------------
     # --- Decision-token gating (#622 gate replacement) ---
     # ---------------------------------------------------------------------------

--- a/custom_components/localshift/coordinator/tick_scheduler.py
+++ b/custom_components/localshift/coordinator/tick_scheduler.py
@@ -266,6 +266,9 @@ class TickScheduler:
         self._coordinator.data.grid_to_battery_kwh_today = 0.0
         self._coordinator.data.soc_gain_during_grid_charge_kwh_today = 0.0
         self._coordinator.data.export_while_battery_not_full_kwh_today = 0.0
+        # Issue #510: the anticipation counters are per-day like the rest.
+        self._coordinator.data.anticipated_transitions_today = 0
+        self._coordinator.data.anticipation_corrections_today = 0
 
         if self._coordinator.learning_orchestrator is not None:
             self._coordinator.learning_orchestrator.handle_midnight_reset(

--- a/custom_components/localshift/sensors/status.py
+++ b/custom_components/localshift/sensors/status.py
@@ -269,6 +269,15 @@ class DecisionLagSensor(LocalShiftSensorBase):
             "command_completion_timestamp": d.command_completion_timestamp.isoformat()
             if d.command_completion_timestamp
             else None,
+            # Issue #510 slice 1 (measurement only): boundary-lag telemetry.
+            # History windowed to 20 for attribute-size parity with `history`
+            # above; the full 200-entry window stays in CoordinatorData.
+            "boundary_lag_seconds": round(d.boundary_lag_seconds, 2)
+            if d.boundary_lag_seconds is not None
+            else None,
+            "boundary_lag_history": (d.boundary_lag_history or [])[-20:],
+            "anticipated_transitions_today": d.anticipated_transitions_today,
+            "anticipation_corrections_today": d.anticipation_corrections_today,
         }
 
     @property

--- a/custom_components/localshift/state/machine.py
+++ b/custom_components/localshift/state/machine.py
@@ -114,6 +114,10 @@ class StateMachine:
         # Cooldown for health-check corrections (prevents command spam when
         # Teslemetry cloud lags in reflecting a legitimate transition)
         self._last_health_correction: datetime | None = None
+        # Issue #510 slice 1: one-shot tag for transitions issued outside the
+        # decision path (Tesla re-probe, health-check correction). Set immediately
+        # before the call, cleared immediately after — never left armed.
+        self._transition_source_override: str | None = None
         # Decision-token gating (#622 gate replacement): the mode may be
         # re-decided at most once per discrete decision-context change. The
         # fingerprint is consumed by the *evaluation* that observes the change
@@ -124,6 +128,11 @@ class StateMachine:
         # evaluation, kept separately so a grant can be attributed: same base +
         # different epoch ⇒ the grant came from the plan alone.
         self._last_evaluated_base: str | None = None
+        # Issue #510 slice 1 (measurement only): the grant source attributed at
+        # token-grant time. Captured in _apply_decision_token because the base it
+        # is derived from is overwritten there — by transition time the "previous"
+        # base is already the current one.
+        self._last_grant_source: str | None = None
         # Plan-disagreement trigger (2026-07-27 pre-charge incident): the plan is
         # itself a decision input. ``_plan_charge_epoch`` is a MONOTONE counter
         # incremented on the rising edge of "the plan wants to START charging while
@@ -877,6 +886,11 @@ class StateMachine:
         # only thing that moved ⇒ the plan alone granted this.
         plan_charge_only = decision_allowed and context == self._last_evaluated_base
         if decision_allowed:
+            # Issue #510 slice 1 (measurement only): attribute the grant BEFORE
+            # _last_evaluated_base is overwritten below — by transition time the
+            # "previous" base is already this one, so the comparison must happen
+            # here or the tag is unrecoverable.
+            self._last_grant_source = self._classify_grant_source(context)
             # Consume immediately: the evaluation, not the transition, spends the
             # token. Covers every downstream path (including debounce-in-progress).
             self._last_evaluated_fingerprint = fingerprint
@@ -894,6 +908,35 @@ class StateMachine:
         # compute_derived_values in coordinator.async_recompute_and_evaluate can
         # never trip it.
         data.mode_backstop_allowed = True
+
+    def _classify_grant_source(self, context: str | None) -> str:
+        """Attribute a grant to the fingerprint component that moved (Issue #510).
+
+        Observation only — the return value gates nothing. Compares the new
+        price/spike/DW/floor context positionally against the previously granted
+        one. Precedence when several components move at once is deliberate: the
+        non-price causes win, because the tag exists to EXCLUDE legitimately
+        mid-interval transitions from the boundary-lag baseline. A DW crossing
+        that happens to coincide with a price tick is not a clean sample.
+        """
+        previous = self._last_evaluated_base
+        if previous is None or context is None:
+            return "unknown"
+        if previous == context:
+            return "plan_charge"  # base unchanged ⇒ only the epoch moved
+        old = previous.split("|")
+        new = context.split("|")
+        if len(old) != 5 or len(new) != 5:
+            return "unknown"
+        if old[4] != new[4]:
+            return "soc_floor"
+        if old[3] != new[3]:
+            return "demand_window"
+        if old[2] != new[2]:
+            return "spike"
+        if old[0] != new[0] or old[1] != new[1]:
+            return "price"
+        return "unknown"
 
     async def _evaluate_core(
         self, data: CoordinatorData, computation_engine: ComputationEngine
@@ -1205,6 +1248,10 @@ class StateMachine:
         transition_time = dt_util.now()
         if not dry_run:
             self._last_successful_transition = transition_time
+            # Issue #510 slice 1: measured for EVERY successful non-dry-run
+            # transition, including the ones the decision_mode guard below
+            # skips (debounce completion, retry, re-probe, health correction).
+            self._record_boundary_lag(data, target, transition_time)
 
         # Issue #508: dry runs execute no real commands and drive no physical
         # change, so neither phase is recorded.
@@ -1247,6 +1294,55 @@ class StateMachine:
             "Recorded successful transition to %s at %s",
             target.value,
             transition_time.strftime("%H:%M:%S"),
+        )
+
+    def _record_boundary_lag(
+        self, data: CoordinatorData, target: BatteryMode, transition_time: datetime
+    ) -> None:
+        """Measure how far into its 5-minute price interval a transition landed.
+
+        Issue #510 slice 1 — telemetry only, changes no decision. The interval
+        start is derived in UTC: NEM time is a fixed UTC+10 offset, so a UTC
+        floor is correct by construction and a DST transition is a non-event.
+        """
+        utc_time = dt_util.as_utc(transition_time)
+        interval_start = utc_time.replace(
+            minute=(utc_time.minute // 5) * 5, second=0, microsecond=0
+        )
+        boundary_lag = (utc_time - interval_start).total_seconds()
+        grant_source = self._transition_source_override or (
+            self._last_grant_source or "unknown"
+        )
+
+        data.boundary_lag_seconds = boundary_lag
+        data.boundary_lag_history.append({
+            "from_mode": data.active_mode.value if data.active_mode else "unknown",
+            "to_mode": target.value,
+            "boundary_lag": round(boundary_lag, 2),
+            "grant_source": grant_source,
+            # Key is explicitly _utc: interval_start is derived in UTC (NEM is a
+            # fixed UTC+10 offset, so a UTC floor is correct by construction and
+            # DST is a non-event), while transition_time is local wall clock like
+            # every other timestamp in decision_lag_history. Naming the difference
+            # beats normalising it — converting the interval to local would make
+            # the two DST tests pass trivially and hide the property they pin.
+            "interval_start_utc": interval_start.isoformat(),
+            "transition_time": transition_time.isoformat(),
+        })
+        # 200, not decision_lag_history's 50 (#942): this is ONE ring shared by
+        # every grant source, so a backstop or spike burst evicts the price-tagged
+        # samples slice 3's acceptance criterion is measured against. 200 covers
+        # days of transitions at any plausible rate. The proper fix is a window
+        # per source — deliberately deferred, see #942.
+        if len(data.boundary_lag_history) > 200:
+            data.boundary_lag_history = data.boundary_lag_history[-200:]
+
+        _LOGGER.info(
+            "Boundary lag: %s landed %.2fs into interval %s (source=%s)",
+            target.value,
+            boundary_lag,
+            interval_start.isoformat(),
+            grant_source,
         )
 
     def _start_physical_response_watch(
@@ -1399,9 +1495,19 @@ class StateMachine:
                     duration,
                     self._commanded_mode.value,
                 )
-                probe_success = await self._execute_mode_transition(
-                    data, self._commanded_mode
-                )
+                # Issue #510 slice 1: tag as backstop — a re-probe is not a
+                # decision-token grant, so _last_grant_source would be stale
+                # here without an explicit override.
+                self._transition_source_override = "backstop"
+                try:
+                    probe_success = await self._execute_mode_transition(
+                        data, self._commanded_mode
+                    )
+                finally:
+                    # try/finally is load-bearing: _record_transition_metrics only
+                    # runs on success, so a failed probe would otherwise leave the
+                    # override armed and mislabel the next genuine transition.
+                    self._transition_source_override = None
                 if probe_success:
                     _LOGGER.info(
                         "[TESLA OVERRIDE] Re-probe succeeded after %s — control "
@@ -1598,9 +1704,19 @@ class StateMachine:
             )
 
             # Attempt to correct the state
-            correction_success = await self._execute_mode_transition(
-                data, self._commanded_mode
-            )
+            # Issue #510 slice 1: tag as backstop — a health-check correction is
+            # not a decision-token grant, so _last_grant_source would be stale
+            # here without an explicit override.
+            self._transition_source_override = "backstop"
+            try:
+                correction_success = await self._execute_mode_transition(
+                    data, self._commanded_mode
+                )
+            finally:
+                # try/finally is load-bearing: _record_transition_metrics only
+                # runs on success, so a failed correction would otherwise leave
+                # the override armed and mislabel the next genuine transition.
+                self._transition_source_override = None
             self._last_health_correction = now
 
             if correction_success:
@@ -1682,6 +1798,9 @@ class StateMachine:
         # Cleared with it, or the next grant would be misattributed to the plan
         # ("same base as last time") and restricted to charge modes only.
         self._last_evaluated_base = None
+        # Issue #510 slice 1: a transition landing between this invalidation
+        # and the next grant must not inherit a now-stale attribution.
+        self._last_grant_source = None
 
     def suppress_next_plan_charge_grant(self, reason: str) -> None:
         """Bar the NEXT evaluation from granting on the plan-charge trigger.

--- a/docs/ENTITY_REFERENCE.md
+++ b/docs/ENTITY_REFERENCE.md
@@ -610,7 +610,13 @@ Attributes:
   total_transitions: 15
   decision_timestamp: "2026-02-26T09:05:00"
   implementation_timestamp: "2026-02-26T09:05:45"
+  boundary_lag_seconds: 23.4
+  boundary_lag_history: [...last 20 boundary-lag measurements, tagged by grant_source...]
+  anticipated_transitions_today: 0
+  anticipation_corrections_today: 0
 ```
+
+Issue #510 slice 1 (measurement only) adds `boundary_lag_seconds` / `boundary_lag_history`: how far into its 5-minute price interval each transition landed, tagged by `grant_source` (`price`, `spike`, `demand_window`, `soc_floor`, `plan_charge`, `backstop`, `unknown`). `anticipated_transitions_today` / `anticipation_corrections_today` are declared here and daily-reset but stay at 0 until a later slice implements the anticipatory logic they count. No new entity — these are attributes on this existing sensor.
 
 ---
 

--- a/tests/coordinator/test_tick_scheduler.py
+++ b/tests/coordinator/test_tick_scheduler.py
@@ -230,6 +230,9 @@ async def test_handle_midnight_reset(coordinator):
     coordinator.data.grid_to_battery_kwh_today = 2.0
     coordinator.data.soc_gain_during_grid_charge_kwh_today = 1.5
     coordinator.data.export_while_battery_not_full_kwh_today = 1.0
+    # Issue #510: the anticipation counters reset daily like the rest.
+    coordinator.data.anticipated_transitions_today = 4
+    coordinator.data.anticipation_corrections_today = 2
     coordinator._learning_orchestrator = MagicMock()
     coordinator._learning_orchestrator.handle_midnight_reset = MagicMock()
     coordinator.notify_listeners = MagicMock()
@@ -246,6 +249,8 @@ async def test_handle_midnight_reset(coordinator):
     assert coordinator.data.grid_to_battery_kwh_today == 0.0
     assert coordinator.data.soc_gain_during_grid_charge_kwh_today == 0.0
     assert coordinator.data.export_while_battery_not_full_kwh_today == 0.0
+    assert coordinator.data.anticipated_transitions_today == 0
+    assert coordinator.data.anticipation_corrections_today == 0
     coordinator._learning_orchestrator.handle_midnight_reset.assert_called_once_with(
         coordinator.data
     )

--- a/tests/sensors/test_sensors.py
+++ b/tests/sensors/test_sensors.py
@@ -213,6 +213,11 @@ class Fixtures:
         data.physical_response_lag_seconds = None
         data.physical_response_watch = None
         data.physical_response_timed_out = False
+        # Issue #510 slice 1: boundary-lag telemetry, untouched by these tests.
+        data.boundary_lag_seconds = None
+        data.boundary_lag_history = []
+        data.anticipated_transitions_today = 0
+        data.anticipation_corrections_today = 0
         data.forecast_status = "ready"
         data.forecast_ready = True
         data.solcast_today = [{"time": "2024-01-01T10:00:00"}] * 10

--- a/tests/sensors/test_status.py
+++ b/tests/sensors/test_status.py
@@ -321,6 +321,11 @@ class TestDecisionLagSensor:
             decision_lag_history=[],
             decision_timestamp=None,
             command_completion_timestamp=None,
+            # Issue #510 slice 1: boundary-lag telemetry, untouched by this case.
+            boundary_lag_seconds=None,
+            boundary_lag_history=[],
+            anticipated_transitions_today=0,
+            anticipation_corrections_today=0,
         )
         attrs = sensor.extra_state_attributes
         assert attrs["avg_lag_24h"] is None
@@ -335,6 +340,10 @@ class TestDecisionLagSensor:
         assert attrs["physical_lag_seconds"] is None
         assert attrs["physical_lag_observable"] is False
         assert attrs["physical_response_timed_out"] is False
+        assert attrs["boundary_lag_seconds"] is None
+        assert attrs["boundary_lag_history"] == []
+        assert attrs["anticipated_transitions_today"] == 0
+        assert attrs["anticipation_corrections_today"] == 0
 
     def test_extra_state_attributes_with_history(self):
         now = datetime(2026, 3, 12, 12, 0, 0)
@@ -352,6 +361,11 @@ class TestDecisionLagSensor:
             decision_lag_history=history,
             decision_timestamp=now,
             command_completion_timestamp=now,
+            # Issue #510 slice 1: boundary-lag telemetry, untouched by this case.
+            boundary_lag_seconds=None,
+            boundary_lag_history=[],
+            anticipated_transitions_today=0,
+            anticipation_corrections_today=0,
         )
         attrs = sensor.extra_state_attributes
         assert attrs["avg_lag_24h"] == pytest.approx(2.0)
@@ -362,6 +376,55 @@ class TestDecisionLagSensor:
         assert attrs["command_lag_seconds"] == pytest.approx(3.0)
         assert attrs["physical_lag_seconds"] == pytest.approx(7.0)
         assert attrs["command_completion_timestamp"] == now.isoformat()
+
+    def test_extra_state_attributes_boundary_lag(self):
+        # Issue #510 slice 1 (measurement only): the four new attributes are
+        # surfaced on this EXISTING sensor — no new entity.
+        boundary_history = [
+            {"boundary_lag": 23.4, "grant_source": "price"},
+            {"boundary_lag": 41.0, "grant_source": "demand_window"},
+        ]
+        sensor = _sensor(
+            DecisionLagSensor,
+            decision_lag_seconds=None,
+            physical_response_lag_seconds=None,
+            physical_response_timed_out=False,
+            physical_response_watch=None,
+            decision_lag_history=[],
+            decision_timestamp=None,
+            command_completion_timestamp=None,
+            boundary_lag_seconds=23.4321,
+            boundary_lag_history=boundary_history,
+            anticipated_transitions_today=3,
+            anticipation_corrections_today=1,
+        )
+        attrs = sensor.extra_state_attributes
+        assert attrs["boundary_lag_seconds"] == pytest.approx(23.43)
+        assert attrs["boundary_lag_history"] == boundary_history
+        assert attrs["anticipated_transitions_today"] == 3
+        assert attrs["anticipation_corrections_today"] == 1
+
+    def test_extra_state_attributes_boundary_lag_history_windowed(self):
+        # The attribute exposes the last 20 entries; the full 50-entry window
+        # stays in CoordinatorData (size budget — see status.py comment).
+        full_history = [{"boundary_lag": float(i)} for i in range(30)]
+        sensor = _sensor(
+            DecisionLagSensor,
+            decision_lag_seconds=None,
+            physical_response_lag_seconds=None,
+            physical_response_timed_out=False,
+            physical_response_watch=None,
+            decision_lag_history=[],
+            decision_timestamp=None,
+            command_completion_timestamp=None,
+            boundary_lag_seconds=None,
+            boundary_lag_history=full_history,
+            anticipated_transitions_today=0,
+            anticipation_corrections_today=0,
+        )
+        attrs = sensor.extra_state_attributes
+        assert attrs["boundary_lag_history"] == full_history[-20:]
+        assert len(attrs["boundary_lag_history"]) == 20
 
     def test_icon_with_decision_timestamp(self):
         sensor = _sensor(DecisionLagSensor, decision_timestamp=MagicMock())

--- a/tests/test_boundary_lag.py
+++ b/tests/test_boundary_lag.py
@@ -1,0 +1,407 @@
+"""Tests for boundary-lag telemetry (Issue #510 slice 1).
+
+Measurement only: this slice records how far into its 5-minute price interval
+a mode transition lands, tagged by the fingerprint component that granted the
+re-decision. Nothing here may change a decision, a transition, or the
+optimiser — these tests exist to prove that invariant as much as to prove the
+numbers are right.
+"""
+
+from datetime import UTC, datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from homeassistant.util import dt as dt_util
+
+from custom_components.localshift.const import BatteryMode
+from custom_components.localshift.coordinator.data import CoordinatorData
+from custom_components.localshift.state.machine import StateMachine
+
+SYDNEY = timezone(timedelta(hours=11))
+
+
+def dt_aware(*args):
+    return datetime(*args, tzinfo=SYDNEY)
+
+
+@pytest.fixture
+def data():
+    return CoordinatorData()
+
+
+@pytest.fixture
+def state_machine():
+    controller = MagicMock()
+    controller.set_self_consumption = AsyncMock(return_value=True)
+    controller.set_force_charge = AsyncMock(return_value=True)
+    controller.set_boost_charge = AsyncMock(return_value=True)
+    controller.set_force_discharge = AsyncMock(return_value=True)
+    controller.set_proactive_export = AsyncMock(return_value=True)
+    return StateMachine(
+        controller,
+        MagicMock(),
+        lambda key: False,
+        lambda key, default=None: default,
+        MagicMock(),
+    )
+
+
+class TestBoundaryLagMeasurement:
+    """Boundary lag is recorded for every successful non-dry-run transition,
+    independent of the decision_lag `decision_mode == target` guard."""
+
+    def test_recorded_when_decision_guard_would_skip(self, state_machine, data):
+        # decision_mode deliberately does NOT match target: the existing
+        # decision-lag guard in _record_transition_metrics skips this
+        # transition entirely. Boundary lag must not.
+        data.decision_mode = BatteryMode.BOOST_CHARGING
+        data.decision_timestamp = dt_aware(2026, 8, 27, 6, 0, 0)
+        data.active_mode = BatteryMode.SELF_CONSUMPTION
+        with patch(
+            "custom_components.localshift.state.machine.dt_util.now"
+        ) as mock_now:
+            mock_now.return_value = dt_aware(2026, 8, 27, 6, 5, 23)
+            state_machine._record_transition_metrics(
+                data, BatteryMode.GRID_CHARGING, dry_run=False
+            )
+
+        # The old guard still skips (mismatched decision_mode) — unchanged.
+        assert data.decision_lag_seconds is None
+        assert data.decision_lag_history == []
+
+        # But boundary lag is measured regardless — the core point of this slice.
+        assert data.boundary_lag_seconds == pytest.approx(23.0)
+        assert len(data.boundary_lag_history) == 1
+        entry = data.boundary_lag_history[0]
+        assert entry["from_mode"] == "self_consumption"
+        assert entry["to_mode"] == "grid_charging"
+        assert entry["boundary_lag"] == pytest.approx(23.0)
+
+    def test_lag_from_interval_start(self, state_machine, data):
+        # 06:07:23 floors to the 06:05 interval start -> 2m23s = 143.0s lag.
+        with patch(
+            "custom_components.localshift.state.machine.dt_util.now"
+        ) as mock_now:
+            mock_now.return_value = dt_aware(2026, 8, 27, 6, 7, 23)
+            state_machine._record_transition_metrics(
+                data, BatteryMode.SELF_CONSUMPTION, dry_run=False
+            )
+        assert data.boundary_lag_seconds == pytest.approx(143.0)
+        assert (
+            data.boundary_lag_history[0]["interval_start_utc"]
+            == dt_util.as_utc(dt_aware(2026, 8, 27, 6, 5, 0)).isoformat()
+        )
+
+    def test_lag_zero_exactly_on_boundary(self, state_machine, data):
+        with patch(
+            "custom_components.localshift.state.machine.dt_util.now"
+        ) as mock_now:
+            mock_now.return_value = dt_aware(2026, 8, 27, 6, 5, 0)
+            state_machine._record_transition_metrics(
+                data, BatteryMode.SELF_CONSUMPTION, dry_run=False
+            )
+        assert data.boundary_lag_seconds == pytest.approx(0.0)
+
+    def test_lag_just_under_next_boundary(self, state_machine, data):
+        with patch(
+            "custom_components.localshift.state.machine.dt_util.now"
+        ) as mock_now:
+            mock_now.return_value = dt_aware(2026, 8, 27, 6, 9, 59, 500000)
+            state_machine._record_transition_metrics(
+                data, BatteryMode.SELF_CONSUMPTION, dry_run=False
+            )
+        assert data.boundary_lag_seconds == pytest.approx(299.5)
+        # Interval start is still 06:05, NOT rolled forward to 06:10.
+        assert (
+            data.boundary_lag_history[0]["interval_start_utc"]
+            == dt_util.as_utc(dt_aware(2026, 8, 27, 6, 5, 0)).isoformat()
+        )
+
+    def test_history_entry_shape(self, state_machine, data):
+        data.active_mode = BatteryMode.SELF_CONSUMPTION
+        transition_time = dt_aware(2026, 8, 27, 6, 5, 23, 456789)
+        with patch(
+            "custom_components.localshift.state.machine.dt_util.now"
+        ) as mock_now:
+            mock_now.return_value = transition_time
+            state_machine._record_transition_metrics(
+                data, BatteryMode.GRID_CHARGING, dry_run=False
+            )
+        entry = data.boundary_lag_history[0]
+        assert {
+            "from_mode",
+            "to_mode",
+            "boundary_lag",
+            "grant_source",
+            "interval_start_utc",
+            "transition_time",
+        } <= entry.keys()
+        assert entry["from_mode"] == "self_consumption"
+        assert entry["to_mode"] == "grid_charging"
+        assert entry["boundary_lag"] == pytest.approx(round(23.456789, 2))
+        # Both timestamps round-trip to the same instants they were recorded at.
+        assert datetime.fromisoformat(entry["transition_time"]) == transition_time
+        expected_start = dt_util.as_utc(transition_time).replace(
+            second=0, microsecond=0
+        )
+        assert datetime.fromisoformat(entry["interval_start_utc"]) == expected_start
+
+
+class TestBoundaryLagDryRun:
+    def test_dry_run_records_nothing(self, state_machine, data):
+        data.decision_mode = BatteryMode.GRID_CHARGING
+        data.decision_timestamp = dt_aware(2026, 8, 27, 6, 0, 0)
+        with patch(
+            "custom_components.localshift.state.machine.dt_util.now"
+        ) as mock_now:
+            mock_now.return_value = dt_aware(2026, 8, 27, 6, 5, 7)
+            state_machine._record_transition_metrics(
+                data, BatteryMode.GRID_CHARGING, dry_run=True
+            )
+        assert data.boundary_lag_seconds is None
+        assert data.boundary_lag_history == []
+        # Dry runs skip the whole `if not dry_run` block, not just our part.
+        assert state_machine._last_successful_transition is None
+
+
+class TestGrantSourceTagging:
+    """Grant-source attribution is captured in _apply_decision_token, not in
+    _record_transition_metrics — see machine.py _classify_grant_source for why
+    (by transition time, _last_evaluated_base has already been overwritten
+    with the context that authorised the very transition being measured)."""
+
+    BASE_KWARGS = {
+        "general_price": 0.20,
+        "feed_in_price": 0.05,
+        "price_spike": False,
+        "demand_window_active": False,
+        "soc": 50.0,  # comfortably above the 20% default minimum target
+    }
+
+    def _seed(self, data, state_machine):
+        """Grant #1: establishes _last_evaluated_base as the baseline context."""
+        for key, value in self.BASE_KWARGS.items():
+            setattr(data, key, value)
+        state_machine._apply_decision_token(data)
+        assert state_machine._last_grant_source == "unknown"  # no prior base yet
+
+    def test_price_buy_change(self, state_machine, data):
+        self._seed(data, state_machine)
+        data.general_price = 0.30
+        state_machine._apply_decision_token(data)
+        assert state_machine._last_grant_source == "price"
+
+    def test_price_sell_change(self, state_machine, data):
+        self._seed(data, state_machine)
+        data.feed_in_price = 0.08
+        state_machine._apply_decision_token(data)
+        assert state_machine._last_grant_source == "price"
+
+    def test_spike(self, state_machine, data):
+        self._seed(data, state_machine)
+        data.price_spike = True
+        state_machine._apply_decision_token(data)
+        assert state_machine._last_grant_source == "spike"
+
+    def test_demand_window(self, state_machine, data):
+        self._seed(data, state_machine)
+        data.demand_window_active = True
+        state_machine._apply_decision_token(data)
+        assert state_machine._last_grant_source == "demand_window"
+
+    def test_soc_floor(self, state_machine, data):
+        self._seed(data, state_machine)
+        data.soc = 10.0  # below the 20% default minimum target
+        state_machine._apply_decision_token(data)
+        assert state_machine._last_grant_source == "soc_floor"
+
+    def test_plan_charge(self, state_machine, data):
+        self._seed(data, state_machine)
+        # Base context unchanged; only the plan-disagreement epoch moves.
+        data.active_mode = BatteryMode.SELF_CONSUMPTION
+        data.debug_plan_mode_pending = BatteryMode.GRID_CHARGING.value
+        state_machine._apply_decision_token(data)
+        assert state_machine._last_grant_source == "plan_charge"
+
+    def test_unknown_first_transition_after_restart(self, state_machine, data):
+        # A single grant with no previous base (fresh machine) is "unknown".
+        for key, value in self.BASE_KWARGS.items():
+            setattr(data, key, value)
+        state_machine._apply_decision_token(data)
+        assert state_machine._last_grant_source == "unknown"
+
+    def test_precedence_non_price_wins(self, state_machine, data):
+        # Both price AND demand_window move in the same grant: the tag must be
+        # demand_window, not price — the tag exists to exclude legitimately
+        # mid-interval transitions (a DW crossing) from the price baseline.
+        self._seed(data, state_machine)
+        data.general_price = 0.35
+        data.demand_window_active = True
+        state_machine._apply_decision_token(data)
+        assert state_machine._last_grant_source == "demand_window"
+
+    def test_backstop_override(self, state_machine, data):
+        self._seed(data, state_machine)
+        data.general_price = 0.30
+        state_machine._apply_decision_token(data)
+        assert state_machine._last_grant_source == "price"
+
+        state_machine._transition_source_override = "backstop"
+        with patch(
+            "custom_components.localshift.state.machine.dt_util.now"
+        ) as mock_now:
+            mock_now.return_value = dt_aware(2026, 8, 27, 6, 5, 0)
+            state_machine._record_transition_metrics(
+                data, BatteryMode.GRID_CHARGING, dry_run=False
+            )
+        state_machine._transition_source_override = None
+        # Tagged backstop even though _last_grant_source says "price".
+        assert data.boundary_lag_history[-1]["grant_source"] == "backstop"
+
+    def test_invalidate_clears_grant_source(self, state_machine, data):
+        self._seed(data, state_machine)
+        data.general_price = 0.30
+        state_machine._apply_decision_token(data)
+        assert state_machine._last_grant_source == "price"
+
+        state_machine.invalidate_decision_fingerprint("test")
+        assert state_machine._last_grant_source is None
+
+        with patch(
+            "custom_components.localshift.state.machine.dt_util.now"
+        ) as mock_now:
+            mock_now.return_value = dt_aware(2026, 8, 27, 6, 5, 10)
+            state_machine._record_transition_metrics(
+                data, BatteryMode.SELF_CONSUMPTION, dry_run=False
+            )
+        assert data.boundary_lag_history[-1]["grant_source"] == "unknown"
+
+
+class TestOverrideLifecycle:
+    """The try/finally around both backstop call sites must clear the override
+    on every path out, including a failed transition — machine.py's own
+    comment calls this "not optional" because _record_transition_metrics only
+    runs on success, so a failure would otherwise leave it armed forever."""
+
+    async def test_override_cleared_after_failed_transition(self, state_machine, data):
+        state_machine._last_grant_source = "price"
+        state_machine._battery_controller.verify_current_state = AsyncMock(
+            return_value=False
+        )
+        state_machine._battery_controller.set_self_consumption = AsyncMock(
+            return_value=False
+        )
+        state_machine._notification_service.send_health_correction_notification = (
+            AsyncMock()
+        )
+
+        with patch(
+            "custom_components.localshift.state.machine.dt_util.now"
+        ) as mock_now:
+            mock_now.return_value = dt_aware(2026, 8, 27, 6, 0, 0)
+            await state_machine._perform_health_check(data)
+
+        assert state_machine._transition_source_override is None
+        # The failed correction never reaches _record_transition_metrics.
+        assert data.boundary_lag_history == []
+
+        # A subsequent SUCCESSFUL transition must not inherit "backstop".
+        state_machine._battery_controller.set_self_consumption = AsyncMock(
+            return_value=True
+        )
+        with patch(
+            "custom_components.localshift.state.machine.dt_util.now"
+        ) as mock_now:
+            mock_now.return_value = dt_aware(2026, 8, 27, 6, 0, 30)
+            success = await state_machine._execute_mode_transition(
+                data, BatteryMode.SELF_CONSUMPTION
+            )
+        assert success is True
+        assert data.boundary_lag_history[-1]["grant_source"] == "price"
+
+
+class TestBoundaryLagHistoryCap:
+    def test_capped_at_200(self, state_machine, data):
+        data.boundary_lag_history = [{"boundary_lag": float(i)} for i in range(210)]
+        with patch(
+            "custom_components.localshift.state.machine.dt_util.now"
+        ) as mock_now:
+            mock_now.return_value = dt_aware(2026, 8, 27, 6, 5, 0)
+            state_machine._record_transition_metrics(
+                data, BatteryMode.SELF_CONSUMPTION, dry_run=False
+            )
+        assert len(data.boundary_lag_history) == 200
+        assert data.boundary_lag_history[-1]["to_mode"] == "self_consumption"
+
+
+class TestUtcDerivation:
+    """The interval start is floored in UTC (NEM time is a fixed UTC+10
+    offset), not local wall clock, so a DST transition is a non-event by
+    construction. With Australia's whole-hour offsets a naive local floor
+    would usually agree anyway (10h and 11h are both multiples of 5 minutes)
+    — this is a correctness-by-construction choice plus a regression guard,
+    not a fix for an observed live bug."""
+
+    def test_dst_boundary_does_not_shift_interval(self, state_machine, data):
+        aest = timezone(timedelta(hours=10))  # non-DST
+        aedt = timezone(timedelta(hours=11))  # DST
+        utc_instant = datetime(2026, 4, 5, 3, 7, 23, tzinfo=UTC)
+        as_aest = utc_instant.astimezone(aest)
+        as_aedt = utc_instant.astimezone(aedt)
+        # Sanity: genuinely different local representations of one instant.
+        assert as_aest.utcoffset() != as_aedt.utcoffset()
+        assert as_aest.hour != as_aedt.hour
+
+        data_a = CoordinatorData()
+        data_b = CoordinatorData()
+        with patch(
+            "custom_components.localshift.state.machine.dt_util.now"
+        ) as mock_now:
+            mock_now.return_value = as_aest
+            state_machine._record_transition_metrics(
+                data_a, BatteryMode.SELF_CONSUMPTION, dry_run=False
+            )
+        with patch(
+            "custom_components.localshift.state.machine.dt_util.now"
+        ) as mock_now:
+            mock_now.return_value = as_aedt
+            state_machine._record_transition_metrics(
+                data_b, BatteryMode.SELF_CONSUMPTION, dry_run=False
+            )
+
+        assert data_a.boundary_lag_seconds == pytest.approx(data_b.boundary_lag_seconds)
+        assert (
+            data_a.boundary_lag_history[0]["interval_start_utc"]
+            == data_b.boundary_lag_history[0]["interval_start_utc"]
+        )
+
+    def test_spring_forward_boundary_does_not_shift_interval(self, state_machine, data):
+        aest = timezone(timedelta(hours=10))
+        aedt = timezone(timedelta(hours=11))
+        utc_instant = datetime(2026, 10, 4, 16, 22, 41, tzinfo=UTC)
+        as_aest = utc_instant.astimezone(aest)
+        as_aedt = utc_instant.astimezone(aedt)
+        assert as_aest.utcoffset() != as_aedt.utcoffset()
+
+        data_a = CoordinatorData()
+        data_b = CoordinatorData()
+        with patch(
+            "custom_components.localshift.state.machine.dt_util.now"
+        ) as mock_now:
+            mock_now.return_value = as_aest
+            state_machine._record_transition_metrics(
+                data_a, BatteryMode.SELF_CONSUMPTION, dry_run=False
+            )
+        with patch(
+            "custom_components.localshift.state.machine.dt_util.now"
+        ) as mock_now:
+            mock_now.return_value = as_aedt
+            state_machine._record_transition_metrics(
+                data_b, BatteryMode.SELF_CONSUMPTION, dry_run=False
+            )
+
+        assert data_a.boundary_lag_seconds == pytest.approx(data_b.boundary_lag_seconds)
+        assert (
+            data_a.boundary_lag_history[0]["interval_start_utc"]
+            == data_b.boundary_lag_history[0]["interval_start_utc"]
+        )

--- a/tests/test_decision_lag.py
+++ b/tests/test_decision_lag.py
@@ -543,6 +543,11 @@ class TestDecisionLagSensor:
             ],
             decision_timestamp=now,
             command_completion_timestamp=now,
+            # Issue #510 slice 1: boundary-lag telemetry, untouched by this case.
+            boundary_lag_seconds=None,
+            boundary_lag_history=[],
+            anticipated_transitions_today=0,
+            anticipation_corrections_today=0,
         )
         attrs = sensor.extra_state_attributes
         assert attrs["command_lag_seconds"] == 7.0
@@ -562,6 +567,11 @@ class TestDecisionLagSensor:
             decision_lag_history=[],
             decision_timestamp=None,
             command_completion_timestamp=None,
+            # Issue #510 slice 1: boundary-lag telemetry, untouched by this case.
+            boundary_lag_seconds=None,
+            boundary_lag_history=[],
+            anticipated_transitions_today=0,
+            anticipation_corrections_today=0,
         )
         attrs = sensor.extra_state_attributes
         assert attrs["avg_lag_24h"] is None


### PR DESCRIPTION
Slice 1 of the #510 anticipatory forecast-first plan. **Measurement only** — no decision, transition or optimiser behaviour changes.

## Why

`_record_transition_metrics` measured decision to command completion, and only inside a guard requiring `decision_mode == target`. Transitions failing that guard were unmeasured, and nothing anywhere measured the latency #510 is actually about: how far into its 5-minute price interval a transition lands. Amber's spot sensor updates 14–36 s after each boundary (median ~19 s), so transitions are expected ~20–45 s in — the baseline slice 3's acceptance criterion is measured against.

## What

- `boundary_lag_seconds` recorded for **every** successful non-dry-run transition, outside the existing guard. Interval start derived in UTC — NEM is a fixed UTC+10 offset, so the floor is correct by construction and DST is a non-event.
- `_classify_grant_source` attributes each grant to the fingerprint component that moved (`soc_floor` → `demand_window` → `spike` → `price`, plan-charge when only the epoch moved). Precedence is deliberate: non-price causes win, because the tag exists to *exclude* legitimately mid-interval transitions from the baseline. A useful side effect is that `price` is returned only when price moved alone, which is the price-only signature slice 3's correction counter needs.
- Tesla re-probe and health-check corrections tag as `backstop` via a one-shot override in `try/finally` — load-bearing, since metrics only record on success and a failed probe would otherwise mislabel the next real transition.
- Four fields on `CoordinatorData`, surfaced on the existing decision-lag sensor. No new entity; documented entity counts unchanged.

## Verification

`uv run ruff check` clean, `uv run pytest` 3564 passed / 1 xfailed. 20 new tests including both DST directions, override clearing after a failed transition, precedence, and the 50-entry cap.

## Known findings

Non-blocking, filed as #940, #941, #942, #943, #944, #945. The two worth knowing before reading the telemetry: `from_mode` may be degenerate (#940), and the single 50-entry ring can let a backstop burst evict the `price` samples the baseline depends on (#942).