### PR TITLE
chore(slot_schedule): remove temporary GENERAL_FORECAST_IN diagnostic

### DIFF
--- a/custom_components/localshift/engine/slot_schedule.py
+++ b/custom_components/localshift/engine/slot_schedule.py
@@ -154,25 +154,6 @@ def compute_hybrid_slot_schedule(
         _LOGGER.warning("compute_hybrid_slot_schedule: Empty general_forecast")
         return [], metadata
 
-    # TEMPORARY DIAGNOSTIC (#510): slice 2 is live but every evaluation still
-    # falls back to synthetic, meaning the entry covering "now" never reaches
-    # the parser. Log what actually arrives so the upstream drop can be located.
-    # Remove once the read path is fixed.
-    _LOGGER.info(
-        "GENERAL_FORECAST_IN: n=%d now_local=%s first3=%s",
-        len(general_forecast or []),
-        now_local.isoformat(),
-        [
-            {
-                "start_time": str(e.get("start_time")),
-                "per_kwh": e.get("per_kwh"),
-                "duration": e.get("duration"),
-                "estimate": e.get("estimate"),
-            }
-            for e in (general_forecast or [])[:3]
-        ],
-    )
-
     all_slots_raw = _parse_forecast_entries(general_forecast, now_local, ha_timezone)
     if not all_slots_raw:
         _LOGGER.warning("compute_hybrid_slot_schedule: No valid slots after parsing")


### PR DESCRIPTION
Removes the temporary INFO diagnostic added in #953, now that #954 is root-caused and fixed live.

The diagnostic proved `general_forecast` arrived one interval ahead with `estimate` unset. Root cause turned out to be configuration, not code: `pricing_data_source` was `amber`, so `create_provider()` returned `AmberProvider` reading the native `sensor.100h_general_forecast` series — forward-only and rounded to cents — rather than Amber Express's `detailedForecast`. Full write-up on #954.

Live config switched to `amber_express` at 09:54 today and verified:

```
09:53:44  SLOT0_CURRENT: start=09:50:00 price=0.0700 source=synthetic        estimate=None
09:54:40  SLOT0_CURRENT: start=09:50:01 price=0.0969 source=forecast_current estimate=False
09:55:35  SLOT0_CURRENT: start=09:55:01 price=0.0913 source=forecast_current estimate=False
```

`SLOT0_CURRENT` is deliberately kept — it is the durable signal and costs one line per evaluation either way.

Tests: `tests/engine` 830 passed.

Hold this until you are satisfied the Express source is stable through a demand window; there is no urgency to strip the diagnostic before then.