### PR TITLE
fix: route midnight reset through CostTracker (#968) and forward the three decorative sliders (#969)

### DIFF
--- a/custom_components/localshift/computation_engine.py
+++ b/custom_components/localshift/computation_engine.py
@@ -15,6 +15,8 @@ from homeassistant.util import dt as dt_util
 from .const import (
     CONF_ALLOW_DW_ENTRY_UNDER_TARGET,
     CONF_BATTERY_TARGET,
+    CONF_CHARGE_TAPER_MIN_FACTOR,
+    CONF_CHARGE_TAPER_START_PCT,
     CONF_COMPARISON_MODE,
     CONF_DEMAND_WINDOW_END,
     CONF_DEMAND_WINDOW_START,
@@ -29,10 +31,13 @@ from .const import (
     CONF_STALE_SOLAR_CONFIDENCE_CEILING,
     CONF_STALE_SOLAR_CONSERVATIVE,
     CONF_SWITCHING_PENALTY,
+    CONF_SWITCHING_PENALTY_PER_KWH,
     CONF_TARGET_PENALTY,
     CONF_WEATHER_LEARNING_ENABLED,
     DEFAULT_ABSENT_SOLAR_CONFIDENCE,
     DEFAULT_BATTERY_TARGET,
+    DEFAULT_CHARGE_TAPER_MIN_FACTOR,
+    DEFAULT_CHARGE_TAPER_START_PCT,
     DEFAULT_CHEAP_PRICE_DEADBAND,
     DEFAULT_COMPARISON_MODE,
     DEFAULT_DEMAND_WINDOW_END,
@@ -48,6 +53,7 @@ from .const import (
     DEFAULT_PRICING_DATA_SOURCE,
     DEFAULT_STALE_SOLAR_CONFIDENCE_CEILING,
     DEFAULT_SWITCHING_PENALTY,
+    DEFAULT_SWITCHING_PENALTY_PER_KWH,
     DEFAULT_TARGET_PENALTY,
     DEFAULT_WEATHER_LEARNING_ENABLED,
     SWITCH_ALLOW_DW_ENTRY_UNDER_TARGET,
@@ -851,6 +857,20 @@ class ComputationEngine:
             ),
             CONF_SWITCHING_PENALTY: self.entry.options.get(
                 CONF_SWITCHING_PENALTY, DEFAULT_SWITCHING_PENALTY
+            ),
+            # Issue #969: the three knobs below were added to the number platform
+            # (#919, #939) but never to this dict, so the runner fell through to
+            # DEFAULT_* and the sliders were decorative. Every CONF the runner reads
+            # via config_options.get() must appear here — enforced by
+            # tests/engine/test_config_options_coverage.py.
+            CONF_SWITCHING_PENALTY_PER_KWH: self.entry.options.get(
+                CONF_SWITCHING_PENALTY_PER_KWH, DEFAULT_SWITCHING_PENALTY_PER_KWH
+            ),
+            CONF_CHARGE_TAPER_START_PCT: self.entry.options.get(
+                CONF_CHARGE_TAPER_START_PCT, DEFAULT_CHARGE_TAPER_START_PCT
+            ),
+            CONF_CHARGE_TAPER_MIN_FACTOR: self.entry.options.get(
+                CONF_CHARGE_TAPER_MIN_FACTOR, DEFAULT_CHARGE_TAPER_MIN_FACTOR
             ),
             CONF_TARGET_PENALTY: self.entry.options.get(
                 CONF_TARGET_PENALTY, DEFAULT_TARGET_PENALTY

--- a/custom_components/localshift/coordinator/tick_scheduler.py
+++ b/custom_components/localshift/coordinator/tick_scheduler.py
@@ -253,19 +253,23 @@ class TickScheduler:
         grid_export_revenue) and the target_reached flag.
 
         Notifies listeners and logs the reset for debugging.
+
+        Issue #968: the cost/energy reset is delegated to
+        ``CostTracker.reset_daily_accumulators`` rather than re-implemented here.
+        That method is the only place that also clears the tracker's SOC
+        baseline (``_last_soc_pct``, Issue #899); an inline copy of the field
+        zeroing on this path left that fix with no production caller, so a grid
+        charge spanning midnight kept smearing overnight SOC gain into the new
+        day's grid-charge-efficiency metric.
         """
-        self._coordinator.data.grid_import_cost = 0.0
-        self._coordinator.data.grid_export_revenue = 0.0
-        self._coordinator.data.battery_savings = 0.0
-        self._coordinator.data.battery_charge_cost = 0.0
-        self._coordinator.data.target_reached_today = False
-        # Issue #868: reset the daily energy accumulators alongside the cost
-        # accumulators so the performance-metric ratios start fresh each day.
-        self._coordinator.data.grid_import_kwh_today = 0.0
-        self._coordinator.data.grid_export_kwh_today = 0.0
-        self._coordinator.data.grid_to_battery_kwh_today = 0.0
-        self._coordinator.data.soc_gain_during_grid_charge_kwh_today = 0.0
-        self._coordinator.data.export_while_battery_not_full_kwh_today = 0.0
+        cost_tracker = self._coordinator.cost_tracker
+        if cost_tracker is not None:
+            cost_tracker.reset_daily_accumulators(self._coordinator.data)
+        else:
+            _LOGGER.warning(
+                "Midnight reset: cost tracker not initialised, daily accumulators "
+                "not reset"
+            )
         # Issue #510: the anticipation counters are per-day like the rest.
         self._coordinator.data.anticipated_transitions_today = 0
         self._coordinator.data.anticipation_corrections_today = 0

--- a/tests/coordinator/test_coordinator.py
+++ b/tests/coordinator/test_coordinator.py
@@ -382,10 +382,17 @@ class TestHandleMidnightReset:
 
         # Mock listeners
         coordinator.notify_listeners = MagicMock()
+        # Issue #968: the reset is delegated to the real CostTracker.
+        from custom_components.localshift.utils.costs import CostTracker
+
+        coordinator._cost_tracker = CostTracker(coordinator.hass)
+        coordinator._cost_tracker._last_soc_pct = 55.0
 
         now = datetime(2026, 2, 17, 0, 0, 0)
         coordinator._handle_midnight_reset(now)
 
+        # Issue #899 / #968: SOC baseline cleared on the live path.
+        assert coordinator._cost_tracker._last_soc_pct is None
         # Verify accumulators were reset
         assert coordinator.data.grid_import_cost == 0.0
         assert coordinator.data.grid_export_revenue == 0.0

--- a/tests/coordinator/test_tick_handlers_delegate.py
+++ b/tests/coordinator/test_tick_handlers_delegate.py
@@ -101,3 +101,61 @@ def test_coordinator_handler_delegates_to_scheduler(scheduler_handler: str) -> N
         f"{scheduler_handler} would never run in production. Delegate rather "
         f"than reimplementing the body inline."
     )
+
+
+# Fields whose reset is owned by CostTracker.reset_daily_accumulators. An inline
+# assignment to any of them inside handle_midnight_reset is the #968 defect
+# reappearing: a second copy of the reset that will drift from the tracker's.
+_COST_TRACKER_OWNED_FIELDS = frozenset({
+    "grid_import_cost",
+    "grid_export_revenue",
+    "battery_savings",
+    "battery_charge_cost",
+    "target_reached_today",
+    "grid_import_kwh_today",
+    "grid_export_kwh_today",
+    "grid_to_battery_kwh_today",
+    "soc_gain_during_grid_charge_kwh_today",
+    "export_while_battery_not_full_kwh_today",
+})
+
+
+def test_midnight_reset_delegates_to_cost_tracker() -> None:
+    """Issue #968: the midnight reset must call reset_daily_accumulators.
+
+    The #899 fix (clear the tracker's ``_last_soc_pct`` at midnight) lives in
+    ``CostTracker.reset_daily_accumulators``. ``handle_midnight_reset`` carried an
+    older inline copy of the field zeroing instead of calling it, so the fix was
+    merged (PR #930) with no production caller and the metric it protects stayed
+    corrupted. This gate is static for the same reason the delegation test above
+    is: calling the tracker method in a unit test proves it works, not that the
+    midnight path reaches it.
+    """
+    scheduler_methods = _methods(_class_def(_TICK_SCHEDULER_PY, "TickScheduler"))
+    handler = scheduler_methods["handle_midnight_reset"]
+
+    calls_tracker = any(
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "reset_daily_accumulators"
+        for node in ast.walk(handler)
+    )
+    assert calls_tracker, (
+        "TickScheduler.handle_midnight_reset does not call "
+        "cost_tracker.reset_daily_accumulators(); the #899 SOC-baseline clear "
+        "only lives there."
+    )
+
+    inline = sorted({
+        target.attr
+        for node in ast.walk(handler)
+        if isinstance(node, ast.Assign)
+        for target in node.targets
+        if isinstance(target, ast.Attribute)
+        and target.attr in _COST_TRACKER_OWNED_FIELDS
+    })
+    assert not inline, (
+        f"handle_midnight_reset assigns {inline} inline. Those fields are reset by "
+        "CostTracker.reset_daily_accumulators; a second copy here is how #899 "
+        "was lost."
+    )

--- a/tests/coordinator/test_tick_scheduler.py
+++ b/tests/coordinator/test_tick_scheduler.py
@@ -236,9 +236,17 @@ async def test_handle_midnight_reset(coordinator):
     coordinator._decision_telemetry = MagicMock()
     coordinator._decision_telemetry.handle_midnight_reset = MagicMock()
     coordinator.notify_listeners = MagicMock()
+    # Issue #968: the reset is delegated to the real CostTracker, which is also
+    # what clears the #899 SOC baseline. Use a real tracker with a stale baseline.
+    from custom_components.localshift.utils.costs import CostTracker
+
+    coordinator._cost_tracker = CostTracker(coordinator.hass)
+    coordinator._cost_tracker._last_soc_pct = 63.0
 
     scheduler.handle_midnight_reset(now)
 
+    # Issue #899 / #968: the SOC baseline must be cleared on the live path.
+    assert coordinator._cost_tracker._last_soc_pct is None
     assert coordinator.data.grid_import_cost == 0.0
     assert coordinator.data.grid_export_revenue == 0.0
     assert coordinator.data.battery_savings == 0.0
@@ -825,6 +833,9 @@ async def test_handle_midnight_reset_no_decision_telemetry(coordinator):
     coordinator.data.target_reached_today = True
     coordinator._decision_telemetry = None
     coordinator.notify_listeners = MagicMock()
+    from custom_components.localshift.utils.costs import CostTracker
+
+    coordinator._cost_tracker = CostTracker(coordinator.hass)
 
     scheduler.handle_midnight_reset(now)
 

--- a/tests/engine/test_config_options_coverage.py
+++ b/tests/engine/test_config_options_coverage.py
@@ -1,0 +1,122 @@
+"""Structural guard: every option the optimizer reads must reach it.
+
+Regression gate for the decorative-slider defect (#965, #969).
+
+``ComputationEngine._build_optimizer_config_options`` hand-copies each option
+from ``entry.options`` into the dict that reaches
+``optimizer_runner._build_optimizer_config`` on the live path. The runner reads
+every knob as ``config_options.get(CONF_X, DEFAULT_X)``, so a knob missing from
+that copy does not fail — the slider moves, the engine silently keeps the
+default. ``max_pre_charge_price`` sat in that state until 2026-09-05 (#965);
+``charge_taper_start_pct``, ``charge_taper_min_factor`` and
+``switching_penalty_per_kwh`` were still in it on 2026-09-06 (#969).
+
+Behavioural tests cannot catch the class: a test that sets one option and
+checks it arrived proves that one option, not the next one. So this check is
+static — it reads both sources and asserts the set of keys the runner (and the
+facade) read is a subset of the set of keys the engine forwards.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+_PKG = Path(__file__).resolve().parents[2] / "custom_components" / "localshift"
+_COMPUTATION_ENGINE = _PKG / "computation_engine.py"
+_RUNNER = _PKG / "engine" / "optimizer_runner.py"
+_FACADE = _PKG / "engine" / "optimizer_facade.py"
+
+# ``config_options.get(CONF_X`` / ``config_options[CONF_X`` in the engine modules.
+_READ_RE = re.compile(r"config_options(?:\.get\(|\[)\s*(CONF_\w+)")
+
+
+def _builder_node() -> ast.FunctionDef:
+    tree = ast.parse(_COMPUTATION_ENGINE.read_text())
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.FunctionDef)
+            and node.name == "_build_optimizer_config_options"
+        ):
+            return node
+    raise AssertionError(
+        "_build_optimizer_config_options not found in computation_engine.py"
+    )
+
+
+def _forwarded_keys() -> set[str]:
+    """CONF_* keys used as dict keys inside ``_build_optimizer_config_options``."""
+    return {
+        key.id
+        for sub in ast.walk(_builder_node())
+        if isinstance(sub, ast.Dict)
+        for key in sub.keys
+        if isinstance(key, ast.Name) and key.id.startswith("CONF_")
+    }
+
+
+def _read_keys(path: Path) -> set[str]:
+    return set(_READ_RE.findall(path.read_text()))
+
+
+def test_engine_forwards_something() -> None:
+    """Sanity: the introspection found the dict at all."""
+    assert len(_forwarded_keys()) >= 10
+
+
+@pytest.mark.parametrize("reader", [_RUNNER, _FACADE], ids=["runner", "facade"])
+def test_every_option_the_optimizer_reads_is_forwarded(reader: Path) -> None:
+    """A CONF read by the engine but absent from the forwarded dict is a
+    decorative slider: the number entity writes entry.options, the engine reads
+    this dict, and the DEFAULT_* fallback wins forever."""
+    missing = sorted(_read_keys(reader) - _forwarded_keys())
+    assert not missing, (
+        f"{reader.name} reads {missing} from config_options but "
+        "ComputationEngine._build_optimizer_config_options never forwards them. "
+        "Add each key to that dict (with its DEFAULT_* fallback) or the slider "
+        "does nothing on the live path (#965, #969)."
+    )
+
+
+def test_every_number_entity_the_runner_reads_is_forwarded() -> None:
+    """Same property stated from the platform side: any number entity whose
+    CONF key the runner reads must be forwarded."""
+    from custom_components.localshift.number import NUMBER_DEFINITIONS
+
+    entity_confs = {conf for conf, _name, _default in NUMBER_DEFINITIONS}
+    runner_reads = _read_keys(_RUNNER)
+    decorative = sorted((entity_confs & runner_reads) - _forwarded_keys())
+    assert not decorative, f"decorative number entities: {decorative}"
+
+
+@pytest.mark.parametrize(
+    ("conf_name", "attr", "value"),
+    [
+        ("CONF_CHARGE_TAPER_START_PCT", "charge_taper_start_pct", 85.0),
+        ("CONF_CHARGE_TAPER_MIN_FACTOR", "charge_taper_min_factor", 0.35),
+        ("CONF_SWITCHING_PENALTY_PER_KWH", "switching_penalty_per_kwh", 0.15),
+    ],
+)
+def test_the_969_sliders_reach_the_engine_on_the_live_path(
+    conf_name: str, attr: str, value: float
+) -> None:
+    """The three knobs #969 found decorative now flow entry.options -> dict -> config."""
+    from custom_components.localshift import const
+    from custom_components.localshift.computation_engine import ComputationEngine
+    from custom_components.localshift.engine.optimizer_runner import (
+        _build_optimizer_config,
+    )
+
+    conf = getattr(const, conf_name)
+    engine = ComputationEngine.__new__(ComputationEngine)
+    engine.entry = SimpleNamespace(options={conf: value})
+    engine._get_switch_state = lambda _key: False
+
+    options = engine._build_optimizer_config_options()
+
+    assert options[conf] == value
+    assert getattr(_build_optimizer_config(SimpleNamespace(), options), attr) == value


### PR DESCRIPTION
## Summary

Two bugs from the 2026-09-05 audit, both of the "fix exists but never reaches the live path" shape.

**#968 — midnight reset never called `reset_daily_accumulators`.** `TickScheduler.handle_midnight_reset` carried an older inline copy of the cost/energy zeroing. The #899 fix (clear `CostTracker._last_soc_pct` so a grid charge spanning midnight does not smear overnight SOC gain into the new day's `grid_charge_efficiency`) was merged in #930 into `reset_daily_accumulators`, which had no production caller. The scheduler now delegates to the tracker; the anticipation counters (#510) stay on the scheduler because the tracker does not own them.

**#969 — three decorative number entities.** `_build_optimizer_config_options` (the dict the DP actually reads) omitted `CONF_CHARGE_TAPER_START_PCT`, `CONF_CHARGE_TAPER_MIN_FACTOR` and `CONF_SWITCHING_PENALTY_PER_KWH`, so `optimizer_runner._build_optimizer_config` fell through to the defaults regardless of the slider. Same class as #965. Live values sit at the defaults today (90.0 / 0.2 / 0.4), so no plan changes on deploy.

## Gates added

- `tests/coordinator/test_tick_handlers_delegate.py::test_midnight_reset_delegates_to_cost_tracker` — static: `handle_midnight_reset` must call `reset_daily_accumulators` and must not assign any tracker-owned field inline.
- `tests/engine/test_config_options_coverage.py` — static: every `CONF_*` read via `config_options.get(`/`[` in `optimizer_runner.py` and `optimizer_facade.py` must be a key in the dict `_build_optimizer_config_options` builds; plus the same property from the `NUMBER_DEFINITIONS` side, plus a live-path flow test for the three knobs. This closes the class, not the instance.

## Test plan

- [x] `uv run pytest -n 4` — 3404 passed (baseline 3396; +8 new)
- [x] `uv run ruff check` / `ruff format --check` clean on `custom_components/localshift` and the new/edited tests
- [x] `uv run vulture custom_components/localshift --min-confidence 80` clean
- [ ] After deploy: first post-midnight `accumulate_costs` sample should not carry the pre-midnight SOC baseline (log "Midnight reset" then check `soc_gain_during_grid_charge_kwh_today` stays 0 until a real grid charge)

Closes #968
Closes #969
