### PR TITLE
Rebuild the dashboard Overview on native cards, repair entity drift, extend Debug

### DIFF
--- a/custom_components/localshift/dashboard.yaml
+++ b/custom_components/localshift/dashboard.yaml
@@ -3,8 +3,8 @@
 # =============================================================================
 #
 # Three views:
-#   - Overview: mission control — a bespoke command card (status + live flows
-#     + a fused plan timeline), the decision feed, money, and quick controls.
+#   - Overview: mission control — status, live flows, the plan timeline, peak
+#     readiness, money, the decision feed, and quick controls.
 #   - Settings: all LocalShift controls, grouped by how often you touch them.
 #   - Debug:    full state dump, decision log, and slot-by-slot optimizer plan.
 #
@@ -14,14 +14,18 @@
 #   - my_home_*  entities from the Tesla Powerwall integration (Teslemetry)
 #   - 100h_*     entities from the Amber Electric YAML package
 #
-# No HACS cards required. The Overview uses LocalShift's own cards, shipped
-# with the integration at custom_components/localshift/www/localshift-cards.js.
-# Install the cards once:
+# No HACS cards required. Everything here is a native Home Assistant card
+# except one: custom:localshift-plan-timeline. Core HA can only plot the past
+# (history-graph, statistics-graph), so the forward plan has no native
+# equivalent — that card, and only that card, ships with the integration at
+# custom_components/localshift/www/localshift-cards.js.
+# Install it once:
 #   1. Copy custom_components/localshift/www/localshift-cards.js
 #      to <ha-config>/www/localshift/localshift-cards.js
 #   2. Settings -> Dashboards -> Resources -> Add resource:
-#        URL:  /local/localshift/localshift-cards.js
+#        URL:  /local/localshift/localshift-cards.js?v=2.0.0
 #        Type: JavaScript module
+#      (bump the ?v= query on update, or browsers keep the old module cached)
 #
 # Add to configuration.yaml:
 #   lovelace:
@@ -39,10 +43,10 @@ title: LocalShift
 views:
   # ===========================================================================
   # VIEW 1: OVERVIEW — mission control
-  # One bespoke command card carries the story: status + live flows + a fused
-  # timeline (price bands, peak window, planned actions, SOC actual & plan).
-  # Supporting cards: the decision feed ("why"), money, and quick controls.
-  # Cards are defined in www/localshift-cards.js (see install note above).
+  # Built from native cards wherever Home Assistant has one. The single custom
+  # element left is the plan timeline: core HA plots the past (history-graph,
+  # statistics-graph) and has nothing that plots a forward series, and the
+  # forward plan is the whole point of this integration.
   # ===========================================================================
   - title: Overview
     path: overview
@@ -50,6 +54,103 @@ views:
     type: sections
     max_columns: 2
     sections:
+      # --- What it is doing, and why ---------------------------------------
+      - type: grid
+        column_span: 2
+        cards:
+          - type: heading
+            heading: Right now
+            heading_style: title
+            icon: mdi:home-battery
+            badges:
+              - type: entity
+                entity: switch.localshift_automation_enabled
+                show_state: true
+              - type: entity
+                entity: switch.localshift_dry_run
+                show_state: true
+              - type: entity
+                entity: binary_sensor.localshift_tesla_override_active
+                show_state: true
+              - type: entity
+                entity: sensor.localshift_integration_status
+                show_state: true
+              - type: entity
+                entity: sensor.localshift_optimizer_summary
+                show_state: true
+
+          - type: markdown
+            content: |
+              {% set mode = states('select.localshift_battery_mode') %}
+              {% set heads = {
+                   'self_consumption': 'Running on sun & stored energy',
+                   'grid_charging': 'Charging on cheap power',
+                   'boost_charging': 'Boost charging before the peak',
+                   'spike_discharge': 'Selling into the spike',
+                   'proactive_export': 'Exporting ahead of negative prices',
+                   'automatic': 'Optimizer in control' } %}
+              {% if not is_state('switch.localshift_automation_enabled', 'on') %}
+              ## Manual control
+              Automation is off — LocalShift is not steering the battery.
+              {% else %}
+              ## {{ heads.get(mode, 'Optimizer in control') }}
+              {{ state_attr('sensor.localshift_decision_log', 'reason') or '' }}
+              {% endif %}
+
+              {% set c = state_attr('sensor.localshift_optimizer_plan_detailed', 'computed_at') %}
+              {% set age = ((now() - as_datetime(c)).total_seconds() / 60) if c else 0 %}
+              {% if age > 30 %}
+              ⚠️ Plan is {{ age | round(0) }} minutes old.
+              {% endif %}
+
+      # --- Live flows -------------------------------------------------------
+      - type: grid
+        column_span: 2
+        cards:
+          - type: heading
+            heading: Live flows
+            heading_style: subtitle
+            icon: mdi:transmission-tower
+
+          - type: tile
+            entity: sensor.my_home_solar_power
+            name: Solar
+            icon: mdi:solar-power
+
+          - type: tile
+            entity: sensor.my_home_load_power
+            name: Home
+            icon: mdi:home-lightning-bolt
+
+          - type: tile
+            entity: sensor.my_home_grid_power
+            name: Grid
+            icon: mdi:transmission-tower
+            state_content:
+              - state
+              - last_changed
+
+          - type: tile
+            entity: sensor.my_home_battery_power
+            name: Battery
+            icon: mdi:battery-charging
+
+          - type: tile
+            entity: sensor.my_home_percentage_charged
+            name: State of charge
+            icon: mdi:battery
+
+          - type: tile
+            entity: sensor.100h_general_price
+            name: Buy now
+            icon: mdi:cash-minus
+
+          - type: tile
+            entity: sensor.100h_feed_in_price
+            name: Sell now
+            icon: mdi:cash-plus
+
+      # --- The plan (the one custom card) ----------------------------------
       - type: grid
         column_span: 2
         cards:
@@ -57,26 +158,127 @@ views:
           # www/localshift-cards.js. Example:
           #   entities:
           #     soc: sensor.my_home_percentage_charged
-          #     buy_price: sensor.100h_general_price
           #   dw_start: "15:00"
           #   dw_end: "21:00"
-          - type: custom:localshift-command-card
+          - type: custom:localshift-plan-timeline
             grid_options:
               columns: full
 
+      # --- Peak readiness ---------------------------------------------------
       - type: grid
         cards:
-          - type: custom:localshift-decisions-card
+          - type: heading
+            heading: Peak window
+            heading_style: subtitle
+            icon: mdi:chart-bell-curve
 
+          - type: markdown
+            content: |
+              {%- set s = 'sensor.localshift_optimizer_summary' %}
+              {%- set target = states('number.localshift_battery_target') | float(95) %}
+              {%- set entry = state_attr(s, 'dw_entry_soc_pct') %}
+              {%- set actual = state_attr(s, 'dw_entry_actual_soc_pct') %}
+              {%- set short = state_attr(s, 'terminal_shortfall_pct') | float(0) %}
+              {%- if is_state('binary_sensor.localshift_demand_window', 'on') %}
+              **In the peak window now.**
+              {% if actual is not none %}Entered at {{ actual | round(1) }}% against a {{ target | round(0) }}% target — {{ (target - actual) | round(1) }}pp {{ 'short' if actual < target else 'over' }}.{% endif %}
+              {%- elif entry is not none %}
+              **Planned entry:** {{ entry | round(0) }}% of a {{ target | round(0) }}% target — {% if entry < target %}**{{ (target - entry) | round(0) }}pp short**{% else %}on target ✓{% endif %}
+              {%- else %}
+              **Planned entry:** on track — solar alone is forecast to reach the {{ target | round(0) }}% target, so the planner computed no pre-charge requirement.
+              {%- endif %}
+
+              Terminal shortfall (measured at the *end* of the window, not at entry): **{{ short | round(1) }}%**
+
+              {% set d = state_attr('sensor.localshift_optimizer_plan_detailed', 'decisions') or [] -%}
+              {%- set labels = {
+                   'charge_grid_normal': 'Charge',
+                   'charge_grid_boost': 'Boost',
+                   'proactive_export': 'Export',
+                   'spike_discharge': 'Sell',
+                   'hold': 'Hold' } -%}
+              {%- set cur = d[0].action if d | length > 0 else none -%}
+              {%- set ns = namespace(next=none) -%}
+              {%- for slot in d if ns.next is none and slot.action != cur -%}
+              {%- set ns.next = slot -%}
+              {%- endfor -%}
+              {%- if ns.next is not none -%}
+              {%- set at = as_datetime(ns.next.timestamp_iso) | as_local -%}
+              **Next move:** {{ labels.get(ns.next.action, ns.next.action) }} at {{ at.strftime('%H:%M') }}{{ '' if at.date() == now().date() else ' ' ~ at.strftime('%a') }}
+              {%- else -%}
+              **Next move:** none planned in this horizon.
+              {%- endif %}
+
+              {% if state_attr(s, 'precharge_backstop_active') -%}
+              🟠 Runway backstop armed ({{ state_attr(s, 'precharge_runway_slack_min') }} min slack).
+              {%- endif %}
+
+      # --- Money ------------------------------------------------------------
       - type: grid
         cards:
