### PR TITLE
fix(slot_schedule): price plan slot 0 from the entry covering now (#510 slice 2)

### DIFF
--- a/custom_components/localshift/engine/slot_schedule.py
+++ b/custom_components/localshift/engine/slot_schedule.py
@@ -17,6 +17,91 @@ TOTAL_SLOTS = 96  # 24 hours × 4 slots/hour
 # Maximum number of 5-minute slots to use from Amber near-term forecast
 MAX_5MIN_FORECAST_HOURS = 1  # Amber typically provides ~45-60 min of 5-min data
 
+# Issue #510 Slice 2: Amber's detailedForecast starts each interval one second
+# after the boundary (the 12:30 interval starts at 12:30:01). Absorb that
+# offset when deciding which interval covers "now" — but only if it really is
+# boundary noise, so a genuinely mid-interval start keeps its own boundary.
+# Why 60s: Amber's observed offset is +1s (the 12:30 interval starts at
+# 12:30:01), so this is ~60x margin — wide enough to absorb provider clock
+# skew without ever reaching the next 5-minute boundary. If the offset were
+# ever to exceed this, the covering entry stops being recognised and slot 0
+# falls back to the synthetic next-interval borrow: the exact defect this
+# slice removes. That failure is loud, not silent — it trips the
+# SYNTHETIC SLOT FALLBACK warning below — but it is the reason to keep this
+# generous rather than tighten it toward the observed +1s.
+_BOUNDARY_OFFSET_TOLERANCE_S = 60
+
+
+def _interval_origin(slot_start: datetime, duration_minutes: int) -> datetime:
+    """Return the true interval boundary for an entry's start time.
+
+    Floors slot_start down to the nearest duration_minutes boundary, but only
+    treats that floor as the real origin when slot_start is within
+    _BOUNDARY_OFFSET_TOLERANCE_S of it — a few seconds of provider clock skew,
+    not a genuinely different (misaligned) start time.
+
+    Args:
+        slot_start: Entry's parsed start time
+        duration_minutes: Entry's duration (5 or 30)
+
+    Returns:
+        The interval's true boundary, or slot_start unchanged if it is not
+        boundary noise.
+
+    """
+    floored = slot_start.replace(
+        minute=(slot_start.minute // duration_minutes) * duration_minutes,
+        second=0,
+        microsecond=0,
+    )
+    if (slot_start - floored).total_seconds() < _BOUNDARY_OFFSET_TOLERANCE_S:
+        return floored
+    return slot_start
+
+
+def _covers_now(
+    slot_start: datetime, duration_minutes: int, now_local: datetime
+) -> bool:
+    """Return True if this entry's interval contains now_local.
+
+    Only 5- and 30-minute entries are eligible — 60-minute entries always
+    return False here, which keeps _split_60min_slot's split-then-drop
+    behaviour for the current hour completely unchanged (see module docstring
+    constraint: 60-min path is untouched by Issue #510 Slice 2).
+
+    Args:
+        slot_start: Entry's parsed start time
+        duration_minutes: Entry's duration (5, 30, or 60)
+        now_local: Current local time
+
+    Returns:
+        True if [interval origin, interval origin + duration) contains now.
+
+    """
+    if duration_minutes not in (5, 30):
+        return False
+    origin = _interval_origin(slot_start, duration_minutes)
+    return origin <= now_local < origin + timedelta(minutes=duration_minutes)
+
+
+def _floor_to_5min(moment: datetime) -> datetime:
+    """Floor a datetime down to the nearest 5-minute wall-clock boundary.
+
+    Shared by the stale-sensor synthetic fallback and by the current-slot
+    re-anchoring in `_parse_single_entry`, so the two "what does a 5-minute
+    'now' slot look like" formulas can never drift apart.
+
+    Args:
+        moment: The datetime to floor.
+
+    Returns:
+        moment with minute rounded down to a multiple of 5 and seconds/
+        microseconds zeroed.
+
+    """
+    current_5min = (moment.minute // 5) * 5
+    return moment.replace(minute=current_5min, second=0, microsecond=0)
+
 
 def compute_hybrid_slot_schedule(
     now_local: datetime,
@@ -45,7 +130,16 @@ def compute_hybrid_slot_schedule(
             - start: datetime of slot start
             - interval_minutes: 5 or 30
             - price: price in $/kWh
-            - price_source: "5min" or "30min"
+            - price_source: "forecast_current" (the entry whose interval covers
+              now), "5min", "30min", or "synthetic" (stale-sensor fallback used
+              only when no entry covers now). A covering 30-min entry is
+              re-anchored to a 5-minute "now" quantum rather than kept at its
+              own 30-min width, so slot 0's width never exceeds 5 minutes
+              regardless of the feed's native granularity — see
+              `_parse_single_entry`.
+            - estimate: bool | None, the covering entry's Amber `estimate` flag
+              (True pre-settlement, False once settled; None on synthetic or
+              60-min-derived slots)
         - metadata: Dict with:
             - timezone: HA timezone
             - slot_intervals: {"5min": count, "30min": count}
@@ -81,6 +175,17 @@ def compute_hybrid_slot_schedule(
     )
 
     _ensure_current_slot_coverage(slots, now_local)
+
+    if slots:
+        _LOGGER.info(
+            "SLOT0_CURRENT: start=%s interval=%dmin price=%.4f source=%s estimate=%s",
+            slots[0]["start"].isoformat(),
+            slots[0]["interval_minutes"],
+            slots[0]["price"],
+            slots[0]["price_source"],
+            slots[0].get("estimate"),
+        )
+
     _compute_slot_metadata(slots, metadata, transition_boundary)
 
     return slots, metadata
@@ -151,11 +256,19 @@ def _parse_single_entry(
         return None
 
     slot_start = parse_slot_time(start_time_str, ha_timezone)
-    if slot_start is None or slot_start < now_local:
+    if slot_start is None:
         return None
 
     duration_minutes = _get_entry_duration(entry, slot_start, ha_timezone)
     if duration_minutes is None or duration_minutes not in (5, 30, 60):
+        return None
+
+    # Issue #510 Slice 2: an entry whose interval covers "now" is retained as
+    # the current slot even though its raw (pre-floor) start may read as
+    # slightly in the past — that's the +1s Amber offset, not staleness. An
+    # entry is only dropped once its interval has genuinely elapsed.
+    is_current = _covers_now(slot_start, duration_minutes, now_local)
+    if not is_current and slot_start < now_local:
         return None
 
     price = float(entry.get("per_kwh", 0))
@@ -163,11 +276,46 @@ def _parse_single_entry(
     if duration_minutes == 60:
         return _split_60min_slot(slot_start, price)
 
+    if is_current and duration_minutes == 30:
+        # SCOPE NOTE (#510): this branch is OUT OF SCOPE per the spec's
+        # Non-goals — "5-min price sites only … 30-min support is out of
+        # scope". On a 5-minute Amber feed the entry covering "now" is
+        # always a 5-minute one, so this branch is unreachable on the site
+        # this was built for and has never been validated against live
+        # 30-minute data. Kept because the reasoning below is sound and it
+        # costs nothing dormant; re-verify against a real 30-minute feed
+        # before relying on it.
+        # Review feedback on #510 Slice 2: retaining this entry at its own
+        # 30-minute width would make slot 0 up to 30 minutes wide no matter
+        # how far into the interval "now" actually is (e.g. still the full
+        # 30-min slot with ten seconds of real time left in it). Every DP
+        # energy term scales by slot width (slot_hours = interval_minutes /
+        # 60), so a mostly-elapsed slot 0 lets the optimiser book
+        # charge/discharge time that no longer exists, and it drags
+        # core.py's DW-runway anchor (minutes_to_dw) and the published
+        # precharge_runway_quantum_min back with it by the same amount.
+        # Re-anchor slot 0 to the same 5-minute "now" quantum the
+        # stale-sensor fallback below already uses, priced from this real
+        # covering entry instead of a synthetic borrowed price — the brief
+        # asked for the covering entry's PRICE, not for slot 0 to grow to
+        # 30 minutes wide. A covering 5-min entry is already at (or under)
+        # that quantum, so it keeps its own start/width untouched below.
+        return {
+            "start": _floor_to_5min(now_local),
+            "interval_minutes": 5,
+            "price": price,
+            "price_source": "forecast_current",
+            "estimate": entry.get("estimate"),
+        }
+
     return {
         "start": slot_start,
         "interval_minutes": duration_minutes,
         "price": price,
-        "price_source": "5min" if duration_minutes == 5 else "30min",
+        "price_source": "forecast_current"
+        if is_current
+        else ("5min" if duration_minutes == 5 else "30min"),
+        "estimate": entry.get("estimate"),
     }
 
 
@@ -320,7 +468,13 @@ def _add_all_30min_slots(
 
 
 def _ensure_current_slot_coverage(slots: list[dict], now_local: datetime) -> None:
-    """Ensure there's a slot covering 'now' by adding synthetic slot if needed.
+    """Ensure there's a slot covering 'now' by adding a synthetic slot if needed.
+
+    Issue #510 Slice 2: this is the stale-sensor FALLBACK, not the steady
+    state. In normal operation _parse_single_entry already retains the real
+    forecast entry covering "now" as slot 0 (price_source="forecast_current"),
+    so this function is a no-op. It only fires when no entry covers now at
+    all — e.g. the price sensor's forecast has gone stale.
 
     Args:
         slots: Slot list (modified in place)
@@ -330,19 +484,20 @@ def _ensure_current_slot_coverage(slots: list[dict], now_local: datetime) -> Non
     if not slots:
         return
 
+    covers_now = _covers_now(slots[0]["start"], slots[0]["interval_minutes"], now_local)
+
     _LOGGER.info(
         "HYBRID_SLOTS: slots=%d, first_slot=%s, now_local=%s, comparison=%s",
         len(slots),
         slots[0]["start"].strftime("%H:%M:%S"),
         now_local.strftime("%H:%M:%S"),
-        "first > now" if slots[0]["start"] > now_local else "first <= now",
+        "covers now" if covers_now else "does not cover now",
     )
 
-    if slots[0]["start"] <= now_local:
+    if covers_now:
         return
 
-    current_5min = (now_local.minute // 5) * 5
-    synthetic_start = now_local.replace(minute=current_5min, second=0, microsecond=0)
+    synthetic_start = _floor_to_5min(now_local)
     estimated_price = slots[0]["price"] if slots else 0.0
 
     synthetic_slot = {
@@ -353,8 +508,10 @@ def _ensure_current_slot_coverage(slots: list[dict], now_local: datetime) -> Non
     }
     slots.insert(0, synthetic_slot)
 
-    _LOGGER.info(
-        "Created synthetic slot at %s (Amber first slot was at %s, gap=%.0fs)",
+    _LOGGER.warning(
+        "SYNTHETIC SLOT FALLBACK: no forecast entry covers %s (first entry %s, "
+        "gap=%.0fs) — price borrowed from the next interval; check the price "
+        "sensor for staleness",
         synthetic_start.strftime("%H:%M:%S"),
         slots[1]["start"].strftime("%H:%M:%S") if len(slots) > 1 else "N/A",
         (slots[1]["start"] - synthetic_start).total_seconds() if len(slots) > 1 else 0,

--- a/custom_components/localshift/engine/types.py
+++ b/custom_components/localshift/engine/types.py
@@ -124,7 +124,7 @@ class SlotContext:
     """True if this slot falls within the demand window."""
 
     price_source: str = "unknown"
-    """Source of price data (e.g. '5min', '30min', 'synthetic')."""
+    """Source of price data (e.g. 'forecast_current', '5min', '30min', 'synthetic')."""
 
 
 # -----------------------------------------------------------------------------

--- a/custom_components/localshift/pricing/provider.py
+++ b/custom_components/localshift/pricing/provider.py
@@ -78,6 +78,7 @@ class _ProviderMixin:
             per_kwh=raw["per_kwh"],
             is_spike=self.is_spike(raw),  # type: ignore[attr-defined]
             source_type=self.name,  # type: ignore[attr-defined]
+            estimate=raw.get("estimate"),
         )
 
     def _infer_duration_minutes(self, raw: dict[str, Any]) -> int:

--- a/custom_components/localshift/pricing/types.py
+++ b/custom_components/localshift/pricing/types.py
@@ -23,6 +23,10 @@ class ForecastSlot:
     per_kwh: float
     is_spike: bool
     source_type: str
+    # Issue #510 Slice 2: Amber's settlement-estimate flag for this interval —
+    # True before the interval settles, False once actual. None when the
+    # source entry didn't carry one (e.g. synthetic/extended slots).
+    estimate: bool | None = None
 
     def get(self, key: str, default: Any = None) -> Any:
         """Dict-compatible accessor for backward compatibility.

--- a/tests/engine/test_slot_schedule_current_coverage.py
+++ b/tests/engine/test_slot_schedule_current_coverage.py
@@ -1,0 +1,252 @@
+"""Tests for Issue #510 Slice 2: retain the forecast entry covering "now".
+
+Before this fix, `_parse_single_entry` dropped any forecast entry whose
+`slot_start < now_local`. Amber's `detailedForecast` entries carry a +1
+second offset on their start times (the 12:30 interval starts at
+12:30:01), so the entry covering the CURRENT interval was always one
+second in the past and always dropped. `_ensure_current_slot_coverage`
+then synthesised slot 0 and priced it from the first SURVIVING entry --
+the NEXT interval -- so plan slot 0 was priced from the wrong interval at
+every evaluation.
+
+These tests pin the fix: an entry whose interval covers `now_local` (after
+flooring its start to the interval boundary) is retained as slot 0 with
+`price_source="forecast_current"`, carrying its own price and its Amber
+`estimate` flag. The synthetic slot becomes a stale-sensor fallback that
+fires only when no entry covers "now" at all.
+
+All entries below build dicts with an explicit `duration` field. Without
+it, `get_slot_duration_minutes` would fall back to computing duration from
+raw start_time/end_time deltas -- and a :01-offset 5-minute entry spans
+299 seconds, which floors to 4 minutes and gets rejected by the
+`duration_minutes not in (5, 30, 60)` guard for an unrelated reason. In
+production this never happens because providers normalize to ForecastSlot
+objects with duration already resolved (see AmberExpressProvider); tests
+must supply it explicitly to exercise the coverage predicate itself.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+
+from custom_components.localshift.engine.slot_schedule import (
+    compute_hybrid_slot_schedule,
+)
+
+AEDT = timezone(timedelta(hours=11))
+
+
+def _entry(
+    start_time: str, duration: int, price: float, *, estimate: bool | None = None
+) -> dict:
+    """Build a raw forecast entry dict with an explicit duration."""
+    entry: dict = {"start_time": start_time, "duration": duration, "per_kwh": price}
+    if estimate is not None:
+        entry["estimate"] = estimate
+    return entry
+
+
+class TestCurrentIntervalRetainedAsSlot0:
+    """An entry whose interval covers "now" becomes slot 0, priced from itself."""
+
+    def test_5min_entry_covering_now_retained_as_slot0(self):
+        """5-min entry covering now is slot 0, priced at its own (not the next) price."""
+        entries = [
+            _entry("2026-03-16T12:30:01+11:00", 5, 0.10),
+            _entry("2026-03-16T12:35:01+11:00", 5, 0.11),
+            _entry("2026-03-16T12:40:01+11:00", 5, 0.12),
+        ]
+        now = datetime(2026, 3, 16, 12, 33, 0, tzinfo=AEDT)
+
+        slots, _metadata = compute_hybrid_slot_schedule(
+            now, entries, "Australia/Sydney"
+        )
+
+        assert slots[0]["price_source"] == "forecast_current"
+        assert slots[0]["price"] == 0.10  # its OWN price, not 0.11 borrowed
+        assert slots[0]["start"].minute == 30
+        assert slots[0]["interval_minutes"] == 5
+
+    def test_30min_entry_covering_now_retained_as_slot0(self):
+        """30-min entry covering now prices slot 0, re-anchored to a 5-min quantum.
+
+        Review feedback on the first cut of this fix: retaining the covering
+        entry at its own 30-minute width (start=12:30:01, interval=30) made
+        slot 0 up to 30 minutes wide, no matter how far into the interval
+        "now" actually was. Every DP energy term scales by slot width
+        (slot_hours = interval_minutes / 60), so a mostly-elapsed slot 0 let
+        the optimiser book charge/discharge time that no longer existed, and
+        it dragged core.py's DW-runway anchor and published
+        precharge_runway_quantum_min back by up to 30 minutes instead of 5.
+        The fix re-anchors slot 0 to the same 5-minute "now" quantum the
+        stale-sensor fallback already uses, priced from the covering entry.
+        """
+        entries = [
+            _entry("2026-03-16T12:30:01+11:00", 30, 0.20),
+            _entry("2026-03-16T13:00:01+11:00", 30, 0.25),
+        ]
+        now = datetime(2026, 3, 16, 12, 47, 0, tzinfo=AEDT)
+
+        slots, _metadata = compute_hybrid_slot_schedule(
+            now, entries, "Australia/Sydney"
+        )
+
+        assert slots[0]["price_source"] == "forecast_current"
+        assert slots[0]["price"] == 0.20  # its OWN price, not 0.25 borrowed
+        # Re-anchored to the 5-min "now" quantum (floor(12:47, 5) = 12:45),
+        # NOT left at the covering entry's own 30-min-wide start (12:30).
+        assert slots[0]["start"] == datetime(2026, 3, 16, 12, 45, 0, tzinfo=AEDT)
+        assert slots[0]["interval_minutes"] == 5
+
+    def test_30min_entry_near_interval_end_stays_bounded_to_5min_quantum(self):
+        """Regression: seconds before a 30-min interval ends, slot 0 must not claim 30 minutes.
+
+        This is the exact shape the review feedback caught: at now=12:59:50,
+        ten seconds before the 12:30-13:00 interval ends, the covering entry
+        must NOT be retained as a 30-min-wide slot 0 (which would tell the
+        optimiser it still has ten seconds *plus thirty minutes* to work
+        with). Slot 0 stays a bounded 5-minute quantum, correctly priced from
+        the covering (12:30) entry rather than the upcoming (13:00) one.
+        """
+        entries = [
+            _entry("2026-03-16T12:30:01+11:00", 30, 0.20),
+            _entry("2026-03-16T13:00:01+11:00", 30, 0.25),
+        ]
+        now = datetime(2026, 3, 16, 12, 59, 50, tzinfo=AEDT)
+
+        slots, _metadata = compute_hybrid_slot_schedule(
+            now, entries, "Australia/Sydney"
+        )
+
+        assert slots[0]["price_source"] == "forecast_current"
+        assert slots[0]["price"] == 0.20  # still the covering (12:30) entry
+        assert slots[0]["interval_minutes"] == 5  # NOT 30 -- the regression
+        assert slots[0]["start"] == datetime(2026, 3, 16, 12, 55, 0, tzinfo=AEDT)
+        # The slot's claimed end (12:55 + 5min = 13:00) never runs past the
+        # real interval boundary, so the DP is never handed elapsed time.
+        slot_end = slots[0]["start"] + timedelta(minutes=slots[0]["interval_minutes"])
+        assert slot_end == datetime(2026, 3, 16, 13, 0, 0, tzinfo=AEDT)
+
+    def test_one_second_offset_does_not_drop_current_interval(self):
+        """Regression: the +1s Amber offset must not push the current entry out.
+
+        This is the exact bug: with a naive `slot_start < now_local` check,
+        the 12:30:01 entry reads as "1 second in the past" relative to
+        anything after 12:30:01, and gets dropped -- forcing a synthetic
+        slot priced from the *next* interval. This test fails on main.
+        """
+        entries = [
+            _entry("2026-03-16T12:30:01+11:00", 5, 0.10),
+            _entry("2026-03-16T12:35:01+11:00", 5, 0.11),
+        ]
+        now = datetime(2026, 3, 16, 12, 30, 30, tzinfo=AEDT)
+
+        slots, _metadata = compute_hybrid_slot_schedule(
+            now, entries, "Australia/Sydney"
+        )
+
+        assert all(s["price_source"] != "synthetic" for s in slots)
+        assert slots[0]["start"] == datetime(2026, 3, 16, 12, 30, 1, tzinfo=AEDT)
+        assert slots[0]["price"] == 0.10
+
+
+class TestSyntheticFallback:
+    """The synthetic slot is a stale-sensor fallback, not the steady state."""
+
+    def test_synthetic_fallback_fires_only_when_no_entry_covers_now(self):
+        """No entry covers now -> synthetic slot borrows the first real entry's price."""
+        entries = [_entry("2026-03-16T12:45:01+11:00", 5, 0.30)]
+        now = datetime(2026, 3, 16, 12, 33, 0, tzinfo=AEDT)
+
+        slots, _metadata = compute_hybrid_slot_schedule(
+            now, entries, "Australia/Sydney"
+        )
+
+        assert slots[0]["price_source"] == "synthetic"
+        assert slots[0]["price"] == 0.30  # borrowed from the first real entry
+        assert slots[1]["start"] == datetime(2026, 3, 16, 12, 45, 1, tzinfo=AEDT)
+
+    def test_covered_case_produces_no_synthetic_slot(self):
+        """Paired with the above: when an entry DOES cover now, no synthetic slot exists."""
+        entries = [
+            _entry("2026-03-16T12:30:01+11:00", 5, 0.10),
+            _entry("2026-03-16T12:35:01+11:00", 5, 0.11),
+        ]
+        now = datetime(2026, 3, 16, 12, 33, 0, tzinfo=AEDT)
+
+        slots, _metadata = compute_hybrid_slot_schedule(
+            now, entries, "Australia/Sydney"
+        )
+
+        assert not any(s["price_source"] == "synthetic" for s in slots)
+
+
+class TestElapsedEntriesStillDropped:
+    """Entries whose interval has genuinely ended are still dropped, as today."""
+
+    def test_fully_elapsed_entry_is_dropped(self):
+        """An entry whose 5-min interval ended before now is dropped, not retained."""
+        entries = [
+            _entry("2026-03-16T12:25:01+11:00", 5, 0.05),  # ended 12:30, elapsed
+            _entry("2026-03-16T12:30:01+11:00", 5, 0.10),  # covers now
+        ]
+        now = datetime(2026, 3, 16, 12, 33, 0, tzinfo=AEDT)
+
+        slots, _metadata = compute_hybrid_slot_schedule(
+            now, entries, "Australia/Sydney"
+        )
+
+        assert all(s["start"].minute != 25 for s in slots)
+        assert slots[0]["price_source"] == "forecast_current"
+        assert slots[0]["price"] == 0.10
+
+    def test_60min_entries_unchanged_by_covering_predicate(self):
+        """Guard against re-enabling coverage-flooring for 60-min entries.
+
+        A 60-min entry starting at 12:00 nominally still "contains" now
+        (12:33) if you floor to the hour -- exactly the shape `_covers_now`
+        must reject via its `duration_minutes not in (5, 30)` guard. If that
+        guard were ever removed, this entry would get retained and handed to
+        `_split_60min_slot`, which would produce a slot 0 already half an
+        hour in the past -- a new bug. Today's (unchanged) rule for 60-min
+        entries is a plain `slot_start < now_local` compare, so it is
+        dropped exactly like it is on main. A second, future entry is
+        included so parsing doesn't return empty outright and the
+        stale-sensor synthetic fallback actually runs.
+        """
+        entries = [
+            _entry("2026-03-16T12:00:00+11:00", 60, 0.40),
+            _entry("2026-03-16T13:00:01+11:00", 30, 0.22),
+        ]
+        now = datetime(2026, 3, 16, 12, 33, 0, tzinfo=AEDT)
+
+        slots, _metadata = compute_hybrid_slot_schedule(
+            now, entries, "Australia/Sydney"
+        )
+
+        assert all(s["start"].hour != 12 or s["start"].minute != 0 for s in slots)
+        assert slots[0]["price_source"] == "synthetic"
+
+
+class TestEstimateFlag:
+    """The covering entry's Amber `estimate` flag is carried through to slot 0."""
+
+    def test_estimate_flag_carried_to_slot0(self, caplog):
+        """estimate=False on the covering entry lands on slots[0] and in the log line."""
+        entries = [
+            _entry("2026-03-16T12:30:01+11:00", 5, 0.10, estimate=False),
+            _entry("2026-03-16T12:35:01+11:00", 5, 0.11, estimate=True),
+        ]
+        now = datetime(2026, 3, 16, 12, 33, 0, tzinfo=AEDT)
+
+        with caplog.at_level(logging.INFO):
+            slots, _metadata = compute_hybrid_slot_schedule(
+                now, entries, "Australia/Sydney"
+            )
+
+        assert slots[0]["estimate"] is False
+        assert any(
+            "SLOT0_CURRENT" in record.message and "estimate=False" in record.message
+            for record in caplog.records
+        )

--- a/tests/pricing/test_pricing_types.py
+++ b/tests/pricing/test_pricing_types.py
@@ -1,6 +1,8 @@
 """Tests for pricing types."""
 
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
+
+import pytest
 
 from custom_components.localshift.pricing.types import ForecastSlot
 
@@ -8,7 +10,7 @@ from custom_components.localshift.pricing.types import ForecastSlot
 def test_forecast_slot_creation():
     """Test ForecastSlot can be created with required fields."""
     slot = ForecastSlot(
-        start_time=datetime(2026, 3, 16, 12, 0, tzinfo=timezone.utc),
+        start_time=datetime(2026, 3, 16, 12, 0, tzinfo=UTC),
         duration=30,
         per_kwh=0.15,
         is_spike=False,
@@ -22,17 +24,14 @@ def test_forecast_slot_creation():
 def test_forecast_slot_is_frozen():
     """Test ForecastSlot is immutable (frozen dataclass)."""
     slot = ForecastSlot(
-        start_time=datetime(2026, 3, 16, 12, 0, tzinfo=timezone.utc),
+        start_time=datetime(2026, 3, 16, 12, 0, tzinfo=UTC),
         duration=30,
         per_kwh=0.15,
         is_spike=False,
         source_type="amber",
     )
-    try:
+    with pytest.raises(AttributeError):
         slot.per_kwh = 0.20
-        assert False, "Should not be able to modify frozen dataclass"
-    except AttributeError:
-        pass
 
 
 class TestForecastSlotGetMethod:
@@ -41,16 +40,14 @@ class TestForecastSlotGetMethod:
     def test_get_existing_fields(self):
         """Test .get() returns existing field values."""
         slot = ForecastSlot(
-            start_time=datetime(2026, 3, 16, 10, 0, tzinfo=timezone.utc),
+            start_time=datetime(2026, 3, 16, 10, 0, tzinfo=UTC),
             duration=30,
             per_kwh=0.25,
             is_spike=False,
             source_type="amber",
         )
 
-        assert slot.get("start_time") == datetime(
-            2026, 3, 16, 10, 0, tzinfo=timezone.utc
-        )
+        assert slot.get("start_time") == datetime(2026, 3, 16, 10, 0, tzinfo=UTC)
         assert slot.get("duration") == 30
         assert slot.get("per_kwh") == 0.25
         assert slot.get("is_spike") is False
@@ -59,7 +56,7 @@ class TestForecastSlotGetMethod:
     def test_get_missing_field_returns_none(self):
         """Test .get() returns None for missing fields by default."""
         slot = ForecastSlot(
-            start_time=datetime(2026, 3, 16, 10, 0, tzinfo=timezone.utc),
+            start_time=datetime(2026, 3, 16, 10, 0, tzinfo=UTC),
             duration=30,
             per_kwh=0.25,
             is_spike=False,
@@ -71,7 +68,7 @@ class TestForecastSlotGetMethod:
     def test_get_missing_field_returns_custom_default(self):
         """Test .get() returns custom default for missing fields."""
         slot = ForecastSlot(
-            start_time=datetime(2026, 3, 16, 10, 0, tzinfo=timezone.utc),
+            start_time=datetime(2026, 3, 16, 10, 0, tzinfo=UTC),
             duration=30,
             per_kwh=0.25,
             is_spike=False,
@@ -84,7 +81,7 @@ class TestForecastSlotGetMethod:
     def test_get_end_time_computed(self):
         """Test .get() computes end_time on demand from start_time + duration."""
         slot = ForecastSlot(
-            start_time=datetime(2026, 3, 16, 10, 0, tzinfo=timezone.utc),
+            start_time=datetime(2026, 3, 16, 10, 0, tzinfo=UTC),
             duration=30,
             per_kwh=0.25,
             is_spike=False,
@@ -92,19 +89,46 @@ class TestForecastSlotGetMethod:
         )
 
         end_time = slot.get("end_time")
-        assert end_time == datetime(2026, 3, 16, 10, 30, tzinfo=timezone.utc)
+        assert end_time == datetime(2026, 3, 16, 10, 30, tzinfo=UTC)
 
     def test_get_end_time_various_durations(self):
         """Test .get() end_time works with different durations."""
         for duration_min in [5, 15, 30, 60]:
             slot = ForecastSlot(
-                start_time=datetime(2026, 3, 16, 10, 0, tzinfo=timezone.utc),
+                start_time=datetime(2026, 3, 16, 10, 0, tzinfo=UTC),
                 duration=duration_min,
                 per_kwh=0.10,
                 is_spike=False,
                 source_type="amber",
             )
-            expected = datetime(2026, 3, 16, 10, 0, tzinfo=timezone.utc) + timedelta(
+            expected = datetime(2026, 3, 16, 10, 0, tzinfo=UTC) + timedelta(
                 minutes=duration_min
             )
             assert slot.get("end_time") == expected
+
+    def test_get_estimate_defaults_to_none(self):
+        """Issue #510 Slice 2: estimate defaults to None when not supplied."""
+        slot = ForecastSlot(
+            start_time=datetime(2026, 3, 16, 10, 0, tzinfo=UTC),
+            duration=30,
+            per_kwh=0.25,
+            is_spike=False,
+            source_type="amber",
+        )
+
+        assert slot.estimate is None
+        assert slot.get("estimate") is None
+
+    def test_get_estimate_explicit_value(self):
+        """Issue #510 Slice 2: an explicit estimate flag round-trips through .get()."""
+        slot = ForecastSlot(
+            start_time=datetime(2026, 3, 16, 10, 0, tzinfo=UTC),
+            duration=30,
+            per_kwh=0.25,
+            is_spike=False,
+            source_type="amber",
+            estimate=False,
+        )
+
+        assert slot.estimate is False
+        assert slot.get("estimate") is False

--- a/tests/pricing/test_provider.py
+++ b/tests/pricing/test_provider.py
@@ -217,9 +217,7 @@ def test_amber_express_v2_reads_detailed_forecast_from_main_entity():
         ],
     }
     # Legacy _price_detailed entity is gone in v2.0.0 → returns None.
-    hass.states.get.side_effect = lambda eid: (
-        None if "detailed" in eid else main_state
-    )
+    hass.states.get.side_effect = lambda eid: None if "detailed" in eid else main_state
 
     slots = provider.read_forecasts(hass, "sensor.amber_express_100h_general_price")
 
@@ -255,9 +253,7 @@ def test_amber_express_simple_forecast_only_yields_empty():
             {"time": "2026-03-16T12:30:00+11:00", "value": 2.50},
         ],
     }
-    hass.states.get.side_effect = lambda eid: (
-        None if "detailed" in eid else main_state
-    )
+    hass.states.get.side_effect = lambda eid: None if "detailed" in eid else main_state
 
     slots = provider.read_forecasts(hass, "sensor.amber_express_100h_general_price")
     assert slots == []
@@ -517,3 +513,41 @@ def test_normalize_slot_negative_duration_defaults_to_5():
     }
     slot = provider._normalize_slot(raw)
     assert slot.duration == 5  # -30 min: abs diffs = |35|, |45|, |60|; 5 wins
+
+
+def test_normalize_slot_carries_estimate():
+    """Issue #510 Slice 2: _normalize_slot carries the raw `estimate` flag through.
+
+    Without this, ForecastSlot.get("estimate") always returned None in
+    production (the field didn't exist on ForecastSlot at all), so the
+    SLOT0_CURRENT log line's estimate=... could never read true/false from
+    real Amber data.
+    """
+    from custom_components.localshift.pricing.provider import AmberExpressProvider
+
+    provider = AmberExpressProvider()
+
+    raw_settled = {
+        "start_time": "2026-03-16T10:00:01+00:00",
+        "end_time": "2026-03-16T10:30:00+00:00",
+        "per_kwh": 0.15,
+        "demand_window": False,
+        "estimate": False,
+    }
+    raw_forecast = {
+        "start_time": "2026-03-16T10:30:01+00:00",
+        "end_time": "2026-03-16T11:00:00+00:00",
+        "per_kwh": 0.18,
+        "demand_window": False,
+        "estimate": True,
+    }
+    raw_missing = {
+        "start_time": "2026-03-16T11:00:01+00:00",
+        "end_time": "2026-03-16T11:30:00+00:00",
+        "per_kwh": 0.20,
+        "demand_window": False,
+    }
+
+    assert provider._normalize_slot(raw_settled).estimate is False
+    assert provider._normalize_slot(raw_forecast).estimate is True
+    assert provider._normalize_slot(raw_missing).estimate is None


### PR DESCRIPTION
Slice 2 of the #510 anticipatory forecast-first plan. Unflagged correctness fix — a hard prerequisite for slice 3.

## Why

`_parse_single_entry` dropped any forecast entry whose `slot_start < now`. Amber's `detailedForecast` entries carry a **+1 second offset** (the 12:30 interval starts at `02:30:01Z`, the same quirk that broke solar-accuracy sampling in #876/#882), so the entry covering the *current* interval was always one second in the past and always dropped. `_ensure_current_slot_coverage` then synthesised slot 0 priced from the first surviving entry — the **next** interval. Plan slot 0 was priced from the wrong interval at every evaluation.

## What

- Retain the entry whose interval covers `now` as slot 0, `price_source="forecast_current"`, flooring entry starts to the interval boundary so the +1 s offset cannot push them out.
- Synthetic demoted to stale-sensor fallback only, and its log promoted `INFO` → `WARNING` naming staleness as the cause — it should no longer be the steady state.
- The covering entry's Amber `estimate` flag is carried through to slot 0 and the `SLOT0_CURRENT` log line, so the §2d.2 actuals property is greppable rather than assumed. This needed the field on `ForecastSlot` too: `general_forecast` is a `list[ForecastSlot]` whose `.get()` is a `getattr` shim, so without it the flag would silently read `None` forever.
- 60-minute split path untouched by construction.

## Scope note

The 30-minute re-anchoring branch is **out of scope** per the spec's Non-goals ("5-min price sites only"). On a 5-minute Amber feed the covering entry is always 5-minute, so it is unreachable on the site this was built for and has never been validated against live 30-minute data. Kept because the reasoning holds and it costs nothing dormant; commented as such in the source.

## Verification

`uv run ruff check` clean, `uv run pytest` 3554 passed / 1 xfailed. 9 new tests covering the `:01` offset, both durations, the elapsed-entry drop, the 60-minute path and the synthetic fallback.

## Known findings

Non-blocking, filed as #946, #947, #948, #949. #946 (duration parsing aborting the schedule on a malformed entry) is the one to read first.