### PR TITLE
fix(engine): forward max_pre_charge_price into the optimizer config options

### DIFF
--- a/custom_components/localshift/computation_engine.py
+++ b/custom_components/localshift/computation_engine.py
@@ -19,6 +19,7 @@ from .const import (
     CONF_DEMAND_WINDOW_END,
     CONF_DEMAND_WINDOW_START,
     CONF_EXPORT_PRICE_MARGIN,
+    CONF_MAX_PRECHARGE_PRICE,
     CONF_MIN_CYCLE_SAVING,
     CONF_MIN_HOLD_SAVING,
     CONF_MINIMUM_TARGET_SOC,
@@ -38,6 +39,7 @@ from .const import (
     DEFAULT_DEMAND_WINDOW_START,
     DEFAULT_EXPORT_PRICE_MARGIN,
     DEFAULT_FORECAST_LOOKAHEAD_HOURS,
+    DEFAULT_MAX_PRECHARGE_PRICE,
     DEFAULT_MIN_CYCLE_SAVING,
     DEFAULT_MIN_HOLD_SAVING,
     DEFAULT_MINIMUM_TARGET_SOC,
@@ -855,6 +857,16 @@ class ComputationEngine:
             ),
             CONF_MIN_CYCLE_SAVING: self.entry.options.get(
                 CONF_MIN_CYCLE_SAVING, DEFAULT_MIN_CYCLE_SAVING
+            ),
+            # Pre-charge price cap. Same trap as the runway margin below: the number
+            # entity writes entry.options, but the DP reads THIS dict, so without this
+            # line the solver's ramp / water level / hard-floor feasibility all ran on
+            # the 0.20 default no matter where the slider sat (2026-09-05: slider at
+            # 0.26, plan still refused 20.5–21.1c pre-DW slots). Only the live "now"
+            # ramp in price_calculator read the real value, so plan and controller
+            # disagreed about what the operator was willing to pay.
+            CONF_MAX_PRECHARGE_PRICE: self.entry.options.get(
+                CONF_MAX_PRECHARGE_PRICE, DEFAULT_MAX_PRECHARGE_PRICE
             ),
             CONF_MIN_HOLD_SAVING: self.entry.options.get(
                 CONF_MIN_HOLD_SAVING, DEFAULT_MIN_HOLD_SAVING

--- a/tests/engine/test_precharge_backstop.py
+++ b/tests/engine/test_precharge_backstop.py
@@ -1056,7 +1056,8 @@ class TestRunwayMarginKnob:
         ``ComputationEngine._build_optimizer_config_options`` hand-copies each option
         into the dict that reaches ``_build_optimizer_config``, so a knob missing from
         that copy is decorative — the slider moves and the engine keeps the default.
-        (``max_pre_charge_price`` is currently in exactly that state.)
+        (``max_pre_charge_price`` sat in exactly that state until 2026-09-05; see
+        ``test_the_precharge_cap_slider_reaches_the_engine``.)
         """
         from custom_components.localshift.computation_engine import ComputationEngine
         from custom_components.localshift.const import (
@@ -1078,6 +1079,47 @@ class TestRunwayMarginKnob:
                 SimpleNamespace(), options
             ).precharge_runway_margin_min
             == 45.0
+        )
+
+    def test_the_precharge_cap_slider_reaches_the_engine(self) -> None:
+        """``number.localshift_max_pre_charge_price`` must reach the DP, not just the ramp.
+
+        2026-09-05 live: the slider was raised 0.20 -> 0.26 to unlock three 20.5–21.1c
+        pre-DW slots and the plan did not move, because
+        ``_build_optimizer_config_options`` never forwarded the option and the runner fell
+        through to ``DEFAULT_MAX_PRECHARGE_PRICE``. Only ``price_calculator``'s live "now"
+        ramp read ``entry.options``, so the controller and the plan disagreed about the
+        operator's ceiling. The cap gates the urgency ramp, the funding water level AND
+        the #885 hard-floor feasibility sim, so a decorative slider silently caps how far
+        strict mode can pre-charge.
+        """
+        from custom_components.localshift.computation_engine import ComputationEngine
+        from custom_components.localshift.const import (
+            CONF_MAX_PRECHARGE_PRICE,
+            DEFAULT_MAX_PRECHARGE_PRICE,
+        )
+        from custom_components.localshift.engine.optimizer_runner import (
+            _build_optimizer_config,
+        )
+
+        engine = ComputationEngine.__new__(ComputationEngine)
+        engine.entry = SimpleNamespace(options={CONF_MAX_PRECHARGE_PRICE: 0.26})
+        engine._get_switch_state = lambda _key: False
+
+        options = engine._build_optimizer_config_options()
+
+        assert options[CONF_MAX_PRECHARGE_PRICE] == 0.26
+        assert (
+            _build_optimizer_config(SimpleNamespace(), options).max_precharge_price
+            == 0.26
+        )
+
+        # And the default still flows when the option is absent.
+        engine.entry = SimpleNamespace(options={})
+        options = engine._build_optimizer_config_options()
+        assert (
+            _build_optimizer_config(SimpleNamespace(), options).max_precharge_price
+            == DEFAULT_MAX_PRECHARGE_PRICE
         )
 
     def test_the_entity_is_actually_exposed(self) -> None:


### PR DESCRIPTION
## What

`number.localshift_max_pre_charge_price` never reached the DP. The entity writes `entry.options`, and `price_calculator`'s live urgency ramp reads that, but `ComputationEngine._build_optimizer_config_options` hand-copies each option into the dict the optimizer actually consumes and the cap was never added, so `optimizer_runner` fell through to `DEFAULT_MAX_PRECHARGE_PRICE` (0.20) regardless of the slider.

The cap gates three things in the solver: the per-slot urgency ramp, the target-funding water level, and the #885 hard-floor feasibility simulation. So the slider silently capped how far strict mode could pre-charge, and the plan and the live controller disagreed about the operator's ceiling.

## Live evidence (2026-09-05)

- `allow_dw_entry_under_target` OFF, hard floor armed, DW entry projected 75% vs 95% target.
- Slider raised 0.20 → 0.26 to unlock three 20.5–21.1c pre-DW slots (13:30/14:00/14:30).
- Re-solved plan did not move: same holds, same 75% entry, `config_options` snapshot never carried the cap.

## Fix

Forward the option exactly the way `CONF_PRECHARGE_RUNWAY_MARGIN_MIN` is forwarded (the comment on that line describes this exact trap). One dict entry plus imports.

## Test

`test_the_precharge_cap_slider_reaches_the_engine` mirrors the existing runway-margin forwarding test: slider value reaches `OptimizerConfig.max_precharge_price`, and the default still flows when the option is absent. The older test's docstring, which named this knob as the one still decorative, is updated.

Stacked on #964 → #962 → `test`. 183 tests green locally across backstop, hard-floor gate, computation engine and number platform; ruff clean.