-          - type: custom:localshift-money-card
+          - type: heading
+            heading: Money
+            heading_style: subtitle
+            icon: mdi:cash-multiple
 
+          - type: tile
+            entity: sensor.localshift_cost_electricity_net
+            name: Net today
+
+          - type: markdown
+            content: |
+              {%- set c = 'sensor.localshift_cost_electricity_net' %}
+              imports **${{ '%.2f' | format(state_attr(c, 'grid_import_cost') | float(0)) }}**
+              · exports **${{ '%.2f' | format(state_attr(c, 'grid_export_revenue') | float(0)) }}**
+              · rest of plan **${{ '%.2f' | format(states('sensor.localshift_optimizer_plan_grid') | float(0)) }}**
+
+          # Native replacement for the old hand-rolled SVG bar chart — the cost
+          # sensor carries state_class: total, so it is a long-term statistic.
+          - type: statistics-graph
+            title: Net cost, last 7 days
+            entities:
+              - entity: sensor.localshift_cost_electricity_net
+                name: Net
+            stat_types:
+              - state
+            period: day
+            chart_type: bar
+            days_to_show: 7
+
+      # --- Why it did that --------------------------------------------------
+      - type: grid
+        column_span: 2
+        cards:
+          - type: heading
+            heading: Why it did that
+            heading_style: subtitle
+            icon: mdi:comment-question-outline
+
+          - type: markdown
+            content: |
+              {%- set h = state_attr('sensor.localshift_decision_log', 'history') or [] -%}
+              {%- set ns = namespace(rows=[], last='') -%}
+              {%- for e in h | reverse -%}
+              {%- if e.reason != ns.last and ns.rows | length < 8 -%}
+              {%- set ns.rows = ns.rows + [e] -%}
+              {%- set ns.last = e.reason -%}
+              {%- endif -%}
+              {%- endfor -%}
+              {%- if ns.rows | length == 0 -%}
+              No decisions logged yet.
+              {%- else -%}
+              {%- for e in ns.rows %}
+              - **{{ e.reason }}** — {{ (as_datetime(e.timestamp) | as_local).strftime('%H:%M') }}, SOC {{ e.soc }}%
+              {%- endfor -%}
+              {%- endif %}
+
+      # --- Quick controls ---------------------------------------------------
       - type: grid
         cards:
           - type: heading
             heading: Quick Controls
-            heading_style: title
+            heading_style: subtitle
+            icon: mdi:tune-variant
 
           - type: tile
             entity: select.localshift_battery_mode
@@ -239,13 +441,26 @@ views:
             entity: switch.localshift_stale_solar_conservative
             name: Stale Solar Conservative
 
+          - type: tile
+            entity: number.localshift_charge_taper_start
+            name: Charge Taper Start
+            features:
+              - type: numeric-input
+                style: slider
+
+          - type: tile
+            entity: number.localshift_charge_taper_min_factor
+            name: Charge Taper Min Factor
+
           - type: markdown
             content: >
               **Allow DW entry under target** lets the demand window start
               below target when solar is forecast to close the gap.
               **Conservative spike discharge** keeps a dynamic reserve while
               selling. **Stale solar conservative** distrusts the solar
-              forecast when Solcast data is stale or missing.
+              forecast when Solcast data is stale or missing. **Charge taper**
+              ramps charge power down as SOC approaches full — *start* is the
+              SOC where tapering begins, *min factor* the floor it tapers to.
 
       # --- Price & Optimizer Tuning (advanced) ---------------------------------------
       - type: grid
@@ -275,12 +490,27 @@ views:
             name: Min Cycle Saving
 
           - type: tile
+            entity: number.localshift_min_hold_saving
+            name: Min Hold Saving
+
+          - type: tile
             entity: number.localshift_switching_penalty
             name: Switching Penalty
 
           - type: tile
+            entity: number.localshift_switching_penalty_per_kwh
+            name: Switching Penalty Per kWh
+
+          - type: tile
             entity: number.localshift_target_shortfall_penalty
             name: Shortfall Penalty
+
+          - type: tile
+            entity: number.localshift_pre_charge_runway_margin
+            name: Pre-charge Runway Margin
+            features:
+              - type: numeric-input
+                style: slider
 
           - type: tile
             entity: number.localshift_stale_solar_confidence_ceiling
@@ -293,9 +523,15 @@ views:
 
               **Cheap price percentile** sets where in the price forecast
               "cheap" begins. **Min cycle saving** is the $/kWh margin needed
-              to justify wearing the battery. **Switching penalty** damps
-              rapid mode flapping. **Shortfall penalty** controls how hard
-              the optimizer pushes to hit the demand window target.
+              to justify wearing the battery; **min hold saving** is the same
+              test applied to holding charge rather than cycling it.
+              **Switching penalty** damps rapid mode flapping — the flat term
+              per change, the *per kWh* term scaling with how much energy the
+              change moves. **Shortfall penalty** controls how hard the
+              optimizer pushes to hit the demand window target. **Pre-charge
+              runway margin** is the safety net: minutes of slack before the
+              demand window at which pre-charge is armed even when solar looks
+              sufficient. Set it to 0 to disarm the backstop entirely.
 
       # --- Decision Telemetry ----------------------------------------------------------
       - type: grid
@@ -316,7 +552,7 @@ views:
               action: perform-action
               perform_action: button.press
               target:
-                entity_id: button.localshift_reset_learning
+                entity_id: button.localshift_reset_learning_data
               confirmation:
                 text: This discards every recorded decision and its outcome. Continue?
             icon_height: 40px
@@ -818,3 +1054,126 @@ views:
               | Battery Target | {{ cfg.get('battery_target', '-') }}% |
               | Allow DW Entry Under Target | {{ cfg.get('allow_dw_entry_under_target', '-') }} |
               | Export Price Margin | {{ cfg.get('export_price_margin', '-') }} |
