### PR TITLE
chore(#510): temporary diagnostic for the slot-0 forecast input

### DIFF
--- a/custom_components/localshift/engine/slot_schedule.py
+++ b/custom_components/localshift/engine/slot_schedule.py
@@ -154,6 +154,25 @@ def compute_hybrid_slot_schedule(
         _LOGGER.warning("compute_hybrid_slot_schedule: Empty general_forecast")
         return [], metadata
 
+    # TEMPORARY DIAGNOSTIC (#510): slice 2 is live but every evaluation still
+    # falls back to synthetic, meaning the entry covering "now" never reaches
+    # the parser. Log what actually arrives so the upstream drop can be located.
+    # Remove once the read path is fixed.
+    _LOGGER.info(
+        "GENERAL_FORECAST_IN: n=%d now_local=%s first3=%s",
+        len(general_forecast or []),
+        now_local.isoformat(),
+        [
+            {
+                "start_time": str(e.get("start_time")),
+                "per_kwh": e.get("per_kwh"),
+                "duration": e.get("duration"),
+                "estimate": e.get("estimate"),
+            }
+            for e in (general_forecast or [])[:3]
+        ],
+    )
+
     all_slots_raw = _parse_forecast_entries(general_forecast, now_local, ha_timezone)
     if not all_slots_raw:
         _LOGGER.warning("compute_hybrid_slot_schedule: No valid slots after parsing")


### PR DESCRIPTION
Temporary, to be removed once the read path is fixed.

Slice 2 (#952) is deployed and behaving correctly in isolation — 9 tests, and the deployed `_parse_single_entry` is byte-for-byte what was reviewed. But **every live evaluation still falls back to synthetic**: 13 of 13 `SLOT0_CURRENT` lines read `source=synthetic`, none `forecast_current`.

The data is present and the right shape. `sensor.amber_express_100h_general_price` holds `detailedForecast[0] = 2026-08-28T12:00:01+00:00, per_kwh 0.1836, estimate: False, duration: 5` — the current interval at the settled price, exactly as the #510 spec verified. Yet the parser reports `HYBRID_SLOTS: slots=58, first_slot=22:05:01` at a moment the sensor still held `22:00:01`.

So the entry covering "now" is removed **upstream of `slot_schedule.py`**, and slice 2 fixed a layer that entry never survives to reach. Ruled out by inspection: the Express provider's `read_forecasts` (normalises every raw entry, no time filter), `_extend_forecast_with_assumed_prices` (append-only), and the computation-engine forecast scans (read-only).

This logs the length and first three entries of `general_forecast` as they arrive at `compute_hybrid_slot_schedule`, which should identify the layer from a single evaluation cycle rather than more static reading.

`uv run ruff check` clean, `uv run pytest` 3663 passed / 1 xfailed.