### PR TITLE
fix(coordinator): route the medium tick through TickScheduler (#959)

### DIFF
--- a/custom_components/localshift/coordinator/coordinator.py
+++ b/custom_components/localshift/coordinator/coordinator.py
@@ -591,73 +591,35 @@ class LocalShiftCoordinator:
         self._check_physical_response_watch()
 
     @callback
-    def _handle_medium_tick(self, now: datetime) -> None:  # pragma: no cover
+    def _handle_medium_tick(self, now: datetime) -> None:
         """Handle MEDIUM tier periodic tasks (5 minutes).
 
-        Learning and monitoring tasks that don't need minute-level accuracy:
-        - Entity health check
-        - Load data refresh
-        - Decision backfill
-        - Weather learning
-        - Baseline calculation
+        Delegates to TickScheduler, matching _handle_fast_tick and
+        _handle_slow_tick.
+
+        This handler previously carried a duplicate inline copy of the
+        scheduler's medium-tick body, in which the solar-accuracy backfill call
+        had been replaced by a bare ``pass``. Because SubscriptionManager
+        registers *this* method, TickScheduler.handle_medium_tick had no
+        production caller and _backfill_solar_actual /
+        _flush_completed_periods were unreachable — the solar-accuracy sampler
+        never recorded a single period and pending forecasts were never
+        evicted. Keep this a thin delegate so the two bodies cannot drift
+        again; test_tick_handlers_delegate.py enforces it.
         """
-        # Read raw entity values
-        self._read_all_external_state()
+        if self._tick_scheduler is not None:
+            self._tick_scheduler.handle_medium_tick(now)
 
-        # Skip expensive operations during startup grace period
-        # This prevents errors when entities haven't populated yet (Issue #551)
-        if self._is_in_startup_grace():
-            _LOGGER.debug("Skipping medium tick operations during startup grace period")
-            return
-
-        # Check entity health
-        self._check_entity_health()
-
-        # Refresh load data (historical and recent)
-        if self._computation_engine is not None:
-            load_entity_id = self.get_entity_id(CONF_TESLEMETRY_LOAD_POWER)
-            self.hass.async_create_task(
-                self._computation_engine.async_get_recent_load_1hr(load_entity_id),
-                "localshift_fetch_recent_load",
-            )
-            self.hass.async_create_task(
-                self._computation_engine.async_get_historical_hourly_averages(
-                    load_entity_id
-                ),
-                "localshift_fetch_historical_load",
-            )
-
-        if self._learning_orchestrator is not None:
-            self._learning_orchestrator.update_medium_tick(self.data)
-
-        # Backfill solar forecast accuracy for completed periods (Issue #378)
-        if (
-            hasattr(self, "solar_accuracy_tracker")
-            and self.solar_accuracy_tracker is not None
-        ):
-            pass
-
-        # Update solar bias metrics from tracker (Issue #378)
-        if (
-            hasattr(self, "solar_accuracy_tracker")
-            and self.solar_accuracy_tracker is not None
-        ):
-            self.data.solar_bias_metrics = self.solar_accuracy_tracker.get_status_dict()
-            self.data.solar_forecast_accuracy = (
-                self.solar_accuracy_tracker.reported_accuracy()
-            )
-
-        # Compute hybrid accuracy combining LocalShift tracker + Solcast MAPE (Issue #778 Phase 2)
-        self._update_hybrid_accuracy()
-
-        # Learn from current temperature/load for weather correlation
-        if self._computation_engine is not None:
-            self.hass.async_create_task(
-                self._computation_engine.async_learn_weather_sample(self.data),
-                "localshift_weather_learning",
-            )
-
-        _LOGGER.debug("Medium tick completed: learning and monitoring tasks")
+        # Issue #778 Phase 2: hybrid accuracy is coordinator-owned and is
+        # computed from the solar metrics the scheduler just refreshed. Kept
+        # here rather than pushed into TickScheduler so the scheduler does not
+        # reach back into a private coordinator method; mirrors the way
+        # _handle_fast_tick calls _check_physical_response_watch after
+        # delegating. Unlike the old inline body this also runs during the
+        # startup grace period, which is harmless: the computation is
+        # null-safe and the next post-grace tick recomputes it.
+        if self.data is not None:
+            self._update_hybrid_accuracy()
 
     def _update_hybrid_accuracy(self) -> None:
         """Compute hybrid accuracy combining LocalShift tracker with Solcast MAPE.

--- a/tests/coordinator/test_coordinator.py
+++ b/tests/coordinator/test_coordinator.py
@@ -674,6 +674,66 @@ class TestHandleSlowTick:
         assert call_args[0][1] == "localshift_save_accuracy_metrics"
 
 
+class TestHandleMediumTick:
+    """Tests for _handle_medium_tick method.
+
+    The medium tick is the tier that drives the solar-accuracy backfill. It was
+    once a duplicate inline copy of TickScheduler.handle_medium_tick with the
+    backfill call stubbed out to ``pass``, which orphaned the scheduler method
+    and silently disabled solar-accuracy sampling. These tests pin the
+    delegation behaviourally; test_tick_handlers_delegate.py pins it
+    structurally.
+    """
+
+    def test_medium_tick_delegates_to_scheduler(self, coordinator, coordinator_data):
+        """The registered handler must route to TickScheduler, not reimplement it."""
+        from datetime import UTC, datetime
+
+        coordinator.data = coordinator_data
+        coordinator._tick_scheduler = MagicMock()
+
+        now = datetime.now(UTC)
+        coordinator._handle_medium_tick(now)
+
+        coordinator._tick_scheduler.handle_medium_tick.assert_called_once_with(now)
+
+    def test_medium_tick_updates_hybrid_accuracy(self, coordinator, coordinator_data):
+        """Hybrid accuracy (#778 Phase 2) is computed after the scheduler runs."""
+        from datetime import UTC, datetime
+
+        coordinator.data = coordinator_data
+        coordinator.data.solcast_mape = 12.0
+        coordinator.data.solar_forecast_accuracy = None
+        coordinator._tick_scheduler = MagicMock()
+
+        coordinator._handle_medium_tick(datetime.now(UTC))
+
+        # No LocalShift samples yet, so it defers wholly to Solcast.
+        assert coordinator.data.hybrid_solar_accuracy == 88.0
+
+    def test_medium_tick_without_scheduler_does_not_raise(
+        self, coordinator, coordinator_data
+    ):
+        """A missing scheduler must not break the tick."""
+        from datetime import UTC, datetime
+
+        coordinator.data = coordinator_data
+        coordinator._tick_scheduler = None
+
+        coordinator._handle_medium_tick(datetime.now(UTC))
+
+    def test_medium_tick_skips_hybrid_accuracy_without_data(self, coordinator):
+        """Before the first refresh ``data`` is None; the tick must stay safe."""
+        from datetime import UTC, datetime
+
+        coordinator.data = None
+        coordinator._tick_scheduler = MagicMock()
+
+        coordinator._handle_medium_tick(datetime.now(UTC))
+
+        coordinator._tick_scheduler.handle_medium_tick.assert_called_once()
+
+
 class TestAsyncStop:
     """Tests for async_stop method."""
 

--- a/tests/coordinator/test_tick_handlers_delegate.py
+++ b/tests/coordinator/test_tick_handlers_delegate.py
@@ -1,0 +1,103 @@
+"""Structural guard: every TickScheduler handler must be reachable in production.
+
+Regression gate for the medium-tick backfill defect.
+
+``SubscriptionManager`` is wired to the *coordinator's* ``_handle_*`` methods,
+not to ``TickScheduler``'s. When ``_handle_medium_tick`` was left as a duplicate
+inline copy of the scheduler's body, ``TickScheduler.handle_medium_tick`` lost
+its only production caller — and with it ``_backfill_solar_actual`` and
+``_flush_completed_periods``. The solar-accuracy sampler therefore never
+recorded a period and never evicted a pending forecast, while the unit tests
+stayed green because they invoke ``handle_medium_tick`` directly.
+
+Behavioural tests cannot catch that: calling the orphan proves it works, not
+that anything calls it. So this check is static — it reads the source and
+asserts each coordinator handler is a thin delegate to its scheduler twin.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+_COORDINATOR_DIR = (
+    Path(__file__).resolve().parents[2]
+    / "custom_components"
+    / "localshift"
+    / "coordinator"
+)
+_COORDINATOR_PY = _COORDINATOR_DIR / "coordinator.py"
+_TICK_SCHEDULER_PY = _COORDINATOR_DIR / "tick_scheduler.py"
+
+
+def _class_def(path: Path, class_name: str) -> ast.ClassDef:
+    tree = ast.parse(path.read_text())
+    for node in tree.body:
+        if isinstance(node, ast.ClassDef) and node.name == class_name:
+            return node
+    raise AssertionError(f"{class_name} not found in {path.name}")
+
+
+def _methods(class_def: ast.ClassDef) -> dict[str, ast.FunctionDef]:
+    return {
+        node.name: node
+        for node in class_def.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+
+
+def _delegates_to(method: ast.FunctionDef, scheduler_method: str) -> bool:
+    """True if the method body contains ``self._tick_scheduler.<scheduler_method>(...)``."""
+    for node in ast.walk(method):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not isinstance(func, ast.Attribute) or func.attr != scheduler_method:
+            continue
+        owner = func.value
+        if (
+            isinstance(owner, ast.Attribute)
+            and owner.attr == "_tick_scheduler"
+            and isinstance(owner.value, ast.Name)
+            and owner.value.id == "self"
+        ):
+            return True
+    return False
+
+
+SCHEDULER_HANDLERS = sorted(
+    name
+    for name in _methods(_class_def(_TICK_SCHEDULER_PY, "TickScheduler"))
+    if name.startswith("handle_")
+)
+
+
+def test_scheduler_exposes_handlers() -> None:
+    """Sanity check that the introspection found the handler set at all."""
+    assert SCHEDULER_HANDLERS, "no handle_* methods found on TickScheduler"
+
+
+@pytest.mark.parametrize("scheduler_handler", SCHEDULER_HANDLERS)
+def test_coordinator_handler_delegates_to_scheduler(scheduler_handler: str) -> None:
+    """Each TickScheduler.handle_* has a coordinator handler that calls it.
+
+    An inline reimplementation on the coordinator side silently orphans the
+    scheduler method and anything only it reaches.
+    """
+    coordinator_handler = f"_{scheduler_handler}"
+    coordinator_methods = _methods(_class_def(_COORDINATOR_PY, "LocalShiftCoordinator"))
+
+    assert coordinator_handler in coordinator_methods, (
+        f"TickScheduler.{scheduler_handler} is orphaned: no "
+        f"LocalShiftCoordinator.{coordinator_handler} to route to it."
+    )
+
+    assert _delegates_to(coordinator_methods[coordinator_handler], scheduler_handler), (
+        f"LocalShiftCoordinator.{coordinator_handler} does not call "
+        f"self._tick_scheduler.{scheduler_handler}(). SubscriptionManager "
+        f"registers the coordinator method, so TickScheduler."
+        f"{scheduler_handler} would never run in production. Delegate rather "
+        f"than reimplementing the body inline."
+    )


### PR DESCRIPTION
Fixes #959.

## What was wrong

`SubscriptionManager` registers the **coordinator's** `_handle_medium_tick`, not
`TickScheduler.handle_medium_tick`. That handler was left as a duplicate inline copy of the
scheduler's body, and in that copy the solar-accuracy backfill call had been replaced by a
bare `pass`:

```python
# coordinator.py:633 (before)
if (
    hasattr(self, "solar_accuracy_tracker")
    and self.solar_accuracy_tracker is not None
):
    pass
```

So `TickScheduler.handle_medium_tick` had zero production callers, and everything reachable
only from it — `_backfill_solar_actual` and `_flush_completed_periods` — never executed.
`_handle_fast_tick` and `_handle_slow_tick` both delegate correctly; medium was the only one
of the seven left inline.

Live confirmation (entry `01KHNE4ZG4PCVV3DF0SDK04635`, 2026-08-30): `period_records: 0`,
`pending_forecasts: 103` with the oldest 14h old against a 4h eviction cutoff, and zero
`Discarding partially-covered solar period` lines in a DEBUG-armed log — so it is not the
70% coverage gate. 62,551 `Recorded solar forecast` lines confirm the forecast side was
always healthy; only the actuals side was dead. Live is byte-identical to `origin/test` for
all four relevant files, so this is source, not deploy.

## The fix

Make `_handle_medium_tick` a thin delegate matching its six siblings.

The subtlety: the two bodies had drifted in **both** directions. The scheduler has the
backfill; the coordinator has `_update_hybrid_accuracy()` (#778 Phase 2), which the scheduler
lacks. A naive "just delegate" silently drops hybrid accuracy. It is kept coordinator-side
and called after delegating, mirroring how `_handle_fast_tick` calls
`_check_physical_response_watch()`.

I first tried moving it into the scheduler to preserve exact grace-period semantics; that
made the scheduler reach into a private coordinator method and broke five existing tests
that build `coordinator.data = MagicMock()`. The wrapper is the better shape.

**Behaviour delta**: hybrid accuracy is now also computed during the startup grace window.
Null-safe, guarded on `self.data is not None`, and recomputed by the next post-grace tick.

## The regression gate

`tests/coordinator/test_tick_handlers_delegate.py` parses the source and asserts every
`TickScheduler.handle_*` has a coordinator handler that actually delegates to it.

It is deliberately **static**. A behavioural test cannot catch this class of bug: the
existing suite calls `scheduler.handle_medium_tick(...)` directly and stayed green
throughout, because calling the orphan proves it works, not that anything calls it. Same
shape as #954 — correct code on a path the live configuration never took.

Verified RED against the pre-fix source: fails on `handle_medium_tick` alone, passes the
other six.

Four behavioural tests (`TestHandleMediumTick`) sit alongside it.

## Verification

- Full suite: 3675 passed, 1 xfailed.
- Coverage on `coordinator.py`: 95% -> 96%. The old body carried `# pragma: no cover`, which
  is why the dead branch was never flagged.
- Ruff check and format clean on all three touched files; the repo's 262 pre-existing
  findings are unchanged from baseline.

## After deploy

Expect the ~103 stale pendings to be evicted on the first medium tick, and
`correction_active` to stay false until 20 samples accumulate (~2 days of daylight). Neither
is a fault.