+
+      # --- Pre-charge, spike funding & demand-window entry ------------------
+      # Added: the optimizer_summary telemetry that #886/#889/#902/#910/#911
+      # introduced. None of it was on the dashboard, so verifying any of those
+      # fixes meant grepping the logs.
+      - type: grid
+        cards:
+          - type: heading
+            heading: Pre-charge, Spike Funding & DW Entry
+            heading_style: title
+
+          - type: markdown
+            content: |
+              {%- set s = 'sensor.localshift_optimizer_summary' -%}
+              {%- macro v(x, unit='') -%}
+              {%- if x is none %}—{% else %}{{ x }}{{ unit }}{% endif -%}
+              {%- endmacro %}
+
+              **Demand-window entry**
+
+              | Field | Value |
+              | :--- | :--- |
+              | Planned DW entry SOC | {{ v(state_attr(s, 'dw_entry_soc_pct'), '%') }} |
+              | Actual DW entry SOC | {{ v(state_attr(s, 'dw_entry_actual_soc_pct'), '%') }} |
+              | Actual DW entry at | {{ v(state_attr(s, 'dw_entry_actual_at')) }} |
+              | Actual entry target | {{ v(state_attr(s, 'dw_entry_actual_target_pct'), '%') }} |
+              | Actual entry shortfall | {{ v(state_attr(s, 'dw_entry_actual_shortfall_pct'), '%') }} |
+              | Terminal shortfall | {{ v(state_attr(s, 'terminal_shortfall_pct'), '%') }} |
+              | Initial SOC (plan basis) | {{ v(state_attr(s, 'initial_soc_pct'), '%') }} |
+              | Peak SOC in plan | {{ v(state_attr(s, 'peak_soc_pct'), '%') }} |
+              | Effective SOC at terminal | {{ v(state_attr(s, 'effective_soc_at_terminal')) }} |
+
+              Planned DW entry is only computed when solar **cannot** reach the
+              target, so a blank value on a sunny day is expected, not a fault.
+              An em dash below means the field is absent; `False` means present
+              and false — the difference matters when checking whether a guard
+              ran at all.
+
+              **Pre-charge runway backstop (#902)**
+
+              | Field | Value |
+              | :--- | :--- |
+              | Backstop active | {{ v(state_attr(s, 'precharge_backstop_active')) }} |
+              | Runway slack | {{ v(state_attr(s, 'precharge_runway_slack_min'), ' min') }} |
+              | Runway margin setting | {{ states('number.localshift_pre_charge_runway_margin') }} min |
+              | Hard floor suppressed by solar | {{ v(state_attr(s, 'hard_floor_suppressed_by_solar')) }} |
+              | Projected solar gain | {{ v(state_attr(s, 'projected_solar_gain_pct'), '%') }} |
+              | Adjusted solar gain | {{ v(state_attr(s, 'adjusted_solar_gain_pct'), '%') }} |
+              | Accuracy discount factor | {{ v(state_attr(s, 'accuracy_discount_factor')) }} |
+
+              The backstop firing on a good-solar day is the #816/#849
+              regression signature — it should stay silent when solar is real.
+
+              **Spike pre-charge funding (#908/#910)**
+
+              | Field | Value |
+              | :--- | :--- |
+              | Funding accepted | {{ v(state_attr(s, 'spike_funding_accepted')) }} |
+              | Funding slot count | {{ v(state_attr(s, 'spike_funding_slot_count')) }} |
+              | Net cost delta | ${{ '%.4f' | format(state_attr(s, 'spike_funding_net_cost_delta') | float(0)) }} |
+              | Price spike coming | {{ states('binary_sensor.localshift_price_spike_coming') }} |
+              | Expensive price coming | {{ states('binary_sensor.localshift_price_expensive_coming') }} |
+              | Amber spike flag | {{ states('binary_sensor.100h_price_spike') }} |
+
+              **Solar confidence**
+
+              | Field | Value |
+              | :--- | :--- |
+              | Confidence regime | {{ v(state_attr(s, 'solar_confidence_regime')) }} |
+              | Confidence average | {{ '%.3f' | format(state_attr(s, 'solar_confidence_avg') | float(0)) }} |
+              | Blend applied | {{ v(state_attr(s, 'solar_blend_applied')) }} |
+              | Solcast confidence today | {{ states('sensor.localshift_solcast_confidence_today') }}% |
+              | Solcast confidence tomorrow | {{ states('sensor.localshift_solcast_confidence_tomorrow') }}% |
+              | Solar forecast accuracy | {{ '%.1f' | format(states('sensor.localshift_solar_forecast_accuracy') | float(0)) }}% |
+              | Forecast accuracy (summary) | {{ '%.3f' | format(state_attr(s, 'forecast_accuracy') | float(0)) }} |
+              | Solar can reach target | {{ states('binary_sensor.localshift_solar_can_reach_target') }} |
+
+      # --- Sensors not surfaced anywhere else -------------------------------
+      - type: grid
+        cards:
+          - type: heading
+            heading: Unsurfaced Sensors
+            heading_style: title
+
+          - type: markdown
+            content: |
+              These exist on the integration but appear on no other card. Kept
+              here so a new sensor is visible the day it ships rather than the
+              day someone remembers to add it.
+
+              | Sensor | State |
+              | :--- | :--- |
+              | Forecast prices | {{ states('sensor.localshift_forecast_prices') }} |
+              | Forecast battery | {{ states('sensor.localshift_forecast_battery') }} |
+              | Forecast history | {{ states('sensor.localshift_forecast_history') }} |
+              | Forecast accuracy comparison | {{ states('sensor.localshift_forecast_accuracy_comparison') }} |
+              | Comparison result | {{ states('sensor.localshift_comparison_result') }} |
+              | Price delta | {{ states('sensor.localshift_price_delta') }} |
+              | Cloud event | {{ states('sensor.localshift_cloud_event') }} |
+              | Solar weighted avg FIT | {{ states('sensor.localshift_solar_weighted_avg_fit') }} |
+              | Excess solar | {{ states('sensor.localshift_excess_solar') }} |
+              | Load shift signal | {{ states('sensor.localshift_load_shift_signal') }} |
+              | Load deviation | {{ states('sensor.localshift_load_deviation') }} |
+              | Decision lag | {{ states('sensor.localshift_decision_lag') }} |
+              | Optimizer plan (slots) | {{ states('sensor.localshift_optimizer_plan') }} |
+              | Target SOC minimum | {{ states('sensor.localshift_target_soc_minimum') }} |
+
+          - type: entities
+            title: Number knobs (live values)
+            entities:
+              - number.localshift_battery_target
+              - number.localshift_minimum_target_soc
+              - number.localshift_cheap_price_percentile
+              - number.localshift_max_pre_charge_price
+              - number.localshift_min_cycle_saving
+              - number.localshift_min_hold_saving
+              - number.localshift_switching_penalty
+              - number.localshift_switching_penalty_per_kwh
+              - number.localshift_target_shortfall_penalty
+              - number.localshift_pre_charge_runway_margin
+              - number.localshift_stale_solar_confidence_ceiling
+              - number.localshift_charge_taper_start
+              - number.localshift_charge_taper_min_factor

--- a/custom_components/localshift/www/localshift-cards.js
+++ b/custom_components/localshift/www/localshift-cards.js
@@ -1,25 +1,30 @@
 /**
- * LocalShift Cards — bespoke Lovelace cards for the LocalShift battery optimizer.
+ * LocalShift Cards — the one Lovelace card core Home Assistant cannot provide.
  *
- * Cards:
- *   custom:localshift-command-card   — verdict headline, live power flows, and the
- *                                      fused plan timeline (prices + actions + SOC + peak window)
- *   custom:localshift-decisions-card — "why did it do that" feed from the decision log
- *   custom:localshift-money-card     — today's net cost + 7-day history bars
+ * Card:
+ *   custom:localshift-plan-timeline — the fused forward plan: price bands,
+ *                                     peak window, planned actions, and SOC
+ *                                     (actual behind now, planned ahead of it)
+ *
+ * Everything else the dashboard shows is built from native cards. `history-graph`
+ * and `statistics-graph` only plot the past, so a forward-looking series is the
+ * single thing left with no native equivalent — this file exists for that alone.
+ * The status headline, live power flows, decision feed and cost history that
+ * earlier versions of this file rendered are now heading/tile/markdown/
+ * statistics-graph cards in dashboard.yaml.
  *
  * Install (no HACS needed):
  *   1. Copy this file to <ha-config>/www/localshift/localshift-cards.js
  *   2. Settings → Dashboards → Resources → Add:
- *        URL:  /local/localshift/localshift-cards.js
+ *        URL:  /local/localshift/localshift-cards.js?v=2.0.0
  *        Type: JavaScript module
- *      (or add it via the lovelace resources API)
+ *      (bump the ?v= query when updating, or browsers keep the old module)
  *
- * All entity ids are configurable per card:
- *   type: custom:localshift-command-card
+ * All entity ids are configurable:
+ *   type: custom:localshift-plan-timeline
  *   entities:
  *     soc: sensor.my_home_percentage_charged   # Tesla/Teslemetry
- *     buy_price: sensor.100h_general_price     # Amber Electric
- *     ...
+ *     plan: sensor.localshift_optimizer_plan_detailed
  *   dw_start: "15:00"   # demand window (peak) start, local time
  *   dw_end: "21:00"
  *
@@ -27,7 +32,7 @@
  * /local/ from <ha-config>/www — copy it there (step 1) when updating.
  */
 
-const LS_VERSION = "1.0.1";
+const LS_VERSION = "2.0.0";
 
 /** Default to full section width in the sections-view grid. */
 const LS_FULL_WIDTH = {
@@ -41,25 +46,10 @@ const LS_FULL_WIDTH = {
 
 const LS_ENTITIES = {
   soc: "sensor.my_home_percentage_charged",
-  battery_power: "sensor.my_home_battery_power",
-  grid_power: "sensor.my_home_grid_power",
-  solar_power: "sensor.my_home_solar_power",
-  load_power: "sensor.my_home_load_power",
-  buy_price: "sensor.100h_general_price",
-  sell_price: "sensor.100h_feed_in_price",
   cheap_price: "sensor.localshift_price_cheap_effective",
   plan: "sensor.localshift_optimizer_plan_detailed",
   summary: "sensor.localshift_optimizer_summary",
-  plan_grid: "sensor.localshift_optimizer_plan_grid",
-  mode: "select.localshift_battery_mode",
-  automation: "switch.localshift_automation_enabled",
-  dry_run: "switch.localshift_dry_run",
-  override: "binary_sensor.localshift_tesla_override_active",
-  integration: "sensor.localshift_integration_status",
   target: "number.localshift_battery_target",
-  dw_active: "binary_sensor.localshift_demand_window",
-  decision_log: "sensor.localshift_decision_log",
-  cost: "sensor.localshift_cost_electricity_net",
 };
 
 const LS_ACTION_META = {
@@ -68,17 +58,6 @@ const LS_ACTION_META = {
   proactive_export: { color: "#a78bfa", label: "Export" },
   spike_discharge: { color: "#f87171", label: "Sell" },
   hold: { color: "rgba(148,163,184,0.22)", label: "Hold" },
-};
-
-const LS_MODE_HEADLINE = {
-  self_consumption: "Running on sun & stored energy",
-  grid_charging: "Charging on cheap power",
-  boost_charging: "Boost charging before the peak",
-  spike_discharge: "Selling into the spike",
-  proactive_export: "Exporting ahead of negative prices",
-  demand_block: "Defending the peak window",
-  hold: "Holding steady",
-  automatic: "Optimizer in control",
 };
 
 /* ---------------------------------------------------------------- helpers */
@@ -97,9 +76,6 @@ function lsAttr(hass, id, attr, fallback = undefined) {
     ? s.attributes[attr]
     : fallback;
 }
-function lsOn(hass, id) {
-  return lsState(hass, id) === "on";
-}
 function lsEsc(str) {
   return String(str ?? "").replace(
     /[&<>"']/g,
@@ -107,28 +83,8 @@ function lsEsc(str) {
       ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[c]
   );
 }
-function lsCents(v) {
-  return Number.isFinite(v) ? `${(v * 100).toFixed(1)}¢` : "—";
-}
-function lsMoney(v) {
-  if (!Number.isFinite(v)) return "—";
-  const sign = v < 0 ? "-" : "";
-  return `${sign}$${Math.abs(v).toFixed(2)}`;
-}
-function lsKw(v) {
-  return Number.isFinite(v) ? `${Math.abs(v).toFixed(1)} kW` : "—";
-}
 function lsHHMM(d) {
   return d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", hour12: false });
-}
-function lsRelTime(iso) {
-  const t = new Date(iso).getTime();
-  if (!Number.isFinite(t)) return lsEsc(String(iso).slice(11, 16));
-  const mins = Math.round((Date.now() - t) / 60000);
-  if (mins < 1) return "now";
-  if (mins < 60) return `${mins}m ago`;
-  if (mins < 24 * 60) return lsHHMM(new Date(t));
-  return new Date(t).toLocaleDateString([], { weekday: "short" }) + " " + lsHHMM(new Date(t));
 }
 function lsParseHHMM(str, base) {
   const m = /^(\d{1,2}):(\d{2})$/.exec(String(str).trim());
@@ -171,14 +127,6 @@ const LS_BASE_CSS = `
   :host { display: block; }
   ha-card { padding: 16px; overflow: hidden; }
   .ls-muted { color: var(--secondary-text-color); }
-  .ls-pills { display: flex; flex-wrap: wrap; gap: 6px; margin-bottom: 10px; }
-  .ls-pill {
-    font-size: 11px; font-weight: 700; letter-spacing: 0.06em; text-transform: uppercase;
-    padding: 3px 9px; border-radius: 999px; line-height: 1.4;
-  }
-  .ls-pill.red { background: rgba(248,113,113,0.18); color: #f87171; }
-  .ls-pill.amber { background: rgba(251,191,36,0.16); color: #d99e16; }
-  .ls-pill.violet { background: rgba(167,139,250,0.16); color: #a78bfa; }
   .ls-setup {
     margin-top: 12px; padding: 8px 10px; border-radius: 8px; font-size: 12px;
     background: rgba(251,191,36,0.10); color: var(--secondary-text-color);
@@ -196,9 +144,9 @@ function lsSetupHint(missing) {
     .join(", ")}</div>`;
 }
 
-/* ======================================================== command card === */
+/* ======================================================= plan timeline === */
 
-class LocalShiftCommandCard extends HTMLElement {
+class LocalShiftPlanTimelineCard extends HTMLElement {
   constructor() {
     super();
     this.attachShadow({ mode: "open" });
@@ -209,11 +157,11 @@ class LocalShiftCommandCard extends HTMLElement {
   setConfig(config) {
     this._e = { ...LS_ENTITIES, ...(config.entities || {}) };
     this._cfg = {
+      title: "Plan",
       dw_start: "15:00",
       dw_end: "21:00",
       price_high: 0.3, // $/kWh — amber tint above this
       price_spike: 0.6, // $/kWh — red tint above this
-      invert_battery: false, // set true if your battery sensor is positive-when-charging
       hours_past: 6,
       hours_future: 24,
       ...config,
@@ -245,11 +193,7 @@ class LocalShiftCommandCard extends HTMLElement {
     this._hass = hass;
     const e = this._e;
     if (!e) return;
-    const watch = [
-      e.plan, e.soc, e.mode, e.automation, e.dry_run, e.override, e.integration,
-      e.buy_price, e.sell_price, e.cheap_price, e.battery_power, e.grid_power,
-      e.solar_power, e.load_power, e.cost, e.summary, e.decision_log,
-    ];
+    const watch = [e.plan, e.soc, e.cheap_price, e.target, e.summary];
     const snap = watch
       .map((id) => {
         const s = hass.states[id];
@@ -263,7 +207,7 @@ class LocalShiftCommandCard extends HTMLElement {
   }
 
   getCardSize() {
-    return 8;
+    return 6;
   }
 
   /* ---- data assembly ---- */
@@ -274,71 +218,6 @@ class LocalShiftCommandCard extends HTMLElement {
       .map((d) => ({ ...d, t: new Date(d.timestamp_iso).getTime() }))
       .filter((d) => Number.isFinite(d.t));
   }
-
-  _narrative(decisions) {
-    const hass = this._hass;
-    const e = this._e;
-    const mode = lsState(hass, e.mode) || "unknown";
-    const automationOn = lsOn(hass, e.automation);
-    if (!automationOn) {
-      return {
-        headline: "Manual control",
-        sub: "Automation is off — LocalShift isn't steering the battery.",
-        dotColor: "#f87171",
-      };
-    }
-    let headline = LS_MODE_HEADLINE[mode] || "Optimizer in control";
-    if (mode === "automatic" && decisions.length) {
-      const a = decisions[0].action;
-      if (a && a !== "hold") headline = `${LS_ACTION_META[a]?.label || a} — optimizer in control`;
-    }
-    const reason = lsAttr(hass, e.decision_log, "reason", "");
-    const colorByMode = {
-      grid_charging: "#34d399",
-      boost_charging: "#fbbf24",
-      spike_discharge: "#f87171",
-      proactive_export: "#a78bfa",
-      demand_block: "#fb923c",
-    };
-    return {
-      headline,
-      sub: reason ? String(reason) : "",
-      dotColor: colorByMode[mode] || "#34d399",
-    };
-  }
-
-  _nextChange(decisions) {
-    if (!decisions.length) return null;
-    const cur = decisions[0].action;
-    for (const d of decisions) {
-      if (d.action !== cur) {
-        return { action: d.action, at: new Date(d.t) };
-      }
-    }
-    return null;
-  }
-
-  _pills() {
-    const hass = this._hass;
-    const e = this._e;
-    const pills = [];
-    if (!lsOn(hass, e.automation)) pills.push(`<span class="ls-pill red">automation off</span>`);
-    if (lsOn(hass, e.dry_run)) pills.push(`<span class="ls-pill amber">dry run</span>`);
-    if (lsOn(hass, e.override)) pills.push(`<span class="ls-pill red">tesla override</span>`);
-    const integ = lsState(hass, e.integration);
-    if (integ && integ !== "ok") pills.push(`<span class="ls-pill amber">health: ${lsEsc(integ)}</span>`);
-    const success = lsAttr(hass, e.summary, "success", true);
-    if (success === false) pills.push(`<span class="ls-pill red">optimizer error</span>`);
-    const computed = lsAttr(hass, e.plan, "computed_at");
-    if (computed) {
-      const age = (Date.now() - new Date(computed).getTime()) / 60000;
-      if (Number.isFinite(age) && age > 30)
-        pills.push(`<span class="ls-pill amber">plan ${Math.round(age)}m old</span>`);
-    }
-    return pills.join("");
-  }
-
-  /* ---- timeline SVG ---- */
 
   _dwIntervals(t0, t1) {
     const out = [];
@@ -486,101 +365,6 @@ class LocalShiftCommandCard extends HTMLElement {
       </svg>`;
   }
 
-  /* ---- flows + battery glyph ---- */
-
-  _batteryGlyph(soc, target) {
-    const w = 46, h = 20;
-    const fillW = Math.max(1, (Math.min(100, soc) / 100) * (w - 6));
-    const color = soc < 20 ? "#f87171" : soc < 50 ? "#fbbf24" : "#34d399";
-    const tickX = Number.isFinite(target) ? 2 + (target / 100) * (w - 6) : null;
-    return `
-      <svg width="${w + 4}" height="${h}" style="vertical-align:-4px">
-        <rect x="0.5" y="0.5" width="${w - 1}" height="${h - 1}" rx="4" fill="none" stroke="rgba(148,163,184,0.6)"/>
-        <rect x="${w}" y="${h / 2 - 4}" width="3" height="8" rx="1" fill="rgba(148,163,184,0.6)"/>
-        <rect x="2.5" y="2.5" width="${fillW}" height="${h - 5}" rx="2.5" fill="${color}"/>
-        ${tickX ? `<line x1="${tickX}" y1="1" x2="${tickX}" y2="${h - 1}" stroke="var(--primary-text-color)" stroke-width="1.5" opacity="0.8"/>` : ""}
-      </svg>`;
-  }
-
-  _flows() {
-    const hass = this._hass;
-    const e = this._e;
-    const solar = lsNum(hass, e.solar_power, NaN);
-    const load = lsNum(hass, e.load_power, NaN);
-    const grid = lsNum(hass, e.grid_power, NaN);
-    let batt = lsNum(hass, e.battery_power, NaN);
-    if (this._cfg.invert_battery && Number.isFinite(batt)) batt = -batt;
-    // convention: battery positive = discharging, grid positive = importing
-    const soc = lsNum(hass, e.soc, NaN);
-    const target = lsNum(hass, e.target, NaN);
-
-    const cell = (label, value, dir, dirColor) => `
-      <div class="ls-flow">
-        <div class="ls-flow-label">${label}</div>
-        <div class="ls-flow-value">${value}</div>
-        ${dir ? `<div class="ls-flow-dir" style="color:${dirColor}">${dir}</div>` : `<div class="ls-flow-dir">&nbsp;</div>`}
-      </div>`;
-
-    const gridDir = !Number.isFinite(grid) || Math.abs(grid) < 0.05 ? "" : grid > 0 ? "importing" : "exporting";
-    const battDir = !Number.isFinite(batt) || Math.abs(batt) < 0.05 ? "idle" : batt > 0 ? "discharging" : "charging";
-    const battColor = battDir === "charging" ? "#34d399" : battDir === "discharging" ? "#fbbf24" : "var(--secondary-text-color)";
-
-    return `
-      <div class="ls-flows">
-        ${cell("Solar", lsKw(solar), Number.isFinite(solar) && solar > 0.05 ? "generating" : "", "#fbbf24")}
-        ${cell("Home", lsKw(load), "", "")}
-        ${cell("Grid", lsKw(grid), gridDir, gridDir === "importing" ? "#f87171" : "#a78bfa")}
-        <div class="ls-flow">
-          <div class="ls-flow-label">Battery</div>
-          <div class="ls-flow-value">${Number.isFinite(soc) ? Math.round(soc) + "%" : "—"} ${this._batteryGlyph(soc, target)}</div>
-          <div class="ls-flow-dir" style="color:${battColor}">${battDir}${Number.isFinite(batt) && Math.abs(batt) >= 0.05 ? " · " + lsKw(batt) : ""}</div>
-        </div>
-      </div>`;
-  }
-
-  _chips(decisions) {
-    const hass = this._hass;
-    const e = this._e;
-    const buy = lsNum(hass, e.buy_price, NaN);
-    const sell = lsNum(hass, e.sell_price, NaN);
-    const cheap = lsNum(hass, e.cheap_price, NaN);
-    const target = lsNum(hass, e.target, NaN);
-    const dwEntry = parseFloat(lsAttr(hass, e.summary, "dw_entry_soc_pct"));
-    const shortfall = parseFloat(lsAttr(hass, e.summary, "terminal_shortfall_pct", 0));
-    const net = lsNum(hass, e.cost, NaN);
-    const next = this._nextChange(decisions);
-    const dwActive = lsOn(hass, e.dw_active);
-
-    const chip = (label, value, cls = "") => `
-      <div class="ls-chip ${cls}">
-        <div class="ls-chip-label">${label}</div>
-        <div class="ls-chip-value">${value}</div>
-      </div>`;
-
-    const buyCls = Number.isFinite(buy) && Number.isFinite(cheap) && buy <= cheap ? "good" : Number.isFinite(buy) && buy >= this._cfg.price_high ? "bad" : "";
-    let readyVal, readyCls;
-    if (dwActive) {
-      readyVal = "in peak now";
-      readyCls = "warn";
-    } else if (Number.isFinite(dwEntry)) {
-      const ok = !Number.isFinite(shortfall) || shortfall <= 5.0;
-      readyVal = `${dwEntry.toFixed(0)}%${Number.isFinite(target) ? " / " + Math.round(target) + "%" : ""} ${ok ? "✓" : "▲ " + shortfall.toFixed(0) + "% short"}`;
-      readyCls = ok ? "good" : "bad";
-    } else {
-      readyVal = "—";
-      readyCls = "";
-    }
-
-    return `
-      <div class="ls-chips">
-        ${chip("Buy now", lsCents(buy), buyCls)}
-        ${chip("Sell now", lsCents(sell))}
-        ${chip("Peak entry", readyVal, readyCls)}
-        ${chip("Next move", next ? `${LS_ACTION_META[next.action]?.label || next.action} ${lsHHMM(next.at)}` : "none planned")}
-        ${chip("Today", Number.isFinite(net) ? (net <= 0 ? lsMoney(-net) + " earned" : lsMoney(net) + " spent") : "—", Number.isFinite(net) && net <= 0 ? "good" : "")}
-      </div>`;
-  }
-
   /* ---- render ---- */
 
   async _ensureHistory() {
@@ -607,24 +391,14 @@ class LocalShiftCommandCard extends HTMLElement {
     if (!this._hass || !this._e) return;
     this._width = this.offsetWidth || this._width || 400;
     const decisions = this._decisions();
-    const n = this._narrative(decisions);
-    const missing = lsMissingEntities(this._hass, [
-      this._e.plan, this._e.soc, this._e.mode, this._e.buy_price,
-    ]);
+    const missing = lsMissingEntities(this._hass, [this._e.plan, this._e.soc]);
 
     this.shadowRoot.innerHTML = `
       <style>
         ${LS_BASE_CSS}
-        .ls-head { display: flex; align-items: flex-start; gap: 10px; }
-        .ls-dot { width: 12px; height: 12px; border-radius: 50%; margin-top: 9px; flex: none;
-                  box-shadow: 0 0 0 4px color-mix(in srgb, currentColor 18%, transparent); }
-        .ls-headline { font-size: 22px; font-weight: 700; line-height: 1.2; letter-spacing: -0.01em; }
-        .ls-sub { font-size: 13px; margin-top: 3px; color: var(--secondary-text-color); }
-        .ls-flows { display: flex; flex-wrap: wrap; gap: 4px 22px; margin: 14px 0 4px; }
-        .ls-flow-label { font-size: 11px; text-transform: uppercase; letter-spacing: 0.07em; color: var(--secondary-text-color); }
-        .ls-flow-value { font-size: 17px; font-weight: 600; margin-top: 1px; white-space: nowrap; }
-        .ls-flow-dir { font-size: 11px; color: var(--secondary-text-color); }
-        .ls-timeline { margin-top: 8px; }
+        h2 { font-size: 14px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.08em;
+             color: var(--secondary-text-color); margin: 0 0 8px; }
+        .ls-timeline { margin-top: 4px; }
         .ls-dw-label { font-size: 10px; font-weight: 700; letter-spacing: 0.12em; fill: rgba(251,146,60,0.9); }
         .ls-ref-label, .ls-axis-label, .ls-now-label { font-size: 10px; fill: var(--secondary-text-color); }
         .ls-now-label { fill: #ef4444; font-weight: 700; }
@@ -632,29 +406,9 @@ class LocalShiftCommandCard extends HTMLElement {
         .ls-legend span { display: inline-flex; align-items: center; gap: 5px; }
         .ls-sw { width: 14px; height: 3px; border-radius: 2px; display: inline-block; }
         .ls-box { width: 10px; height: 10px; border-radius: 3px; display: inline-block; }
-        .ls-chips { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 14px; }
-        .ls-chip { background: var(--secondary-background-color, rgba(148,163,184,0.08));
-                   border-radius: 10px; padding: 7px 12px; min-width: 84px; }
-        .ls-chip-label { font-size: 10px; text-transform: uppercase; letter-spacing: 0.07em; color: var(--secondary-text-color); }
-        .ls-chip-value { font-size: 15px; font-weight: 650; margin-top: 1px; white-space: nowrap; }
-        .ls-chip.good .ls-chip-value { color: #34d399; }
-        .ls-chip.bad .ls-chip-value { color: #f87171; }
-        .ls-chip.warn .ls-chip-value { color: #fb923c; }
-        @media (max-width: 460px) {
-          .ls-headline { font-size: 18px; }
-          .ls-chip { min-width: 72px; padding: 6px 10px; }
-        }
       </style>
       <ha-card>
-        <div class="ls-pills">${this._pills()}</div>
-        <div class="ls-head">
-          <div class="ls-dot" style="background:${n.dotColor}; color:${n.dotColor}"></div>
-          <div>
-            <div class="ls-headline">${lsEsc(n.headline)}</div>
-            ${n.sub ? `<div class="ls-sub">${lsEsc(n.sub)}</div>` : ""}
-          </div>
-        </div>
-        ${this._flows()}
+        <h2>${lsEsc(this._cfg.title)}</h2>
         <div class="ls-timeline">${this._timelineSvg(decisions, this._socHist, this._width)}</div>
         <div class="ls-legend">
           <span><span class="ls-sw" style="background:var(--primary-text-color)"></span>actual</span>
@@ -665,252 +419,30 @@ class LocalShiftCommandCard extends HTMLElement {
           <span><span class="ls-box" style="background:repeating-linear-gradient(45deg, rgba(251,146,60,0.5) 0 2px, transparent 2px 5px)"></span>peak window</span>
           <span><span class="ls-box" style="background:rgba(52,211,153,0.25)"></span>cheap power</span>
         </div>
-        ${this._chips(decisions)}
         ${lsSetupHint(missing)}
       </ha-card>`;
 
-    this._ensureHistory();
-  }
-}
-
-/* ====================================================== decisions card === */
-
-class LocalShiftDecisionsCard extends HTMLElement {
-  constructor() {
-    super();
-    this.attachShadow({ mode: "open" });
-  }
-  setConfig(config) {
-    this._cfg = { entity: LS_ENTITIES.decision_log, limit: 8, title: "Why it did that", ...config };
-    if (this._hass) this._render();
-  }
-  set hass(hass) {
-    this._hass = hass;
-    const s = hass.states[this._cfg?.entity];
-    const snap = s ? `${s.state}@${s.last_updated}` : "∅";
-    if (snap !== this._snap) {
-      this._snap = snap;
-      this._render();
-    }
-  }
-  getCardSize() {
-    return 4;
-  }
-  _render() {
-    if (!this._hass || !this._cfg) return;
-    // collapse runs of identical reasons into one entry with a count
-    const raw = lsAttr(this._hass, this._cfg.entity, "history", []) || [];
-    const groups = [];
-    for (const h of raw) {
-      const reason = h.reason || "—";
-      const last = groups[groups.length - 1];
-      if (last && last.reason === reason) {
-        last.count += 1;
-        last.latest = h;
-      } else {
-        groups.push({ reason, count: 1, first: h, latest: h });
-      }
-    }
-    const shown = groups.slice(-this._cfg.limit).reverse();
-    const missing = lsMissingEntities(this._hass, [this._cfg.entity]);
-    const rows = shown.length
-      ? shown
-          .map((g, idx) => {
-            const ts = g.latest.timestamp || g.latest.time || "";
-            const since = g.first.timestamp || g.first.time || "";
-            const extra =
-              g.count > 1 ? ` · ×${g.count} since ${lsEsc(lsRelTime(since))}` : "";
-            return `
-            <div class="ls-row ${idx === 0 ? "first" : ""}">
-              <div class="ls-rail"><div class="ls-node"></div>${idx < shown.length - 1 ? '<div class="ls-line"></div>' : ""}</div>
-              <div class="ls-body">
-                <div class="ls-reason">${lsEsc(g.reason)}</div>
-                <div class="ls-meta">${lsEsc(lsRelTime(ts))}${g.latest.soc !== undefined ? ` · SOC ${lsEsc(g.latest.soc)}%` : ""}${extra}</div>
-              </div>
-            </div>`;
-          })
-          .join("")
-      : `<div class="ls-muted" style="font-size:13px">No decisions logged yet.</div>`;
-    this.shadowRoot.innerHTML = `
-      <style>
-        ${LS_BASE_CSS}
-        h2 { font-size: 14px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.08em;
-             color: var(--secondary-text-color); margin: 0 0 12px; }
-        .ls-row { display: flex; gap: 10px; }
-        .ls-rail { display: flex; flex-direction: column; align-items: center; width: 12px; flex: none; }
-        .ls-node { width: 8px; height: 8px; border-radius: 50%; background: rgba(148,163,184,0.7); margin-top: 5px; flex: none; }
-        .ls-row.first .ls-node { background: #34d399; box-shadow: 0 0 0 3px rgba(52,211,153,0.2); }
-        .ls-line { width: 2px; flex: 1; background: rgba(148,163,184,0.2); margin: 3px 0; }
-        .ls-body { padding-bottom: 12px; min-width: 0; }
-        .ls-reason { font-size: 13.5px; line-height: 1.35; }
-        .ls-meta { font-size: 11.5px; color: var(--secondary-text-color); margin-top: 2px; }
-      </style>
-      <ha-card>
-        <h2>${lsEsc(this._cfg.title)}</h2>
-        ${rows}
-        ${lsSetupHint(missing)}
-      </ha-card>`;
-  }
-}
-
-/* ========================================================== money card === */
-
-class LocalShiftMoneyCard extends HTMLElement {
-  constructor() {
-    super();
-    this.attachShadow({ mode: "open" });
-    this._histCache = {};
-  }
-  setConfig(config) {
-    this._cfg = { entity: LS_ENTITIES.cost, plan_grid: LS_ENTITIES.plan_grid, days: 7, title: "Money", ...config };
-    if (this._hass) this._render();
-  }
-  set hass(hass) {
-    this._hass = hass;
-    const s = hass.states[this._cfg?.entity];
-    const snap = s ? `${s.state}@${s.last_updated}` : "∅";
-    if (snap !== this._snap) {
-      this._snap = snap;
-      this._render();
-    }
-  }
-  getCardSize() {
-    return 4;
-  }
-
-  async _ensureHistory() {
-    const now = new Date();
-    const start = new Date(now);
-    start.setDate(start.getDate() - (this._cfg.days - 1));
-    start.setHours(0, 0, 0, 0);
-    const data = await lsFetchHistory(
-      this._hass, this._histCache, "cost", this._cfg.entity,
-      start.getTime(), now.getTime(), 10 * 60e3
-    );
-    // bucket: last reading per local day
-    const byDay = new Map();
-    for (const p of data) {
-      const d = new Date(p.t);
-      byDay.set(d.toDateString(), p.v);
-    }
-    byDay.set(now.toDateString(), lsNum(this._hass, this._cfg.entity, byDay.get(now.toDateString())));
-    const days = [];
-    for (let i = this._cfg.days - 1; i >= 0; i--) {
-      const d = new Date(now);
-      d.setDate(d.getDate() - i);
-      days.push({
-        label: d.toLocaleDateString([], { weekday: "narrow" }),
-        v: byDay.has(d.toDateString()) ? byDay.get(d.toDateString()) : null,
-        today: i === 0,
-      });
-    }
-    const key = JSON.stringify(days);
-    if (key !== this._daysKey) {
-      this._daysKey = key;
-      this._days = days;
-      this._renderBars();
-    }
-  }
-
-  _barsSvg() {
-    const days = this._days;
-    if (!days || !days.some((d) => d.v !== null)) {
-      return `<div class="ls-muted" style="font-size:12px">Collecting history…</div>`;
-    }
-    const W = 280, H = 96, padB = 16, barW = W / days.length - 8;
-    const maxAbs = Math.max(0.5, ...days.map((d) => Math.abs(d.v ?? 0)));
-    const zeroY = (H - padB) / 2 + 4;
-    const scale = ((H - padB) / 2 - 6) / maxAbs;
-    let svg = `<line x1="0" y1="${zeroY}" x2="${W}" y2="${zeroY}" stroke="rgba(148,163,184,0.3)"/>`;
-    days.forEach((d, idx) => {
-      const cx = (idx + 0.5) * (W / days.length);
-      if (d.v !== null) {
-        const h = Math.max(1.5, Math.abs(d.v) * scale);
-        const earned = d.v <= 0;
-        const yTop = earned ? zeroY - h : zeroY;
-        svg += `<rect x="${cx - barW / 2}" y="${yTop}" width="${barW}" height="${h}" rx="2.5"
-                 fill="${earned ? "#34d399" : "#f87171"}" opacity="${d.today ? 1 : 0.65}"/>`;
-      }
-      svg += `<text x="${cx}" y="${H - 3}" text-anchor="middle" class="ls-bar-label">${lsEsc(d.label)}</text>`;
-    });
-    return `<svg viewBox="0 0 ${W} ${H}" width="100%" height="${H}" preserveAspectRatio="xMidYMid meet">${svg}</svg>`;
-  }
-
-  _renderBars() {
-    const holder = this.shadowRoot.querySelector(".ls-bars");
-    if (holder) holder.innerHTML = this._barsSvg();
-  }
-
-  _render() {
-    if (!this._hass || !this._cfg) return;
-    const net = lsNum(this._hass, this._cfg.entity, NaN);
-    const imp = parseFloat(lsAttr(this._hass, this._cfg.entity, "grid_import_cost", NaN));
-    const exp = parseFloat(lsAttr(this._hass, this._cfg.entity, "grid_export_revenue", NaN));
-    const planNet = lsNum(this._hass, this._cfg.plan_grid, NaN);
-    const missing = lsMissingEntities(this._hass, [this._cfg.entity]);
-    const earned = Number.isFinite(net) && net <= 0;
-
-    this.shadowRoot.innerHTML = `
-      <style>
-        ${LS_BASE_CSS}
-        h2 { font-size: 14px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.08em;
-             color: var(--secondary-text-color); margin: 0 0 10px; }
-        .ls-big { font-size: 34px; font-weight: 750; letter-spacing: -0.02em; line-height: 1;
-                  color: ${earned ? "#34d399" : "var(--primary-text-color)"}; }
-        .ls-big small { font-size: 14px; font-weight: 600; color: var(--secondary-text-color); margin-left: 6px; }
-        .ls-split { display: flex; gap: 18px; margin: 10px 0 14px; font-size: 12.5px; color: var(--secondary-text-color); }
-        .ls-split b { color: var(--primary-text-color); font-weight: 600; }
-        .ls-bar-label { font-size: 9px; fill: var(--secondary-text-color); }
-      </style>
-      <ha-card>
-        <h2>${lsEsc(this._cfg.title)}</h2>
-        <div class="ls-big">${Number.isFinite(net) ? lsMoney(Math.abs(net)) : "—"}<small>${earned ? "earned today" : "spent today"}</small></div>
-        <div class="ls-split">
-          <span>imports <b>${Number.isFinite(imp) ? lsMoney(imp) : "—"}</b></span>
-          <span>exports <b>${Number.isFinite(exp) ? lsMoney(exp) : "—"}</b></span>
-          <span>rest of plan <b>${Number.isFinite(planNet) ? (planNet <= 0 ? lsMoney(-planNet) + " earn" : lsMoney(planNet)) : "—"}</b></span>
-        </div>
-        <div class="ls-bars">${this._barsSvg()}</div>
-        ${lsSetupHint(missing)}
-      </ha-card>`;
     this._ensureHistory();
   }
 }
 
 /* ============================================================ register === */
 
-Object.assign(LocalShiftCommandCard.prototype, LS_FULL_WIDTH);
-Object.assign(LocalShiftDecisionsCard.prototype, LS_FULL_WIDTH);
-Object.assign(LocalShiftMoneyCard.prototype, LS_FULL_WIDTH);
+Object.assign(LocalShiftPlanTimelineCard.prototype, LS_FULL_WIDTH);
 
-if (!customElements.get("localshift-command-card"))
-  customElements.define("localshift-command-card", LocalShiftCommandCard);
-if (!customElements.get("localshift-decisions-card"))
-  customElements.define("localshift-decisions-card", LocalShiftDecisionsCard);
-if (!customElements.get("localshift-money-card"))
-  customElements.define("localshift-money-card", LocalShiftMoneyCard);
+if (!customElements.get("localshift-plan-timeline"))
+  customElements.define("localshift-plan-timeline", LocalShiftPlanTimelineCard);
 
 window.customCards = window.customCards || [];
-window.customCards.push(
-  {
-    type: "localshift-command-card",
-    name: "LocalShift Command",
-    description: "Battery optimizer mission control: status, flows, and the fused plan timeline.",
-  },
-  {
-    type: "localshift-decisions-card",
-    name: "LocalShift Decisions",
-    description: "Recent optimizer decisions with reasons.",
-  },
-  {
-    type: "localshift-money-card",
-    name: "LocalShift Money",
-    description: "Today's net electricity cost and 7-day history.",
-  }
-);
+if (!window.customCards.some((c) => c.type === "localshift-plan-timeline")) {
+  window.customCards.push({
+    type: "localshift-plan-timeline",
+    name: "LocalShift Plan Timeline",
+    description:
+      "Forward optimizer plan: price bands, peak window, planned actions and SOC (actual + planned).",
+  });
+}
 
-console.info(
-  `%c LOCALSHIFT-CARDS %c v${LS_VERSION} `,
-  "background:#34d399;color:#000;font-weight:700;border-radius:3px 0 0 3px",
-  "background:#1f2937;color:#fff;border-radius:0 3px 3px 0"
-);
+console.info(`%c LOCALSHIFT-CARDS %c ${LS_VERSION} `,
+  "color:#0b1220;background:#34d399;font-weight:700",
+  "color:#34d399;background:#0b1220");

--- a/scripts/check_dashboard_entities.py
+++ b/scripts/check_dashboard_entities.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Validate dashboard.yaml against a live Home Assistant.
+
+Three checks, all of which need live state and so cannot live in the unit
+tests:
+
+1. **Every entity the dashboard references exists.** This is the check that
+   matters. `button.localshift_reset_learning` sat on the Settings view for a
+   month after the parameter-learning cut renamed it to
+   `..._reset_learning_data`; the button silently did nothing and no test
+   noticed, because no test can know what the live entity registry holds.
+2. **Every LocalShift entity appears somewhere on the dashboard.** Catches the
+   opposite drift — a sensor ships and nothing surfaces it.
+3. **Every markdown card's Jinja renders.** A template that raises renders as a
+   card-wide error in the UI and is invisible from the repo.
+
+Credentials come from ``HOMEASSISTANT_URL`` / ``HOMEASSISTANT_TOKEN`` in the
+environment, or from the same keys anywhere in ``~/.claude.json``.
+
+Usage::
+
+    python3 scripts/check_dashboard_entities.py
+    python3 scripts/check_dashboard_entities.py --dashboard path/to/dashboard.yaml
+    python3 scripts/check_dashboard_entities.py --no-unreferenced
+
+Exits non-zero if any check fails. Run it after every deploy that touches the
+dashboard — the dashboard is YAML-mode, so HA picks up changes on a Lovelace
+reload, with no restart and no validation of its entity references.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_DASHBOARD = REPO_ROOT / "custom_components" / "localshift" / "dashboard.yaml"
+
+# Entity ids anywhere in the file — structured `entity:` keys and Jinja alike.
+ENTITY_RE = re.compile(
+    r"\b(?:sensor|binary_sensor|switch|select|number|button|input_boolean|input_number)"
+    r"\.[a-z0-9_]+"
+)
+# `button.press` is an action name, not an entity.
+NOT_ENTITIES = {"button.press"}
+
+LOCALSHIFT_PREFIXES = (
+    "sensor.localshift_",
+    "binary_sensor.localshift_",
+    "switch.localshift_",
+    "select.localshift_",
+    "number.localshift_",
+    "button.localshift_",
+)
+
+
+def load_credentials() -> tuple[str, str]:
+    """Return (base_url, token) from the environment or ~/.claude.json."""
+    url = os.environ.get("HOMEASSISTANT_URL")
+    token = os.environ.get("HOMEASSISTANT_TOKEN")
+    if url and token:
+        return url.rstrip("/"), token
+
+    claude_json = Path.home() / ".claude.json"
+    if claude_json.exists():
+        found = _find_credentials(json.loads(claude_json.read_text()))
+        if found:
+            return found[0].rstrip("/"), found[1]
+
+    raise SystemExit(
+        "No Home Assistant credentials. Set HOMEASSISTANT_URL and "
+        "HOMEASSISTANT_TOKEN, or add them to ~/.claude.json."
+    )
+
+
+def _find_credentials(node: Any) -> tuple[str, str] | None:
+    if isinstance(node, dict):
+        if "HOMEASSISTANT_URL" in node and "HOMEASSISTANT_TOKEN" in node:
+            return node["HOMEASSISTANT_URL"], node["HOMEASSISTANT_TOKEN"]
+        for value in node.values():
+            found = _find_credentials(value)
+            if found:
+                return found
+    elif isinstance(node, list):
+        for value in node:
+            found = _find_credentials(value)
+            if found:
+                return found
+    return None
+
+
+def ha_get(url: str, token: str, path: str) -> Any:
+    request = urllib.request.Request(
+        f"{url}/api/{path}", headers={"Authorization": f"Bearer {token}"}
+    )
+    return json.loads(urllib.request.urlopen(request, timeout=30).read())
+
+
+def ha_render(url: str, token: str, template: str) -> tuple[bool, str]:
+    request = urllib.request.Request(
+        f"{url}/api/template",
+        data=json.dumps({"template": template}).encode(),
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+    try:
+        return True, urllib.request.urlopen(request, timeout=30).read().decode()
+    except urllib.error.HTTPError as err:
+        return False, err.read().decode()[:400]
+
+
+def collect_markdown(node: Any, path: str, out: list[tuple[str, str]]) -> None:
+    if isinstance(node, dict):
+        if node.get("type") == "markdown" and "content" in node:
+            out.append((path, node["content"]))
+        for key, value in node.items():
+            collect_markdown(value, f"{path}/{key}", out)
+    elif isinstance(node, list):
+        for index, value in enumerate(node):
+            collect_markdown(value, f"{path}[{index}]", out)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dashboard", type=Path, default=DEFAULT_DASHBOARD)
+    parser.add_argument(
+        "--no-unreferenced",
+        action="store_true",
+        help="Skip check 2 (LocalShift entities missing from the dashboard).",
+    )
+    args = parser.parse_args()
+
+    raw = args.dashboard.read_text()
+    config = yaml.safe_load(raw)
+    url, token = load_credentials()
+
+    live = {state["entity_id"] for state in ha_get(url, token, "states")}
+    referenced = {e for e in ENTITY_RE.findall(raw) if e not in NOT_ENTITIES}
+
+    failures = 0
+
+    missing = sorted(e for e in referenced if e not in live)
+    print(
+        f"[1/3] entity references: {len(referenced)} referenced, {len(missing)} missing"
+    )
+    for entity in missing:
+        failures += 1
+        print(f"      MISSING  {entity}")
+
+    if not args.no_unreferenced:
+        unreferenced = sorted(
+            e for e in live if e.startswith(LOCALSHIFT_PREFIXES) and e not in referenced
+        )
+        print(f"[2/3] unreferenced LocalShift entities: {len(unreferenced)}")
+        for entity in unreferenced:
+            failures += 1
+            print(f"      UNSURFACED  {entity}")
+    else:
+        print("[2/3] unreferenced check skipped")
+
+    templates: list[tuple[str, str]] = []
+    for view in config.get("views", []):
+        collect_markdown(view, view.get("title", "?"), templates)
+    broken = 0
+    for path, template in templates:
+        ok, detail = ha_render(url, token, template)
+        if not ok:
+            broken += 1
+            failures += 1
+            print(f"      RENDER FAILED  {path}: {detail}")
+    print(f"[3/3] markdown templates: {len(templates)} rendered, {broken} failed")
+
+    if failures:
+        print(f"\nFAILED — {failures} problem(s).")
+        return 1
+    print("\nAll checks passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Stacked on `cut/parameter-learning` (#962), because that is the branch live actually runs. Basing this on `main` or `test` would have reverted the learning cut on the next deploy.

## Why

The dashboard had drifted from the live entity registry, and was carrying three custom Lovelace cards where Home Assistant now ships native equivalents.

## Repairs

- **The Settings "Reset Decision Telemetry" button was dead.** It targeted `button.localshift_reset_learning`; the parameter-learning cut renamed the entity to `..._reset_learning_data`. The button had been silently doing nothing on live since 2026-09-04.
- **Five `number` entities existed but appeared on no card**, including `pre_charge_runway_margin` — the dial for the #902 runway backstop, which is the thing the runway watch checklist says to tune. Added alongside `min_hold_saving`, `switching_penalty_per_kwh`, and the charge-taper pair.

## Custom elements → native

`localshift-cards.js` drops from three cards to one, 37.5 KB → 17.7 KB. Core HA can only plot the past (`history-graph`, `statistics-graph`), so a forward series has no native equivalent — the plan timeline stays, renamed `localshift-plan-timeline`. Everything else moved:

| Was | Now | Note |
| --- | --- | --- |
| `localshift-money-card` | `tile` + `statistics-graph` | the cost sensor carries `state_class: total`, so the 7-day bars are a real long-term statistic rather than a hand-rolled SVG over a REST history fetch |
| `localshift-decisions-card` | `markdown` over the `decision_log` history attribute | keeps the run-collapsing and SOC annotation the JS did |
| `localshift-command-card` — pills | `heading` card with entity badges | |
| `localshift-command-card` — flows | `tile` cards | |
| `localshift-command-card` — headline / chips | `markdown` | |

Peak readiness now distinguishes "no pre-charge planned because solar covers the target" from "no data" — `dw_entry_soc_pct` is only computed when solar *cannot* reach target, so a blank value on a sunny day is expected, not a fault. It also reports the entry gap separately from `terminal_shortfall_pct`, which is measured at the *end* of the window; the old card conflated the two.

## Debug — extended only, nothing removed

Adds the `optimizer_summary` telemetry that #886 / #889 / #902 / #910 / #911 introduced — planned vs actual DW entry, runway backstop state and slack, spike funding, solar confidence. None of it was on the dashboard, so verifying any of those fixes meant grepping logs. Plus the nine sensors that appeared nowhere and a live view of every `number` knob.

Booleans render as `False`, not as an em dash — `default(x, true)` was hiding a present-and-false guard behind the same glyph as an absent field, which is exactly the distinction you need when checking whether a guard ran at all.

## Gate

`scripts/check_dashboard_entities.py` validates the dashboard against a live HA: every reference resolves, every LocalShift entity is surfaced somewhere, every markdown template renders. This needs live state, which is why it is a script and not a unit test — no unit test can know what the live entity registry holds, which is why the dead button survived a month of green CI.

Verified to fail on the reset-button bug and pass once fixed:

```
$ python3 scripts/check_dashboard_entities.py     # with the bug reintroduced
[1/3] entity references: 78 referenced, 1 missing
      MISSING  button.localshift_reset_learning
[2/3] unreferenced LocalShift entities: 1
      UNSURFACED  button.localshift_reset_learning_data
FAILED — 2 problem(s).
```

## Verification

Deployed to live and checked from the system, not the screen:

- Served JS at `?v=2.0.0` is byte-identical to the repo file (sha `dd05a9d3`), defines `localshift-plan-timeline`, no longer defines the three old cards.
- HA re-read the YAML on its own; the served Overview config returns the new card.
- 78 entity references, **0 missing**; **0** LocalShift entities unsurfaced; 18 markdown templates rendered live, **0 failed**.
- Long-term statistics exist for the cost sensor — 8 daily values including two negative (earn) days — so the `statistics-graph` has real data.
- The integration code in the deploy source was byte-identical to live, so nothing restarted and no optimizer behaviour moved.

## Deploy note

`deploy.sh` does not touch `www/`. The served copy at `<ha-config>/www/localshift/localshift-cards.js` is a manual copy, and the Lovelace resource `?v=` must be bumped with it or browsers keep the cached module and the Overview shows a missing-custom-element error. Both were done for this deploy; worth folding into `deploy.sh` separately.
