### PR TITLE
feat(#510): boundary-lag telemetry + slot-0 covering-entry pricing (slices 1 and 2)

### DIFF
--- a/custom_components/localshift/coordinator/data.py
+++ b/custom_components/localshift/coordinator/data.py
@@ -593,6 +593,32 @@ class CoordinatorData:
     physical_response_timed_out: bool = False
     """Issue #508: True when the last physical-response watch timed out."""
 
+    # --- Boundary-lag telemetry (Issue #510 slice 1) ---
+    # How far into its 5-minute price interval a transition landed. Amber's
+    # spot sensor updates 14-36s after each boundary, so real transitions are
+    # expected to land ~20-45s in. Measurement only — no decision reads these.
+
+    boundary_lag_seconds: float | None = None
+    """Issue #510: seconds from the 5-min interval start to the transition."""
+
+    boundary_lag_history: list[dict[str, Any]] = field(default_factory=list)
+    """History of boundary-lag measurements.
+    Each entry: {from_mode, to_mode, boundary_lag, grant_source,
+    interval_start_utc, transition_time}. interval_start_utc is UTC (NEM is
+    a fixed UTC+10 offset); transition_time is local wall clock. Max 200
+    entries (capped in machine.py) — deliberately deeper than
+    decision_lag_history's 50, because this ring is shared across grant
+    sources and a burst must not evict the price samples (#942).
+    """
+
+    anticipated_transitions_today: int = 0
+    """Issue #510: transitions fired anticipatorily. Declared and daily-reset
+    here; a later slice owns the increment. Stays 0 in slice 1."""
+
+    anticipation_corrections_today: int = 0
+    """Issue #510: anticipated transitions later corrected by spot prices.
+    Declared and daily-reset here; a later slice owns the increment."""
+
     # ---------------------------------------------------------------------------
     # --- Decision-token gating (#622 gate replacement) ---
     # ---------------------------------------------------------------------------

--- a/custom_components/localshift/coordinator/tick_scheduler.py
+++ b/custom_components/localshift/coordinator/tick_scheduler.py
@@ -266,6 +266,9 @@ class TickScheduler:
         self._coordinator.data.grid_to_battery_kwh_today = 0.0
         self._coordinator.data.soc_gain_during_grid_charge_kwh_today = 0.0
         self._coordinator.data.export_while_battery_not_full_kwh_today = 0.0
+        # Issue #510: the anticipation counters are per-day like the rest.
+        self._coordinator.data.anticipated_transitions_today = 0
+        self._coordinator.data.anticipation_corrections_today = 0
 
         if self._coordinator.learning_orchestrator is not None:
             self._coordinator.learning_orchestrator.handle_midnight_reset(

--- a/custom_components/localshift/engine/slot_schedule.py
+++ b/custom_components/localshift/engine/slot_schedule.py
@@ -17,6 +17,91 @@ TOTAL_SLOTS = 96  # 24 hours × 4 slots/hour
 # Maximum number of 5-minute slots to use from Amber near-term forecast
 MAX_5MIN_FORECAST_HOURS = 1  # Amber typically provides ~45-60 min of 5-min data
 
+# Issue #510 Slice 2: Amber's detailedForecast starts each interval one second
+# after the boundary (the 12:30 interval starts at 12:30:01). Absorb that
+# offset when deciding which interval covers "now" — but only if it really is
+# boundary noise, so a genuinely mid-interval start keeps its own boundary.
+# Why 60s: Amber's observed offset is +1s (the 12:30 interval starts at
+# 12:30:01), so this is ~60x margin — wide enough to absorb provider clock
+# skew without ever reaching the next 5-minute boundary. If the offset were
+# ever to exceed this, the covering entry stops being recognised and slot 0
+# falls back to the synthetic next-interval borrow: the exact defect this
+# slice removes. That failure is loud, not silent — it trips the
+# SYNTHETIC SLOT FALLBACK warning below — but it is the reason to keep this
+# generous rather than tighten it toward the observed +1s.
+_BOUNDARY_OFFSET_TOLERANCE_S = 60
+
+
+def _interval_origin(slot_start: datetime, duration_minutes: int) -> datetime:
+    """Return the true interval boundary for an entry's start time.
+
+    Floors slot_start down to the nearest duration_minutes boundary, but only
+    treats that floor as the real origin when slot_start is within
+    _BOUNDARY_OFFSET_TOLERANCE_S of it — a few seconds of provider clock skew,
+    not a genuinely different (misaligned) start time.
+
+    Args:
+        slot_start: Entry's parsed start time
+        duration_minutes: Entry's duration (5 or 30)
+
+    Returns:
+        The interval's true boundary, or slot_start unchanged if it is not
+        boundary noise.
+
+    """
+    floored = slot_start.replace(
+        minute=(slot_start.minute // duration_minutes) * duration_minutes,
+        second=0,
+        microsecond=0,
+    )
+    if (slot_start - floored).total_seconds() < _BOUNDARY_OFFSET_TOLERANCE_S:
+        return floored
+    return slot_start
+
+
+def _covers_now(
+    slot_start: datetime, duration_minutes: int, now_local: datetime
+) -> bool:
+    """Return True if this entry's interval contains now_local.
+
+    Only 5- and 30-minute entries are eligible — 60-minute entries always
+    return False here, which keeps _split_60min_slot's split-then-drop
+    behaviour for the current hour completely unchanged (see module docstring
+    constraint: 60-min path is untouched by Issue #510 Slice 2).
+
+    Args:
+        slot_start: Entry's parsed start time
+        duration_minutes: Entry's duration (5, 30, or 60)
+        now_local: Current local time
+
+    Returns:
+        True if [interval origin, interval origin + duration) contains now.
+
+    """
+    if duration_minutes not in (5, 30):
+        return False
+    origin = _interval_origin(slot_start, duration_minutes)
+    return origin <= now_local < origin + timedelta(minutes=duration_minutes)
+
+
+def _floor_to_5min(moment: datetime) -> datetime:
+    """Floor a datetime down to the nearest 5-minute wall-clock boundary.
+
+    Shared by the stale-sensor synthetic fallback and by the current-slot
+    re-anchoring in `_parse_single_entry`, so the two "what does a 5-minute
+    'now' slot look like" formulas can never drift apart.
+
+    Args:
+        moment: The datetime to floor.
+
+    Returns:
+        moment with minute rounded down to a multiple of 5 and seconds/
+        microseconds zeroed.
+
+    """
+    current_5min = (moment.minute // 5) * 5
+    return moment.replace(minute=current_5min, second=0, microsecond=0)
+
 
 def compute_hybrid_slot_schedule(
     now_local: datetime,
@@ -45,7 +130,16 @@ def compute_hybrid_slot_schedule(
             - start: datetime of slot start
             - interval_minutes: 5 or 30
             - price: price in $/kWh
-            - price_source: "5min" or "30min"
+            - price_source: "forecast_current" (the entry whose interval covers
+              now), "5min", "30min", or "synthetic" (stale-sensor fallback used
+              only when no entry covers now). A covering 30-min entry is
+              re-anchored to a 5-minute "now" quantum rather than kept at its
+              own 30-min width, so slot 0's width never exceeds 5 minutes
+              regardless of the feed's native granularity — see
+              `_parse_single_entry`.
+            - estimate: bool | None, the covering entry's Amber `estimate` flag
+              (True pre-settlement, False once settled; None on synthetic or
+              60-min-derived slots)
         - metadata: Dict with:
             - timezone: HA timezone
             - slot_intervals: {"5min": count, "30min": count}
@@ -81,6 +175,17 @@ def compute_hybrid_slot_schedule(
     )
 
     _ensure_current_slot_coverage(slots, now_local)
+
+    if slots:
+        _LOGGER.info(
+            "SLOT0_CURRENT: start=%s interval=%dmin price=%.4f source=%s estimate=%s",
+            slots[0]["start"].isoformat(),
+            slots[0]["interval_minutes"],
+            slots[0]["price"],
+            slots[0]["price_source"],
+            slots[0].get("estimate"),
+        )
+
     _compute_slot_metadata(slots, metadata, transition_boundary)
 
     return slots, metadata
@@ -151,11 +256,19 @@ def _parse_single_entry(
         return None
 
     slot_start = parse_slot_time(start_time_str, ha_timezone)
-    if slot_start is None or slot_start < now_local:
+    if slot_start is None:
         return None
 
     duration_minutes = _get_entry_duration(entry, slot_start, ha_timezone)
     if duration_minutes is None or duration_minutes not in (5, 30, 60):
+        return None
+
+    # Issue #510 Slice 2: an entry whose interval covers "now" is retained as
+    # the current slot even though its raw (pre-floor) start may read as
+    # slightly in the past — that's the +1s Amber offset, not staleness. An
+    # entry is only dropped once its interval has genuinely elapsed.
+    is_current = _covers_now(slot_start, duration_minutes, now_local)
+    if not is_current and slot_start < now_local:
         return None
 
     price = float(entry.get("per_kwh", 0))
@@ -163,11 +276,46 @@ def _parse_single_entry(
     if duration_minutes == 60:
         return _split_60min_slot(slot_start, price)
 
+    if is_current and duration_minutes == 30:
+        # SCOPE NOTE (#510): this branch is OUT OF SCOPE per the spec's
+        # Non-goals — "5-min price sites only … 30-min support is out of
+        # scope". On a 5-minute Amber feed the entry covering "now" is
+        # always a 5-minute one, so this branch is unreachable on the site
+        # this was built for and has never been validated against live
+        # 30-minute data. Kept because the reasoning below is sound and it
+        # costs nothing dormant; re-verify against a real 30-minute feed
+        # before relying on it.
+        # Review feedback on #510 Slice 2: retaining this entry at its own
+        # 30-minute width would make slot 0 up to 30 minutes wide no matter
+        # how far into the interval "now" actually is (e.g. still the full
+        # 30-min slot with ten seconds of real time left in it). Every DP
+        # energy term scales by slot width (slot_hours = interval_minutes /
+        # 60), so a mostly-elapsed slot 0 lets the optimiser book
+        # charge/discharge time that no longer exists, and it drags
+        # core.py's DW-runway anchor (minutes_to_dw) and the published
+        # precharge_runway_quantum_min back with it by the same amount.
+        # Re-anchor slot 0 to the same 5-minute "now" quantum the
+        # stale-sensor fallback below already uses, priced from this real
+        # covering entry instead of a synthetic borrowed price — the brief
+        # asked for the covering entry's PRICE, not for slot 0 to grow to
+        # 30 minutes wide. A covering 5-min entry is already at (or under)
+        # that quantum, so it keeps its own start/width untouched below.
+        return {
+            "start": _floor_to_5min(now_local),
+            "interval_minutes": 5,
+            "price": price,
+            "price_source": "forecast_current",
+            "estimate": entry.get("estimate"),
+        }
+
     return {
         "start": slot_start,
         "interval_minutes": duration_minutes,
         "price": price,
-        "price_source": "5min" if duration_minutes == 5 else "30min",
+        "price_source": "forecast_current"
+        if is_current
+        else ("5min" if duration_minutes == 5 else "30min"),
+        "estimate": entry.get("estimate"),
     }
 
 
@@ -320,7 +468,13 @@ def _add_all_30min_slots(
 
 
 def _ensure_current_slot_coverage(slots: list[dict], now_local: datetime) -> None:
-    """Ensure there's a slot covering 'now' by adding synthetic slot if needed.
+    """Ensure there's a slot covering 'now' by adding a synthetic slot if needed.
+
+    Issue #510 Slice 2: this is the stale-sensor FALLBACK, not the steady
+    state. In normal operation _parse_single_entry already retains the real
+    forecast entry covering "now" as slot 0 (price_source="forecast_current"),
+    so this function is a no-op. It only fires when no entry covers now at
+    all — e.g. the price sensor's forecast has gone stale.
 
     Args:
         slots: Slot list (modified in place)
@@ -330,19 +484,20 @@ def _ensure_current_slot_coverage(slots: list[dict], now_local: datetime) -> Non
     if not slots:
         return
 
+    covers_now = _covers_now(slots[0]["start"], slots[0]["interval_minutes"], now_local)
+
     _LOGGER.info(
         "HYBRID_SLOTS: slots=%d, first_slot=%s, now_local=%s, comparison=%s",
         len(slots),
         slots[0]["start"].strftime("%H:%M:%S"),
         now_local.strftime("%H:%M:%S"),
-        "first > now" if slots[0]["start"] > now_local else "first <= now",
+        "covers now" if covers_now else "does not cover now",
     )
 
-    if slots[0]["start"] <= now_local:
+    if covers_now:
         return
 
-    current_5min = (now_local.minute // 5) * 5
-    synthetic_start = now_local.replace(minute=current_5min, second=0, microsecond=0)
+    synthetic_start = _floor_to_5min(now_local)
     estimated_price = slots[0]["price"] if slots else 0.0
 
     synthetic_slot = {
@@ -353,8 +508,10 @@ def _ensure_current_slot_coverage(slots: list[dict], now_local: datetime) -> Non
     }
     slots.insert(0, synthetic_slot)
 
-    _LOGGER.info(
-        "Created synthetic slot at %s (Amber first slot was at %s, gap=%.0fs)",
+    _LOGGER.warning(
+        "SYNTHETIC SLOT FALLBACK: no forecast entry covers %s (first entry %s, "
+        "gap=%.0fs) — price borrowed from the next interval; check the price "
+        "sensor for staleness",
         synthetic_start.strftime("%H:%M:%S"),
         slots[1]["start"].strftime("%H:%M:%S") if len(slots) > 1 else "N/A",
         (slots[1]["start"] - synthetic_start).total_seconds() if len(slots) > 1 else 0,

--- a/custom_components/localshift/engine/types.py
+++ b/custom_components/localshift/engine/types.py
@@ -135,7 +135,7 @@ class SlotContext:
     """True if this slot falls within the demand window."""
 
     price_source: str = "unknown"
-    """Source of price data (e.g. '5min', '30min', 'synthetic')."""
+    """Source of price data (e.g. 'forecast_current', '5min', '30min', 'synthetic')."""
 
 
 # -----------------------------------------------------------------------------

--- a/custom_components/localshift/pricing/provider.py
+++ b/custom_components/localshift/pricing/provider.py
@@ -78,6 +78,7 @@ class _ProviderMixin:
             per_kwh=float(raw["per_kwh"]),
             is_spike=self.is_spike(raw),  # type: ignore[attr-defined]
             source_type=self.name,  # type: ignore[attr-defined]
+            estimate=raw.get("estimate"),
         )
 
     def _infer_duration_minutes(self, raw: dict[str, Any]) -> int:

--- a/custom_components/localshift/pricing/types.py
+++ b/custom_components/localshift/pricing/types.py
@@ -23,6 +23,10 @@ class ForecastSlot:
     per_kwh: float
     is_spike: bool
     source_type: str
+    # Issue #510 Slice 2: Amber's settlement-estimate flag for this interval —
+    # True before the interval settles, False once actual. None when the
+    # source entry didn't carry one (e.g. synthetic/extended slots).
+    estimate: bool | None = None
 
     def get(self, key: str, default: Any = None) -> Any:
         """Dict-compatible accessor for backward compatibility.

--- a/custom_components/localshift/sensors/status.py
+++ b/custom_components/localshift/sensors/status.py
@@ -269,6 +269,15 @@ class DecisionLagSensor(LocalShiftSensorBase):
             "command_completion_timestamp": d.command_completion_timestamp.isoformat()
             if d.command_completion_timestamp
             else None,
+            # Issue #510 slice 1 (measurement only): boundary-lag telemetry.
+            # History windowed to 20 for attribute-size parity with `history`
+            # above; the full 200-entry window stays in CoordinatorData.
+            "boundary_lag_seconds": round(d.boundary_lag_seconds, 2)
+            if d.boundary_lag_seconds is not None
+            else None,
+            "boundary_lag_history": (d.boundary_lag_history or [])[-20:],
+            "anticipated_transitions_today": d.anticipated_transitions_today,
+            "anticipation_corrections_today": d.anticipation_corrections_today,
         }
 
     @property

--- a/custom_components/localshift/state/machine.py
+++ b/custom_components/localshift/state/machine.py
@@ -118,6 +118,10 @@ class StateMachine:
         self._last_health_correction: datetime | None = None
         # Listener for reactive grid_charging correction (#491)
         self._grid_charging_listener: Callable | None = None
+        # Issue #510 slice 1: one-shot tag for transitions issued outside the
+        # decision path (Tesla re-probe, health-check correction). Set immediately
+        # before the call, cleared immediately after — never left armed.
+        self._transition_source_override: str | None = None
         # Decision-token gating (#622 gate replacement): the mode may be
         # re-decided at most once per discrete decision-context change. The
         # fingerprint is consumed by the *evaluation* that observes the change
@@ -128,6 +132,11 @@ class StateMachine:
         # evaluation, kept separately so a grant can be attributed: same base +
         # different epoch ⇒ the grant came from the plan alone.
         self._last_evaluated_base: str | None = None
+        # Issue #510 slice 1 (measurement only): the grant source attributed at
+        # token-grant time. Captured in _apply_decision_token because the base it
+        # is derived from is overwritten there — by transition time the "previous"
+        # base is already the current one.
+        self._last_grant_source: str | None = None
         # Plan-disagreement trigger (2026-07-27 pre-charge incident): the plan is
         # itself a decision input. ``_plan_charge_epoch`` is a MONOTONE counter
         # incremented on the rising edge of "the plan wants to START charging while
@@ -881,6 +890,11 @@ class StateMachine:
         # only thing that moved ⇒ the plan alone granted this.
         plan_charge_only = decision_allowed and context == self._last_evaluated_base
         if decision_allowed:
+            # Issue #510 slice 1 (measurement only): attribute the grant BEFORE
+            # _last_evaluated_base is overwritten below — by transition time the
+            # "previous" base is already this one, so the comparison must happen
+            # here or the tag is unrecoverable.
+            self._last_grant_source = self._classify_grant_source(context)
             # Consume immediately: the evaluation, not the transition, spends the
             # token. Covers every downstream path (including debounce-in-progress).
             self._last_evaluated_fingerprint = fingerprint
@@ -898,6 +912,35 @@ class StateMachine:
         # compute_derived_values in coordinator.async_recompute_and_evaluate can
         # never trip it.
         data.mode_backstop_allowed = True
+
+    def _classify_grant_source(self, context: str | None) -> str:
+        """Attribute a grant to the fingerprint component that moved (Issue #510).
+
+        Observation only — the return value gates nothing. Compares the new
+        price/spike/DW/floor context positionally against the previously granted
+        one. Precedence when several components move at once is deliberate: the
+        non-price causes win, because the tag exists to EXCLUDE legitimately
+        mid-interval transitions from the boundary-lag baseline. A DW crossing
+        that happens to coincide with a price tick is not a clean sample.
+        """
+        previous = self._last_evaluated_base
+        if previous is None or context is None:
+            return "unknown"
+        if previous == context:
+            return "plan_charge"  # base unchanged ⇒ only the epoch moved
+        old = previous.split("|")
+        new = context.split("|")
+        if len(old) != 5 or len(new) != 5:
+            return "unknown"
+        if old[4] != new[4]:
+            return "soc_floor"
+        if old[3] != new[3]:
+            return "demand_window"
+        if old[2] != new[2]:
+            return "spike"
+        if old[0] != new[0] or old[1] != new[1]:
+            return "price"
+        return "unknown"
 
     async def _evaluate_core(
         self, data: CoordinatorData, computation_engine: ComputationEngine
@@ -1209,6 +1252,10 @@ class StateMachine:
         transition_time = dt_util.now()
         if not dry_run:
             self._last_successful_transition = transition_time
+            # Issue #510 slice 1: measured for EVERY successful non-dry-run
+            # transition, including the ones the decision_mode guard below
+            # skips (debounce completion, retry, re-probe, health correction).
+            self._record_boundary_lag(data, target, transition_time)
 
         # Issue #508: dry runs execute no real commands and drive no physical
         # change, so neither phase is recorded.
@@ -1251,6 +1298,55 @@ class StateMachine:
             "Recorded successful transition to %s at %s",
             target.value,
             transition_time.strftime("%H:%M:%S"),
+        )
+
+    def _record_boundary_lag(
+        self, data: CoordinatorData, target: BatteryMode, transition_time: datetime
+    ) -> None:
+        """Measure how far into its 5-minute price interval a transition landed.
+
+        Issue #510 slice 1 — telemetry only, changes no decision. The interval
+        start is derived in UTC: NEM time is a fixed UTC+10 offset, so a UTC
+        floor is correct by construction and a DST transition is a non-event.
+        """
+        utc_time = dt_util.as_utc(transition_time)
+        interval_start = utc_time.replace(
+            minute=(utc_time.minute // 5) * 5, second=0, microsecond=0
+        )
+        boundary_lag = (utc_time - interval_start).total_seconds()
+        grant_source = self._transition_source_override or (
+            self._last_grant_source or "unknown"
+        )
+
+        data.boundary_lag_seconds = boundary_lag
+        data.boundary_lag_history.append({
+            "from_mode": data.active_mode.value if data.active_mode else "unknown",
+            "to_mode": target.value,
+            "boundary_lag": round(boundary_lag, 2),
+            "grant_source": grant_source,
+            # Key is explicitly _utc: interval_start is derived in UTC (NEM is a
+            # fixed UTC+10 offset, so a UTC floor is correct by construction and
+            # DST is a non-event), while transition_time is local wall clock like
+            # every other timestamp in decision_lag_history. Naming the difference
+            # beats normalising it — converting the interval to local would make
+            # the two DST tests pass trivially and hide the property they pin.
+            "interval_start_utc": interval_start.isoformat(),
+            "transition_time": transition_time.isoformat(),
+        })
+        # 200, not decision_lag_history's 50 (#942): this is ONE ring shared by
+        # every grant source, so a backstop or spike burst evicts the price-tagged
+        # samples slice 3's acceptance criterion is measured against. 200 covers
+        # days of transitions at any plausible rate. The proper fix is a window
+        # per source — deliberately deferred, see #942.
+        if len(data.boundary_lag_history) > 200:
+            data.boundary_lag_history = data.boundary_lag_history[-200:]
+
+        _LOGGER.info(
+            "Boundary lag: %s landed %.2fs into interval %s (source=%s)",
+            target.value,
+            boundary_lag,
+            interval_start.isoformat(),
+            grant_source,
         )
 
     def _start_physical_response_watch(
@@ -1403,9 +1499,19 @@ class StateMachine:
                     duration,
                     self._commanded_mode.value,
                 )
-                probe_success = await self._execute_mode_transition(
-                    data, self._commanded_mode
-                )
+                # Issue #510 slice 1: tag as backstop — a re-probe is not a
+                # decision-token grant, so _last_grant_source would be stale
+                # here without an explicit override.
+                self._transition_source_override = "backstop"
+                try:
+                    probe_success = await self._execute_mode_transition(
+                        data, self._commanded_mode
+                    )
+                finally:
+                    # try/finally is load-bearing: _record_transition_metrics only
+                    # runs on success, so a failed probe would otherwise leave the
+                    # override armed and mislabel the next genuine transition.
+                    self._transition_source_override = None
                 if probe_success:
                     _LOGGER.info(
                         "[TESLA OVERRIDE] Re-probe succeeded after %s — control "
@@ -1602,9 +1708,19 @@ class StateMachine:
             )
 
             # Attempt to correct the state
-            correction_success = await self._execute_mode_transition(
-                data, self._commanded_mode
-            )
+            # Issue #510 slice 1: tag as backstop — a health-check correction is
+            # not a decision-token grant, so _last_grant_source would be stale
+            # here without an explicit override.
+            self._transition_source_override = "backstop"
+            try:
+                correction_success = await self._execute_mode_transition(
+                    data, self._commanded_mode
+                )
+            finally:
+                # try/finally is load-bearing: _record_transition_metrics only
+                # runs on success, so a failed correction would otherwise leave
+                # the override armed and mislabel the next genuine transition.
+                self._transition_source_override = None
             self._last_health_correction = now
 
             if correction_success:
@@ -1686,6 +1802,9 @@ class StateMachine:
         # Cleared with it, or the next grant would be misattributed to the plan
         # ("same base as last time") and restricted to charge modes only.
         self._last_evaluated_base = None
+        # Issue #510 slice 1: a transition landing between this invalidation
+        # and the next grant must not inherit a now-stale attribution.
+        self._last_grant_source = None
 
     def suppress_next_plan_charge_grant(self, reason: str) -> None:
         """Bar the NEXT evaluation from granting on the plan-charge trigger.

--- a/docs/ENTITY_REFERENCE.md
+++ b/docs/ENTITY_REFERENCE.md
@@ -610,7 +610,13 @@ Attributes:
   total_transitions: 15
   decision_timestamp: "2026-02-26T09:05:00"
   implementation_timestamp: "2026-02-26T09:05:45"
+  boundary_lag_seconds: 23.4
+  boundary_lag_history: [...last 20 boundary-lag measurements, tagged by grant_source...]
+  anticipated_transitions_today: 0
+  anticipation_corrections_today: 0
 ```
+
+Issue #510 slice 1 (measurement only) adds `boundary_lag_seconds` / `boundary_lag_history`: how far into its 5-minute price interval each transition landed, tagged by `grant_source` (`price`, `spike`, `demand_window`, `soc_floor`, `plan_charge`, `backstop`, `unknown`). `anticipated_transitions_today` / `anticipation_corrections_today` are declared here and daily-reset but stay at 0 until a later slice implements the anticipatory logic they count. No new entity — these are attributes on this existing sensor.
 
 ---
 

--- a/tests/coordinator/test_tick_scheduler.py
+++ b/tests/coordinator/test_tick_scheduler.py
@@ -230,6 +230,9 @@ async def test_handle_midnight_reset(coordinator):
     coordinator.data.grid_to_battery_kwh_today = 2.0
     coordinator.data.soc_gain_during_grid_charge_kwh_today = 1.5
     coordinator.data.export_while_battery_not_full_kwh_today = 1.0
+    # Issue #510: the anticipation counters reset daily like the rest.
+    coordinator.data.anticipated_transitions_today = 4
+    coordinator.data.anticipation_corrections_today = 2
     coordinator._learning_orchestrator = MagicMock()
     coordinator._learning_orchestrator.handle_midnight_reset = MagicMock()
     coordinator.notify_listeners = MagicMock()
@@ -246,6 +249,8 @@ async def test_handle_midnight_reset(coordinator):
     assert coordinator.data.grid_to_battery_kwh_today == 0.0
     assert coordinator.data.soc_gain_during_grid_charge_kwh_today == 0.0
     assert coordinator.data.export_while_battery_not_full_kwh_today == 0.0
+    assert coordinator.data.anticipated_transitions_today == 0
+    assert coordinator.data.anticipation_corrections_today == 0
     coordinator._learning_orchestrator.handle_midnight_reset.assert_called_once_with(
         coordinator.data
     )

--- a/tests/engine/test_slot_schedule_current_coverage.py
+++ b/tests/engine/test_slot_schedule_current_coverage.py
@@ -1,0 +1,252 @@
+"""Tests for Issue #510 Slice 2: retain the forecast entry covering "now".
+
+Before this fix, `_parse_single_entry` dropped any forecast entry whose
+`slot_start < now_local`. Amber's `detailedForecast` entries carry a +1
+second offset on their start times (the 12:30 interval starts at
+12:30:01), so the entry covering the CURRENT interval was always one
+second in the past and always dropped. `_ensure_current_slot_coverage`
+then synthesised slot 0 and priced it from the first SURVIVING entry --
+the NEXT interval -- so plan slot 0 was priced from the wrong interval at
+every evaluation.
+
+These tests pin the fix: an entry whose interval covers `now_local` (after
+flooring its start to the interval boundary) is retained as slot 0 with
+`price_source="forecast_current"`, carrying its own price and its Amber
+`estimate` flag. The synthetic slot becomes a stale-sensor fallback that
+fires only when no entry covers "now" at all.
+
+All entries below build dicts with an explicit `duration` field. Without
+it, `get_slot_duration_minutes` would fall back to computing duration from
+raw start_time/end_time deltas -- and a :01-offset 5-minute entry spans
+299 seconds, which floors to 4 minutes and gets rejected by the
+`duration_minutes not in (5, 30, 60)` guard for an unrelated reason. In
+production this never happens because providers normalize to ForecastSlot
+objects with duration already resolved (see AmberExpressProvider); tests
+must supply it explicitly to exercise the coverage predicate itself.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+
+from custom_components.localshift.engine.slot_schedule import (
+    compute_hybrid_slot_schedule,
+)
+
+AEDT = timezone(timedelta(hours=11))
+
+
+def _entry(
+    start_time: str, duration: int, price: float, *, estimate: bool | None = None
+) -> dict:
+    """Build a raw forecast entry dict with an explicit duration."""
+    entry: dict = {"start_time": start_time, "duration": duration, "per_kwh": price}
+    if estimate is not None:
+        entry["estimate"] = estimate
+    return entry
+
+
+class TestCurrentIntervalRetainedAsSlot0:
+    """An entry whose interval covers "now" becomes slot 0, priced from itself."""
+
+    def test_5min_entry_covering_now_retained_as_slot0(self):
+        """5-min entry covering now is slot 0, priced at its own (not the next) price."""
+        entries = [
+            _entry("2026-03-16T12:30:01+11:00", 5, 0.10),
+            _entry("2026-03-16T12:35:01+11:00", 5, 0.11),
+            _entry("2026-03-16T12:40:01+11:00", 5, 0.12),
+        ]
+        now = datetime(2026, 3, 16, 12, 33, 0, tzinfo=AEDT)
+
+        slots, _metadata = compute_hybrid_slot_schedule(
+            now, entries, "Australia/Sydney"
+        )
+
+        assert slots[0]["price_source"] == "forecast_current"
+        assert slots[0]["price"] == 0.10  # its OWN price, not 0.11 borrowed
+        assert slots[0]["start"].minute == 30
+        assert slots[0]["interval_minutes"] == 5
+
+    def test_30min_entry_covering_now_retained_as_slot0(self):
+        """30-min entry covering now prices slot 0, re-anchored to a 5-min quantum.
+
+        Review feedback on the first cut of this fix: retaining the covering
+        entry at its own 30-minute width (start=12:30:01, interval=30) made
+        slot 0 up to 30 minutes wide, no matter how far into the interval
+        "now" actually was. Every DP energy term scales by slot width
+        (slot_hours = interval_minutes / 60), so a mostly-elapsed slot 0 let
+        the optimiser book charge/discharge time that no longer existed, and
+        it dragged core.py's DW-runway anchor and published
+        precharge_runway_quantum_min back by up to 30 minutes instead of 5.
+        The fix re-anchors slot 0 to the same 5-minute "now" quantum the
+        stale-sensor fallback already uses, priced from the covering entry.
+        """
+        entries = [
+            _entry("2026-03-16T12:30:01+11:00", 30, 0.20),
+            _entry("2026-03-16T13:00:01+11:00", 30, 0.25),
+        ]
+        now = datetime(2026, 3, 16, 12, 47, 0, tzinfo=AEDT)
+
+        slots, _metadata = compute_hybrid_slot_schedule(
+            now, entries, "Australia/Sydney"
+        )
+
+        assert slots[0]["price_source"] == "forecast_current"
+        assert slots[0]["price"] == 0.20  # its OWN price, not 0.25 borrowed
+        # Re-anchored to the 5-min "now" quantum (floor(12:47, 5) = 12:45),
+        # NOT left at the covering entry's own 30-min-wide start (12:30).
+        assert slots[0]["start"] == datetime(2026, 3, 16, 12, 45, 0, tzinfo=AEDT)
+        assert slots[0]["interval_minutes"] == 5
+
+    def test_30min_entry_near_interval_end_stays_bounded_to_5min_quantum(self):
+        """Regression: seconds before a 30-min interval ends, slot 0 must not claim 30 minutes.
+
+        This is the exact shape the review feedback caught: at now=12:59:50,
+        ten seconds before the 12:30-13:00 interval ends, the covering entry
+        must NOT be retained as a 30-min-wide slot 0 (which would tell the
+        optimiser it still has ten seconds *plus thirty minutes* to work
+        with). Slot 0 stays a bounded 5-minute quantum, correctly priced from
+        the covering (12:30) entry rather than the upcoming (13:00) one.
+        """
+        entries = [
+            _entry("2026-03-16T12:30:01+11:00", 30, 0.20),
+            _entry("2026-03-16T13:00:01+11:00", 30, 0.25),
+        ]
+        now = datetime(2026, 3, 16, 12, 59, 50, tzinfo=AEDT)
+
+        slots, _metadata = compute_hybrid_slot_schedule(
+            now, entries, "Australia/Sydney"
+        )
+
+        assert slots[0]["price_source"] == "forecast_current"
+        assert slots[0]["price"] == 0.20  # still the covering (12:30) entry
+        assert slots[0]["interval_minutes"] == 5  # NOT 30 -- the regression
+        assert slots[0]["start"] == datetime(2026, 3, 16, 12, 55, 0, tzinfo=AEDT)
+        # The slot's claimed end (12:55 + 5min = 13:00) never runs past the
+        # real interval boundary, so the DP is never handed elapsed time.
+        slot_end = slots[0]["start"] + timedelta(minutes=slots[0]["interval_minutes"])
+        assert slot_end == datetime(2026, 3, 16, 13, 0, 0, tzinfo=AEDT)
+
+    def test_one_second_offset_does_not_drop_current_interval(self):
+        """Regression: the +1s Amber offset must not push the current entry out.
+
+        This is the exact bug: with a naive `slot_start < now_local` check,
+        the 12:30:01 entry reads as "1 second in the past" relative to
+        anything after 12:30:01, and gets dropped -- forcing a synthetic
+        slot priced from the *next* interval. This test fails on main.
+        """
+        entries = [
+            _entry("2026-03-16T12:30:01+11:00", 5, 0.10),
+            _entry("2026-03-16T12:35:01+11:00", 5, 0.11),
+        ]
+        now = datetime(2026, 3, 16, 12, 30, 30, tzinfo=AEDT)
+
+        slots, _metadata = compute_hybrid_slot_schedule(
+            now, entries, "Australia/Sydney"
+        )
+
+        assert all(s["price_source"] != "synthetic" for s in slots)
+        assert slots[0]["start"] == datetime(2026, 3, 16, 12, 30, 1, tzinfo=AEDT)
+        assert slots[0]["price"] == 0.10
+
+
+class TestSyntheticFallback:
+    """The synthetic slot is a stale-sensor fallback, not the steady state."""
+
+    def test_synthetic_fallback_fires_only_when_no_entry_covers_now(self):
+        """No entry covers now -> synthetic slot borrows the first real entry's price."""
+        entries = [_entry("2026-03-16T12:45:01+11:00", 5, 0.30)]
+        now = datetime(2026, 3, 16, 12, 33, 0, tzinfo=AEDT)
+
+        slots, _metadata = compute_hybrid_slot_schedule(
+            now, entries, "Australia/Sydney"
+        )
+
+        assert slots[0]["price_source"] == "synthetic"
+        assert slots[0]["price"] == 0.30  # borrowed from the first real entry
+        assert slots[1]["start"] == datetime(2026, 3, 16, 12, 45, 1, tzinfo=AEDT)
+
+    def test_covered_case_produces_no_synthetic_slot(self):
+        """Paired with the above: when an entry DOES cover now, no synthetic slot exists."""
+        entries = [
+            _entry("2026-03-16T12:30:01+11:00", 5, 0.10),
+            _entry("2026-03-16T12:35:01+11:00", 5, 0.11),
+        ]
+        now = datetime(2026, 3, 16, 12, 33, 0, tzinfo=AEDT)
+
+        slots, _metadata = compute_hybrid_slot_schedule(
+            now, entries, "Australia/Sydney"
+        )
+
+        assert not any(s["price_source"] == "synthetic" for s in slots)
+
+
+class TestElapsedEntriesStillDropped:
+    """Entries whose interval has genuinely ended are still dropped, as today."""
+
+    def test_fully_elapsed_entry_is_dropped(self):
+        """An entry whose 5-min interval ended before now is dropped, not retained."""
+        entries = [
+            _entry("2026-03-16T12:25:01+11:00", 5, 0.05),  # ended 12:30, elapsed
+            _entry("2026-03-16T12:30:01+11:00", 5, 0.10),  # covers now
+        ]
+        now = datetime(2026, 3, 16, 12, 33, 0, tzinfo=AEDT)
+
+        slots, _metadata = compute_hybrid_slot_schedule(
+            now, entries, "Australia/Sydney"
+        )
+
+        assert all(s["start"].minute != 25 for s in slots)
+        assert slots[0]["price_source"] == "forecast_current"
+        assert slots[0]["price"] == 0.10
+
+    def test_60min_entries_unchanged_by_covering_predicate(self):
+        """Guard against re-enabling coverage-flooring for 60-min entries.
+
+        A 60-min entry starting at 12:00 nominally still "contains" now
+        (12:33) if you floor to the hour -- exactly the shape `_covers_now`
+        must reject via its `duration_minutes not in (5, 30)` guard. If that
+        guard were ever removed, this entry would get retained and handed to
+        `_split_60min_slot`, which would produce a slot 0 already half an
+        hour in the past -- a new bug. Today's (unchanged) rule for 60-min
+        entries is a plain `slot_start < now_local` compare, so it is
+        dropped exactly like it is on main. A second, future entry is
+        included so parsing doesn't return empty outright and the
+        stale-sensor synthetic fallback actually runs.
+        """
+        entries = [
+            _entry("2026-03-16T12:00:00+11:00", 60, 0.40),
+            _entry("2026-03-16T13:00:01+11:00", 30, 0.22),
+        ]
+        now = datetime(2026, 3, 16, 12, 33, 0, tzinfo=AEDT)
+
+        slots, _metadata = compute_hybrid_slot_schedule(
+            now, entries, "Australia/Sydney"
+        )
+
+        assert all(s["start"].hour != 12 or s["start"].minute != 0 for s in slots)
+        assert slots[0]["price_source"] == "synthetic"
+
+
+class TestEstimateFlag:
+    """The covering entry's Amber `estimate` flag is carried through to slot 0."""
+
+    def test_estimate_flag_carried_to_slot0(self, caplog):
+        """estimate=False on the covering entry lands on slots[0] and in the log line."""
+        entries = [
+            _entry("2026-03-16T12:30:01+11:00", 5, 0.10, estimate=False),
+            _entry("2026-03-16T12:35:01+11:00", 5, 0.11, estimate=True),
+        ]
+        now = datetime(2026, 3, 16, 12, 33, 0, tzinfo=AEDT)
+
+        with caplog.at_level(logging.INFO):
+            slots, _metadata = compute_hybrid_slot_schedule(
+                now, entries, "Australia/Sydney"
+            )
+
+        assert slots[0]["estimate"] is False
+        assert any(
+            "SLOT0_CURRENT" in record.message and "estimate=False" in record.message
+            for record in caplog.records
+        )

--- a/tests/pricing/test_pricing_types.py
+++ b/tests/pricing/test_pricing_types.py
@@ -1,6 +1,8 @@
 """Tests for pricing types."""
 
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
+
+import pytest
 
 from custom_components.localshift.pricing.types import ForecastSlot
 
@@ -8,7 +10,7 @@ from custom_components.localshift.pricing.types import ForecastSlot
 def test_forecast_slot_creation():
     """Test ForecastSlot can be created with required fields."""
     slot = ForecastSlot(
-        start_time=datetime(2026, 3, 16, 12, 0, tzinfo=timezone.utc),
+        start_time=datetime(2026, 3, 16, 12, 0, tzinfo=UTC),
         duration=30,
         per_kwh=0.15,
         is_spike=False,
@@ -22,17 +24,14 @@ def test_forecast_slot_creation():
 def test_forecast_slot_is_frozen():
     """Test ForecastSlot is immutable (frozen dataclass)."""
     slot = ForecastSlot(
-        start_time=datetime(2026, 3, 16, 12, 0, tzinfo=timezone.utc),
+        start_time=datetime(2026, 3, 16, 12, 0, tzinfo=UTC),
         duration=30,
         per_kwh=0.15,
         is_spike=False,
         source_type="amber",
     )
-    try:
+    with pytest.raises(AttributeError):
         slot.per_kwh = 0.20
-        assert False, "Should not be able to modify frozen dataclass"
-    except AttributeError:
-        pass
 
 
 class TestForecastSlotGetMethod:
@@ -41,16 +40,14 @@ class TestForecastSlotGetMethod:
     def test_get_existing_fields(self):
         """Test .get() returns existing field values."""
         slot = ForecastSlot(
-            start_time=datetime(2026, 3, 16, 10, 0, tzinfo=timezone.utc),
+            start_time=datetime(2026, 3, 16, 10, 0, tzinfo=UTC),
             duration=30,
             per_kwh=0.25,
             is_spike=False,
             source_type="amber",
         )
 
-        assert slot.get("start_time") == datetime(
-            2026, 3, 16, 10, 0, tzinfo=timezone.utc
-        )
+        assert slot.get("start_time") == datetime(2026, 3, 16, 10, 0, tzinfo=UTC)
         assert slot.get("duration") == 30
         assert slot.get("per_kwh") == 0.25
         assert slot.get("is_spike") is False
@@ -59,7 +56,7 @@ class TestForecastSlotGetMethod:
     def test_get_missing_field_returns_none(self):
         """Test .get() returns None for missing fields by default."""
         slot = ForecastSlot(
-            start_time=datetime(2026, 3, 16, 10, 0, tzinfo=timezone.utc),
+            start_time=datetime(2026, 3, 16, 10, 0, tzinfo=UTC),
             duration=30,
             per_kwh=0.25,
             is_spike=False,
@@ -71,7 +68,7 @@ class TestForecastSlotGetMethod:
     def test_get_missing_field_returns_custom_default(self):
         """Test .get() returns custom default for missing fields."""
         slot = ForecastSlot(
-            start_time=datetime(2026, 3, 16, 10, 0, tzinfo=timezone.utc),
+            start_time=datetime(2026, 3, 16, 10, 0, tzinfo=UTC),
             duration=30,
             per_kwh=0.25,
             is_spike=False,
@@ -84,7 +81,7 @@ class TestForecastSlotGetMethod:
     def test_get_end_time_computed(self):
         """Test .get() computes end_time on demand from start_time + duration."""
         slot = ForecastSlot(
-            start_time=datetime(2026, 3, 16, 10, 0, tzinfo=timezone.utc),
+            start_time=datetime(2026, 3, 16, 10, 0, tzinfo=UTC),
             duration=30,
             per_kwh=0.25,
             is_spike=False,
@@ -92,19 +89,46 @@ class TestForecastSlotGetMethod:
         )
 
         end_time = slot.get("end_time")
-        assert end_time == datetime(2026, 3, 16, 10, 30, tzinfo=timezone.utc)
+        assert end_time == datetime(2026, 3, 16, 10, 30, tzinfo=UTC)
 
     def test_get_end_time_various_durations(self):
         """Test .get() end_time works with different durations."""
         for duration_min in [5, 15, 30, 60]:
             slot = ForecastSlot(
-                start_time=datetime(2026, 3, 16, 10, 0, tzinfo=timezone.utc),
+                start_time=datetime(2026, 3, 16, 10, 0, tzinfo=UTC),
                 duration=duration_min,
                 per_kwh=0.10,
                 is_spike=False,
                 source_type="amber",
             )
-            expected = datetime(2026, 3, 16, 10, 0, tzinfo=timezone.utc) + timedelta(
+            expected = datetime(2026, 3, 16, 10, 0, tzinfo=UTC) + timedelta(
                 minutes=duration_min
             )
             assert slot.get("end_time") == expected
+
+    def test_get_estimate_defaults_to_none(self):
+        """Issue #510 Slice 2: estimate defaults to None when not supplied."""
+        slot = ForecastSlot(
+            start_time=datetime(2026, 3, 16, 10, 0, tzinfo=UTC),
+            duration=30,
+            per_kwh=0.25,
+            is_spike=False,
+            source_type="amber",
+        )
+
+        assert slot.estimate is None
+        assert slot.get("estimate") is None
+
+    def test_get_estimate_explicit_value(self):
+        """Issue #510 Slice 2: an explicit estimate flag round-trips through .get()."""
+        slot = ForecastSlot(
+            start_time=datetime(2026, 3, 16, 10, 0, tzinfo=UTC),
+            duration=30,
+            per_kwh=0.25,
+            is_spike=False,
+            source_type="amber",
+            estimate=False,
+        )
+
+        assert slot.estimate is False
+        assert slot.get("estimate") is False

--- a/tests/pricing/test_provider.py
+++ b/tests/pricing/test_provider.py
@@ -217,9 +217,7 @@ def test_amber_express_v2_reads_detailed_forecast_from_main_entity():
         ],
     }
     # Legacy _price_detailed entity is gone in v2.0.0 → returns None.
-    hass.states.get.side_effect = lambda eid: (
-        None if "detailed" in eid else main_state
-    )
+    hass.states.get.side_effect = lambda eid: None if "detailed" in eid else main_state
 
     slots = provider.read_forecasts(hass, "sensor.amber_express_100h_general_price")
 
@@ -255,9 +253,7 @@ def test_amber_express_simple_forecast_only_yields_empty():
             {"time": "2026-03-16T12:30:00+11:00", "value": 2.50},
         ],
     }
-    hass.states.get.side_effect = lambda eid: (
-        None if "detailed" in eid else main_state
-    )
+    hass.states.get.side_effect = lambda eid: None if "detailed" in eid else main_state
 
     slots = provider.read_forecasts(hass, "sensor.amber_express_100h_general_price")
     assert slots == []
@@ -557,3 +553,41 @@ def test_normalize_slot_integer_per_kwh_coerced_to_float():
 
     assert isinstance(slot.per_kwh, float)
     assert slot.per_kwh == 0.0
+
+
+def test_normalize_slot_carries_estimate():
+    """Issue #510 Slice 2: _normalize_slot carries the raw `estimate` flag through.
+
+    Without this, ForecastSlot.get("estimate") always returned None in
+    production (the field didn't exist on ForecastSlot at all), so the
+    SLOT0_CURRENT log line's estimate=... could never read true/false from
+    real Amber data.
+    """
+    from custom_components.localshift.pricing.provider import AmberExpressProvider
+
+    provider = AmberExpressProvider()
+
+    raw_settled = {
+        "start_time": "2026-03-16T10:00:01+00:00",
+        "end_time": "2026-03-16T10:30:00+00:00",
+        "per_kwh": 0.15,
+        "demand_window": False,
+        "estimate": False,
+    }
+    raw_forecast = {
+        "start_time": "2026-03-16T10:30:01+00:00",
+        "end_time": "2026-03-16T11:00:00+00:00",
+        "per_kwh": 0.18,
+        "demand_window": False,
+        "estimate": True,
+    }
+    raw_missing = {
+        "start_time": "2026-03-16T11:00:01+00:00",
+        "end_time": "2026-03-16T11:30:00+00:00",
+        "per_kwh": 0.20,
+        "demand_window": False,
+    }
+
+    assert provider._normalize_slot(raw_settled).estimate is False
+    assert provider._normalize_slot(raw_forecast).estimate is True
+    assert provider._normalize_slot(raw_missing).estimate is None

--- a/tests/sensors/test_sensors.py
+++ b/tests/sensors/test_sensors.py
@@ -213,6 +213,11 @@ class Fixtures:
         data.physical_response_lag_seconds = None
         data.physical_response_watch = None
         data.physical_response_timed_out = False
+        # Issue #510 slice 1: boundary-lag telemetry, untouched by these tests.
+        data.boundary_lag_seconds = None
+        data.boundary_lag_history = []
+        data.anticipated_transitions_today = 0
+        data.anticipation_corrections_today = 0
         data.forecast_status = "ready"
         data.forecast_ready = True
         data.solcast_today = [{"time": "2024-01-01T10:00:00"}] * 10

--- a/tests/sensors/test_status.py
+++ b/tests/sensors/test_status.py
@@ -321,6 +321,11 @@ class TestDecisionLagSensor:
             decision_lag_history=[],
             decision_timestamp=None,
             command_completion_timestamp=None,
+            # Issue #510 slice 1: boundary-lag telemetry, untouched by this case.
+            boundary_lag_seconds=None,
+            boundary_lag_history=[],
+            anticipated_transitions_today=0,
+            anticipation_corrections_today=0,
         )
         attrs = sensor.extra_state_attributes
         assert attrs["avg_lag_24h"] is None
@@ -335,6 +340,10 @@ class TestDecisionLagSensor:
         assert attrs["physical_lag_seconds"] is None
         assert attrs["physical_lag_observable"] is False
         assert attrs["physical_response_timed_out"] is False
+        assert attrs["boundary_lag_seconds"] is None
+        assert attrs["boundary_lag_history"] == []
+        assert attrs["anticipated_transitions_today"] == 0
+        assert attrs["anticipation_corrections_today"] == 0
 
     def test_extra_state_attributes_with_history(self):
         now = datetime(2026, 3, 12, 12, 0, 0)
@@ -352,6 +361,11 @@ class TestDecisionLagSensor:
             decision_lag_history=history,
             decision_timestamp=now,
             command_completion_timestamp=now,
+            # Issue #510 slice 1: boundary-lag telemetry, untouched by this case.
+            boundary_lag_seconds=None,
+            boundary_lag_history=[],
+            anticipated_transitions_today=0,
+            anticipation_corrections_today=0,
         )
         attrs = sensor.extra_state_attributes
         assert attrs["avg_lag_24h"] == pytest.approx(2.0)
@@ -362,6 +376,55 @@ class TestDecisionLagSensor:
         assert attrs["command_lag_seconds"] == pytest.approx(3.0)
         assert attrs["physical_lag_seconds"] == pytest.approx(7.0)
         assert attrs["command_completion_timestamp"] == now.isoformat()
+
+    def test_extra_state_attributes_boundary_lag(self):
+        # Issue #510 slice 1 (measurement only): the four new attributes are
+        # surfaced on this EXISTING sensor — no new entity.
+        boundary_history = [
+            {"boundary_lag": 23.4, "grant_source": "price"},
+            {"boundary_lag": 41.0, "grant_source": "demand_window"},
+        ]
+        sensor = _sensor(
+            DecisionLagSensor,
+            decision_lag_seconds=None,
+            physical_response_lag_seconds=None,
+            physical_response_timed_out=False,
+            physical_response_watch=None,
+            decision_lag_history=[],
+            decision_timestamp=None,
+            command_completion_timestamp=None,
+            boundary_lag_seconds=23.4321,
+            boundary_lag_history=boundary_history,
+            anticipated_transitions_today=3,
+            anticipation_corrections_today=1,
+        )
+        attrs = sensor.extra_state_attributes
+        assert attrs["boundary_lag_seconds"] == pytest.approx(23.43)
+        assert attrs["boundary_lag_history"] == boundary_history
+        assert attrs["anticipated_transitions_today"] == 3
+        assert attrs["anticipation_corrections_today"] == 1
+
+    def test_extra_state_attributes_boundary_lag_history_windowed(self):
+        # The attribute exposes the last 20 entries; the full 50-entry window
+        # stays in CoordinatorData (size budget — see status.py comment).
+        full_history = [{"boundary_lag": float(i)} for i in range(30)]
+        sensor = _sensor(
+            DecisionLagSensor,
+            decision_lag_seconds=None,
+            physical_response_lag_seconds=None,
+            physical_response_timed_out=False,
+            physical_response_watch=None,
+            decision_lag_history=[],
+            decision_timestamp=None,
+            command_completion_timestamp=None,
+            boundary_lag_seconds=None,
+            boundary_lag_history=full_history,
+            anticipated_transitions_today=0,
+            anticipation_corrections_today=0,
+        )
+        attrs = sensor.extra_state_attributes
+        assert attrs["boundary_lag_history"] == full_history[-20:]
+        assert len(attrs["boundary_lag_history"]) == 20
 
     def test_icon_with_decision_timestamp(self):
         sensor = _sensor(DecisionLagSensor, decision_timestamp=MagicMock())

--- a/tests/test_boundary_lag.py
+++ b/tests/test_boundary_lag.py
@@ -1,0 +1,407 @@
+"""Tests for boundary-lag telemetry (Issue #510 slice 1).
+
+Measurement only: this slice records how far into its 5-minute price interval
+a mode transition lands, tagged by the fingerprint component that granted the
+re-decision. Nothing here may change a decision, a transition, or the
+optimiser — these tests exist to prove that invariant as much as to prove the
+numbers are right.
+"""
+
+from datetime import UTC, datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from homeassistant.util import dt as dt_util
+
+from custom_components.localshift.const import BatteryMode
+from custom_components.localshift.coordinator.data import CoordinatorData
+from custom_components.localshift.state.machine import StateMachine
+
+SYDNEY = timezone(timedelta(hours=11))
+
+
+def dt_aware(*args):
+    return datetime(*args, tzinfo=SYDNEY)
+
+
+@pytest.fixture
+def data():
+    return CoordinatorData()
+
+
+@pytest.fixture
+def state_machine():
+    controller = MagicMock()
+    controller.set_self_consumption = AsyncMock(return_value=True)
+    controller.set_force_charge = AsyncMock(return_value=True)
+    controller.set_boost_charge = AsyncMock(return_value=True)
+    controller.set_force_discharge = AsyncMock(return_value=True)
+    controller.set_proactive_export = AsyncMock(return_value=True)
+    return StateMachine(
+        controller,
+        MagicMock(),
+        lambda key: False,
+        lambda key, default=None: default,
+        MagicMock(),
+    )
+
+
+class TestBoundaryLagMeasurement:
+    """Boundary lag is recorded for every successful non-dry-run transition,
+    independent of the decision_lag `decision_mode == target` guard."""
+
+    def test_recorded_when_decision_guard_would_skip(self, state_machine, data):
+        # decision_mode deliberately does NOT match target: the existing
+        # decision-lag guard in _record_transition_metrics skips this
+        # transition entirely. Boundary lag must not.
+        data.decision_mode = BatteryMode.BOOST_CHARGING
+        data.decision_timestamp = dt_aware(2026, 8, 27, 6, 0, 0)
+        data.active_mode = BatteryMode.SELF_CONSUMPTION
+        with patch(
+            "custom_components.localshift.state.machine.dt_util.now"
+        ) as mock_now:
+            mock_now.return_value = dt_aware(2026, 8, 27, 6, 5, 23)
+            state_machine._record_transition_metrics(
+                data, BatteryMode.GRID_CHARGING, dry_run=False
+            )
+
+        # The old guard still skips (mismatched decision_mode) — unchanged.
+        assert data.decision_lag_seconds is None
+        assert data.decision_lag_history == []
+
+        # But boundary lag is measured regardless — the core point of this slice.
+        assert data.boundary_lag_seconds == pytest.approx(23.0)
+        assert len(data.boundary_lag_history) == 1
+        entry = data.boundary_lag_history[0]
+        assert entry["from_mode"] == "self_consumption"
+        assert entry["to_mode"] == "grid_charging"
+        assert entry["boundary_lag"] == pytest.approx(23.0)
+
+    def test_lag_from_interval_start(self, state_machine, data):
+        # 06:07:23 floors to the 06:05 interval start -> 2m23s = 143.0s lag.
+        with patch(
+            "custom_components.localshift.state.machine.dt_util.now"
+        ) as mock_now:
+            mock_now.return_value = dt_aware(2026, 8, 27, 6, 7, 23)
+            state_machine._record_transition_metrics(
+                data, BatteryMode.SELF_CONSUMPTION, dry_run=False
+            )
+        assert data.boundary_lag_seconds == pytest.approx(143.0)
+        assert (
+            data.boundary_lag_history[0]["interval_start_utc"]
+            == dt_util.as_utc(dt_aware(2026, 8, 27, 6, 5, 0)).isoformat()
+        )
+
+    def test_lag_zero_exactly_on_boundary(self, state_machine, data):
+        with patch(
+            "custom_components.localshift.state.machine.dt_util.now"
+        ) as mock_now:
+            mock_now.return_value = dt_aware(2026, 8, 27, 6, 5, 0)
+            state_machine._record_transition_metrics(
+                data, BatteryMode.SELF_CONSUMPTION, dry_run=False
+            )
+        assert data.boundary_lag_seconds == pytest.approx(0.0)
+
+    def test_lag_just_under_next_boundary(self, state_machine, data):
+        with patch(
+            "custom_components.localshift.state.machine.dt_util.now"
+        ) as mock_now:
+            mock_now.return_value = dt_aware(2026, 8, 27, 6, 9, 59, 500000)
+            state_machine._record_transition_metrics(
+                data, BatteryMode.SELF_CONSUMPTION, dry_run=False
+            )
+        assert data.boundary_lag_seconds == pytest.approx(299.5)
+        # Interval start is still 06:05, NOT rolled forward to 06:10.
+        assert (
+            data.boundary_lag_history[0]["interval_start_utc"]
+            == dt_util.as_utc(dt_aware(2026, 8, 27, 6, 5, 0)).isoformat()
+        )
+
+    def test_history_entry_shape(self, state_machine, data):
+        data.active_mode = BatteryMode.SELF_CONSUMPTION
+        transition_time = dt_aware(2026, 8, 27, 6, 5, 23, 456789)
+        with patch(
+            "custom_components.localshift.state.machine.dt_util.now"
+        ) as mock_now:
+            mock_now.return_value = transition_time
+            state_machine._record_transition_metrics(
+                data, BatteryMode.GRID_CHARGING, dry_run=False
+            )
+        entry = data.boundary_lag_history[0]
+        assert {
+            "from_mode",
+            "to_mode",
+            "boundary_lag",
+            "grant_source",
+            "interval_start_utc",
+            "transition_time",
+        } <= entry.keys()
+        assert entry["from_mode"] == "self_consumption"
+        assert entry["to_mode"] == "grid_charging"
+        assert entry["boundary_lag"] == pytest.approx(round(23.456789, 2))
+        # Both timestamps round-trip to the same instants they were recorded at.
+        assert datetime.fromisoformat(entry["transition_time"]) == transition_time
+        expected_start = dt_util.as_utc(transition_time).replace(
+            second=0, microsecond=0
+        )
+        assert datetime.fromisoformat(entry["interval_start_utc"]) == expected_start
+
+
+class TestBoundaryLagDryRun:
+    def test_dry_run_records_nothing(self, state_machine, data):
+        data.decision_mode = BatteryMode.GRID_CHARGING
+        data.decision_timestamp = dt_aware(2026, 8, 27, 6, 0, 0)
+        with patch(
+            "custom_components.localshift.state.machine.dt_util.now"
+        ) as mock_now:
+            mock_now.return_value = dt_aware(2026, 8, 27, 6, 5, 7)
+            state_machine._record_transition_metrics(
+                data, BatteryMode.GRID_CHARGING, dry_run=True
+            )
+        assert data.boundary_lag_seconds is None
+        assert data.boundary_lag_history == []
+        # Dry runs skip the whole `if not dry_run` block, not just our part.
+        assert state_machine._last_successful_transition is None
+
+
+class TestGrantSourceTagging:
+    """Grant-source attribution is captured in _apply_decision_token, not in
+    _record_transition_metrics — see machine.py _classify_grant_source for why
+    (by transition time, _last_evaluated_base has already been overwritten
+    with the context that authorised the very transition being measured)."""
+
+    BASE_KWARGS = {
+        "general_price": 0.20,
+        "feed_in_price": 0.05,
+        "price_spike": False,
+        "demand_window_active": False,
+        "soc": 50.0,  # comfortably above the 20% default minimum target
+    }
+
+    def _seed(self, data, state_machine):
+        """Grant #1: establishes _last_evaluated_base as the baseline context."""
+        for key, value in self.BASE_KWARGS.items():
+            setattr(data, key, value)
+        state_machine._apply_decision_token(data)
+        assert state_machine._last_grant_source == "unknown"  # no prior base yet
+
+    def test_price_buy_change(self, state_machine, data):
+        self._seed(data, state_machine)
+        data.general_price = 0.30
+        state_machine._apply_decision_token(data)
+        assert state_machine._last_grant_source == "price"
+
+    def test_price_sell_change(self, state_machine, data):
+        self._seed(data, state_machine)
+        data.feed_in_price = 0.08
+        state_machine._apply_decision_token(data)
+        assert state_machine._last_grant_source == "price"
+
+    def test_spike(self, state_machine, data):
+        self._seed(data, state_machine)
+        data.price_spike = True
+        state_machine._apply_decision_token(data)
+        assert state_machine._last_grant_source == "spike"
+
+    def test_demand_window(self, state_machine, data):
+        self._seed(data, state_machine)
+        data.demand_window_active = True
+        state_machine._apply_decision_token(data)
+        assert state_machine._last_grant_source == "demand_window"
+
+    def test_soc_floor(self, state_machine, data):
+        self._seed(data, state_machine)
+        data.soc = 10.0  # below the 20% default minimum target
+        state_machine._apply_decision_token(data)
+        assert state_machine._last_grant_source == "soc_floor"
+
+    def test_plan_charge(self, state_machine, data):
+        self._seed(data, state_machine)
+        # Base context unchanged; only the plan-disagreement epoch moves.
+        data.active_mode = BatteryMode.SELF_CONSUMPTION
+        data.debug_plan_mode_pending = BatteryMode.GRID_CHARGING.value
+        state_machine._apply_decision_token(data)
+        assert state_machine._last_grant_source == "plan_charge"
+
+    def test_unknown_first_transition_after_restart(self, state_machine, data):
+        # A single grant with no previous base (fresh machine) is "unknown".
+        for key, value in self.BASE_KWARGS.items():
+            setattr(data, key, value)
+        state_machine._apply_decision_token(data)
+        assert state_machine._last_grant_source == "unknown"
+
+    def test_precedence_non_price_wins(self, state_machine, data):
+        # Both price AND demand_window move in the same grant: the tag must be
+        # demand_window, not price — the tag exists to exclude legitimately
+        # mid-interval transitions (a DW crossing) from the price baseline.
+        self._seed(data, state_machine)
+        data.general_price = 0.35
+        data.demand_window_active = True
+        state_machine._apply_decision_token(data)
+        assert state_machine._last_grant_source == "demand_window"
+
+    def test_backstop_override(self, state_machine, data):
+        self._seed(data, state_machine)
+        data.general_price = 0.30
+        state_machine._apply_decision_token(data)
+        assert state_machine._last_grant_source == "price"
+
+        state_machine._transition_source_override = "backstop"
+        with patch(
+            "custom_components.localshift.state.machine.dt_util.now"
+        ) as mock_now:
+            mock_now.return_value = dt_aware(2026, 8, 27, 6, 5, 0)
+            state_machine._record_transition_metrics(
+                data, BatteryMode.GRID_CHARGING, dry_run=False
+            )
+        state_machine._transition_source_override = None
+        # Tagged backstop even though _last_grant_source says "price".
+        assert data.boundary_lag_history[-1]["grant_source"] == "backstop"
+
+    def test_invalidate_clears_grant_source(self, state_machine, data):
+        self._seed(data, state_machine)
+        data.general_price = 0.30
+        state_machine._apply_decision_token(data)
+        assert state_machine._last_grant_source == "price"
+
+        state_machine.invalidate_decision_fingerprint("test")
+        assert state_machine._last_grant_source is None
+
+        with patch(
+            "custom_components.localshift.state.machine.dt_util.now"
+        ) as mock_now:
+            mock_now.return_value = dt_aware(2026, 8, 27, 6, 5, 10)
+            state_machine._record_transition_metrics(
+                data, BatteryMode.SELF_CONSUMPTION, dry_run=False
+            )
+        assert data.boundary_lag_history[-1]["grant_source"] == "unknown"
+
+
+class TestOverrideLifecycle:
+    """The try/finally around both backstop call sites must clear the override
+    on every path out, including a failed transition — machine.py's own
+    comment calls this "not optional" because _record_transition_metrics only
+    runs on success, so a failure would otherwise leave it armed forever."""
+
+    async def test_override_cleared_after_failed_transition(self, state_machine, data):
+        state_machine._last_grant_source = "price"
+        state_machine._battery_controller.verify_current_state = AsyncMock(
+            return_value=False
+        )
+        state_machine._battery_controller.set_self_consumption = AsyncMock(
+            return_value=False
+        )
+        state_machine._notification_service.send_health_correction_notification = (
+            AsyncMock()
+        )
+
+        with patch(
+            "custom_components.localshift.state.machine.dt_util.now"
+        ) as mock_now:
+            mock_now.return_value = dt_aware(2026, 8, 27, 6, 0, 0)
+            await state_machine._perform_health_check(data)
+
+        assert state_machine._transition_source_override is None
+        # The failed correction never reaches _record_transition_metrics.
+        assert data.boundary_lag_history == []
+
+        # A subsequent SUCCESSFUL transition must not inherit "backstop".
+        state_machine._battery_controller.set_self_consumption = AsyncMock(
+            return_value=True
+        )
+        with patch(
+            "custom_components.localshift.state.machine.dt_util.now"
+        ) as mock_now:
+            mock_now.return_value = dt_aware(2026, 8, 27, 6, 0, 30)
+            success = await state_machine._execute_mode_transition(
+                data, BatteryMode.SELF_CONSUMPTION
+            )
+        assert success is True
+        assert data.boundary_lag_history[-1]["grant_source"] == "price"
+
+
+class TestBoundaryLagHistoryCap:
+    def test_capped_at_200(self, state_machine, data):
+        data.boundary_lag_history = [{"boundary_lag": float(i)} for i in range(210)]
+        with patch(
+            "custom_components.localshift.state.machine.dt_util.now"
+        ) as mock_now:
+            mock_now.return_value = dt_aware(2026, 8, 27, 6, 5, 0)
+            state_machine._record_transition_metrics(
+                data, BatteryMode.SELF_CONSUMPTION, dry_run=False
+            )
+        assert len(data.boundary_lag_history) == 200
+        assert data.boundary_lag_history[-1]["to_mode"] == "self_consumption"
+
+
+class TestUtcDerivation:
+    """The interval start is floored in UTC (NEM time is a fixed UTC+10
+    offset), not local wall clock, so a DST transition is a non-event by
+    construction. With Australia's whole-hour offsets a naive local floor
+    would usually agree anyway (10h and 11h are both multiples of 5 minutes)
+    — this is a correctness-by-construction choice plus a regression guard,
+    not a fix for an observed live bug."""
+
+    def test_dst_boundary_does_not_shift_interval(self, state_machine, data):
+        aest = timezone(timedelta(hours=10))  # non-DST
+        aedt = timezone(timedelta(hours=11))  # DST
+        utc_instant = datetime(2026, 4, 5, 3, 7, 23, tzinfo=UTC)
+        as_aest = utc_instant.astimezone(aest)
+        as_aedt = utc_instant.astimezone(aedt)
+        # Sanity: genuinely different local representations of one instant.
+        assert as_aest.utcoffset() != as_aedt.utcoffset()
+        assert as_aest.hour != as_aedt.hour
+
+        data_a = CoordinatorData()
+        data_b = CoordinatorData()
+        with patch(
+            "custom_components.localshift.state.machine.dt_util.now"
+        ) as mock_now:
+            mock_now.return_value = as_aest
+            state_machine._record_transition_metrics(
+                data_a, BatteryMode.SELF_CONSUMPTION, dry_run=False
+            )
+        with patch(
+            "custom_components.localshift.state.machine.dt_util.now"
+        ) as mock_now:
+            mock_now.return_value = as_aedt
+            state_machine._record_transition_metrics(
+                data_b, BatteryMode.SELF_CONSUMPTION, dry_run=False
+            )
+
+        assert data_a.boundary_lag_seconds == pytest.approx(data_b.boundary_lag_seconds)
+        assert (
+            data_a.boundary_lag_history[0]["interval_start_utc"]
+            == data_b.boundary_lag_history[0]["interval_start_utc"]
+        )
+
+    def test_spring_forward_boundary_does_not_shift_interval(self, state_machine, data):
+        aest = timezone(timedelta(hours=10))
+        aedt = timezone(timedelta(hours=11))
+        utc_instant = datetime(2026, 10, 4, 16, 22, 41, tzinfo=UTC)
+        as_aest = utc_instant.astimezone(aest)
+        as_aedt = utc_instant.astimezone(aedt)
+        assert as_aest.utcoffset() != as_aedt.utcoffset()
+
+        data_a = CoordinatorData()
+        data_b = CoordinatorData()
+        with patch(
+            "custom_components.localshift.state.machine.dt_util.now"
+        ) as mock_now:
+            mock_now.return_value = as_aest
+            state_machine._record_transition_metrics(
+                data_a, BatteryMode.SELF_CONSUMPTION, dry_run=False
+            )
+        with patch(
+            "custom_components.localshift.state.machine.dt_util.now"
+        ) as mock_now:
+            mock_now.return_value = as_aedt
+            state_machine._record_transition_metrics(
+                data_b, BatteryMode.SELF_CONSUMPTION, dry_run=False
+            )
+
+        assert data_a.boundary_lag_seconds == pytest.approx(data_b.boundary_lag_seconds)
+        assert (
+            data_a.boundary_lag_history[0]["interval_start_utc"]
+            == data_b.boundary_lag_history[0]["interval_start_utc"]
+        )

--- a/tests/test_decision_lag.py
+++ b/tests/test_decision_lag.py
@@ -543,6 +543,11 @@ class TestDecisionLagSensor:
             ],
             decision_timestamp=now,
             command_completion_timestamp=now,
+            # Issue #510 slice 1: boundary-lag telemetry, untouched by this case.
+            boundary_lag_seconds=None,
+            boundary_lag_history=[],
+            anticipated_transitions_today=0,
+            anticipation_corrections_today=0,
         )
         attrs = sensor.extra_state_attributes
         assert attrs["command_lag_seconds"] == 7.0
@@ -562,6 +567,11 @@ class TestDecisionLagSensor:
             decision_lag_history=[],
             decision_timestamp=None,
             command_completion_timestamp=None,
+            # Issue #510 slice 1: boundary-lag telemetry, untouched by this case.
+            boundary_lag_seconds=None,
+            boundary_lag_history=[],
+            anticipated_transitions_today=0,
+            anticipation_corrections_today=0,
         )
         attrs = sensor.extra_state_attributes
         assert attrs["avg_lag_24h"] is None


### PR DESCRIPTION
Slices 1 and 2 of the #510 anticipatory forecast-first plan, re-landed on `test`.

Originally built and merged onto `fix/719-trajectory-aware-headroom` (PRs #950, #951) before it was established that `fix/719` is superseded — `test` carries PR #939 (`7bb5450`), which is the current form of the same trajectory-headroom and taper work `fix/719` holds in older form, plus HOLD_STRICT, salvage value, futile-cycling relief and the grid-charging listener fix. Live runs `test`. These are the same two commits cherry-picked onto the right base.

Two conflicts, both adjacency rather than semantics, both resolved as "keep both":
- `state/machine.py` — the `#491` grid-charging listener and slice 1's `_transition_source_override` declare independent attributes on the same `__init__` line.
- `tests/pricing/test_provider.py` — the `#897` per-kWh coercion test and slice 2's `estimate` test were added at the same point in the file. Rebuilt from `origin/test` plus slice 2's function verbatim rather than patched.

## Slice 1 — boundary-lag telemetry (measurement only)

Records how far into its 5-minute price interval every successful non-dry-run transition lands, tagged by the fingerprint component that granted it. Interval start derived in UTC (NEM is a fixed UTC+10 offset), so DST is a non-event by construction. This is the baseline slice 3's acceptance criterion is measured against. History capped at 200 rather than `decision_lag_history`'s 50 — one ring is shared across grant sources, so a backstop or spike burst must not evict the `price` samples (#942 tracks the proper per-source partition).

## Slice 2 — slot-0 covering-entry pricing (unflagged correctness fix)

Amber's `detailedForecast` entries start one second after the boundary, so the entry covering the current interval was always dropped and slot 0 was priced from the **next** interval at every evaluation. Now retained as `forecast_current` with the boundary floored to absorb the offset; synthetic demoted to a stale-sensor fallback with a `WARNING`. Hard prerequisite for slice 3.

## Verification

`uv run ruff check` clean, `uv run pytest` **3663 passed / 1 xfailed** on this branch.

## Known findings

Non-blocking, filed as #940–#949 during the build. #942 (shared ring eviction, partly mitigated by the cap here) and #946 (duration parsing aborting the schedule on a malformed entry) are the two worth reading.